### PR TITLE
Add cfu

### DIFF
--- a/pythondata_cpu_vexriscv/verilog/Makefile
+++ b/pythondata_cpu_vexriscv/verilog/Makefile
@@ -1,6 +1,6 @@
 SRC := ${shell find . -type f -name \*.scala}
 
-all: VexRiscv.v VexRiscv_Debug.v VexRiscv_Lite.v VexRiscv_LiteDebug.v VexRiscv_IMAC.v VexRiscv_IMACDebug.v VexRiscv_Min.v VexRiscv_MinDebug.v VexRiscv_Full.v VexRiscv_FullDebug.v VexRiscv_Linux.v VexRiscv_LinuxDebug.v VexRiscv_LinuxNoDspFmax.v VexRiscv_Secure.v VexRiscv_SecureDebug.v 
+all: VexRiscv.v VexRiscv_Debug.v VexRiscv_Lite.v VexRiscv_LiteDebug.v VexRiscv_IMAC.v VexRiscv_IMACDebug.v VexRiscv_Min.v VexRiscv_MinDebug.v VexRiscv_Full.v VexRiscv_FullDebug.v VexRiscv_FullCfu.v VexRiscv_FullCfuDebug.v VexRiscv_Linux.v VexRiscv_LinuxDebug.v VexRiscv_LinuxNoDspFmax.v VexRiscv_Secure.v VexRiscv_SecureDebug.v
 
 VexRiscv.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault"
@@ -31,6 +31,12 @@ VexRiscv_Full.v: $(SRC)
 
 VexRiscv_FullDebug.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig all -d --outputFile VexRiscv_FullDebug"
+
+VexRiscv_FullCfu.v: $(SRC)
+	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig all --cfu true --outputFile VexRiscv_FullCfu"
+
+VexRiscv_FullCfuDebug.v: $(SRC)
+	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig all --cfu true -d --outputFile VexRiscv_FullCfuDebug"
 
 VexRiscv_Linux.v: $(SRC)
 	sbt compile "runMain vexriscv.GenCoreDefault --csrPluginConfig linux-minimal --outputFile VexRiscv_Linux"

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv.v
@@ -1,7 +1,12 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:37:30
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
+
+`define EnvCtrlEnum_defaultEncoding_type [1:0]
+`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
+`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
+`define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
 
 `define BranchCtrlEnum_defaultEncoding_type [1:0]
 `define BranchCtrlEnum_defaultEncoding_INC 2'b00
@@ -20,21 +25,16 @@
 `define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
 `define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
 
-`define EnvCtrlEnum_defaultEncoding_type [1:0]
-`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
-`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
-`define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
-
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
-
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
 `define Src2CtrlEnum_defaultEncoding_IMI 2'b01
 `define Src2CtrlEnum_defaultEncoding_IMS 2'b10
 `define Src2CtrlEnum_defaultEncoding_PC 2'b11
+
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
 `define Src1CtrlEnum_defaultEncoding_type [1:0]
 `define Src1CtrlEnum_defaultEncoding_RS 2'b00
@@ -42,1013 +42,6 @@
 `define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
 `define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire       [0:0]    _zz_14_;
-  wire       [0:0]    _zz_15_;
-  wire       [21:0]   _zz_16_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* syn_keep , keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* syn_keep , keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-
-  assign _zz_12_ = (! lineLoader_flushCounter[7]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [0:0]    _zz_18_;
-  wire       [0:0]    _zz_19_;
-  wire       [2:0]    _zz_20_;
-  wire       [1:0]    _zz_21_;
-  wire       [21:0]   _zz_22_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  wire       [31:0]   stageB_requestDataBypass;
-  wire                stageB_isAmo;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_23_;
-  reg [7:0] _zz_24_;
-  reg [7:0] _zz_25_;
-  reg [7:0] _zz_26_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmo)));
-  assign _zz_15_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_16_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_17_ = _zz_4_[0 : 0];
-  assign _zz_18_ = _zz_4_[1 : 1];
-  assign _zz_19_ = loader_counter_willIncrement;
-  assign _zz_20_ = {2'd0, _zz_19_};
-  assign _zz_21_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_22_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_22_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_26_, _zz_25_, _zz_24_, _zz_23_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_23_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_24_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_25_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_26_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_17_[0];
-  assign ways_0_tagsReadRsp_error = _zz_18_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  assign stageB_requestDataBypass = stageB_request_data;
-  assign stageB_isAmo = 1'b0;
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((((! stageB_request_wr) || stageB_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0))))begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_15_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_20_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_16_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_16_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_15_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_21_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1064,8 +57,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1075,40 +68,45 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset 
+  input               reset
 );
-  wire                _zz_166_;
-  wire                _zz_167_;
-  wire                _zz_168_;
-  wire                _zz_169_;
-  wire                _zz_170_;
-  wire                _zz_171_;
-  wire                _zz_172_;
-  reg                 _zz_173_;
-  wire                _zz_174_;
-  wire       [31:0]   _zz_175_;
-  wire                _zz_176_;
-  wire       [31:0]   _zz_177_;
-  reg                 _zz_178_;
-  wire                _zz_179_;
-  wire                _zz_180_;
-  wire       [31:0]   _zz_181_;
-  wire                _zz_182_;
-  wire                _zz_183_;
-  reg        [31:0]   _zz_184_;
-  reg        [31:0]   _zz_185_;
-  reg        [31:0]   _zz_186_;
+  wire                _zz_165;
+  wire                _zz_166;
+  wire                _zz_167;
+  wire                _zz_168;
+  wire                _zz_169;
+  wire                _zz_170;
+  wire                _zz_171;
+  wire                _zz_172;
+  reg                 _zz_173;
+  wire                _zz_174;
+  wire       [31:0]   _zz_175;
+  wire                _zz_176;
+  wire       [31:0]   _zz_177;
+  reg                 _zz_178;
+  wire                _zz_179;
+  wire                _zz_180;
+  wire       [31:0]   _zz_181;
+  wire                _zz_182;
+  wire                _zz_183;
+  wire                _zz_184;
+  wire                _zz_185;
+  wire                _zz_186;
+  wire                _zz_187;
+  wire                _zz_188;
+  wire                _zz_189;
+  wire       [3:0]    _zz_190;
+  wire                _zz_191;
+  wire                _zz_192;
+  reg        [31:0]   _zz_193;
+  reg        [31:0]   _zz_194;
+  reg        [31:0]   _zz_195;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -1118,408 +116,406 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_187_;
-  wire                _zz_188_;
-  wire                _zz_189_;
-  wire                _zz_190_;
-  wire                _zz_191_;
-  wire                _zz_192_;
-  wire                _zz_193_;
-  wire                _zz_194_;
-  wire                _zz_195_;
-  wire                _zz_196_;
-  wire                _zz_197_;
-  wire                _zz_198_;
-  wire                _zz_199_;
-  wire       [1:0]    _zz_200_;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire                _zz_203_;
-  wire                _zz_204_;
-  wire                _zz_205_;
-  wire                _zz_206_;
-  wire                _zz_207_;
-  wire                _zz_208_;
-  wire                _zz_209_;
-  wire       [1:0]    _zz_210_;
-  wire                _zz_211_;
-  wire                _zz_212_;
-  wire                _zz_213_;
-  wire                _zz_214_;
-  wire                _zz_215_;
-  wire                _zz_216_;
-  wire                _zz_217_;
-  wire                _zz_218_;
-  wire       [1:0]    _zz_219_;
-  wire                _zz_220_;
-  wire       [1:0]    _zz_221_;
-  wire       [0:0]    _zz_222_;
-  wire       [0:0]    _zz_223_;
-  wire       [32:0]   _zz_224_;
-  wire       [31:0]   _zz_225_;
-  wire       [32:0]   _zz_226_;
-  wire       [0:0]    _zz_227_;
-  wire       [0:0]    _zz_228_;
-  wire       [0:0]    _zz_229_;
-  wire       [0:0]    _zz_230_;
-  wire       [51:0]   _zz_231_;
-  wire       [51:0]   _zz_232_;
-  wire       [51:0]   _zz_233_;
-  wire       [32:0]   _zz_234_;
-  wire       [51:0]   _zz_235_;
-  wire       [49:0]   _zz_236_;
-  wire       [51:0]   _zz_237_;
-  wire       [49:0]   _zz_238_;
-  wire       [51:0]   _zz_239_;
-  wire       [0:0]    _zz_240_;
-  wire       [0:0]    _zz_241_;
-  wire       [0:0]    _zz_242_;
-  wire       [0:0]    _zz_243_;
-  wire       [0:0]    _zz_244_;
-  wire       [0:0]    _zz_245_;
-  wire       [0:0]    _zz_246_;
-  wire       [0:0]    _zz_247_;
-  wire       [0:0]    _zz_248_;
-  wire       [0:0]    _zz_249_;
-  wire       [0:0]    _zz_250_;
-  wire       [3:0]    _zz_251_;
-  wire       [2:0]    _zz_252_;
-  wire       [31:0]   _zz_253_;
-  wire       [11:0]   _zz_254_;
-  wire       [31:0]   _zz_255_;
-  wire       [19:0]   _zz_256_;
-  wire       [11:0]   _zz_257_;
-  wire       [31:0]   _zz_258_;
-  wire       [31:0]   _zz_259_;
-  wire       [19:0]   _zz_260_;
-  wire       [11:0]   _zz_261_;
-  wire       [2:0]    _zz_262_;
-  wire       [2:0]    _zz_263_;
-  wire       [0:0]    _zz_264_;
-  wire       [2:0]    _zz_265_;
-  wire       [4:0]    _zz_266_;
-  wire       [11:0]   _zz_267_;
-  wire       [11:0]   _zz_268_;
-  wire       [31:0]   _zz_269_;
-  wire       [31:0]   _zz_270_;
-  wire       [31:0]   _zz_271_;
-  wire       [31:0]   _zz_272_;
-  wire       [31:0]   _zz_273_;
-  wire       [31:0]   _zz_274_;
-  wire       [31:0]   _zz_275_;
-  wire       [11:0]   _zz_276_;
-  wire       [19:0]   _zz_277_;
-  wire       [11:0]   _zz_278_;
-  wire       [31:0]   _zz_279_;
-  wire       [31:0]   _zz_280_;
-  wire       [31:0]   _zz_281_;
-  wire       [11:0]   _zz_282_;
-  wire       [19:0]   _zz_283_;
-  wire       [11:0]   _zz_284_;
-  wire       [2:0]    _zz_285_;
-  wire       [1:0]    _zz_286_;
-  wire       [1:0]    _zz_287_;
-  wire       [65:0]   _zz_288_;
-  wire       [65:0]   _zz_289_;
-  wire       [31:0]   _zz_290_;
-  wire       [31:0]   _zz_291_;
-  wire       [0:0]    _zz_292_;
-  wire       [5:0]    _zz_293_;
-  wire       [32:0]   _zz_294_;
-  wire       [31:0]   _zz_295_;
-  wire       [31:0]   _zz_296_;
-  wire       [32:0]   _zz_297_;
-  wire       [32:0]   _zz_298_;
-  wire       [32:0]   _zz_299_;
-  wire       [32:0]   _zz_300_;
-  wire       [0:0]    _zz_301_;
-  wire       [32:0]   _zz_302_;
-  wire       [0:0]    _zz_303_;
-  wire       [32:0]   _zz_304_;
-  wire       [0:0]    _zz_305_;
-  wire       [31:0]   _zz_306_;
-  wire       [0:0]    _zz_307_;
-  wire       [0:0]    _zz_308_;
-  wire       [0:0]    _zz_309_;
-  wire       [0:0]    _zz_310_;
-  wire       [0:0]    _zz_311_;
-  wire       [0:0]    _zz_312_;
-  wire       [26:0]   _zz_313_;
-  wire                _zz_314_;
-  wire                _zz_315_;
-  wire       [1:0]    _zz_316_;
-  wire       [31:0]   _zz_317_;
-  wire       [31:0]   _zz_318_;
-  wire       [31:0]   _zz_319_;
-  wire                _zz_320_;
-  wire       [0:0]    _zz_321_;
-  wire       [13:0]   _zz_322_;
-  wire       [31:0]   _zz_323_;
-  wire       [31:0]   _zz_324_;
-  wire       [31:0]   _zz_325_;
-  wire                _zz_326_;
-  wire       [0:0]    _zz_327_;
-  wire       [7:0]    _zz_328_;
-  wire       [31:0]   _zz_329_;
-  wire       [31:0]   _zz_330_;
-  wire       [31:0]   _zz_331_;
-  wire                _zz_332_;
-  wire       [0:0]    _zz_333_;
-  wire       [1:0]    _zz_334_;
-  wire                _zz_335_;
-  wire                _zz_336_;
-  wire                _zz_337_;
-  wire       [31:0]   _zz_338_;
-  wire       [31:0]   _zz_339_;
-  wire       [31:0]   _zz_340_;
-  wire       [31:0]   _zz_341_;
-  wire       [31:0]   _zz_342_;
-  wire       [31:0]   _zz_343_;
-  wire                _zz_344_;
-  wire       [1:0]    _zz_345_;
-  wire       [1:0]    _zz_346_;
-  wire                _zz_347_;
-  wire       [0:0]    _zz_348_;
-  wire       [25:0]   _zz_349_;
-  wire       [31:0]   _zz_350_;
-  wire       [31:0]   _zz_351_;
-  wire                _zz_352_;
-  wire                _zz_353_;
-  wire       [0:0]    _zz_354_;
-  wire       [0:0]    _zz_355_;
-  wire                _zz_356_;
-  wire       [0:0]    _zz_357_;
-  wire       [22:0]   _zz_358_;
-  wire       [31:0]   _zz_359_;
-  wire       [31:0]   _zz_360_;
-  wire       [31:0]   _zz_361_;
-  wire                _zz_362_;
-  wire       [0:0]    _zz_363_;
-  wire       [0:0]    _zz_364_;
-  wire                _zz_365_;
-  wire       [0:0]    _zz_366_;
-  wire       [18:0]   _zz_367_;
-  wire       [31:0]   _zz_368_;
-  wire                _zz_369_;
-  wire                _zz_370_;
-  wire                _zz_371_;
-  wire       [0:0]    _zz_372_;
-  wire       [0:0]    _zz_373_;
-  wire                _zz_374_;
-  wire       [0:0]    _zz_375_;
-  wire       [14:0]   _zz_376_;
-  wire       [31:0]   _zz_377_;
-  wire       [0:0]    _zz_378_;
-  wire       [3:0]    _zz_379_;
-  wire       [0:0]    _zz_380_;
-  wire       [2:0]    _zz_381_;
-  wire       [0:0]    _zz_382_;
-  wire       [0:0]    _zz_383_;
-  wire                _zz_384_;
-  wire       [0:0]    _zz_385_;
-  wire       [11:0]   _zz_386_;
-  wire       [31:0]   _zz_387_;
-  wire       [31:0]   _zz_388_;
-  wire       [31:0]   _zz_389_;
-  wire                _zz_390_;
-  wire       [0:0]    _zz_391_;
-  wire       [0:0]    _zz_392_;
-  wire       [31:0]   _zz_393_;
-  wire       [31:0]   _zz_394_;
-  wire       [31:0]   _zz_395_;
-  wire                _zz_396_;
-  wire                _zz_397_;
-  wire       [31:0]   _zz_398_;
-  wire                _zz_399_;
-  wire       [0:0]    _zz_400_;
-  wire       [2:0]    _zz_401_;
-  wire       [0:0]    _zz_402_;
-  wire       [0:0]    _zz_403_;
-  wire       [0:0]    _zz_404_;
-  wire       [0:0]    _zz_405_;
-  wire                _zz_406_;
-  wire       [0:0]    _zz_407_;
-  wire       [8:0]    _zz_408_;
-  wire       [31:0]   _zz_409_;
-  wire       [31:0]   _zz_410_;
-  wire       [31:0]   _zz_411_;
-  wire       [31:0]   _zz_412_;
-  wire       [31:0]   _zz_413_;
-  wire       [31:0]   _zz_414_;
-  wire       [31:0]   _zz_415_;
-  wire       [31:0]   _zz_416_;
-  wire                _zz_417_;
-  wire       [0:0]    _zz_418_;
-  wire       [0:0]    _zz_419_;
-  wire       [31:0]   _zz_420_;
-  wire       [31:0]   _zz_421_;
-  wire       [31:0]   _zz_422_;
-  wire       [31:0]   _zz_423_;
-  wire                _zz_424_;
-  wire       [1:0]    _zz_425_;
-  wire       [1:0]    _zz_426_;
-  wire                _zz_427_;
-  wire       [0:0]    _zz_428_;
-  wire       [6:0]    _zz_429_;
-  wire       [31:0]   _zz_430_;
-  wire       [31:0]   _zz_431_;
-  wire       [31:0]   _zz_432_;
-  wire       [31:0]   _zz_433_;
-  wire       [31:0]   _zz_434_;
-  wire       [31:0]   _zz_435_;
-  wire                _zz_436_;
-  wire                _zz_437_;
-  wire       [0:0]    _zz_438_;
-  wire       [1:0]    _zz_439_;
-  wire       [2:0]    _zz_440_;
-  wire       [2:0]    _zz_441_;
-  wire                _zz_442_;
-  wire       [0:0]    _zz_443_;
-  wire       [4:0]    _zz_444_;
-  wire       [31:0]   _zz_445_;
-  wire       [31:0]   _zz_446_;
-  wire       [31:0]   _zz_447_;
-  wire       [31:0]   _zz_448_;
-  wire                _zz_449_;
-  wire                _zz_450_;
-  wire                _zz_451_;
-  wire       [0:0]    _zz_452_;
-  wire       [0:0]    _zz_453_;
-  wire       [0:0]    _zz_454_;
-  wire       [3:0]    _zz_455_;
-  wire       [1:0]    _zz_456_;
-  wire       [1:0]    _zz_457_;
-  wire                _zz_458_;
-  wire       [0:0]    _zz_459_;
-  wire       [2:0]    _zz_460_;
-  wire       [31:0]   _zz_461_;
-  wire       [31:0]   _zz_462_;
-  wire       [31:0]   _zz_463_;
-  wire       [31:0]   _zz_464_;
-  wire       [31:0]   _zz_465_;
-  wire       [31:0]   _zz_466_;
-  wire       [31:0]   _zz_467_;
-  wire                _zz_468_;
-  wire       [0:0]    _zz_469_;
-  wire       [1:0]    _zz_470_;
-  wire                _zz_471_;
-  wire                _zz_472_;
-  wire       [2:0]    _zz_473_;
-  wire       [2:0]    _zz_474_;
-  wire                _zz_475_;
-  wire       [0:0]    _zz_476_;
-  wire       [0:0]    _zz_477_;
-  wire       [31:0]   _zz_478_;
-  wire       [31:0]   _zz_479_;
-  wire       [31:0]   _zz_480_;
-  wire                _zz_481_;
-  wire                _zz_482_;
-  wire       [31:0]   _zz_483_;
-  wire       [31:0]   _zz_484_;
-  wire                _zz_485_;
-  wire       [0:0]    _zz_486_;
-  wire       [0:0]    _zz_487_;
-  wire                _zz_488_;
-  wire       [1:0]    _zz_489_;
-  wire       [1:0]    _zz_490_;
-  wire       [1:0]    _zz_491_;
-  wire       [1:0]    _zz_492_;
-  wire       [31:0]   _zz_493_;
-  wire       [31:0]   _zz_494_;
-  wire       [31:0]   _zz_495_;
-  wire       [31:0]   _zz_496_;
-  wire       [31:0]   _zz_497_;
-  wire       [31:0]   _zz_498_;
-  wire                _zz_499_;
-  wire                _zz_500_;
-  wire                _zz_501_;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_196;
+  wire                _zz_197;
+  wire                _zz_198;
+  wire                _zz_199;
+  wire                _zz_200;
+  wire                _zz_201;
+  wire                _zz_202;
+  wire                _zz_203;
+  wire                _zz_204;
+  wire                _zz_205;
+  wire                _zz_206;
+  wire                _zz_207;
+  wire                _zz_208;
+  wire       [1:0]    _zz_209;
+  wire                _zz_210;
+  wire                _zz_211;
+  wire                _zz_212;
+  wire                _zz_213;
+  wire                _zz_214;
+  wire                _zz_215;
+  wire                _zz_216;
+  wire                _zz_217;
+  wire                _zz_218;
+  wire       [1:0]    _zz_219;
+  wire                _zz_220;
+  wire                _zz_221;
+  wire                _zz_222;
+  wire                _zz_223;
+  wire                _zz_224;
+  wire                _zz_225;
+  wire                _zz_226;
+  wire                _zz_227;
+  wire       [1:0]    _zz_228;
+  wire                _zz_229;
+  wire       [1:0]    _zz_230;
+  wire       [51:0]   _zz_231;
+  wire       [51:0]   _zz_232;
+  wire       [51:0]   _zz_233;
+  wire       [32:0]   _zz_234;
+  wire       [51:0]   _zz_235;
+  wire       [49:0]   _zz_236;
+  wire       [51:0]   _zz_237;
+  wire       [49:0]   _zz_238;
+  wire       [51:0]   _zz_239;
+  wire       [32:0]   _zz_240;
+  wire       [31:0]   _zz_241;
+  wire       [32:0]   _zz_242;
+  wire       [0:0]    _zz_243;
+  wire       [0:0]    _zz_244;
+  wire       [0:0]    _zz_245;
+  wire       [0:0]    _zz_246;
+  wire       [0:0]    _zz_247;
+  wire       [0:0]    _zz_248;
+  wire       [0:0]    _zz_249;
+  wire       [0:0]    _zz_250;
+  wire       [0:0]    _zz_251;
+  wire       [0:0]    _zz_252;
+  wire       [0:0]    _zz_253;
+  wire       [0:0]    _zz_254;
+  wire       [0:0]    _zz_255;
+  wire       [0:0]    _zz_256;
+  wire       [0:0]    _zz_257;
+  wire       [0:0]    _zz_258;
+  wire       [0:0]    _zz_259;
+  wire       [3:0]    _zz_260;
+  wire       [2:0]    _zz_261;
+  wire       [31:0]   _zz_262;
+  wire       [11:0]   _zz_263;
+  wire       [31:0]   _zz_264;
+  wire       [19:0]   _zz_265;
+  wire       [11:0]   _zz_266;
+  wire       [31:0]   _zz_267;
+  wire       [31:0]   _zz_268;
+  wire       [19:0]   _zz_269;
+  wire       [11:0]   _zz_270;
+  wire       [2:0]    _zz_271;
+  wire       [2:0]    _zz_272;
+  wire       [0:0]    _zz_273;
+  wire       [2:0]    _zz_274;
+  wire       [4:0]    _zz_275;
+  wire       [11:0]   _zz_276;
+  wire       [11:0]   _zz_277;
+  wire       [31:0]   _zz_278;
+  wire       [31:0]   _zz_279;
+  wire       [31:0]   _zz_280;
+  wire       [31:0]   _zz_281;
+  wire       [31:0]   _zz_282;
+  wire       [31:0]   _zz_283;
+  wire       [31:0]   _zz_284;
+  wire       [11:0]   _zz_285;
+  wire       [19:0]   _zz_286;
+  wire       [11:0]   _zz_287;
+  wire       [31:0]   _zz_288;
+  wire       [31:0]   _zz_289;
+  wire       [31:0]   _zz_290;
+  wire       [11:0]   _zz_291;
+  wire       [19:0]   _zz_292;
+  wire       [11:0]   _zz_293;
+  wire       [2:0]    _zz_294;
+  wire       [1:0]    _zz_295;
+  wire       [1:0]    _zz_296;
+  wire       [65:0]   _zz_297;
+  wire       [65:0]   _zz_298;
+  wire       [31:0]   _zz_299;
+  wire       [31:0]   _zz_300;
+  wire       [0:0]    _zz_301;
+  wire       [5:0]    _zz_302;
+  wire       [32:0]   _zz_303;
+  wire       [31:0]   _zz_304;
+  wire       [31:0]   _zz_305;
+  wire       [32:0]   _zz_306;
+  wire       [32:0]   _zz_307;
+  wire       [32:0]   _zz_308;
+  wire       [32:0]   _zz_309;
+  wire       [0:0]    _zz_310;
+  wire       [32:0]   _zz_311;
+  wire       [0:0]    _zz_312;
+  wire       [32:0]   _zz_313;
+  wire       [0:0]    _zz_314;
+  wire       [31:0]   _zz_315;
+  wire       [0:0]    _zz_316;
+  wire       [0:0]    _zz_317;
+  wire       [0:0]    _zz_318;
+  wire       [0:0]    _zz_319;
+  wire       [0:0]    _zz_320;
+  wire       [0:0]    _zz_321;
+  wire       [26:0]   _zz_322;
+  wire                _zz_323;
+  wire                _zz_324;
+  wire       [1:0]    _zz_325;
+  wire       [31:0]   _zz_326;
+  wire       [31:0]   _zz_327;
+  wire       [31:0]   _zz_328;
+  wire                _zz_329;
+  wire       [0:0]    _zz_330;
+  wire       [13:0]   _zz_331;
+  wire       [31:0]   _zz_332;
+  wire       [31:0]   _zz_333;
+  wire       [31:0]   _zz_334;
+  wire                _zz_335;
+  wire       [0:0]    _zz_336;
+  wire       [7:0]    _zz_337;
+  wire       [31:0]   _zz_338;
+  wire       [31:0]   _zz_339;
+  wire       [31:0]   _zz_340;
+  wire                _zz_341;
+  wire       [0:0]    _zz_342;
+  wire       [1:0]    _zz_343;
+  wire                _zz_344;
+  wire                _zz_345;
+  wire                _zz_346;
+  wire       [31:0]   _zz_347;
+  wire       [31:0]   _zz_348;
+  wire                _zz_349;
+  wire       [0:0]    _zz_350;
+  wire       [0:0]    _zz_351;
+  wire                _zz_352;
+  wire       [0:0]    _zz_353;
+  wire       [24:0]   _zz_354;
+  wire       [31:0]   _zz_355;
+  wire                _zz_356;
+  wire                _zz_357;
+  wire       [0:0]    _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [0:0]    _zz_360;
+  wire       [0:0]    _zz_361;
+  wire                _zz_362;
+  wire       [0:0]    _zz_363;
+  wire       [20:0]   _zz_364;
+  wire       [31:0]   _zz_365;
+  wire       [31:0]   _zz_366;
+  wire                _zz_367;
+  wire                _zz_368;
+  wire       [0:0]    _zz_369;
+  wire       [1:0]    _zz_370;
+  wire       [0:0]    _zz_371;
+  wire       [0:0]    _zz_372;
+  wire                _zz_373;
+  wire       [0:0]    _zz_374;
+  wire       [17:0]   _zz_375;
+  wire       [31:0]   _zz_376;
+  wire       [31:0]   _zz_377;
+  wire       [31:0]   _zz_378;
+  wire       [31:0]   _zz_379;
+  wire       [31:0]   _zz_380;
+  wire       [31:0]   _zz_381;
+  wire       [31:0]   _zz_382;
+  wire       [31:0]   _zz_383;
+  wire                _zz_384;
+  wire       [1:0]    _zz_385;
+  wire       [1:0]    _zz_386;
+  wire                _zz_387;
+  wire       [0:0]    _zz_388;
+  wire       [14:0]   _zz_389;
+  wire       [31:0]   _zz_390;
+  wire       [31:0]   _zz_391;
+  wire       [31:0]   _zz_392;
+  wire       [31:0]   _zz_393;
+  wire       [31:0]   _zz_394;
+  wire       [31:0]   _zz_395;
+  wire       [0:0]    _zz_396;
+  wire       [0:0]    _zz_397;
+  wire       [2:0]    _zz_398;
+  wire       [2:0]    _zz_399;
+  wire                _zz_400;
+  wire       [0:0]    _zz_401;
+  wire       [11:0]   _zz_402;
+  wire       [31:0]   _zz_403;
+  wire       [31:0]   _zz_404;
+  wire       [31:0]   _zz_405;
+  wire       [31:0]   _zz_406;
+  wire                _zz_407;
+  wire                _zz_408;
+  wire       [31:0]   _zz_409;
+  wire       [31:0]   _zz_410;
+  wire       [0:0]    _zz_411;
+  wire       [3:0]    _zz_412;
+  wire       [4:0]    _zz_413;
+  wire       [4:0]    _zz_414;
+  wire                _zz_415;
+  wire       [0:0]    _zz_416;
+  wire       [8:0]    _zz_417;
+  wire       [31:0]   _zz_418;
+  wire       [31:0]   _zz_419;
+  wire       [31:0]   _zz_420;
+  wire       [31:0]   _zz_421;
+  wire       [0:0]    _zz_422;
+  wire       [1:0]    _zz_423;
+  wire       [0:0]    _zz_424;
+  wire       [2:0]    _zz_425;
+  wire       [0:0]    _zz_426;
+  wire       [4:0]    _zz_427;
+  wire       [1:0]    _zz_428;
+  wire       [1:0]    _zz_429;
+  wire                _zz_430;
+  wire       [0:0]    _zz_431;
+  wire       [6:0]    _zz_432;
+  wire       [31:0]   _zz_433;
+  wire       [31:0]   _zz_434;
+  wire                _zz_435;
+  wire                _zz_436;
+  wire       [31:0]   _zz_437;
+  wire       [31:0]   _zz_438;
+  wire                _zz_439;
+  wire       [0:0]    _zz_440;
+  wire       [0:0]    _zz_441;
+  wire                _zz_442;
+  wire       [0:0]    _zz_443;
+  wire       [2:0]    _zz_444;
+  wire                _zz_445;
+  wire       [0:0]    _zz_446;
+  wire       [0:0]    _zz_447;
+  wire       [0:0]    _zz_448;
+  wire       [0:0]    _zz_449;
+  wire                _zz_450;
+  wire       [0:0]    _zz_451;
+  wire       [4:0]    _zz_452;
+  wire       [31:0]   _zz_453;
+  wire       [31:0]   _zz_454;
+  wire       [31:0]   _zz_455;
+  wire       [31:0]   _zz_456;
+  wire       [31:0]   _zz_457;
+  wire       [31:0]   _zz_458;
+  wire       [31:0]   _zz_459;
+  wire       [31:0]   _zz_460;
+  wire       [31:0]   _zz_461;
+  wire       [31:0]   _zz_462;
+  wire                _zz_463;
+  wire       [0:0]    _zz_464;
+  wire       [0:0]    _zz_465;
+  wire       [31:0]   _zz_466;
+  wire       [31:0]   _zz_467;
+  wire       [31:0]   _zz_468;
+  wire       [31:0]   _zz_469;
+  wire       [31:0]   _zz_470;
+  wire                _zz_471;
+  wire       [3:0]    _zz_472;
+  wire       [3:0]    _zz_473;
+  wire                _zz_474;
+  wire       [0:0]    _zz_475;
+  wire       [2:0]    _zz_476;
+  wire       [31:0]   _zz_477;
+  wire       [31:0]   _zz_478;
+  wire       [31:0]   _zz_479;
+  wire       [31:0]   _zz_480;
+  wire       [31:0]   _zz_481;
+  wire       [31:0]   _zz_482;
+  wire                _zz_483;
+  wire       [0:0]    _zz_484;
+  wire       [1:0]    _zz_485;
+  wire                _zz_486;
+  wire       [2:0]    _zz_487;
+  wire       [2:0]    _zz_488;
+  wire                _zz_489;
+  wire       [0:0]    _zz_490;
+  wire       [0:0]    _zz_491;
+  wire       [31:0]   _zz_492;
+  wire       [31:0]   _zz_493;
+  wire       [31:0]   _zz_494;
+  wire       [31:0]   _zz_495;
+  wire       [31:0]   _zz_496;
+  wire       [31:0]   _zz_497;
+  wire       [31:0]   _zz_498;
+  wire                _zz_499;
+  wire                _zz_500;
+  wire                _zz_501;
+  wire       [0:0]    _zz_502;
+  wire       [0:0]    _zz_503;
+  wire                _zz_504;
+  wire                _zz_505;
+  wire                _zz_506;
+  wire                _zz_507;
+  wire       [51:0]   memory_MUL_LOW;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
   wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
   wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
   wire       [31:0]   memory_PC;
-  wire                decode_IS_RS2_SIGNED;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire                decode_MEMORY_MANAGMENT;
-  wire       [33:0]   execute_MUL_LH;
-  wire                execute_BRANCH_DO;
-  wire       [31:0]   execute_SHIFT_RIGHT;
-  wire                decode_IS_CSR;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire                memory_MEMORY_WR;
-  wire                decode_MEMORY_WR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_3_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       [31:0]   execute_MUL_LL;
-  wire                memory_IS_MUL;
-  wire                execute_IS_MUL;
-  wire                decode_IS_MUL;
-  wire       [51:0]   memory_MUL_LOW;
-  wire                decode_IS_DIV;
-  wire                decode_IS_RS1_SIGNED;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23_;
-  wire       [33:0]   memory_MUL_HH;
-  wire       [33:0]   execute_MUL_HH;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26_;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire                decode_CSR_READ_OPCODE;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire                decode_SRC2_FORCE_ZERO;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -1534,22 +530,22 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* syn_keep , keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1559,66 +555,67 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49_;
-  reg        [31:0]   _zz_50_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
-  (* syn_keep , keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_51_;
-  reg                 _zz_51__2;
-  reg                 _zz_51__1;
-  reg                 _zz_51__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53_;
-  reg        [31:0]   _zz_54_;
+  reg        [31:0]   _zz_52;
+  reg        [31:0]   _zz_53;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -1634,7 +631,7 @@ module VexRiscv (
   wire                decode_arbitration_isMoving;
   wire                decode_arbitration_isFiring;
   reg                 execute_arbitration_haltItself;
-  wire                execute_arbitration_haltByOther;
+  reg                 execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
   wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
@@ -1673,7 +670,7 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetcherHalt;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
-  (* syn_keep , keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
   reg                 IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   wire                IBusCachedPlugin_decodePrediction_rsp_wasWrong;
   wire                IBusCachedPlugin_pcValids_0;
@@ -1683,28 +680,47 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                DBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -1740,11 +756,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55_;
-  wire       [3:0]    _zz_56_;
-  wire                _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
+  wire       [3:0]    _zz_54;
+  wire       [3:0]    _zz_55;
+  wire                _zz_56;
+  wire                _zz_57;
+  wire                _zz_58;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -1781,16 +797,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_60_;
-  wire                _zz_61_;
-  wire                _zz_62_;
+  wire                _zz_59;
+  wire                _zz_60;
+  wire                _zz_61;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63_;
-  wire                _zz_64_;
-  reg                 _zz_65_;
-  wire                _zz_66_;
-  reg                 _zz_67_;
-  reg        [31:0]   _zz_68_;
+  wire                _zz_62;
+  wire                _zz_63;
+  reg                 _zz_64;
+  wire                _zz_65;
+  reg                 _zz_66;
+  reg        [31:0]   _zz_67;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1803,17 +819,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_69_;
-  reg        [18:0]   _zz_70_;
-  wire                _zz_71_;
-  reg        [10:0]   _zz_72_;
-  wire                _zz_73_;
-  reg        [18:0]   _zz_74_;
-  reg                 _zz_75_;
-  wire                _zz_76_;
-  reg        [10:0]   _zz_77_;
-  wire                _zz_78_;
-  reg        [18:0]   _zz_79_;
+  wire                _zz_68;
+  reg        [18:0]   _zz_69;
+  wire                _zz_70;
+  reg        [10:0]   _zz_71;
+  wire                _zz_72;
+  reg        [18:0]   _zz_73;
+  reg                 _zz_74;
+  wire                _zz_75;
+  reg        [10:0]   _zz_76;
+  wire                _zz_77;
+  reg        [18:0]   _zz_78;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1821,7 +837,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_80_;
+  wire       [31:0]   _zz_79;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1829,122 +845,115 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_81_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_80;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_82_;
+  reg        [31:0]   _zz_81;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_83_;
-  reg        [31:0]   _zz_84_;
-  wire                _zz_85_;
-  reg        [31:0]   _zz_86_;
+  wire                _zz_82;
+  reg        [31:0]   _zz_83;
+  wire                _zz_84;
+  reg        [31:0]   _zz_85;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [31:0]   _zz_87_;
-  wire                _zz_88_;
-  wire                _zz_89_;
-  wire                _zz_90_;
-  wire                _zz_91_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_92_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_93_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_94_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_95_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_96_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_97_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_98_;
+  wire       [31:0]   _zz_86;
+  wire                _zz_87;
+  wire                _zz_88;
+  wire                _zz_89;
+  wire                _zz_90;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_91;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_92;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_93;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_94;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_95;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_96;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_97;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_99_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_98;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_100_;
-  reg        [31:0]   _zz_101_;
-  wire                _zz_102_;
-  reg        [19:0]   _zz_103_;
-  wire                _zz_104_;
-  reg        [19:0]   _zz_105_;
-  reg        [31:0]   _zz_106_;
+  reg        [31:0]   _zz_99;
+  reg        [31:0]   _zz_100;
+  wire                _zz_101;
+  reg        [19:0]   _zz_102;
+  wire                _zz_103;
+  reg        [19:0]   _zz_104;
+  reg        [31:0]   _zz_105;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_107_;
+  reg        [31:0]   _zz_106;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_108_;
-  reg                 _zz_109_;
-  reg                 _zz_110_;
-  reg                 _zz_111_;
-  reg        [4:0]    _zz_112_;
-  reg        [31:0]   _zz_113_;
-  wire                _zz_114_;
-  wire                _zz_115_;
-  wire                _zz_116_;
-  wire                _zz_117_;
-  wire                _zz_118_;
-  wire                _zz_119_;
+  reg        [31:0]   _zz_107;
+  reg                 _zz_108;
+  reg                 _zz_109;
+  reg                 _zz_110;
+  reg        [4:0]    _zz_111;
+  reg        [31:0]   _zz_112;
+  wire                _zz_113;
+  wire                _zz_114;
+  wire                _zz_115;
+  wire                _zz_116;
+  wire                _zz_117;
+  wire                _zz_118;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_120_;
-  reg                 _zz_121_;
-  reg                 _zz_122_;
-  wire                _zz_123_;
-  reg        [19:0]   _zz_124_;
-  wire                _zz_125_;
-  reg        [10:0]   _zz_126_;
-  wire                _zz_127_;
-  reg        [18:0]   _zz_128_;
-  reg                 _zz_129_;
+  wire       [2:0]    _zz_119;
+  reg                 _zz_120;
+  reg                 _zz_121;
+  wire                _zz_122;
+  reg        [19:0]   _zz_123;
+  wire                _zz_124;
+  reg        [10:0]   _zz_125;
+  wire                _zz_126;
+  reg        [18:0]   _zz_127;
+  reg                 _zz_128;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_130_;
-  reg        [19:0]   _zz_131_;
-  wire                _zz_132_;
-  reg        [10:0]   _zz_133_;
-  wire                _zz_134_;
-  reg        [18:0]   _zz_135_;
+  wire                _zz_129;
+  reg        [19:0]   _zz_130;
+  wire                _zz_131;
+  reg        [10:0]   _zz_132;
+  wire                _zz_133;
+  reg        [18:0]   _zz_134;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
@@ -1965,9 +974,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_136_;
-  wire                _zz_137_;
-  wire                _zz_138_;
+  wire                _zz_135;
+  wire                _zz_136;
+  wire                _zz_137;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1980,8 +989,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_139_;
-  wire                _zz_140_;
+  wire       [1:0]    _zz_138;
+  wire                _zz_139;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -1993,7 +1002,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2034,79 +1043,80 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_141_;
+  wire       [31:0]   _zz_140;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_142_;
-  wire                _zz_143_;
-  wire                _zz_144_;
-  reg        [32:0]   _zz_145_;
+  wire       [31:0]   _zz_141;
+  wire                _zz_142;
+  wire                _zz_143;
+  reg        [32:0]   _zz_144;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_146_;
-  wire       [31:0]   _zz_147_;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 memory_to_writeBack_IS_MUL;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg        [31:0]   execute_to_memory_MUL_LL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg                 decode_to_execute_MEMORY_WR;
-  reg                 execute_to_memory_MEMORY_WR;
-  reg                 memory_to_writeBack_MEMORY_WR;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg                 decode_to_execute_IS_CSR;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg        [33:0]   execute_to_memory_MUL_LH;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   _zz_145;
+  wire       [31:0]   _zz_146;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
+  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 memory_to_writeBack_IS_MUL;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
   reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
   reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
@@ -2117,590 +1127,658 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_835;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_148_;
-  reg        [31:0]   _zz_149_;
-  reg        [31:0]   _zz_150_;
-  reg        [31:0]   _zz_151_;
-  reg        [31:0]   _zz_152_;
-  reg        [31:0]   _zz_153_;
-  reg        [31:0]   _zz_154_;
-  reg        [31:0]   _zz_155_;
-  reg        [31:0]   _zz_156_;
-  reg        [2:0]    _zz_157_;
-  reg                 _zz_158_;
+  reg        [31:0]   _zz_147;
+  reg        [31:0]   _zz_148;
+  reg        [31:0]   _zz_149;
+  reg        [31:0]   _zz_150;
+  reg        [31:0]   _zz_151;
+  reg        [31:0]   _zz_152;
+  reg        [31:0]   _zz_153;
+  reg        [31:0]   _zz_154;
+  reg        [31:0]   _zz_155;
+  reg        [2:0]    _zz_156;
+  reg                 _zz_157;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_159_;
-  wire                _zz_160_;
-  wire                _zz_161_;
-  wire                _zz_162_;
-  wire                _zz_163_;
-  wire                _zz_164_;
-  reg                 _zz_165_;
+  reg        [2:0]    _zz_158;
+  wire                _zz_159;
+  wire                _zz_160;
+  wire                _zz_161;
+  wire                _zz_162;
+  wire                _zz_163;
+  reg                 _zz_164;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [31:0] _zz_1__string;
-  reg [31:0] _zz_2__string;
-  reg [71:0] _zz_3__string;
-  reg [71:0] _zz_4__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_5__string;
-  reg [71:0] _zz_6__string;
-  reg [71:0] _zz_7__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_8__string;
-  reg [39:0] _zz_9__string;
-  reg [39:0] _zz_10__string;
-  reg [39:0] _zz_11__string;
-  reg [39:0] _zz_12__string;
-  reg [39:0] _zz_13__string;
-  reg [39:0] _zz_14__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_15__string;
-  reg [39:0] _zz_16__string;
-  reg [39:0] _zz_17__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_18__string;
-  reg [63:0] _zz_19__string;
-  reg [63:0] _zz_20__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_21__string;
-  reg [23:0] _zz_22__string;
-  reg [23:0] _zz_23__string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24__string;
-  reg [95:0] _zz_25__string;
-  reg [95:0] _zz_26__string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [63:0] _zz_43__string;
-  reg [23:0] _zz_44__string;
-  reg [39:0] _zz_45__string;
-  reg [39:0] _zz_46__string;
-  reg [71:0] _zz_47__string;
-  reg [31:0] _zz_48__string;
-  reg [95:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52__string;
-  reg [95:0] _zz_92__string;
-  reg [31:0] _zz_93__string;
-  reg [71:0] _zz_94__string;
-  reg [39:0] _zz_95__string;
-  reg [39:0] _zz_96__string;
-  reg [23:0] _zz_97__string;
-  reg [63:0] _zz_98__string;
+  reg [31:0] _zz_51_string;
+  reg [95:0] _zz_91_string;
+  reg [63:0] _zz_92_string;
+  reg [23:0] _zz_93_string;
+  reg [39:0] _zz_94_string;
+  reg [71:0] _zz_95_string;
+  reg [31:0] _zz_96_string;
+  reg [39:0] _zz_97_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
-  reg [39:0] decode_to_execute_ENV_CTRL_string;
-  reg [39:0] execute_to_memory_ENV_CTRL_string;
-  reg [39:0] memory_to_writeBack_ENV_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
   reg [71:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
+  reg [39:0] decode_to_execute_ENV_CTRL_string;
+  reg [39:0] execute_to_memory_ENV_CTRL_string;
+  reg [39:0] memory_to_writeBack_ENV_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_187_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_188_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_189_ = 1'b1;
-  assign _zz_190_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_191_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_192_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_193_ = ((_zz_170_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_51__2));
-  assign _zz_194_ = ((_zz_170_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_51__1));
-  assign _zz_195_ = ((_zz_170_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_51__0));
-  assign _zz_196_ = ((_zz_170_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_197_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_198_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_199_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_200_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_201_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_202_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_203_ = (1'b0 || (! 1'b1));
-  assign _zz_204_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_205_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_206_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_207_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_208_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_209_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_210_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_211_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_212_ = (! memory_arbitration_isStuck);
-  assign _zz_213_ = (iBus_cmd_valid || (_zz_157_ != (3'b000)));
-  assign _zz_214_ = (_zz_183_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_215_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_216_ = ((_zz_136_ && 1'b1) && (! 1'b0));
-  assign _zz_217_ = ((_zz_137_ && 1'b1) && (! 1'b0));
-  assign _zz_218_ = ((_zz_138_ && 1'b1) && (! 1'b0));
-  assign _zz_219_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_220_ = execute_INSTRUCTION[13];
-  assign _zz_221_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_222_ = _zz_87_[11 : 11];
-  assign _zz_223_ = _zz_87_[18 : 18];
-  assign _zz_224_ = ($signed(_zz_226_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_225_ = _zz_224_[31 : 0];
-  assign _zz_226_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_227_ = _zz_87_[12 : 12];
-  assign _zz_228_ = _zz_87_[13 : 13];
-  assign _zz_229_ = _zz_87_[10 : 10];
-  assign _zz_230_ = _zz_87_[24 : 24];
-  assign _zz_231_ = ($signed(_zz_232_) + $signed(_zz_237_));
-  assign _zz_232_ = ($signed(_zz_233_) + $signed(_zz_235_));
-  assign _zz_233_ = 52'h0;
-  assign _zz_234_ = {1'b0,memory_MUL_LL};
-  assign _zz_235_ = {{19{_zz_234_[32]}}, _zz_234_};
-  assign _zz_236_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_237_ = {{2{_zz_236_[49]}}, _zz_236_};
-  assign _zz_238_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_239_ = {{2{_zz_238_[49]}}, _zz_238_};
-  assign _zz_240_ = _zz_87_[26 : 26];
-  assign _zz_241_ = _zz_87_[25 : 25];
-  assign _zz_242_ = _zz_87_[6 : 6];
-  assign _zz_243_ = _zz_87_[19 : 19];
-  assign _zz_244_ = _zz_87_[31 : 31];
-  assign _zz_245_ = _zz_87_[15 : 15];
-  assign _zz_246_ = _zz_87_[3 : 3];
-  assign _zz_247_ = _zz_87_[2 : 2];
-  assign _zz_248_ = _zz_87_[16 : 16];
-  assign _zz_249_ = _zz_87_[17 : 17];
-  assign _zz_250_ = _zz_87_[14 : 14];
-  assign _zz_251_ = (_zz_55_ - (4'b0001));
-  assign _zz_252_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_253_ = {29'd0, _zz_252_};
-  assign _zz_254_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_255_ = {{_zz_70_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_256_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_257_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_258_ = {{_zz_72_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_259_ = {{_zz_74_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_260_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_261_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_262_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_263_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_264_ = execute_SRC_LESS;
-  assign _zz_265_ = (3'b100);
-  assign _zz_266_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_267_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_268_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_269_ = ($signed(_zz_270_) + $signed(_zz_273_));
-  assign _zz_270_ = ($signed(_zz_271_) + $signed(_zz_272_));
-  assign _zz_271_ = execute_SRC1;
-  assign _zz_272_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_273_ = (execute_SRC_USE_SUB_LESS ? _zz_274_ : _zz_275_);
-  assign _zz_274_ = 32'h00000001;
-  assign _zz_275_ = 32'h0;
-  assign _zz_276_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_277_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_278_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_279_ = {_zz_124_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_280_ = {{_zz_126_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_281_ = {{_zz_128_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_282_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_283_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_284_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_285_ = (3'b100);
-  assign _zz_286_ = (_zz_139_ & (~ _zz_287_));
-  assign _zz_287_ = (_zz_139_ - (2'b01));
-  assign _zz_288_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_289_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_290_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_291_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_292_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_293_ = {5'd0, _zz_292_};
-  assign _zz_294_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_295_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_296_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_297_ = {_zz_141_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_298_ = _zz_299_;
-  assign _zz_299_ = _zz_300_;
-  assign _zz_300_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_142_) : _zz_142_)} + _zz_302_);
-  assign _zz_301_ = memory_DivPlugin_div_needRevert;
-  assign _zz_302_ = {32'd0, _zz_301_};
-  assign _zz_303_ = _zz_144_;
-  assign _zz_304_ = {32'd0, _zz_303_};
-  assign _zz_305_ = _zz_143_;
-  assign _zz_306_ = {31'd0, _zz_305_};
-  assign _zz_307_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_308_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_309_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_310_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_311_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_312_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_313_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_314_ = 1'b1;
-  assign _zz_315_ = 1'b1;
-  assign _zz_316_ = {_zz_59_,_zz_58_};
-  assign _zz_317_ = 32'h0000107f;
-  assign _zz_318_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_319_ = 32'h00002073;
-  assign _zz_320_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_321_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_322_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_323_) == 32'h00000003),{(_zz_324_ == _zz_325_),{_zz_326_,{_zz_327_,_zz_328_}}}}}};
-  assign _zz_323_ = 32'h0000505f;
-  assign _zz_324_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_325_ = 32'h00000063;
-  assign _zz_326_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_327_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_328_ = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_329_) == 32'h00001013),{(_zz_330_ == _zz_331_),{_zz_332_,{_zz_333_,_zz_334_}}}}}};
-  assign _zz_329_ = 32'hfc00307f;
-  assign _zz_330_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_331_ = 32'h00005033;
-  assign _zz_332_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_333_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_334_ = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_335_ = decode_INSTRUCTION[31];
-  assign _zz_336_ = decode_INSTRUCTION[31];
-  assign _zz_337_ = decode_INSTRUCTION[7];
-  assign _zz_338_ = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_339_ = 32'h00000020;
-  assign _zz_340_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_341_ = 32'h00000020;
-  assign _zz_342_ = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_343_ = 32'h00004010;
-  assign _zz_344_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz_345_ = {_zz_90_,(_zz_350_ == _zz_351_)};
-  assign _zz_346_ = (2'b00);
-  assign _zz_347_ = ({_zz_90_,_zz_352_} != (2'b00));
-  assign _zz_348_ = (_zz_353_ != (1'b0));
-  assign _zz_349_ = {(_zz_354_ != _zz_355_),{_zz_356_,{_zz_357_,_zz_358_}}};
-  assign _zz_350_ = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_351_ = 32'h00000020;
-  assign _zz_352_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz_353_ = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_354_ = _zz_91_;
-  assign _zz_355_ = (1'b0);
-  assign _zz_356_ = (((decode_INSTRUCTION & _zz_359_) == 32'h02000030) != (1'b0));
-  assign _zz_357_ = ((_zz_360_ == _zz_361_) != (1'b0));
-  assign _zz_358_ = {(_zz_362_ != (1'b0)),{(_zz_363_ != _zz_364_),{_zz_365_,{_zz_366_,_zz_367_}}}};
-  assign _zz_359_ = 32'h02004074;
-  assign _zz_360_ = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_361_ = 32'h00001000;
-  assign _zz_362_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_363_ = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
-  assign _zz_364_ = (1'b0);
-  assign _zz_365_ = (((decode_INSTRUCTION & _zz_368_) == 32'h10000050) != (1'b0));
-  assign _zz_366_ = ({_zz_369_,_zz_370_} != (2'b00));
-  assign _zz_367_ = {(_zz_371_ != (1'b0)),{(_zz_372_ != _zz_373_),{_zz_374_,{_zz_375_,_zz_376_}}}};
-  assign _zz_368_ = 32'h10403050;
-  assign _zz_369_ = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_370_ = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz_371_ = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz_372_ = ((decode_INSTRUCTION & _zz_377_) == 32'h0);
-  assign _zz_373_ = (1'b0);
-  assign _zz_374_ = ({_zz_89_,{_zz_378_,_zz_379_}} != 6'h0);
-  assign _zz_375_ = ({_zz_380_,_zz_381_} != (4'b0000));
-  assign _zz_376_ = {(_zz_382_ != _zz_383_),{_zz_384_,{_zz_385_,_zz_386_}}};
-  assign _zz_377_ = 32'h00000058;
-  assign _zz_378_ = ((decode_INSTRUCTION & _zz_387_) == 32'h00001010);
-  assign _zz_379_ = {(_zz_388_ == _zz_389_),{_zz_390_,{_zz_391_,_zz_392_}}};
-  assign _zz_380_ = ((decode_INSTRUCTION & _zz_393_) == 32'h0);
-  assign _zz_381_ = {(_zz_394_ == _zz_395_),{_zz_396_,_zz_397_}};
-  assign _zz_382_ = ((decode_INSTRUCTION & _zz_398_) == 32'h00001008);
-  assign _zz_383_ = (1'b0);
-  assign _zz_384_ = ({_zz_399_,{_zz_400_,_zz_401_}} != 5'h0);
-  assign _zz_385_ = ({_zz_402_,_zz_403_} != (2'b00));
-  assign _zz_386_ = {(_zz_404_ != _zz_405_),{_zz_406_,{_zz_407_,_zz_408_}}};
-  assign _zz_387_ = 32'h00001010;
-  assign _zz_388_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_389_ = 32'h00002010;
-  assign _zz_390_ = ((decode_INSTRUCTION & _zz_409_) == 32'h00000010);
-  assign _zz_391_ = (_zz_410_ == _zz_411_);
-  assign _zz_392_ = (_zz_412_ == _zz_413_);
-  assign _zz_393_ = 32'h00000044;
-  assign _zz_394_ = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_395_ = 32'h0;
-  assign _zz_396_ = ((decode_INSTRUCTION & _zz_414_) == 32'h00002000);
-  assign _zz_397_ = ((decode_INSTRUCTION & _zz_415_) == 32'h00001000);
-  assign _zz_398_ = 32'h00005048;
-  assign _zz_399_ = ((decode_INSTRUCTION & _zz_416_) == 32'h00000040);
-  assign _zz_400_ = _zz_90_;
-  assign _zz_401_ = {_zz_417_,{_zz_418_,_zz_419_}};
-  assign _zz_402_ = (_zz_420_ == _zz_421_);
-  assign _zz_403_ = (_zz_422_ == _zz_423_);
-  assign _zz_404_ = _zz_91_;
-  assign _zz_405_ = (1'b0);
-  assign _zz_406_ = (_zz_424_ != (1'b0));
-  assign _zz_407_ = (_zz_425_ != _zz_426_);
-  assign _zz_408_ = {_zz_427_,{_zz_428_,_zz_429_}};
-  assign _zz_409_ = 32'h00000050;
-  assign _zz_410_ = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_411_ = 32'h00000004;
-  assign _zz_412_ = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_413_ = 32'h0;
-  assign _zz_414_ = 32'h00006004;
-  assign _zz_415_ = 32'h00005004;
-  assign _zz_416_ = 32'h00000040;
-  assign _zz_417_ = ((decode_INSTRUCTION & _zz_430_) == 32'h00004020);
-  assign _zz_418_ = (_zz_431_ == _zz_432_);
-  assign _zz_419_ = (_zz_433_ == _zz_434_);
-  assign _zz_420_ = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_421_ = 32'h00001050;
-  assign _zz_422_ = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_423_ = 32'h00002050;
-  assign _zz_424_ = ((decode_INSTRUCTION & _zz_435_) == 32'h00000020);
-  assign _zz_425_ = {_zz_436_,_zz_437_};
-  assign _zz_426_ = (2'b00);
-  assign _zz_427_ = ({_zz_438_,_zz_439_} != (3'b000));
-  assign _zz_428_ = (_zz_440_ != _zz_441_);
-  assign _zz_429_ = {_zz_442_,{_zz_443_,_zz_444_}};
-  assign _zz_430_ = 32'h00004020;
-  assign _zz_431_ = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_432_ = 32'h00000010;
-  assign _zz_433_ = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_434_ = 32'h00000020;
-  assign _zz_435_ = 32'h00000020;
-  assign _zz_436_ = ((decode_INSTRUCTION & _zz_445_) == 32'h00005010);
-  assign _zz_437_ = ((decode_INSTRUCTION & _zz_446_) == 32'h00005020);
-  assign _zz_438_ = (_zz_447_ == _zz_448_);
-  assign _zz_439_ = {_zz_449_,_zz_450_};
-  assign _zz_440_ = {_zz_451_,{_zz_452_,_zz_453_}};
-  assign _zz_441_ = (3'b000);
-  assign _zz_442_ = ({_zz_454_,_zz_455_} != 5'h0);
-  assign _zz_443_ = (_zz_456_ != _zz_457_);
-  assign _zz_444_ = {_zz_458_,{_zz_459_,_zz_460_}};
-  assign _zz_445_ = 32'h00007034;
-  assign _zz_446_ = 32'h02007064;
-  assign _zz_447_ = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_448_ = 32'h40001010;
-  assign _zz_449_ = ((decode_INSTRUCTION & _zz_461_) == 32'h00001010);
-  assign _zz_450_ = ((decode_INSTRUCTION & _zz_462_) == 32'h00001010);
-  assign _zz_451_ = ((decode_INSTRUCTION & _zz_463_) == 32'h00000040);
-  assign _zz_452_ = (_zz_464_ == _zz_465_);
-  assign _zz_453_ = (_zz_466_ == _zz_467_);
-  assign _zz_454_ = _zz_90_;
-  assign _zz_455_ = {_zz_468_,{_zz_469_,_zz_470_}};
-  assign _zz_456_ = {_zz_89_,_zz_471_};
-  assign _zz_457_ = (2'b00);
-  assign _zz_458_ = (_zz_472_ != (1'b0));
-  assign _zz_459_ = (_zz_473_ != _zz_474_);
-  assign _zz_460_ = {_zz_475_,{_zz_476_,_zz_477_}};
-  assign _zz_461_ = 32'h00007034;
-  assign _zz_462_ = 32'h02007054;
-  assign _zz_463_ = 32'h00000050;
-  assign _zz_464_ = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_465_ = 32'h0;
-  assign _zz_466_ = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz_467_ = 32'h00000040;
-  assign _zz_468_ = ((decode_INSTRUCTION & _zz_478_) == 32'h00002010);
-  assign _zz_469_ = (_zz_479_ == _zz_480_);
-  assign _zz_470_ = {_zz_481_,_zz_482_};
-  assign _zz_471_ = ((decode_INSTRUCTION & _zz_483_) == 32'h00000004);
-  assign _zz_472_ = ((decode_INSTRUCTION & _zz_484_) == 32'h00000040);
-  assign _zz_473_ = {_zz_485_,{_zz_486_,_zz_487_}};
-  assign _zz_474_ = (3'b000);
-  assign _zz_475_ = (_zz_488_ != (1'b0));
-  assign _zz_476_ = (_zz_489_ != _zz_490_);
-  assign _zz_477_ = (_zz_491_ != _zz_492_);
-  assign _zz_478_ = 32'h00002030;
-  assign _zz_479_ = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_480_ = 32'h00000010;
-  assign _zz_481_ = ((decode_INSTRUCTION & 32'h02002060) == 32'h00002020);
-  assign _zz_482_ = ((decode_INSTRUCTION & 32'h02003020) == 32'h00000020);
-  assign _zz_483_ = 32'h0000001c;
-  assign _zz_484_ = 32'h00000058;
-  assign _zz_485_ = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_486_ = ((decode_INSTRUCTION & _zz_493_) == 32'h00002010);
-  assign _zz_487_ = ((decode_INSTRUCTION & _zz_494_) == 32'h40000030);
-  assign _zz_488_ = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_489_ = {(_zz_495_ == _zz_496_),_zz_88_};
-  assign _zz_490_ = (2'b00);
-  assign _zz_491_ = {(_zz_497_ == _zz_498_),_zz_88_};
-  assign _zz_492_ = (2'b00);
-  assign _zz_493_ = 32'h00002014;
-  assign _zz_494_ = 32'h40000034;
-  assign _zz_495_ = (decode_INSTRUCTION & 32'h00000014);
-  assign _zz_496_ = 32'h00000004;
-  assign _zz_497_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_498_ = 32'h00000004;
-  assign _zz_499_ = execute_INSTRUCTION[31];
-  assign _zz_500_ = execute_INSTRUCTION[31];
-  assign _zz_501_ = execute_INSTRUCTION[7];
+  assign _zz_196 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_197 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_198 = 1'b1;
+  assign _zz_199 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_200 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_201 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_202 = ((_zz_170 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_203 = ((_zz_170 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_204 = ((_zz_170 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_205 = ((_zz_170 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_206 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_207 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_208 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_209 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_210 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_211 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_212 = (1'b0 || (! 1'b1));
+  assign _zz_213 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_214 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_215 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_216 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_217 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_218 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_219 = execute_INSTRUCTION[13 : 12];
+  assign _zz_220 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_221 = (! memory_arbitration_isStuck);
+  assign _zz_222 = (iBus_cmd_valid || (_zz_156 != 3'b000));
+  assign _zz_223 = (_zz_192 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_224 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_225 = ((_zz_135 && 1'b1) && (! 1'b0));
+  assign _zz_226 = ((_zz_136 && 1'b1) && (! 1'b0));
+  assign _zz_227 = ((_zz_137 && 1'b1) && (! 1'b0));
+  assign _zz_228 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_229 = execute_INSTRUCTION[13];
+  assign _zz_230 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_231 = ($signed(_zz_232) + $signed(_zz_237));
+  assign _zz_232 = ($signed(_zz_233) + $signed(_zz_235));
+  assign _zz_233 = 52'h0;
+  assign _zz_234 = {1'b0,memory_MUL_LL};
+  assign _zz_235 = {{19{_zz_234[32]}}, _zz_234};
+  assign _zz_236 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_237 = {{2{_zz_236[49]}}, _zz_236};
+  assign _zz_238 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_239 = {{2{_zz_238[49]}}, _zz_238};
+  assign _zz_240 = ($signed(_zz_242) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_241 = _zz_240[31 : 0];
+  assign _zz_242 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_243 = _zz_86[31 : 31];
+  assign _zz_244 = _zz_86[30 : 30];
+  assign _zz_245 = _zz_86[29 : 29];
+  assign _zz_246 = _zz_86[28 : 28];
+  assign _zz_247 = _zz_86[25 : 25];
+  assign _zz_248 = _zz_86[17 : 17];
+  assign _zz_249 = _zz_86[16 : 16];
+  assign _zz_250 = _zz_86[13 : 13];
+  assign _zz_251 = _zz_86[12 : 12];
+  assign _zz_252 = _zz_86[11 : 11];
+  assign _zz_253 = _zz_86[15 : 15];
+  assign _zz_254 = _zz_86[5 : 5];
+  assign _zz_255 = _zz_86[3 : 3];
+  assign _zz_256 = _zz_86[20 : 20];
+  assign _zz_257 = _zz_86[10 : 10];
+  assign _zz_258 = _zz_86[4 : 4];
+  assign _zz_259 = _zz_86[0 : 0];
+  assign _zz_260 = (_zz_54 - 4'b0001);
+  assign _zz_261 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_262 = {29'd0, _zz_261};
+  assign _zz_263 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_264 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_265 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_266 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_267 = {{_zz_71,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_268 = {{_zz_73,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_269 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_270 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_271 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_272 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_273 = execute_SRC_LESS;
+  assign _zz_274 = 3'b100;
+  assign _zz_275 = execute_INSTRUCTION[19 : 15];
+  assign _zz_276 = execute_INSTRUCTION[31 : 20];
+  assign _zz_277 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_278 = ($signed(_zz_279) + $signed(_zz_282));
+  assign _zz_279 = ($signed(_zz_280) + $signed(_zz_281));
+  assign _zz_280 = execute_SRC1;
+  assign _zz_281 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_282 = (execute_SRC_USE_SUB_LESS ? _zz_283 : _zz_284);
+  assign _zz_283 = 32'h00000001;
+  assign _zz_284 = 32'h0;
+  assign _zz_285 = execute_INSTRUCTION[31 : 20];
+  assign _zz_286 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_287 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_288 = {_zz_123,execute_INSTRUCTION[31 : 20]};
+  assign _zz_289 = {{_zz_125,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_290 = {{_zz_127,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_291 = execute_INSTRUCTION[31 : 20];
+  assign _zz_292 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_293 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_294 = 3'b100;
+  assign _zz_295 = (_zz_138 & (~ _zz_296));
+  assign _zz_296 = (_zz_138 - 2'b01);
+  assign _zz_297 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_298 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_299 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_300 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_301 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_302 = {5'd0, _zz_301};
+  assign _zz_303 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_304 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_305 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_306 = {_zz_140,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_307 = _zz_308;
+  assign _zz_308 = _zz_309;
+  assign _zz_309 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_141) : _zz_141)} + _zz_311);
+  assign _zz_310 = memory_DivPlugin_div_needRevert;
+  assign _zz_311 = {32'd0, _zz_310};
+  assign _zz_312 = _zz_143;
+  assign _zz_313 = {32'd0, _zz_312};
+  assign _zz_314 = _zz_142;
+  assign _zz_315 = {31'd0, _zz_314};
+  assign _zz_316 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_317 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_318 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_319 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_320 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_321 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_322 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_323 = 1'b1;
+  assign _zz_324 = 1'b1;
+  assign _zz_325 = {_zz_58,_zz_57};
+  assign _zz_326 = 32'h0000107f;
+  assign _zz_327 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_328 = 32'h00002073;
+  assign _zz_329 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_330 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_331 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_332) == 32'h00000003),{(_zz_333 == _zz_334),{_zz_335,{_zz_336,_zz_337}}}}}};
+  assign _zz_332 = 32'h0000505f;
+  assign _zz_333 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_334 = 32'h00000063;
+  assign _zz_335 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_336 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_337 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_338) == 32'h00001013),{(_zz_339 == _zz_340),{_zz_341,{_zz_342,_zz_343}}}}}};
+  assign _zz_338 = 32'hfc00307f;
+  assign _zz_339 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_340 = 32'h00005033;
+  assign _zz_341 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_342 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_343 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_344 = decode_INSTRUCTION[31];
+  assign _zz_345 = decode_INSTRUCTION[31];
+  assign _zz_346 = decode_INSTRUCTION[7];
+  assign _zz_347 = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz_348 = 32'h02004020;
+  assign _zz_349 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz_350 = ((decode_INSTRUCTION & 32'h10003050) == 32'h00000050);
+  assign _zz_351 = 1'b0;
+  assign _zz_352 = (((decode_INSTRUCTION & _zz_355) == 32'h10000050) != 1'b0);
+  assign _zz_353 = ({_zz_356,_zz_357} != 2'b00);
+  assign _zz_354 = {({_zz_358,_zz_359} != 2'b00),{(_zz_360 != _zz_361),{_zz_362,{_zz_363,_zz_364}}}};
+  assign _zz_355 = 32'h10403050;
+  assign _zz_356 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz_357 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz_358 = _zz_89;
+  assign _zz_359 = ((decode_INSTRUCTION & _zz_365) == 32'h00000004);
+  assign _zz_360 = ((decode_INSTRUCTION & _zz_366) == 32'h00000040);
+  assign _zz_361 = 1'b0;
+  assign _zz_362 = ({_zz_367,_zz_368} != 2'b00);
+  assign _zz_363 = ({_zz_369,_zz_370} != 3'b000);
+  assign _zz_364 = {(_zz_371 != _zz_372),{_zz_373,{_zz_374,_zz_375}}};
+  assign _zz_365 = 32'h0000001c;
+  assign _zz_366 = 32'h00000058;
+  assign _zz_367 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz_368 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz_369 = ((decode_INSTRUCTION & _zz_376) == 32'h40001010);
+  assign _zz_370 = {(_zz_377 == _zz_378),(_zz_379 == _zz_380)};
+  assign _zz_371 = ((decode_INSTRUCTION & _zz_381) == 32'h00000024);
+  assign _zz_372 = 1'b0;
+  assign _zz_373 = ((_zz_382 == _zz_383) != 1'b0);
+  assign _zz_374 = (_zz_384 != 1'b0);
+  assign _zz_375 = {(_zz_385 != _zz_386),{_zz_387,{_zz_388,_zz_389}}};
+  assign _zz_376 = 32'h40003054;
+  assign _zz_377 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_378 = 32'h00001010;
+  assign _zz_379 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz_380 = 32'h00001010;
+  assign _zz_381 = 32'h00000064;
+  assign _zz_382 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz_383 = 32'h00001000;
+  assign _zz_384 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_385 = {(_zz_390 == _zz_391),(_zz_392 == _zz_393)};
+  assign _zz_386 = 2'b00;
+  assign _zz_387 = ((_zz_394 == _zz_395) != 1'b0);
+  assign _zz_388 = ({_zz_396,_zz_397} != 2'b00);
+  assign _zz_389 = {(_zz_398 != _zz_399),{_zz_400,{_zz_401,_zz_402}}};
+  assign _zz_390 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_391 = 32'h00002000;
+  assign _zz_392 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz_393 = 32'h00001000;
+  assign _zz_394 = (decode_INSTRUCTION & 32'h00004048);
+  assign _zz_395 = 32'h00004008;
+  assign _zz_396 = ((decode_INSTRUCTION & _zz_403) == 32'h00000020);
+  assign _zz_397 = ((decode_INSTRUCTION & _zz_404) == 32'h00000020);
+  assign _zz_398 = {(_zz_405 == _zz_406),{_zz_407,_zz_408}};
+  assign _zz_399 = 3'b000;
+  assign _zz_400 = ((_zz_409 == _zz_410) != 1'b0);
+  assign _zz_401 = ({_zz_411,_zz_412} != 5'h0);
+  assign _zz_402 = {(_zz_413 != _zz_414),{_zz_415,{_zz_416,_zz_417}}};
+  assign _zz_403 = 32'h00000034;
+  assign _zz_404 = 32'h00000064;
+  assign _zz_405 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_406 = 32'h00000040;
+  assign _zz_407 = ((decode_INSTRUCTION & _zz_418) == 32'h0);
+  assign _zz_408 = ((decode_INSTRUCTION & _zz_419) == 32'h00000040);
+  assign _zz_409 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_410 = 32'h00000020;
+  assign _zz_411 = (_zz_420 == _zz_421);
+  assign _zz_412 = {_zz_88,{_zz_422,_zz_423}};
+  assign _zz_413 = {_zz_88,{_zz_424,_zz_425}};
+  assign _zz_414 = 5'h0;
+  assign _zz_415 = ({_zz_426,_zz_427} != 6'h0);
+  assign _zz_416 = (_zz_428 != _zz_429);
+  assign _zz_417 = {_zz_430,{_zz_431,_zz_432}};
+  assign _zz_418 = 32'h00000038;
+  assign _zz_419 = 32'h00403040;
+  assign _zz_420 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_421 = 32'h00000040;
+  assign _zz_422 = (_zz_433 == _zz_434);
+  assign _zz_423 = {_zz_435,_zz_436};
+  assign _zz_424 = (_zz_437 == _zz_438);
+  assign _zz_425 = {_zz_439,{_zz_440,_zz_441}};
+  assign _zz_426 = _zz_89;
+  assign _zz_427 = {_zz_442,{_zz_443,_zz_444}};
+  assign _zz_428 = {_zz_88,_zz_445};
+  assign _zz_429 = 2'b00;
+  assign _zz_430 = ({_zz_446,_zz_447} != 2'b00);
+  assign _zz_431 = (_zz_448 != _zz_449);
+  assign _zz_432 = {_zz_450,{_zz_451,_zz_452}};
+  assign _zz_433 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz_434 = 32'h00004020;
+  assign _zz_435 = ((decode_INSTRUCTION & _zz_453) == 32'h00000010);
+  assign _zz_436 = ((decode_INSTRUCTION & _zz_454) == 32'h00000020);
+  assign _zz_437 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz_438 = 32'h00002010;
+  assign _zz_439 = ((decode_INSTRUCTION & _zz_455) == 32'h00000010);
+  assign _zz_440 = (_zz_456 == _zz_457);
+  assign _zz_441 = (_zz_458 == _zz_459);
+  assign _zz_442 = ((decode_INSTRUCTION & _zz_460) == 32'h00001010);
+  assign _zz_443 = (_zz_461 == _zz_462);
+  assign _zz_444 = {_zz_463,{_zz_464,_zz_465}};
+  assign _zz_445 = ((decode_INSTRUCTION & _zz_466) == 32'h00000020);
+  assign _zz_446 = _zz_88;
+  assign _zz_447 = (_zz_467 == _zz_468);
+  assign _zz_448 = (_zz_469 == _zz_470);
+  assign _zz_449 = 1'b0;
+  assign _zz_450 = (_zz_471 != 1'b0);
+  assign _zz_451 = (_zz_472 != _zz_473);
+  assign _zz_452 = {_zz_474,{_zz_475,_zz_476}};
+  assign _zz_453 = 32'h00000030;
+  assign _zz_454 = 32'h02000020;
+  assign _zz_455 = 32'h00001030;
+  assign _zz_456 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz_457 = 32'h00002020;
+  assign _zz_458 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz_459 = 32'h00000020;
+  assign _zz_460 = 32'h00001010;
+  assign _zz_461 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_462 = 32'h00002010;
+  assign _zz_463 = ((decode_INSTRUCTION & _zz_477) == 32'h00000010);
+  assign _zz_464 = (_zz_478 == _zz_479);
+  assign _zz_465 = (_zz_480 == _zz_481);
+  assign _zz_466 = 32'h00000070;
+  assign _zz_467 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_468 = 32'h0;
+  assign _zz_469 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz_470 = 32'h00004010;
+  assign _zz_471 = ((decode_INSTRUCTION & _zz_482) == 32'h00002010);
+  assign _zz_472 = {_zz_483,{_zz_484,_zz_485}};
+  assign _zz_473 = 4'b0000;
+  assign _zz_474 = (_zz_486 != 1'b0);
+  assign _zz_475 = (_zz_487 != _zz_488);
+  assign _zz_476 = {_zz_489,{_zz_490,_zz_491}};
+  assign _zz_477 = 32'h00000050;
+  assign _zz_478 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz_479 = 32'h00000004;
+  assign _zz_480 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_481 = 32'h0;
+  assign _zz_482 = 32'h00006014;
+  assign _zz_483 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz_484 = ((decode_INSTRUCTION & _zz_492) == 32'h0);
+  assign _zz_485 = {(_zz_493 == _zz_494),(_zz_495 == _zz_496)};
+  assign _zz_486 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz_487 = {(_zz_497 == _zz_498),{_zz_499,_zz_500}};
+  assign _zz_488 = 3'b000;
+  assign _zz_489 = ({_zz_501,_zz_87} != 2'b00);
+  assign _zz_490 = ({_zz_502,_zz_503} != 2'b00);
+  assign _zz_491 = (_zz_504 != 1'b0);
+  assign _zz_492 = 32'h00000018;
+  assign _zz_493 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz_494 = 32'h00002000;
+  assign _zz_495 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz_496 = 32'h00001000;
+  assign _zz_497 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_498 = 32'h00000040;
+  assign _zz_499 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_500 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz_501 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz_502 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_503 = _zz_87;
+  assign _zz_504 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_505 = execute_INSTRUCTION[31];
+  assign _zz_506 = execute_INSTRUCTION[31];
+  assign _zz_507 = execute_INSTRUCTION[7];
   always @ (posedge clk) begin
-    if(_zz_314_) begin
-      _zz_184_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_323) begin
+      _zz_193 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_315_) begin
-      _zz_185_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_324) begin
+      _zz_194 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_166_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_167_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_168_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_169_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_170_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_171_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_172_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_173_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_165                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_166                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_167                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_168                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_169                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_170                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_171                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_172                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_173                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_174_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_175_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (execute_MEMORY_WR                                           ), //i
-    .io_cpu_execute_args_data                      (_zz_82_[31:0]                                               ), //i
-    .io_cpu_execute_args_size                      (execute_DBusCachedPlugin_size[1:0]                          ), //i
-    .io_cpu_memory_isValid                         (_zz_176_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_177_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_178_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_179_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_180_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_181_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_182_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_183_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_174                                            ), //i
+    .io_cpu_execute_address                    (_zz_175[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
+    .io_cpu_execute_args_data                  (_zz_81[31:0]                                       ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_176                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_177[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_178                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_writeBack_isValid                  (_zz_179                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_180                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_181[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_182                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_183                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_184                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_185                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_186                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_187                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_188                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_189                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_190[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_191                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_192                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_316_)
+    case(_zz_325)
       2'b00 : begin
-        _zz_186_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_195 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_186_ = CsrPlugin_jumpInterface_payload;
+        _zz_195 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_186_ = BranchPlugin_jumpInterface_payload;
+        _zz_195 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_186_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_195 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_1__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_1__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_1__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_1__string = "JALR";
-      default : _zz_1__string = "????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_2__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_2__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_2__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_2__string = "JALR";
-      default : _zz_2__string = "????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_3__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_3__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_3__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_3__string = "SRA_1    ";
-      default : _zz_3__string = "?????????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_4__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_4__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_4__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_4__string = "SRA_1    ";
-      default : _zz_4__string = "?????????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
+      default : decode_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2713,30 +1791,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_5__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_5__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_5__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_5__string = "SRA_1    ";
-      default : _zz_5__string = "?????????";
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_6_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_6__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_6__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_6__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_6__string = "SRA_1    ";
-      default : _zz_6__string = "?????????";
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_7_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_7__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_7__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_7__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_7__string = "SRA_1    ";
-      default : _zz_7__string = "?????????";
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2748,123 +1826,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_8__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_8__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_8__string = "AND_1";
-      default : _zz_8__string = "?????";
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_9_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_9__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_9__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_9__string = "AND_1";
-      default : _zz_9__string = "?????";
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_10_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_10__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_10__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_10__string = "AND_1";
-      default : _zz_10__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_11_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_11__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_11__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_11__string = "ECALL";
-      default : _zz_11__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_12__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_12__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_12__string = "ECALL";
-      default : _zz_12__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_13__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_13__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_13__string = "ECALL";
-      default : _zz_13__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_14__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_14__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_14__string = "ECALL";
-      default : _zz_14__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
-      default : decode_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_15__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_15__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_15__string = "ECALL";
-      default : _zz_15__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_16__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_16__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_16__string = "ECALL";
-      default : _zz_16__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_17__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_17__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_17__string = "ECALL";
-      default : _zz_17__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_18__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_18__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_18__string = "BITWISE ";
-      default : _zz_18__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_19__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_19__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_19__string = "BITWISE ";
-      default : _zz_19__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20__string = "BITWISE ";
-      default : _zz_20__string = "????????";
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2877,30 +1859,62 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_21__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_21__string = "PC ";
-      default : _zz_21__string = "???";
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_22__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_22__string = "PC ";
-      default : _zz_22__string = "???";
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_23__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_23__string = "PC ";
-      default : _zz_23__string = "???";
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2913,30 +1927,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24__string = "URS1        ";
-      default : _zz_24__string = "????????????";
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25__string = "URS1        ";
-      default : _zz_25__string = "????????????";
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26__string = "URS1        ";
-      default : _zz_26__string = "????????????";
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2948,11 +1962,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2964,11 +1978,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2980,11 +1994,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2997,12 +2011,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -3015,12 +2029,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3033,12 +2047,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3051,12 +2065,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -3069,12 +2083,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3086,11 +2100,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3102,71 +2116,71 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_43__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_43__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_43__string = "BITWISE ";
-      default : _zz_43__string = "????????";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_44__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_44__string = "PC ";
-      default : _zz_44__string = "???";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_45__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_45__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_45__string = "AND_1";
-      default : _zz_45__string = "?????";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_46__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_46__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_46__string = "ECALL";
-      default : _zz_46__string = "?????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_47__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_47__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_47__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_47__string = "SRA_1    ";
-      default : _zz_47__string = "?????????";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_48__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_48__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_48__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_48__string = "JALR";
-      default : _zz_48__string = "????";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49__string = "URS1        ";
-      default : _zz_49__string = "????????????";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3179,72 +2193,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52__string = "JALR";
-      default : _zz_52__string = "????";
+    case(_zz_51)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
+      default : _zz_51_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_92_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_92__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_92__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_92__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_92__string = "URS1        ";
-      default : _zz_92__string = "????????????";
+    case(_zz_91)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_91_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_91_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_91_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_91_string = "URS1        ";
+      default : _zz_91_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_93__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_93__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_93__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_93__string = "JALR";
-      default : _zz_93__string = "????";
+    case(_zz_92)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_92_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_92_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_92_string = "BITWISE ";
+      default : _zz_92_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_94_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_94__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_94__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_94__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_94__string = "SRA_1    ";
-      default : _zz_94__string = "?????????";
+    case(_zz_93)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_93_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_93_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_93_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_93_string = "PC ";
+      default : _zz_93_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_95__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_95__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_95__string = "ECALL";
-      default : _zz_95__string = "?????";
+    case(_zz_94)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_94_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_94_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_94_string = "AND_1";
+      default : _zz_94_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_96_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_96__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_96__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_96__string = "AND_1";
-      default : _zz_96__string = "?????";
+    case(_zz_95)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_95_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_95_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_95_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_95_string = "SRA_1    ";
+      default : _zz_95_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_97_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_97__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_97__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_97__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_97__string = "PC ";
-      default : _zz_97__string = "???";
+    case(_zz_96)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_96_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_96_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_96_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_96_string = "JALR";
+      default : _zz_96_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_98_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_98__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_98__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_98__string = "BITWISE ";
-      default : _zz_98__string = "????????";
+    case(_zz_97)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_97_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_97_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_97_string = "ECALL";
+      default : _zz_97_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3257,15 +2271,6 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
     case(decode_to_execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
@@ -3274,27 +2279,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
-      default : decode_to_execute_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
-      default : execute_to_memory_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
-      default : memory_to_writeBack_ENV_CTRL_string = "?????";
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
     endcase
   end
   always @(*) begin
@@ -3332,59 +2322,84 @@ module VexRiscv (
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
+  always @(*) begin
+    case(decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : decode_to_execute_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : execute_to_memory_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : memory_to_writeBack_ENV_CTRL_string = "?????";
+    endcase
+  end
   `endif
 
+  assign memory_MUL_LOW = ($signed(_zz_231) + $signed(_zz_239));
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_SHIFT_RIGHT = _zz_241;
+  assign execute_REGFILE_WRITE_DATA = _zz_99;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_175[1 : 0];
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_243[0];
+  assign decode_IS_RS1_SIGNED = _zz_244[0];
+  assign decode_IS_DIV = _zz_245[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_246[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_247[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_248[0];
+  assign decode_MEMORY_MANAGMENT = _zz_249[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_250[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_251[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_252[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
-  assign decode_IS_RS2_SIGNED = _zz_222_[0];
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign decode_MEMORY_MANAGMENT = _zz_223_[0];
-  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_225_;
-  assign decode_IS_CSR = _zz_227_[0];
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_175_[1 : 0];
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_228_[0];
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_229_[0];
-  assign _zz_1_ = _zz_2_;
-  assign _zz_3_ = _zz_4_;
-  assign decode_SHIFT_CTRL = _zz_5_;
-  assign _zz_6_ = _zz_7_;
-  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_230_[0];
-  assign memory_MUL_LOW = ($signed(_zz_231_) + $signed(_zz_239_));
-  assign decode_IS_DIV = _zz_240_[0];
-  assign decode_IS_RS1_SIGNED = _zz_241_[0];
-  assign decode_ALU_BITWISE_CTRL = _zz_8_;
-  assign _zz_9_ = _zz_10_;
-  assign _zz_11_ = _zz_12_;
-  assign _zz_13_ = _zz_14_;
-  assign decode_ENV_CTRL = _zz_15_;
-  assign _zz_16_ = _zz_17_;
-  assign decode_ALU_CTRL = _zz_18_;
-  assign _zz_19_ = _zz_20_;
-  assign decode_SRC2_CTRL = _zz_21_;
-  assign _zz_22_ = _zz_23_;
-  assign memory_MUL_HH = execute_to_memory_MUL_HH;
-  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign decode_SRC1_CTRL = _zz_24_;
-  assign _zz_25_ = _zz_26_;
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_242_[0];
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign execute_REGFILE_WRITE_DATA = _zz_100_;
-  assign decode_SRC_LESS_UNSIGNED = _zz_243_[0];
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3398,22 +2413,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_122_;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_244_[0];
-  assign decode_RS1_USE = _zz_245_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_121;
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_253[0];
+  assign decode_RS1_USE = _zz_254[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_187_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_196)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
   end
 
@@ -3425,29 +2440,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_111_)begin
-      if((_zz_112_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_113_;
+    if(_zz_110)begin
+      if((_zz_111 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_112;
       end
     end
-    if(_zz_188_)begin
-      if(_zz_189_)begin
-        if(_zz_115_)begin
-          decode_RS2 = _zz_50_;
+    if(_zz_197)begin
+      if(_zz_198)begin
+        if(_zz_114)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_190_)begin
+    if(_zz_199)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_117_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_116)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_191_)begin
+    if(_zz_200)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_119_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_118)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -3455,29 +2470,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_111_)begin
-      if((_zz_112_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_113_;
+    if(_zz_110)begin
+      if((_zz_111 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_112;
       end
     end
-    if(_zz_188_)begin
-      if(_zz_189_)begin
-        if(_zz_114_)begin
-          decode_RS1 = _zz_50_;
+    if(_zz_197)begin
+      if(_zz_198)begin
+        if(_zz_113)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_190_)begin
+    if(_zz_199)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_115)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_191_)begin
+    if(_zz_200)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_117)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -3485,70 +2500,70 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_108_;
+          _zz_32 = _zz_107;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_192_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_201)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_246_[0];
-  assign decode_SRC_ADD_ZERO = _zz_247_[0];
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_255[0];
+  assign decode_SRC_ADD_ZERO = _zz_256[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_106_;
-  assign execute_SRC1 = _zz_101_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_105;
+  assign execute_SRC1 = _zz_100;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_248_[0];
+    decode_REGFILE_WRITE_VALID = _zz_257[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_317_) == 32'h00001073),{(_zz_318_ == _zz_319_),{_zz_320_,{_zz_321_,_zz_322_}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_326) == 32'h00001073),{(_zz_327 == _zz_328),{_zz_329,{_zz_330,_zz_331}}}}}}} != 21'h0);
   always @ (*) begin
-    _zz_50_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_221_)
+      case(_zz_230)
         2'b00 : begin
-          _zz_50_ = _zz_290_;
+          _zz_50 = _zz_299;
         end
         default : begin
-          _zz_50_ = _zz_291_;
+          _zz_50 = _zz_300;
         end
       endcase
     end
@@ -3560,55 +2575,56 @@ module VexRiscv (
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_249_[0];
-  assign decode_FLUSH_ALL = _zz_250_[0];
+  assign decode_MEMORY_ENABLE = _zz_258[0];
+  assign decode_FLUSH_ALL = _zz_259[0];
   always @ (*) begin
-    _zz_51_ = _zz_51__2;
-    if(_zz_193_)begin
-      _zz_51_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_202)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(_zz_194_)begin
-      _zz_51__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_203)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(_zz_195_)begin
-      _zz_51__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_204)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_196_)begin
-      _zz_51__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_205)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52_;
+  assign decode_BRANCH_CTRL = _zz_51;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_53_ = memory_FORMAL_PC_NEXT;
+    _zz_52 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_53_ = BranchPlugin_jumpInterface_payload;
+      _zz_52 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_54_ = decode_FORMAL_PC_NEXT;
+    _zz_53 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_54_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -3624,20 +2640,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_109_ || _zz_110_)))begin
+    if((decode_arbitration_isValid && (_zz_108 || _zz_109)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_197_)begin
+    if(_zz_206)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3651,27 +2667,30 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_197_)begin
+    if(_zz_206)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_182_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_191 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_187_)begin
+    if(_zz_196)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  assign execute_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    execute_arbitration_haltByOther = 1'b0;
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+  end
+
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
     if(CsrPlugin_selfException_valid)begin
@@ -3692,7 +2711,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_192_)begin
+    if(_zz_201)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -3723,7 +2742,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3754,10 +2773,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_198_)begin
+    if(_zz_207)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_199_)begin
+    if(_zz_208)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3768,13 +2787,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_198_)begin
+    if(_zz_207)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_199_)begin
+    if(_zz_208)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3790,21 +2809,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_198_)begin
+    if(_zz_207)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_199_)begin
+    if(_zz_208)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_198_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_207)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_199_)begin
-      case(_zz_200_)
+    if(_zz_208)begin
+      case(_zz_209)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3817,14 +2836,14 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_55_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56_ = (_zz_55_ & (~ _zz_251_));
-  assign _zz_57_ = _zz_56_[3];
-  assign _zz_58_ = (_zz_56_[1] || _zz_57_);
-  assign _zz_59_ = (_zz_56_[2] || _zz_57_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_186_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
+  assign _zz_54 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_55 = (_zz_54 & (~ _zz_260));
+  assign _zz_56 = _zz_55[3];
+  assign _zz_57 = (_zz_55[1] || _zz_56);
+  assign _zz_58 = (_zz_55[2] || _zz_56);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_195;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -3844,7 +2863,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_253_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_262);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -3884,44 +2903,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_60_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60_);
+  assign _zz_59 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_59);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_59);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_61_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61_);
+  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_60);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_60);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_51_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_62_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62_);
+  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_61);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_61);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63_;
-  assign _zz_63_ = ((1'b0 && (! _zz_64_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64_ = _zz_65_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62;
+  assign _zz_62 = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_63 = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_66_ = _zz_67_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_65)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_65 = _zz_66;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_65;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_67;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -3935,125 +2954,125 @@ module VexRiscv (
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_69_ = _zz_254_[11];
+  assign _zz_68 = _zz_263[11];
   always @ (*) begin
-    _zz_70_[18] = _zz_69_;
-    _zz_70_[17] = _zz_69_;
-    _zz_70_[16] = _zz_69_;
-    _zz_70_[15] = _zz_69_;
-    _zz_70_[14] = _zz_69_;
-    _zz_70_[13] = _zz_69_;
-    _zz_70_[12] = _zz_69_;
-    _zz_70_[11] = _zz_69_;
-    _zz_70_[10] = _zz_69_;
-    _zz_70_[9] = _zz_69_;
-    _zz_70_[8] = _zz_69_;
-    _zz_70_[7] = _zz_69_;
-    _zz_70_[6] = _zz_69_;
-    _zz_70_[5] = _zz_69_;
-    _zz_70_[4] = _zz_69_;
-    _zz_70_[3] = _zz_69_;
-    _zz_70_[2] = _zz_69_;
-    _zz_70_[1] = _zz_69_;
-    _zz_70_[0] = _zz_69_;
+    _zz_69[18] = _zz_68;
+    _zz_69[17] = _zz_68;
+    _zz_69[16] = _zz_68;
+    _zz_69[15] = _zz_68;
+    _zz_69[14] = _zz_68;
+    _zz_69[13] = _zz_68;
+    _zz_69[12] = _zz_68;
+    _zz_69[11] = _zz_68;
+    _zz_69[10] = _zz_68;
+    _zz_69[9] = _zz_68;
+    _zz_69[8] = _zz_68;
+    _zz_69[7] = _zz_68;
+    _zz_69[6] = _zz_68;
+    _zz_69[5] = _zz_68;
+    _zz_69[4] = _zz_68;
+    _zz_69[3] = _zz_68;
+    _zz_69[2] = _zz_68;
+    _zz_69[1] = _zz_68;
+    _zz_69[0] = _zz_68;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_255_[31]));
-    if(_zz_75_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_264[31]));
+    if(_zz_74)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_71_ = _zz_256_[19];
+  assign _zz_70 = _zz_265[19];
   always @ (*) begin
-    _zz_72_[10] = _zz_71_;
-    _zz_72_[9] = _zz_71_;
-    _zz_72_[8] = _zz_71_;
-    _zz_72_[7] = _zz_71_;
-    _zz_72_[6] = _zz_71_;
-    _zz_72_[5] = _zz_71_;
-    _zz_72_[4] = _zz_71_;
-    _zz_72_[3] = _zz_71_;
-    _zz_72_[2] = _zz_71_;
-    _zz_72_[1] = _zz_71_;
-    _zz_72_[0] = _zz_71_;
+    _zz_71[10] = _zz_70;
+    _zz_71[9] = _zz_70;
+    _zz_71[8] = _zz_70;
+    _zz_71[7] = _zz_70;
+    _zz_71[6] = _zz_70;
+    _zz_71[5] = _zz_70;
+    _zz_71[4] = _zz_70;
+    _zz_71[3] = _zz_70;
+    _zz_71[2] = _zz_70;
+    _zz_71[1] = _zz_70;
+    _zz_71[0] = _zz_70;
   end
 
-  assign _zz_73_ = _zz_257_[11];
+  assign _zz_72 = _zz_266[11];
   always @ (*) begin
-    _zz_74_[18] = _zz_73_;
-    _zz_74_[17] = _zz_73_;
-    _zz_74_[16] = _zz_73_;
-    _zz_74_[15] = _zz_73_;
-    _zz_74_[14] = _zz_73_;
-    _zz_74_[13] = _zz_73_;
-    _zz_74_[12] = _zz_73_;
-    _zz_74_[11] = _zz_73_;
-    _zz_74_[10] = _zz_73_;
-    _zz_74_[9] = _zz_73_;
-    _zz_74_[8] = _zz_73_;
-    _zz_74_[7] = _zz_73_;
-    _zz_74_[6] = _zz_73_;
-    _zz_74_[5] = _zz_73_;
-    _zz_74_[4] = _zz_73_;
-    _zz_74_[3] = _zz_73_;
-    _zz_74_[2] = _zz_73_;
-    _zz_74_[1] = _zz_73_;
-    _zz_74_[0] = _zz_73_;
+    _zz_73[18] = _zz_72;
+    _zz_73[17] = _zz_72;
+    _zz_73[16] = _zz_72;
+    _zz_73[15] = _zz_72;
+    _zz_73[14] = _zz_72;
+    _zz_73[13] = _zz_72;
+    _zz_73[12] = _zz_72;
+    _zz_73[11] = _zz_72;
+    _zz_73[10] = _zz_72;
+    _zz_73[9] = _zz_72;
+    _zz_73[8] = _zz_72;
+    _zz_73[7] = _zz_72;
+    _zz_73[6] = _zz_72;
+    _zz_73[5] = _zz_72;
+    _zz_73[4] = _zz_72;
+    _zz_73[3] = _zz_72;
+    _zz_73[2] = _zz_72;
+    _zz_73[1] = _zz_72;
+    _zz_73[0] = _zz_72;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_75_ = _zz_258_[1];
+        _zz_74 = _zz_267[1];
       end
       default : begin
-        _zz_75_ = _zz_259_[1];
+        _zz_74 = _zz_268[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_76_ = _zz_260_[19];
+  assign _zz_75 = _zz_269[19];
   always @ (*) begin
-    _zz_77_[10] = _zz_76_;
-    _zz_77_[9] = _zz_76_;
-    _zz_77_[8] = _zz_76_;
-    _zz_77_[7] = _zz_76_;
-    _zz_77_[6] = _zz_76_;
-    _zz_77_[5] = _zz_76_;
-    _zz_77_[4] = _zz_76_;
-    _zz_77_[3] = _zz_76_;
-    _zz_77_[2] = _zz_76_;
-    _zz_77_[1] = _zz_76_;
-    _zz_77_[0] = _zz_76_;
+    _zz_76[10] = _zz_75;
+    _zz_76[9] = _zz_75;
+    _zz_76[8] = _zz_75;
+    _zz_76[7] = _zz_75;
+    _zz_76[6] = _zz_75;
+    _zz_76[5] = _zz_75;
+    _zz_76[4] = _zz_75;
+    _zz_76[3] = _zz_75;
+    _zz_76[2] = _zz_75;
+    _zz_76[1] = _zz_75;
+    _zz_76[0] = _zz_75;
   end
 
-  assign _zz_78_ = _zz_261_[11];
+  assign _zz_77 = _zz_270[11];
   always @ (*) begin
-    _zz_79_[18] = _zz_78_;
-    _zz_79_[17] = _zz_78_;
-    _zz_79_[16] = _zz_78_;
-    _zz_79_[15] = _zz_78_;
-    _zz_79_[14] = _zz_78_;
-    _zz_79_[13] = _zz_78_;
-    _zz_79_[12] = _zz_78_;
-    _zz_79_[11] = _zz_78_;
-    _zz_79_[10] = _zz_78_;
-    _zz_79_[9] = _zz_78_;
-    _zz_79_[8] = _zz_78_;
-    _zz_79_[7] = _zz_78_;
-    _zz_79_[6] = _zz_78_;
-    _zz_79_[5] = _zz_78_;
-    _zz_79_[4] = _zz_78_;
-    _zz_79_[3] = _zz_78_;
-    _zz_79_[2] = _zz_78_;
-    _zz_79_[1] = _zz_78_;
-    _zz_79_[0] = _zz_78_;
+    _zz_78[18] = _zz_77;
+    _zz_78[17] = _zz_77;
+    _zz_78[16] = _zz_77;
+    _zz_78[15] = _zz_77;
+    _zz_78[14] = _zz_77;
+    _zz_78[13] = _zz_77;
+    _zz_78[12] = _zz_77;
+    _zz_78[11] = _zz_77;
+    _zz_78[10] = _zz_77;
+    _zz_78[9] = _zz_77;
+    _zz_78[8] = _zz_77;
+    _zz_78[7] = _zz_77;
+    _zz_78[6] = _zz_77;
+    _zz_78[5] = _zz_77;
+    _zz_78[4] = _zz_77;
+    _zz_78[3] = _zz_77;
+    _zz_78[2] = _zz_77;
+    _zz_78[1] = _zz_77;
+    _zz_78[0] = _zz_77;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77_,{{{_zz_335_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79_,{{{_zz_336_,_zz_337_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_76,{{{_zz_344,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_78,{{{_zz_345,_zz_346},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4062,123 +3081,128 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_167_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_168_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_169_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_170_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_171_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_172_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_166 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_167 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_168 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_167;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_170 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_171 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_172 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_196_)begin
+    if(_zz_205)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_194_)begin
+    if(_zz_203)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_173_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_194_)begin
-      _zz_173_ = 1'b1;
+    _zz_173 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_203)begin
+      _zz_173 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_195_)begin
+    if(_zz_204)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_193_)begin
+    if(_zz_202)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_195_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_204)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_193_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_202)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_166_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_183_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_165 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_192 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_174_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_175_ = execute_SRC_ADD;
+  assign _zz_174 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_175 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_82_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_81 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_82_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_81 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_82_ = execute_RS2[31 : 0];
+        _zz_81 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_182_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_176_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_177_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+  assign _zz_191 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_176 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_177 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_176;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_177;
+  assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @ (*) begin
-    _zz_178_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_178_ = 1'b1;
+    _zz_178 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_178 = 1'b1;
     end
   end
 
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_179_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_180_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_181_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_179 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_180 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_181 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_201_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_210)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -4187,17 +3211,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_201_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_210)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -4205,94 +3229,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_201_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_262_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_210)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_271};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_263_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_272};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_83_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_82 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_84_[31] = _zz_83_;
-    _zz_84_[30] = _zz_83_;
-    _zz_84_[29] = _zz_83_;
-    _zz_84_[28] = _zz_83_;
-    _zz_84_[27] = _zz_83_;
-    _zz_84_[26] = _zz_83_;
-    _zz_84_[25] = _zz_83_;
-    _zz_84_[24] = _zz_83_;
-    _zz_84_[23] = _zz_83_;
-    _zz_84_[22] = _zz_83_;
-    _zz_84_[21] = _zz_83_;
-    _zz_84_[20] = _zz_83_;
-    _zz_84_[19] = _zz_83_;
-    _zz_84_[18] = _zz_83_;
-    _zz_84_[17] = _zz_83_;
-    _zz_84_[16] = _zz_83_;
-    _zz_84_[15] = _zz_83_;
-    _zz_84_[14] = _zz_83_;
-    _zz_84_[13] = _zz_83_;
-    _zz_84_[12] = _zz_83_;
-    _zz_84_[11] = _zz_83_;
-    _zz_84_[10] = _zz_83_;
-    _zz_84_[9] = _zz_83_;
-    _zz_84_[8] = _zz_83_;
-    _zz_84_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_83[31] = _zz_82;
+    _zz_83[30] = _zz_82;
+    _zz_83[29] = _zz_82;
+    _zz_83[28] = _zz_82;
+    _zz_83[27] = _zz_82;
+    _zz_83[26] = _zz_82;
+    _zz_83[25] = _zz_82;
+    _zz_83[24] = _zz_82;
+    _zz_83[23] = _zz_82;
+    _zz_83[22] = _zz_82;
+    _zz_83[21] = _zz_82;
+    _zz_83[20] = _zz_82;
+    _zz_83[19] = _zz_82;
+    _zz_83[18] = _zz_82;
+    _zz_83[17] = _zz_82;
+    _zz_83[16] = _zz_82;
+    _zz_83[15] = _zz_82;
+    _zz_83[14] = _zz_82;
+    _zz_83[13] = _zz_82;
+    _zz_83[12] = _zz_82;
+    _zz_83[11] = _zz_82;
+    _zz_83[10] = _zz_82;
+    _zz_83[9] = _zz_82;
+    _zz_83[8] = _zz_82;
+    _zz_83[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_85_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_84 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_86_[31] = _zz_85_;
-    _zz_86_[30] = _zz_85_;
-    _zz_86_[29] = _zz_85_;
-    _zz_86_[28] = _zz_85_;
-    _zz_86_[27] = _zz_85_;
-    _zz_86_[26] = _zz_85_;
-    _zz_86_[25] = _zz_85_;
-    _zz_86_[24] = _zz_85_;
-    _zz_86_[23] = _zz_85_;
-    _zz_86_[22] = _zz_85_;
-    _zz_86_[21] = _zz_85_;
-    _zz_86_[20] = _zz_85_;
-    _zz_86_[19] = _zz_85_;
-    _zz_86_[18] = _zz_85_;
-    _zz_86_[17] = _zz_85_;
-    _zz_86_[16] = _zz_85_;
-    _zz_86_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_85[31] = _zz_84;
+    _zz_85[30] = _zz_84;
+    _zz_85[29] = _zz_84;
+    _zz_85[28] = _zz_84;
+    _zz_85[27] = _zz_84;
+    _zz_85[26] = _zz_84;
+    _zz_85[25] = _zz_84;
+    _zz_85[24] = _zz_84;
+    _zz_85[23] = _zz_84;
+    _zz_85[22] = _zz_84;
+    _zz_85[21] = _zz_84;
+    _zz_85[20] = _zz_84;
+    _zz_85[19] = _zz_84;
+    _zz_85[18] = _zz_84;
+    _zz_85[17] = _zz_84;
+    _zz_85[16] = _zz_84;
+    _zz_85[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_219_)
+    case(_zz_228)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_84_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_83;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_85;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -4300,57 +3324,71 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_88_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_89_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_90_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_91_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_87_ = {({(_zz_338_ == _zz_339_),(_zz_340_ == _zz_341_)} != (2'b00)),{((_zz_342_ == _zz_343_) != (1'b0)),{(_zz_344_ != (1'b0)),{(_zz_345_ != _zz_346_),{_zz_347_,{_zz_348_,_zz_349_}}}}}};
-  assign _zz_92_ = _zz_87_[1 : 0];
-  assign _zz_49_ = _zz_92_;
-  assign _zz_93_ = _zz_87_[5 : 4];
-  assign _zz_48_ = _zz_93_;
-  assign _zz_94_ = _zz_87_[9 : 8];
-  assign _zz_47_ = _zz_94_;
-  assign _zz_95_ = _zz_87_[21 : 20];
-  assign _zz_46_ = _zz_95_;
-  assign _zz_96_ = _zz_87_[23 : 22];
-  assign _zz_45_ = _zz_96_;
-  assign _zz_97_ = _zz_87_[28 : 27];
-  assign _zz_44_ = _zz_97_;
-  assign _zz_98_ = _zz_87_[30 : 29];
-  assign _zz_43_ = _zz_98_;
+  assign _zz_87 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_88 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_90 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_86 = {(_zz_90 != 1'b0),{(_zz_90 != 1'b0),{((_zz_347 == _zz_348) != 1'b0),{(_zz_349 != 1'b0),{(_zz_350 != _zz_351),{_zz_352,{_zz_353,_zz_354}}}}}}};
+  assign _zz_91 = _zz_86[2 : 1];
+  assign _zz_49 = _zz_91;
+  assign _zz_92 = _zz_86[7 : 6];
+  assign _zz_48 = _zz_92;
+  assign _zz_93 = _zz_86[9 : 8];
+  assign _zz_47 = _zz_93;
+  assign _zz_94 = _zz_86[19 : 18];
+  assign _zz_46 = _zz_94;
+  assign _zz_95 = _zz_86[22 : 21];
+  assign _zz_45 = _zz_95;
+  assign _zz_96 = _zz_86[24 : 23];
+  assign _zz_44 = _zz_96;
+  assign _zz_97 = _zz_86[27 : 26];
+  assign _zz_43 = _zz_97;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_184_;
-  assign decode_RegFilePlugin_rs2Data = _zz_185_;
+  assign decode_RegFilePlugin_rs1Data = _zz_193;
+  assign decode_RegFilePlugin_rs2Data = _zz_194;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_99_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_98)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_50_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_98)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_98)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -4368,13 +3406,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_100_ = execute_IntAluPlugin_bitwise;
+        _zz_99 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_100_ = {31'd0, _zz_264_};
+        _zz_99 = {31'd0, _zz_273};
       end
       default : begin
-        _zz_100_ = execute_SRC_ADD_SUB;
+        _zz_99 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -4382,87 +3420,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_101_ = execute_RS1;
+        _zz_100 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_101_ = {29'd0, _zz_265_};
+        _zz_100 = {29'd0, _zz_274};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_101_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_100 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_101_ = {27'd0, _zz_266_};
+        _zz_100 = {27'd0, _zz_275};
       end
     endcase
   end
 
-  assign _zz_102_ = _zz_267_[11];
+  assign _zz_101 = _zz_276[11];
   always @ (*) begin
-    _zz_103_[19] = _zz_102_;
-    _zz_103_[18] = _zz_102_;
-    _zz_103_[17] = _zz_102_;
-    _zz_103_[16] = _zz_102_;
-    _zz_103_[15] = _zz_102_;
-    _zz_103_[14] = _zz_102_;
-    _zz_103_[13] = _zz_102_;
-    _zz_103_[12] = _zz_102_;
-    _zz_103_[11] = _zz_102_;
-    _zz_103_[10] = _zz_102_;
-    _zz_103_[9] = _zz_102_;
-    _zz_103_[8] = _zz_102_;
-    _zz_103_[7] = _zz_102_;
-    _zz_103_[6] = _zz_102_;
-    _zz_103_[5] = _zz_102_;
-    _zz_103_[4] = _zz_102_;
-    _zz_103_[3] = _zz_102_;
-    _zz_103_[2] = _zz_102_;
-    _zz_103_[1] = _zz_102_;
-    _zz_103_[0] = _zz_102_;
+    _zz_102[19] = _zz_101;
+    _zz_102[18] = _zz_101;
+    _zz_102[17] = _zz_101;
+    _zz_102[16] = _zz_101;
+    _zz_102[15] = _zz_101;
+    _zz_102[14] = _zz_101;
+    _zz_102[13] = _zz_101;
+    _zz_102[12] = _zz_101;
+    _zz_102[11] = _zz_101;
+    _zz_102[10] = _zz_101;
+    _zz_102[9] = _zz_101;
+    _zz_102[8] = _zz_101;
+    _zz_102[7] = _zz_101;
+    _zz_102[6] = _zz_101;
+    _zz_102[5] = _zz_101;
+    _zz_102[4] = _zz_101;
+    _zz_102[3] = _zz_101;
+    _zz_102[2] = _zz_101;
+    _zz_102[1] = _zz_101;
+    _zz_102[0] = _zz_101;
   end
 
-  assign _zz_104_ = _zz_268_[11];
+  assign _zz_103 = _zz_277[11];
   always @ (*) begin
-    _zz_105_[19] = _zz_104_;
-    _zz_105_[18] = _zz_104_;
-    _zz_105_[17] = _zz_104_;
-    _zz_105_[16] = _zz_104_;
-    _zz_105_[15] = _zz_104_;
-    _zz_105_[14] = _zz_104_;
-    _zz_105_[13] = _zz_104_;
-    _zz_105_[12] = _zz_104_;
-    _zz_105_[11] = _zz_104_;
-    _zz_105_[10] = _zz_104_;
-    _zz_105_[9] = _zz_104_;
-    _zz_105_[8] = _zz_104_;
-    _zz_105_[7] = _zz_104_;
-    _zz_105_[6] = _zz_104_;
-    _zz_105_[5] = _zz_104_;
-    _zz_105_[4] = _zz_104_;
-    _zz_105_[3] = _zz_104_;
-    _zz_105_[2] = _zz_104_;
-    _zz_105_[1] = _zz_104_;
-    _zz_105_[0] = _zz_104_;
+    _zz_104[19] = _zz_103;
+    _zz_104[18] = _zz_103;
+    _zz_104[17] = _zz_103;
+    _zz_104[16] = _zz_103;
+    _zz_104[15] = _zz_103;
+    _zz_104[14] = _zz_103;
+    _zz_104[13] = _zz_103;
+    _zz_104[12] = _zz_103;
+    _zz_104[11] = _zz_103;
+    _zz_104[10] = _zz_103;
+    _zz_104[9] = _zz_103;
+    _zz_104[8] = _zz_103;
+    _zz_104[7] = _zz_103;
+    _zz_104[6] = _zz_103;
+    _zz_104[5] = _zz_103;
+    _zz_104[4] = _zz_103;
+    _zz_104[3] = _zz_103;
+    _zz_104[2] = _zz_103;
+    _zz_104[1] = _zz_103;
+    _zz_104[0] = _zz_103;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_106_ = execute_RS2;
+        _zz_105 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_106_ = {_zz_103_,execute_INSTRUCTION[31 : 20]};
+        _zz_105 = {_zz_102,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_106_ = {_zz_105_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_105 = {_zz_104,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_106_ = _zz_35_;
+        _zz_105 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_269_;
+    execute_SrcPlugin_addSub = _zz_278;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -4471,246 +3509,246 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_107_[0] = execute_SRC1[31];
-    _zz_107_[1] = execute_SRC1[30];
-    _zz_107_[2] = execute_SRC1[29];
-    _zz_107_[3] = execute_SRC1[28];
-    _zz_107_[4] = execute_SRC1[27];
-    _zz_107_[5] = execute_SRC1[26];
-    _zz_107_[6] = execute_SRC1[25];
-    _zz_107_[7] = execute_SRC1[24];
-    _zz_107_[8] = execute_SRC1[23];
-    _zz_107_[9] = execute_SRC1[22];
-    _zz_107_[10] = execute_SRC1[21];
-    _zz_107_[11] = execute_SRC1[20];
-    _zz_107_[12] = execute_SRC1[19];
-    _zz_107_[13] = execute_SRC1[18];
-    _zz_107_[14] = execute_SRC1[17];
-    _zz_107_[15] = execute_SRC1[16];
-    _zz_107_[16] = execute_SRC1[15];
-    _zz_107_[17] = execute_SRC1[14];
-    _zz_107_[18] = execute_SRC1[13];
-    _zz_107_[19] = execute_SRC1[12];
-    _zz_107_[20] = execute_SRC1[11];
-    _zz_107_[21] = execute_SRC1[10];
-    _zz_107_[22] = execute_SRC1[9];
-    _zz_107_[23] = execute_SRC1[8];
-    _zz_107_[24] = execute_SRC1[7];
-    _zz_107_[25] = execute_SRC1[6];
-    _zz_107_[26] = execute_SRC1[5];
-    _zz_107_[27] = execute_SRC1[4];
-    _zz_107_[28] = execute_SRC1[3];
-    _zz_107_[29] = execute_SRC1[2];
-    _zz_107_[30] = execute_SRC1[1];
-    _zz_107_[31] = execute_SRC1[0];
+    _zz_106[0] = execute_SRC1[31];
+    _zz_106[1] = execute_SRC1[30];
+    _zz_106[2] = execute_SRC1[29];
+    _zz_106[3] = execute_SRC1[28];
+    _zz_106[4] = execute_SRC1[27];
+    _zz_106[5] = execute_SRC1[26];
+    _zz_106[6] = execute_SRC1[25];
+    _zz_106[7] = execute_SRC1[24];
+    _zz_106[8] = execute_SRC1[23];
+    _zz_106[9] = execute_SRC1[22];
+    _zz_106[10] = execute_SRC1[21];
+    _zz_106[11] = execute_SRC1[20];
+    _zz_106[12] = execute_SRC1[19];
+    _zz_106[13] = execute_SRC1[18];
+    _zz_106[14] = execute_SRC1[17];
+    _zz_106[15] = execute_SRC1[16];
+    _zz_106[16] = execute_SRC1[15];
+    _zz_106[17] = execute_SRC1[14];
+    _zz_106[18] = execute_SRC1[13];
+    _zz_106[19] = execute_SRC1[12];
+    _zz_106[20] = execute_SRC1[11];
+    _zz_106[21] = execute_SRC1[10];
+    _zz_106[22] = execute_SRC1[9];
+    _zz_106[23] = execute_SRC1[8];
+    _zz_106[24] = execute_SRC1[7];
+    _zz_106[25] = execute_SRC1[6];
+    _zz_106[26] = execute_SRC1[5];
+    _zz_106[27] = execute_SRC1[4];
+    _zz_106[28] = execute_SRC1[3];
+    _zz_106[29] = execute_SRC1[2];
+    _zz_106[30] = execute_SRC1[1];
+    _zz_106[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_107_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_106 : execute_SRC1);
   always @ (*) begin
-    _zz_108_[0] = memory_SHIFT_RIGHT[31];
-    _zz_108_[1] = memory_SHIFT_RIGHT[30];
-    _zz_108_[2] = memory_SHIFT_RIGHT[29];
-    _zz_108_[3] = memory_SHIFT_RIGHT[28];
-    _zz_108_[4] = memory_SHIFT_RIGHT[27];
-    _zz_108_[5] = memory_SHIFT_RIGHT[26];
-    _zz_108_[6] = memory_SHIFT_RIGHT[25];
-    _zz_108_[7] = memory_SHIFT_RIGHT[24];
-    _zz_108_[8] = memory_SHIFT_RIGHT[23];
-    _zz_108_[9] = memory_SHIFT_RIGHT[22];
-    _zz_108_[10] = memory_SHIFT_RIGHT[21];
-    _zz_108_[11] = memory_SHIFT_RIGHT[20];
-    _zz_108_[12] = memory_SHIFT_RIGHT[19];
-    _zz_108_[13] = memory_SHIFT_RIGHT[18];
-    _zz_108_[14] = memory_SHIFT_RIGHT[17];
-    _zz_108_[15] = memory_SHIFT_RIGHT[16];
-    _zz_108_[16] = memory_SHIFT_RIGHT[15];
-    _zz_108_[17] = memory_SHIFT_RIGHT[14];
-    _zz_108_[18] = memory_SHIFT_RIGHT[13];
-    _zz_108_[19] = memory_SHIFT_RIGHT[12];
-    _zz_108_[20] = memory_SHIFT_RIGHT[11];
-    _zz_108_[21] = memory_SHIFT_RIGHT[10];
-    _zz_108_[22] = memory_SHIFT_RIGHT[9];
-    _zz_108_[23] = memory_SHIFT_RIGHT[8];
-    _zz_108_[24] = memory_SHIFT_RIGHT[7];
-    _zz_108_[25] = memory_SHIFT_RIGHT[6];
-    _zz_108_[26] = memory_SHIFT_RIGHT[5];
-    _zz_108_[27] = memory_SHIFT_RIGHT[4];
-    _zz_108_[28] = memory_SHIFT_RIGHT[3];
-    _zz_108_[29] = memory_SHIFT_RIGHT[2];
-    _zz_108_[30] = memory_SHIFT_RIGHT[1];
-    _zz_108_[31] = memory_SHIFT_RIGHT[0];
+    _zz_107[0] = memory_SHIFT_RIGHT[31];
+    _zz_107[1] = memory_SHIFT_RIGHT[30];
+    _zz_107[2] = memory_SHIFT_RIGHT[29];
+    _zz_107[3] = memory_SHIFT_RIGHT[28];
+    _zz_107[4] = memory_SHIFT_RIGHT[27];
+    _zz_107[5] = memory_SHIFT_RIGHT[26];
+    _zz_107[6] = memory_SHIFT_RIGHT[25];
+    _zz_107[7] = memory_SHIFT_RIGHT[24];
+    _zz_107[8] = memory_SHIFT_RIGHT[23];
+    _zz_107[9] = memory_SHIFT_RIGHT[22];
+    _zz_107[10] = memory_SHIFT_RIGHT[21];
+    _zz_107[11] = memory_SHIFT_RIGHT[20];
+    _zz_107[12] = memory_SHIFT_RIGHT[19];
+    _zz_107[13] = memory_SHIFT_RIGHT[18];
+    _zz_107[14] = memory_SHIFT_RIGHT[17];
+    _zz_107[15] = memory_SHIFT_RIGHT[16];
+    _zz_107[16] = memory_SHIFT_RIGHT[15];
+    _zz_107[17] = memory_SHIFT_RIGHT[14];
+    _zz_107[18] = memory_SHIFT_RIGHT[13];
+    _zz_107[19] = memory_SHIFT_RIGHT[12];
+    _zz_107[20] = memory_SHIFT_RIGHT[11];
+    _zz_107[21] = memory_SHIFT_RIGHT[10];
+    _zz_107[22] = memory_SHIFT_RIGHT[9];
+    _zz_107[23] = memory_SHIFT_RIGHT[8];
+    _zz_107[24] = memory_SHIFT_RIGHT[7];
+    _zz_107[25] = memory_SHIFT_RIGHT[6];
+    _zz_107[26] = memory_SHIFT_RIGHT[5];
+    _zz_107[27] = memory_SHIFT_RIGHT[4];
+    _zz_107[28] = memory_SHIFT_RIGHT[3];
+    _zz_107[29] = memory_SHIFT_RIGHT[2];
+    _zz_107[30] = memory_SHIFT_RIGHT[1];
+    _zz_107[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_109_ = 1'b0;
-    if(_zz_202_)begin
-      if(_zz_203_)begin
-        if(_zz_114_)begin
-          _zz_109_ = 1'b1;
+    _zz_108 = 1'b0;
+    if(_zz_211)begin
+      if(_zz_212)begin
+        if(_zz_113)begin
+          _zz_108 = 1'b1;
         end
       end
     end
-    if(_zz_204_)begin
-      if(_zz_205_)begin
-        if(_zz_116_)begin
-          _zz_109_ = 1'b1;
+    if(_zz_213)begin
+      if(_zz_214)begin
+        if(_zz_115)begin
+          _zz_108 = 1'b1;
         end
       end
     end
-    if(_zz_206_)begin
-      if(_zz_207_)begin
-        if(_zz_118_)begin
-          _zz_109_ = 1'b1;
+    if(_zz_215)begin
+      if(_zz_216)begin
+        if(_zz_117)begin
+          _zz_108 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_109_ = 1'b0;
+      _zz_108 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_110_ = 1'b0;
-    if(_zz_202_)begin
-      if(_zz_203_)begin
-        if(_zz_115_)begin
-          _zz_110_ = 1'b1;
+    _zz_109 = 1'b0;
+    if(_zz_211)begin
+      if(_zz_212)begin
+        if(_zz_114)begin
+          _zz_109 = 1'b1;
         end
       end
     end
-    if(_zz_204_)begin
-      if(_zz_205_)begin
-        if(_zz_117_)begin
-          _zz_110_ = 1'b1;
+    if(_zz_213)begin
+      if(_zz_214)begin
+        if(_zz_116)begin
+          _zz_109 = 1'b1;
         end
       end
     end
-    if(_zz_206_)begin
-      if(_zz_207_)begin
-        if(_zz_119_)begin
-          _zz_110_ = 1'b1;
+    if(_zz_215)begin
+      if(_zz_216)begin
+        if(_zz_118)begin
+          _zz_109 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_110_ = 1'b0;
+      _zz_109 = 1'b0;
     end
   end
 
-  assign _zz_114_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_115_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_116_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_117_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_118_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_119_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_113 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_115 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_117 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_120_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_119 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_120_ == (3'b000))) begin
-        _zz_121_ = execute_BranchPlugin_eq;
-    end else if((_zz_120_ == (3'b001))) begin
-        _zz_121_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_120_ & (3'b101)) == (3'b101)))) begin
-        _zz_121_ = (! execute_SRC_LESS);
+    if((_zz_119 == 3'b000)) begin
+        _zz_120 = execute_BranchPlugin_eq;
+    end else if((_zz_119 == 3'b001)) begin
+        _zz_120 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_119 & 3'b101) == 3'b101))) begin
+        _zz_120 = (! execute_SRC_LESS);
     end else begin
-        _zz_121_ = execute_SRC_LESS;
+        _zz_120 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_122_ = 1'b0;
+        _zz_121 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_122_ = 1'b1;
+        _zz_121 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_122_ = 1'b1;
+        _zz_121 = 1'b1;
       end
       default : begin
-        _zz_122_ = _zz_121_;
+        _zz_121 = _zz_120;
       end
     endcase
   end
 
-  assign _zz_123_ = _zz_276_[11];
+  assign _zz_122 = _zz_285[11];
   always @ (*) begin
-    _zz_124_[19] = _zz_123_;
-    _zz_124_[18] = _zz_123_;
-    _zz_124_[17] = _zz_123_;
-    _zz_124_[16] = _zz_123_;
-    _zz_124_[15] = _zz_123_;
-    _zz_124_[14] = _zz_123_;
-    _zz_124_[13] = _zz_123_;
-    _zz_124_[12] = _zz_123_;
-    _zz_124_[11] = _zz_123_;
-    _zz_124_[10] = _zz_123_;
-    _zz_124_[9] = _zz_123_;
-    _zz_124_[8] = _zz_123_;
-    _zz_124_[7] = _zz_123_;
-    _zz_124_[6] = _zz_123_;
-    _zz_124_[5] = _zz_123_;
-    _zz_124_[4] = _zz_123_;
-    _zz_124_[3] = _zz_123_;
-    _zz_124_[2] = _zz_123_;
-    _zz_124_[1] = _zz_123_;
-    _zz_124_[0] = _zz_123_;
+    _zz_123[19] = _zz_122;
+    _zz_123[18] = _zz_122;
+    _zz_123[17] = _zz_122;
+    _zz_123[16] = _zz_122;
+    _zz_123[15] = _zz_122;
+    _zz_123[14] = _zz_122;
+    _zz_123[13] = _zz_122;
+    _zz_123[12] = _zz_122;
+    _zz_123[11] = _zz_122;
+    _zz_123[10] = _zz_122;
+    _zz_123[9] = _zz_122;
+    _zz_123[8] = _zz_122;
+    _zz_123[7] = _zz_122;
+    _zz_123[6] = _zz_122;
+    _zz_123[5] = _zz_122;
+    _zz_123[4] = _zz_122;
+    _zz_123[3] = _zz_122;
+    _zz_123[2] = _zz_122;
+    _zz_123[1] = _zz_122;
+    _zz_123[0] = _zz_122;
   end
 
-  assign _zz_125_ = _zz_277_[19];
+  assign _zz_124 = _zz_286[19];
   always @ (*) begin
-    _zz_126_[10] = _zz_125_;
-    _zz_126_[9] = _zz_125_;
-    _zz_126_[8] = _zz_125_;
-    _zz_126_[7] = _zz_125_;
-    _zz_126_[6] = _zz_125_;
-    _zz_126_[5] = _zz_125_;
-    _zz_126_[4] = _zz_125_;
-    _zz_126_[3] = _zz_125_;
-    _zz_126_[2] = _zz_125_;
-    _zz_126_[1] = _zz_125_;
-    _zz_126_[0] = _zz_125_;
+    _zz_125[10] = _zz_124;
+    _zz_125[9] = _zz_124;
+    _zz_125[8] = _zz_124;
+    _zz_125[7] = _zz_124;
+    _zz_125[6] = _zz_124;
+    _zz_125[5] = _zz_124;
+    _zz_125[4] = _zz_124;
+    _zz_125[3] = _zz_124;
+    _zz_125[2] = _zz_124;
+    _zz_125[1] = _zz_124;
+    _zz_125[0] = _zz_124;
   end
 
-  assign _zz_127_ = _zz_278_[11];
+  assign _zz_126 = _zz_287[11];
   always @ (*) begin
-    _zz_128_[18] = _zz_127_;
-    _zz_128_[17] = _zz_127_;
-    _zz_128_[16] = _zz_127_;
-    _zz_128_[15] = _zz_127_;
-    _zz_128_[14] = _zz_127_;
-    _zz_128_[13] = _zz_127_;
-    _zz_128_[12] = _zz_127_;
-    _zz_128_[11] = _zz_127_;
-    _zz_128_[10] = _zz_127_;
-    _zz_128_[9] = _zz_127_;
-    _zz_128_[8] = _zz_127_;
-    _zz_128_[7] = _zz_127_;
-    _zz_128_[6] = _zz_127_;
-    _zz_128_[5] = _zz_127_;
-    _zz_128_[4] = _zz_127_;
-    _zz_128_[3] = _zz_127_;
-    _zz_128_[2] = _zz_127_;
-    _zz_128_[1] = _zz_127_;
-    _zz_128_[0] = _zz_127_;
+    _zz_127[18] = _zz_126;
+    _zz_127[17] = _zz_126;
+    _zz_127[16] = _zz_126;
+    _zz_127[15] = _zz_126;
+    _zz_127[14] = _zz_126;
+    _zz_127[13] = _zz_126;
+    _zz_127[12] = _zz_126;
+    _zz_127[11] = _zz_126;
+    _zz_127[10] = _zz_126;
+    _zz_127[9] = _zz_126;
+    _zz_127[8] = _zz_126;
+    _zz_127[7] = _zz_126;
+    _zz_127[6] = _zz_126;
+    _zz_127[5] = _zz_126;
+    _zz_127[4] = _zz_126;
+    _zz_127[3] = _zz_126;
+    _zz_127[2] = _zz_126;
+    _zz_127[1] = _zz_126;
+    _zz_127[0] = _zz_126;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_129_ = (_zz_279_[1] ^ execute_RS1[1]);
+        _zz_128 = (_zz_288[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_129_ = _zz_280_[1];
+        _zz_128 = _zz_289[1];
       end
       default : begin
-        _zz_129_ = _zz_281_[1];
+        _zz_128 = _zz_290[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_129_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_128);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -4722,108 +3760,108 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_130_ = _zz_282_[11];
+  assign _zz_129 = _zz_291[11];
   always @ (*) begin
-    _zz_131_[19] = _zz_130_;
-    _zz_131_[18] = _zz_130_;
-    _zz_131_[17] = _zz_130_;
-    _zz_131_[16] = _zz_130_;
-    _zz_131_[15] = _zz_130_;
-    _zz_131_[14] = _zz_130_;
-    _zz_131_[13] = _zz_130_;
-    _zz_131_[12] = _zz_130_;
-    _zz_131_[11] = _zz_130_;
-    _zz_131_[10] = _zz_130_;
-    _zz_131_[9] = _zz_130_;
-    _zz_131_[8] = _zz_130_;
-    _zz_131_[7] = _zz_130_;
-    _zz_131_[6] = _zz_130_;
-    _zz_131_[5] = _zz_130_;
-    _zz_131_[4] = _zz_130_;
-    _zz_131_[3] = _zz_130_;
-    _zz_131_[2] = _zz_130_;
-    _zz_131_[1] = _zz_130_;
-    _zz_131_[0] = _zz_130_;
+    _zz_130[19] = _zz_129;
+    _zz_130[18] = _zz_129;
+    _zz_130[17] = _zz_129;
+    _zz_130[16] = _zz_129;
+    _zz_130[15] = _zz_129;
+    _zz_130[14] = _zz_129;
+    _zz_130[13] = _zz_129;
+    _zz_130[12] = _zz_129;
+    _zz_130[11] = _zz_129;
+    _zz_130[10] = _zz_129;
+    _zz_130[9] = _zz_129;
+    _zz_130[8] = _zz_129;
+    _zz_130[7] = _zz_129;
+    _zz_130[6] = _zz_129;
+    _zz_130[5] = _zz_129;
+    _zz_130[4] = _zz_129;
+    _zz_130[3] = _zz_129;
+    _zz_130[2] = _zz_129;
+    _zz_130[1] = _zz_129;
+    _zz_130[0] = _zz_129;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_131_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_130,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_133_,{{{_zz_499_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_135_,{{{_zz_500_,_zz_501_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_132,{{{_zz_505,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_134,{{{_zz_506,_zz_507},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_285_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_294};
         end
       end
     endcase
   end
 
-  assign _zz_132_ = _zz_283_[19];
+  assign _zz_131 = _zz_292[19];
   always @ (*) begin
-    _zz_133_[10] = _zz_132_;
-    _zz_133_[9] = _zz_132_;
-    _zz_133_[8] = _zz_132_;
-    _zz_133_[7] = _zz_132_;
-    _zz_133_[6] = _zz_132_;
-    _zz_133_[5] = _zz_132_;
-    _zz_133_[4] = _zz_132_;
-    _zz_133_[3] = _zz_132_;
-    _zz_133_[2] = _zz_132_;
-    _zz_133_[1] = _zz_132_;
-    _zz_133_[0] = _zz_132_;
+    _zz_132[10] = _zz_131;
+    _zz_132[9] = _zz_131;
+    _zz_132[8] = _zz_131;
+    _zz_132[7] = _zz_131;
+    _zz_132[6] = _zz_131;
+    _zz_132[5] = _zz_131;
+    _zz_132[4] = _zz_131;
+    _zz_132[3] = _zz_131;
+    _zz_132[2] = _zz_131;
+    _zz_132[1] = _zz_131;
+    _zz_132[0] = _zz_131;
   end
 
-  assign _zz_134_ = _zz_284_[11];
+  assign _zz_133 = _zz_293[11];
   always @ (*) begin
-    _zz_135_[18] = _zz_134_;
-    _zz_135_[17] = _zz_134_;
-    _zz_135_[16] = _zz_134_;
-    _zz_135_[15] = _zz_134_;
-    _zz_135_[14] = _zz_134_;
-    _zz_135_[13] = _zz_134_;
-    _zz_135_[12] = _zz_134_;
-    _zz_135_[11] = _zz_134_;
-    _zz_135_[10] = _zz_134_;
-    _zz_135_[9] = _zz_134_;
-    _zz_135_[8] = _zz_134_;
-    _zz_135_[7] = _zz_134_;
-    _zz_135_[6] = _zz_134_;
-    _zz_135_[5] = _zz_134_;
-    _zz_135_[4] = _zz_134_;
-    _zz_135_[3] = _zz_134_;
-    _zz_135_[2] = _zz_134_;
-    _zz_135_[1] = _zz_134_;
-    _zz_135_[0] = _zz_134_;
+    _zz_134[18] = _zz_133;
+    _zz_134[17] = _zz_133;
+    _zz_134[16] = _zz_133;
+    _zz_134[15] = _zz_133;
+    _zz_134[14] = _zz_133;
+    _zz_134[13] = _zz_133;
+    _zz_134[12] = _zz_133;
+    _zz_134[11] = _zz_133;
+    _zz_134[10] = _zz_133;
+    _zz_134[9] = _zz_133;
+    _zz_134[8] = _zz_133;
+    _zz_134[7] = _zz_133;
+    _zz_134[6] = _zz_133;
+    _zz_134[5] = _zz_133;
+    _zz_134[4] = _zz_133;
+    _zz_134[3] = _zz_133;
+    _zz_134[2] = _zz_133;
+    _zz_134[1] = _zz_133;
+    _zz_134[0] = _zz_133;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_136_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_137_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_138_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_135 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_136 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_137 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_139_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_140_ = _zz_286_[0];
+  assign _zz_138 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_139 = _zz_295[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_197_)begin
+    if(_zz_206)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -4870,7 +3908,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -4894,7 +3932,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -4916,7 +3954,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -4959,7 +3997,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_208_)begin
+    if(_zz_217)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -4978,20 +4016,20 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_209_)begin
+    if(_zz_218)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_209_)begin
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_218)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -5000,14 +4038,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_208_)begin
+    if(_zz_217)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_208_)begin
+    if(_zz_217)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5016,7 +4054,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_220_)
+    case(_zz_229)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -5030,7 +4068,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_210_)
+    case(_zz_219)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5044,7 +4082,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_210_)
+    case(_zz_219)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5063,12 +4101,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_288_) + $signed(_zz_289_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_297) + $signed(_zz_298));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_192_)begin
-      if(_zz_211_)begin
+    if(_zz_201)begin
+      if(_zz_220)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -5076,7 +4114,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_212_)begin
+    if(_zz_221)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -5087,59 +4125,59 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_293_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_302);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_141_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_141_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_294_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_295_ : _zz_296_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_297_[31:0];
-  assign _zz_142_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_143_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_144_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_140 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_140[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_303);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_304 : _zz_305);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_306[31:0];
+  assign _zz_141 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_142 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_143 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_145_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_145_[31 : 0] = execute_RS1;
+    _zz_144[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_144[31 : 0] = execute_RS1;
   end
 
-  assign _zz_147_ = (_zz_146_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_147_ != 32'h0);
-  assign _zz_26_ = decode_SRC1_CTRL;
-  assign _zz_24_ = _zz_49_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_23_ = decode_SRC2_CTRL;
-  assign _zz_21_ = _zz_44_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_20_ = decode_ALU_CTRL;
-  assign _zz_18_ = _zz_43_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign _zz_17_ = decode_ENV_CTRL;
-  assign _zz_14_ = execute_ENV_CTRL;
-  assign _zz_12_ = memory_ENV_CTRL;
-  assign _zz_15_ = _zz_46_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_10_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_8_ = _zz_45_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_7_ = decode_SHIFT_CTRL;
-  assign _zz_4_ = execute_SHIFT_CTRL;
-  assign _zz_5_ = _zz_47_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_2_ = decode_BRANCH_CTRL;
-  assign _zz_52_ = _zz_48_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_146 = (_zz_145 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_146 != 32'h0);
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_51 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -5157,116 +4195,116 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_148_ = 32'h0;
+    _zz_147 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_148_[12 : 0] = 13'h1000;
-      _zz_148_[25 : 20] = 6'h20;
+      _zz_147[12 : 0] = 13'h1000;
+      _zz_147[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_149_ = 32'h0;
+    _zz_148 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_149_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_149_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_149_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_148[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_148[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_148[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_150_ = 32'h0;
+    _zz_149 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_150_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_150_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_150_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_149[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_149[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_149[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_151_ = 32'h0;
+    _zz_150 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_151_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_151_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_151_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_150[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_150[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_150[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_152_ = 32'h0;
+    _zz_151 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_152_[31 : 0] = CsrPlugin_mepc;
+      _zz_151[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_153_ = 32'h0;
+    _zz_152 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_153_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_153_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_152[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_152[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_154_ = 32'h0;
+    _zz_153 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_154_[31 : 0] = CsrPlugin_mtval;
+      _zz_153[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_155_ = 32'h0;
+    _zz_154 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_155_[31 : 0] = _zz_146_;
+      _zz_154[31 : 0] = _zz_145;
     end
   end
 
   always @ (*) begin
-    _zz_156_ = 32'h0;
+    _zz_155 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_156_[31 : 0] = _zz_147_;
+      _zz_155[31 : 0] = _zz_146;
     end
   end
 
-  assign execute_CsrPlugin_readData = ((((_zz_148_ | _zz_149_) | (_zz_150_ | _zz_151_)) | ((_zz_152_ | _zz_153_) | (_zz_154_ | _zz_155_))) | _zz_156_);
-  assign iBusWishbone_ADR = {_zz_313_,_zz_157_};
-  assign iBusWishbone_CTI = ((_zz_157_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = ((((_zz_147 | _zz_148) | (_zz_149 | _zz_150)) | ((_zz_151 | _zz_152) | (_zz_153 | _zz_154))) | _zz_155);
+  assign iBusWishbone_ADR = {_zz_322,_zz_156};
+  assign iBusWishbone_CTI = ((_zz_156 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_213_)begin
+    if(_zz_222)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_213_)begin
+    if(_zz_222)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_158_;
+  assign iBus_rsp_valid = _zz_157;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_164_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_160_ = dBus_cmd_valid;
-  assign _zz_162_ = dBus_cmd_payload_wr;
-  assign _zz_163_ = (_zz_159_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_161_ && (_zz_162_ || _zz_163_));
-  assign dBusWishbone_ADR = ((_zz_164_ ? {{dBus_cmd_payload_address[31 : 5],_zz_159_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_164_ ? (_zz_163_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_162_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_162_;
+  assign _zz_163 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_159 = dBus_cmd_valid;
+  assign _zz_161 = dBus_cmd_payload_wr;
+  assign _zz_162 = (_zz_158 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_160 && (_zz_161 || _zz_162));
+  assign dBusWishbone_ADR = ((_zz_163 ? {{dBus_cmd_payload_address[31 : 5],_zz_158},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_163 ? (_zz_162 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_161 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_161;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_161_ = (_zz_160_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_160_;
-  assign dBusWishbone_STB = _zz_160_;
-  assign dBus_rsp_valid = _zz_165_;
+  assign _zz_160 = (_zz_159 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_159;
+  assign dBusWishbone_STB = _zz_159;
+  assign dBus_rsp_valid = _zz_164;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -5275,24 +4313,24 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_65_ <= 1'b0;
-      _zz_67_ <= 1'b0;
+      _zz_64 <= 1'b0;
+      _zz_66 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_80_;
+      IBusCachedPlugin_rspCounter <= _zz_79;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_81_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_80;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_99_ <= 1'b1;
-      _zz_111_ <= 1'b0;
+      _zz_98 <= 1'b1;
+      _zz_110 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -5307,16 +4345,14 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_146_ <= 32'h0;
+      _zz_145 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_157_ <= (3'b000);
-      _zz_158_ <= 1'b0;
-      _zz_159_ <= (3'b000);
-      _zz_165_ <= 1'b0;
+      _zz_156 <= 3'b000;
+      _zz_157 <= 1'b0;
+      _zz_158 <= 3'b000;
+      _zz_164 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -5338,16 +4374,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65_ <= 1'b0;
+        _zz_64 <= 1'b0;
       end
-      if(_zz_63_)begin
-        _zz_65_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_62)begin
+        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67_ <= 1'b0;
+        _zz_66 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_67_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_66 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -5394,20 +4430,20 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_214_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_223)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_99_ <= 1'b0;
-      _zz_111_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_98 <= 1'b0;
+      _zz_110 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -5429,14 +4465,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_215_)begin
-        if(_zz_216_)begin
+      if(_zz_224)begin
+        if(_zz_225)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_217_)begin
+        if(_zz_226)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_218_)begin
+        if(_zz_227)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -5460,7 +4496,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_198_)begin
+      if(_zz_207)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5471,10 +4507,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_199_)begin
-        case(_zz_200_)
+      if(_zz_208)begin
+        case(_zz_209)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -5482,14 +4518,8 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_138_,{_zz_137_,_zz_136_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_137,{_zz_136,_zz_135}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -5511,41 +4541,41 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_307_[0];
-          CsrPlugin_mstatus_MIE <= _zz_308_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_316[0];
+          CsrPlugin_mstatus_MIE <= _zz_317[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_310_[0];
-          CsrPlugin_mie_MTIE <= _zz_311_[0];
-          CsrPlugin_mie_MSIE <= _zz_312_[0];
+          CsrPlugin_mie_MEIE <= _zz_319[0];
+          CsrPlugin_mie_MTIE <= _zz_320[0];
+          CsrPlugin_mie_MSIE <= _zz_321[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_146_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_145 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_213_)begin
+      if(_zz_222)begin
         if(iBusWishbone_ACK)begin
-          _zz_157_ <= (_zz_157_ + (3'b001));
+          _zz_156 <= (_zz_156 + 3'b001);
         end
       end
-      _zz_158_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_160_ && _zz_161_))begin
-        _zz_159_ <= (_zz_159_ + (3'b001));
-        if(_zz_163_)begin
-          _zz_159_ <= (3'b000);
+      _zz_157 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_159 && _zz_160))begin
+        _zz_158 <= (_zz_158 + 3'b001);
+        if(_zz_162)begin
+          _zz_158 <= 3'b000;
         end
       end
-      _zz_165_ <= ((_zz_160_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_164 <= ((_zz_159 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_68_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_67 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -5553,24 +4583,26 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_214_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_223)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_112_ <= _zz_40_[11 : 7];
-    _zz_113_ <= _zz_50_;
+    _zz_111 <= _zz_40[11 : 7];
+    _zz_112 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -5578,9 +4610,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_197_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_140_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_140_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_206)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -5594,21 +4626,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_215_)begin
-      if(_zz_216_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_224)begin
+      if(_zz_225)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_217_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_226)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_218_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_227)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_198_)begin
+    if(_zz_207)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5628,96 +4660,57 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_192_)begin
-      if(_zz_211_)begin
+    if(_zz_201)begin
+      if(_zz_220)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_298_[31:0];
+          memory_DivPlugin_div_result <= _zz_307[31:0];
         end
       end
     end
-    if(_zz_212_)begin
+    if(_zz_221)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_144_ ? (~ _zz_145_) : _zz_145_) + _zz_304_);
-      memory_DivPlugin_rs2 <= ((_zz_143_ ? (~ execute_RS2) : execute_RS2) + _zz_306_);
-      memory_DivPlugin_div_needRevert <= ((_zz_144_ ^ (_zz_143_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_143 ? (~ _zz_144) : _zz_144) + _zz_313);
+      memory_DivPlugin_rs2 <= ((_zz_142 ? (~ execute_RS2) : execute_RS2) + _zz_315);
+      memory_DivPlugin_div_needRevert <= ((_zz_143 ^ (_zz_142 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      execute_to_memory_PC <= _zz_35;
+    end
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_22_;
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_19_;
+      decode_to_execute_SRC1_CTRL <= _zz_25;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_16_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_13_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_11_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_9_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -5728,17 +4721,29 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_CTRL <= _zz_22;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_6_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_3_;
+      decode_to_execute_SRC2_CTRL <= _zz_19;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_1_;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
@@ -5750,19 +4755,73 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_RS1 <= decode_RS1;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
@@ -5770,8 +4829,11 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
@@ -5780,46 +4842,25 @@ module VexRiscv (
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_54_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
     if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
       execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -5853,7 +4894,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_309_[0];
+        CsrPlugin_mip_MSIP <= _zz_318[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -5869,6 +4910,1092 @@ module VexRiscv (
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire       [0:0]    _zz_19;
+  wire       [0:0]    _zz_20;
+  wire       [9:0]    _zz_21;
+  wire       [9:0]    _zz_22;
+  wire       [0:0]    _zz_23;
+  wire       [0:0]    _zz_24;
+  wire       [2:0]    _zz_25;
+  wire       [1:0]    _zz_26;
+  wire       [21:0]   _zz_27;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  wire                stage0_isAmo;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire                stageA_isAmo;
+  wire                stageA_isLrsc;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  wire                stageB_isAmo;
+  wire                stageB_isAmoCached;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  wire       [31:0]   stageB_requestDataBypass;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_28;
+  reg [7:0] _zz_29;
+  reg [7:0] _zz_30;
+  reg [7:0] _zz_31;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign _zz_17 = (! stageB_flusher_hold);
+  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_19 = _zz_4[0 : 0];
+  assign _zz_20 = _zz_4[1 : 1];
+  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_23 = 1'b1;
+  assign _zz_24 = loader_counter_willIncrement;
+  assign _zz_25 = {2'd0, _zz_24};
+  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_19[0];
+  assign ways_0_tagsReadRsp_error = _zz_20[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_23[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign stage0_isAmo = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign stageA_isAmo = 1'b0;
+  assign stageA_isLrsc = 1'b0;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_16)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isAmo = 1'b0;
+  assign stageB_isAmoCached = 1'b0;
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  assign stageB_requestDataBypass = stageB_request_data;
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          io_mem_cmd_valid = (! memCmdSent);
+        end else begin
+          if(_zz_16)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_14)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_25);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_17)begin
+        if(_zz_18)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_17)begin
+          if(! _zz_18) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_14)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_26[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_9;
+  reg        [21:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [21:0]   _zz_15;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_11 = (! lineLoader_flushCounter[7]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_9 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_10 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_11)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_12)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_11)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_12)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
   end
 
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Debug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Debug.v
@@ -1,7 +1,12 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:37:50
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
+
+`define EnvCtrlEnum_defaultEncoding_type [1:0]
+`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
+`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
+`define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
 
 `define BranchCtrlEnum_defaultEncoding_type [1:0]
 `define BranchCtrlEnum_defaultEncoding_INC 2'b00
@@ -15,21 +20,10 @@
 `define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
 `define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
-
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
 `define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
 `define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
 `define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
-
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -37,1023 +31,17 @@
 `define Src2CtrlEnum_defaultEncoding_IMS 2'b10
 `define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
-`define EnvCtrlEnum_defaultEncoding_type [1:0]
-`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
-`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
-`define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_10_,
-  input      [31:0]   _zz_11_,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_12_;
-  reg        [31:0]   _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire       [0:0]    _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [21:0]   _zz_18_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-
-  assign _zz_14_ = (! lineLoader_flushCounter[7]);
-  assign _zz_15_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_16_ = _zz_7_[0 : 0];
-  assign _zz_17_ = _zz_7_[1 : 1];
-  assign _zz_18_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_18_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_12_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_13_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_14_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_12_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_16_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_17_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_13_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_15_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_14_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_15_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-    if((_zz_10_ != (3'b000)))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_11_;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [0:0]    _zz_18_;
-  wire       [0:0]    _zz_19_;
-  wire       [2:0]    _zz_20_;
-  wire       [1:0]    _zz_21_;
-  wire       [21:0]   _zz_22_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  wire       [31:0]   stageB_requestDataBypass;
-  wire                stageB_isAmo;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_23_;
-  reg [7:0] _zz_24_;
-  reg [7:0] _zz_25_;
-  reg [7:0] _zz_26_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmo)));
-  assign _zz_15_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_16_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_17_ = _zz_4_[0 : 0];
-  assign _zz_18_ = _zz_4_[1 : 1];
-  assign _zz_19_ = loader_counter_willIncrement;
-  assign _zz_20_ = {2'd0, _zz_19_};
-  assign _zz_21_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_22_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_22_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_26_, _zz_25_, _zz_24_, _zz_23_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_23_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_24_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_25_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_26_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_17_[0];
-  assign ways_0_tagsReadRsp_error = _zz_18_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  assign stageB_requestDataBypass = stageB_request_data;
-  assign stageB_isAmo = 1'b0;
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((((! stageB_request_wr) || stageB_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0))))begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_15_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_20_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_16_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_16_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_15_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_21_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1076,8 +64,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1087,41 +75,46 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
   input               reset,
-  input               debugReset 
+  input               debugReset
 );
-  wire                _zz_169_;
-  wire                _zz_170_;
-  wire                _zz_171_;
-  wire                _zz_172_;
-  wire                _zz_173_;
-  wire                _zz_174_;
-  wire                _zz_175_;
-  reg                 _zz_176_;
-  wire                _zz_177_;
-  wire       [31:0]   _zz_178_;
-  wire                _zz_179_;
-  wire       [31:0]   _zz_180_;
-  reg                 _zz_181_;
-  wire                _zz_182_;
-  wire                _zz_183_;
-  wire       [31:0]   _zz_184_;
-  wire                _zz_185_;
-  wire                _zz_186_;
-  reg        [31:0]   _zz_187_;
-  reg        [31:0]   _zz_188_;
-  reg        [31:0]   _zz_189_;
+  wire                _zz_168;
+  wire                _zz_169;
+  wire                _zz_170;
+  wire                _zz_171;
+  wire                _zz_172;
+  wire                _zz_173;
+  wire                _zz_174;
+  wire                _zz_175;
+  reg                 _zz_176;
+  wire                _zz_177;
+  wire       [31:0]   _zz_178;
+  wire                _zz_179;
+  wire       [31:0]   _zz_180;
+  reg                 _zz_181;
+  wire                _zz_182;
+  wire                _zz_183;
+  wire       [31:0]   _zz_184;
+  wire                _zz_185;
+  wire                _zz_186;
+  wire                _zz_187;
+  wire                _zz_188;
+  wire                _zz_189;
+  wire                _zz_190;
+  wire                _zz_191;
+  wire                _zz_192;
+  wire       [3:0]    _zz_193;
+  wire                _zz_194;
+  wire                _zz_195;
+  reg        [31:0]   _zz_196;
+  reg        [31:0]   _zz_197;
+  reg        [31:0]   _zz_198;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -1131,407 +124,412 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_190_;
-  wire                _zz_191_;
-  wire                _zz_192_;
-  wire                _zz_193_;
-  wire                _zz_194_;
-  wire                _zz_195_;
-  wire                _zz_196_;
-  wire                _zz_197_;
-  wire                _zz_198_;
-  wire                _zz_199_;
-  wire                _zz_200_;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire                _zz_203_;
-  wire                _zz_204_;
-  wire                _zz_205_;
-  wire       [1:0]    _zz_206_;
-  wire                _zz_207_;
-  wire                _zz_208_;
-  wire                _zz_209_;
-  wire                _zz_210_;
-  wire                _zz_211_;
-  wire                _zz_212_;
-  wire                _zz_213_;
-  wire                _zz_214_;
-  wire                _zz_215_;
-  wire       [1:0]    _zz_216_;
-  wire                _zz_217_;
-  wire                _zz_218_;
-  wire       [5:0]    _zz_219_;
-  wire                _zz_220_;
-  wire                _zz_221_;
-  wire                _zz_222_;
-  wire                _zz_223_;
-  wire                _zz_224_;
-  wire                _zz_225_;
-  wire       [1:0]    _zz_226_;
-  wire                _zz_227_;
-  wire       [1:0]    _zz_228_;
-  wire       [51:0]   _zz_229_;
-  wire       [51:0]   _zz_230_;
-  wire       [51:0]   _zz_231_;
-  wire       [32:0]   _zz_232_;
-  wire       [51:0]   _zz_233_;
-  wire       [49:0]   _zz_234_;
-  wire       [51:0]   _zz_235_;
-  wire       [49:0]   _zz_236_;
-  wire       [51:0]   _zz_237_;
-  wire       [0:0]    _zz_238_;
-  wire       [32:0]   _zz_239_;
-  wire       [31:0]   _zz_240_;
-  wire       [32:0]   _zz_241_;
-  wire       [0:0]    _zz_242_;
-  wire       [0:0]    _zz_243_;
-  wire       [0:0]    _zz_244_;
-  wire       [0:0]    _zz_245_;
-  wire       [0:0]    _zz_246_;
-  wire       [0:0]    _zz_247_;
-  wire       [0:0]    _zz_248_;
-  wire       [0:0]    _zz_249_;
-  wire       [0:0]    _zz_250_;
-  wire       [0:0]    _zz_251_;
-  wire       [0:0]    _zz_252_;
-  wire       [0:0]    _zz_253_;
-  wire       [0:0]    _zz_254_;
-  wire       [0:0]    _zz_255_;
-  wire       [0:0]    _zz_256_;
-  wire       [0:0]    _zz_257_;
-  wire       [0:0]    _zz_258_;
-  wire       [3:0]    _zz_259_;
-  wire       [2:0]    _zz_260_;
-  wire       [31:0]   _zz_261_;
-  wire       [11:0]   _zz_262_;
-  wire       [31:0]   _zz_263_;
-  wire       [19:0]   _zz_264_;
-  wire       [11:0]   _zz_265_;
-  wire       [31:0]   _zz_266_;
-  wire       [31:0]   _zz_267_;
-  wire       [19:0]   _zz_268_;
-  wire       [11:0]   _zz_269_;
-  wire       [2:0]    _zz_270_;
-  wire       [2:0]    _zz_271_;
-  wire       [0:0]    _zz_272_;
-  wire       [2:0]    _zz_273_;
-  wire       [4:0]    _zz_274_;
-  wire       [11:0]   _zz_275_;
-  wire       [11:0]   _zz_276_;
-  wire       [31:0]   _zz_277_;
-  wire       [31:0]   _zz_278_;
-  wire       [31:0]   _zz_279_;
-  wire       [31:0]   _zz_280_;
-  wire       [31:0]   _zz_281_;
-  wire       [31:0]   _zz_282_;
-  wire       [31:0]   _zz_283_;
-  wire       [11:0]   _zz_284_;
-  wire       [19:0]   _zz_285_;
-  wire       [11:0]   _zz_286_;
-  wire       [31:0]   _zz_287_;
-  wire       [31:0]   _zz_288_;
-  wire       [31:0]   _zz_289_;
-  wire       [11:0]   _zz_290_;
-  wire       [19:0]   _zz_291_;
-  wire       [11:0]   _zz_292_;
-  wire       [2:0]    _zz_293_;
-  wire       [1:0]    _zz_294_;
-  wire       [1:0]    _zz_295_;
-  wire       [65:0]   _zz_296_;
-  wire       [65:0]   _zz_297_;
-  wire       [31:0]   _zz_298_;
-  wire       [31:0]   _zz_299_;
-  wire       [0:0]    _zz_300_;
-  wire       [5:0]    _zz_301_;
-  wire       [32:0]   _zz_302_;
-  wire       [31:0]   _zz_303_;
-  wire       [31:0]   _zz_304_;
-  wire       [32:0]   _zz_305_;
-  wire       [32:0]   _zz_306_;
-  wire       [32:0]   _zz_307_;
-  wire       [32:0]   _zz_308_;
-  wire       [0:0]    _zz_309_;
-  wire       [32:0]   _zz_310_;
-  wire       [0:0]    _zz_311_;
-  wire       [32:0]   _zz_312_;
-  wire       [0:0]    _zz_313_;
-  wire       [31:0]   _zz_314_;
-  wire       [0:0]    _zz_315_;
-  wire       [0:0]    _zz_316_;
-  wire       [0:0]    _zz_317_;
-  wire       [0:0]    _zz_318_;
-  wire       [0:0]    _zz_319_;
-  wire       [0:0]    _zz_320_;
-  wire       [26:0]   _zz_321_;
-  wire                _zz_322_;
-  wire                _zz_323_;
-  wire       [1:0]    _zz_324_;
-  wire       [31:0]   _zz_325_;
-  wire       [31:0]   _zz_326_;
-  wire       [31:0]   _zz_327_;
-  wire                _zz_328_;
-  wire       [0:0]    _zz_329_;
-  wire       [13:0]   _zz_330_;
-  wire       [31:0]   _zz_331_;
-  wire       [31:0]   _zz_332_;
-  wire       [31:0]   _zz_333_;
-  wire                _zz_334_;
-  wire       [0:0]    _zz_335_;
-  wire       [7:0]    _zz_336_;
-  wire       [31:0]   _zz_337_;
-  wire       [31:0]   _zz_338_;
-  wire       [31:0]   _zz_339_;
-  wire                _zz_340_;
-  wire       [0:0]    _zz_341_;
-  wire       [1:0]    _zz_342_;
-  wire                _zz_343_;
-  wire                _zz_344_;
-  wire                _zz_345_;
-  wire       [31:0]   _zz_346_;
-  wire       [31:0]   _zz_347_;
-  wire       [31:0]   _zz_348_;
-  wire                _zz_349_;
-  wire       [3:0]    _zz_350_;
-  wire       [3:0]    _zz_351_;
-  wire                _zz_352_;
-  wire       [0:0]    _zz_353_;
-  wire       [26:0]   _zz_354_;
-  wire       [31:0]   _zz_355_;
-  wire       [31:0]   _zz_356_;
-  wire                _zz_357_;
-  wire       [0:0]    _zz_358_;
-  wire       [0:0]    _zz_359_;
-  wire       [31:0]   _zz_360_;
-  wire       [31:0]   _zz_361_;
-  wire                _zz_362_;
-  wire       [1:0]    _zz_363_;
-  wire       [1:0]    _zz_364_;
-  wire                _zz_365_;
-  wire       [0:0]    _zz_366_;
-  wire       [23:0]   _zz_367_;
-  wire       [31:0]   _zz_368_;
-  wire       [31:0]   _zz_369_;
-  wire       [31:0]   _zz_370_;
-  wire       [31:0]   _zz_371_;
-  wire                _zz_372_;
-  wire       [0:0]    _zz_373_;
-  wire       [0:0]    _zz_374_;
-  wire       [5:0]    _zz_375_;
-  wire       [5:0]    _zz_376_;
-  wire                _zz_377_;
-  wire       [0:0]    _zz_378_;
-  wire       [20:0]   _zz_379_;
-  wire       [31:0]   _zz_380_;
-  wire       [31:0]   _zz_381_;
-  wire                _zz_382_;
-  wire       [0:0]    _zz_383_;
-  wire       [2:0]    _zz_384_;
-  wire       [31:0]   _zz_385_;
-  wire       [31:0]   _zz_386_;
-  wire                _zz_387_;
-  wire       [1:0]    _zz_388_;
-  wire       [1:0]    _zz_389_;
-  wire                _zz_390_;
-  wire       [0:0]    _zz_391_;
-  wire       [17:0]   _zz_392_;
-  wire       [31:0]   _zz_393_;
-  wire       [31:0]   _zz_394_;
-  wire       [31:0]   _zz_395_;
-  wire                _zz_396_;
-  wire                _zz_397_;
-  wire       [31:0]   _zz_398_;
-  wire       [31:0]   _zz_399_;
-  wire       [31:0]   _zz_400_;
-  wire       [31:0]   _zz_401_;
-  wire                _zz_402_;
-  wire       [0:0]    _zz_403_;
-  wire       [0:0]    _zz_404_;
-  wire                _zz_405_;
-  wire       [0:0]    _zz_406_;
-  wire       [0:0]    _zz_407_;
-  wire                _zz_408_;
-  wire       [0:0]    _zz_409_;
-  wire       [14:0]   _zz_410_;
-  wire       [31:0]   _zz_411_;
-  wire       [31:0]   _zz_412_;
-  wire       [31:0]   _zz_413_;
-  wire       [31:0]   _zz_414_;
-  wire       [31:0]   _zz_415_;
-  wire       [31:0]   _zz_416_;
-  wire       [31:0]   _zz_417_;
-  wire       [31:0]   _zz_418_;
-  wire       [31:0]   _zz_419_;
-  wire       [31:0]   _zz_420_;
-  wire       [0:0]    _zz_421_;
-  wire       [0:0]    _zz_422_;
-  wire       [0:0]    _zz_423_;
-  wire       [0:0]    _zz_424_;
-  wire                _zz_425_;
-  wire       [0:0]    _zz_426_;
-  wire       [12:0]   _zz_427_;
-  wire       [31:0]   _zz_428_;
-  wire       [31:0]   _zz_429_;
-  wire       [31:0]   _zz_430_;
-  wire       [0:0]    _zz_431_;
-  wire       [0:0]    _zz_432_;
-  wire                _zz_433_;
-  wire       [0:0]    _zz_434_;
-  wire       [8:0]    _zz_435_;
-  wire                _zz_436_;
-  wire       [0:0]    _zz_437_;
-  wire       [1:0]    _zz_438_;
-  wire                _zz_439_;
-  wire       [0:0]    _zz_440_;
-  wire       [2:0]    _zz_441_;
-  wire       [0:0]    _zz_442_;
-  wire       [1:0]    _zz_443_;
-  wire       [1:0]    _zz_444_;
-  wire       [1:0]    _zz_445_;
-  wire                _zz_446_;
-  wire       [0:0]    _zz_447_;
-  wire       [3:0]    _zz_448_;
-  wire       [31:0]   _zz_449_;
-  wire       [31:0]   _zz_450_;
-  wire       [31:0]   _zz_451_;
-  wire                _zz_452_;
-  wire                _zz_453_;
-  wire       [31:0]   _zz_454_;
-  wire                _zz_455_;
-  wire       [0:0]    _zz_456_;
-  wire       [0:0]    _zz_457_;
-  wire       [31:0]   _zz_458_;
-  wire       [31:0]   _zz_459_;
-  wire                _zz_460_;
-  wire                _zz_461_;
-  wire                _zz_462_;
-  wire                _zz_463_;
-  wire                _zz_464_;
-  wire       [1:0]    _zz_465_;
-  wire       [1:0]    _zz_466_;
-  wire                _zz_467_;
-  wire       [0:0]    _zz_468_;
-  wire       [1:0]    _zz_469_;
-  wire       [31:0]   _zz_470_;
-  wire       [31:0]   _zz_471_;
-  wire       [31:0]   _zz_472_;
-  wire       [31:0]   _zz_473_;
-  wire       [31:0]   _zz_474_;
-  wire       [31:0]   _zz_475_;
-  wire       [31:0]   _zz_476_;
-  wire       [31:0]   _zz_477_;
-  wire       [31:0]   _zz_478_;
-  wire       [31:0]   _zz_479_;
-  wire       [31:0]   _zz_480_;
-  wire       [31:0]   _zz_481_;
-  wire                _zz_482_;
-  wire                _zz_483_;
-  wire       [0:0]    _zz_484_;
-  wire       [1:0]    _zz_485_;
-  wire       [1:0]    _zz_486_;
-  wire       [1:0]    _zz_487_;
-  wire                _zz_488_;
-  wire                _zz_489_;
-  wire       [31:0]   _zz_490_;
-  wire       [31:0]   _zz_491_;
-  wire       [31:0]   _zz_492_;
-  wire       [31:0]   _zz_493_;
-  wire       [31:0]   _zz_494_;
-  wire       [31:0]   _zz_495_;
-  wire       [31:0]   _zz_496_;
-  wire                _zz_497_;
-  wire       [31:0]   _zz_498_;
-  wire       [31:0]   _zz_499_;
-  wire                _zz_500_;
-  wire                _zz_501_;
-  wire                _zz_502_;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_199;
+  wire                _zz_200;
+  wire                _zz_201;
+  wire                _zz_202;
+  wire                _zz_203;
+  wire                _zz_204;
+  wire                _zz_205;
+  wire                _zz_206;
+  wire                _zz_207;
+  wire                _zz_208;
+  wire                _zz_209;
+  wire                _zz_210;
+  wire                _zz_211;
+  wire                _zz_212;
+  wire                _zz_213;
+  wire                _zz_214;
+  wire       [1:0]    _zz_215;
+  wire                _zz_216;
+  wire                _zz_217;
+  wire                _zz_218;
+  wire                _zz_219;
+  wire                _zz_220;
+  wire                _zz_221;
+  wire                _zz_222;
+  wire                _zz_223;
+  wire                _zz_224;
+  wire       [1:0]    _zz_225;
+  wire                _zz_226;
+  wire                _zz_227;
+  wire       [5:0]    _zz_228;
+  wire                _zz_229;
+  wire                _zz_230;
+  wire                _zz_231;
+  wire                _zz_232;
+  wire                _zz_233;
+  wire                _zz_234;
+  wire       [1:0]    _zz_235;
+  wire                _zz_236;
+  wire       [1:0]    _zz_237;
+  wire       [51:0]   _zz_238;
+  wire       [51:0]   _zz_239;
+  wire       [51:0]   _zz_240;
+  wire       [32:0]   _zz_241;
+  wire       [51:0]   _zz_242;
+  wire       [49:0]   _zz_243;
+  wire       [51:0]   _zz_244;
+  wire       [49:0]   _zz_245;
+  wire       [51:0]   _zz_246;
+  wire       [32:0]   _zz_247;
+  wire       [31:0]   _zz_248;
+  wire       [32:0]   _zz_249;
+  wire       [0:0]    _zz_250;
+  wire       [0:0]    _zz_251;
+  wire       [0:0]    _zz_252;
+  wire       [0:0]    _zz_253;
+  wire       [0:0]    _zz_254;
+  wire       [0:0]    _zz_255;
+  wire       [0:0]    _zz_256;
+  wire       [0:0]    _zz_257;
+  wire       [0:0]    _zz_258;
+  wire       [0:0]    _zz_259;
+  wire       [0:0]    _zz_260;
+  wire       [0:0]    _zz_261;
+  wire       [0:0]    _zz_262;
+  wire       [0:0]    _zz_263;
+  wire       [0:0]    _zz_264;
+  wire       [0:0]    _zz_265;
+  wire       [0:0]    _zz_266;
+  wire       [0:0]    _zz_267;
+  wire       [3:0]    _zz_268;
+  wire       [2:0]    _zz_269;
+  wire       [31:0]   _zz_270;
+  wire       [11:0]   _zz_271;
+  wire       [31:0]   _zz_272;
+  wire       [19:0]   _zz_273;
+  wire       [11:0]   _zz_274;
+  wire       [31:0]   _zz_275;
+  wire       [31:0]   _zz_276;
+  wire       [19:0]   _zz_277;
+  wire       [11:0]   _zz_278;
+  wire       [2:0]    _zz_279;
+  wire       [2:0]    _zz_280;
+  wire       [0:0]    _zz_281;
+  wire       [2:0]    _zz_282;
+  wire       [4:0]    _zz_283;
+  wire       [11:0]   _zz_284;
+  wire       [11:0]   _zz_285;
+  wire       [31:0]   _zz_286;
+  wire       [31:0]   _zz_287;
+  wire       [31:0]   _zz_288;
+  wire       [31:0]   _zz_289;
+  wire       [31:0]   _zz_290;
+  wire       [31:0]   _zz_291;
+  wire       [31:0]   _zz_292;
+  wire       [11:0]   _zz_293;
+  wire       [19:0]   _zz_294;
+  wire       [11:0]   _zz_295;
+  wire       [31:0]   _zz_296;
+  wire       [31:0]   _zz_297;
+  wire       [31:0]   _zz_298;
+  wire       [11:0]   _zz_299;
+  wire       [19:0]   _zz_300;
+  wire       [11:0]   _zz_301;
+  wire       [2:0]    _zz_302;
+  wire       [1:0]    _zz_303;
+  wire       [1:0]    _zz_304;
+  wire       [65:0]   _zz_305;
+  wire       [65:0]   _zz_306;
+  wire       [31:0]   _zz_307;
+  wire       [31:0]   _zz_308;
+  wire       [0:0]    _zz_309;
+  wire       [5:0]    _zz_310;
+  wire       [32:0]   _zz_311;
+  wire       [31:0]   _zz_312;
+  wire       [31:0]   _zz_313;
+  wire       [32:0]   _zz_314;
+  wire       [32:0]   _zz_315;
+  wire       [32:0]   _zz_316;
+  wire       [32:0]   _zz_317;
+  wire       [0:0]    _zz_318;
+  wire       [32:0]   _zz_319;
+  wire       [0:0]    _zz_320;
+  wire       [32:0]   _zz_321;
+  wire       [0:0]    _zz_322;
+  wire       [31:0]   _zz_323;
+  wire       [0:0]    _zz_324;
+  wire       [0:0]    _zz_325;
+  wire       [0:0]    _zz_326;
+  wire       [0:0]    _zz_327;
+  wire       [0:0]    _zz_328;
+  wire       [0:0]    _zz_329;
+  wire       [26:0]   _zz_330;
+  wire                _zz_331;
+  wire                _zz_332;
+  wire       [1:0]    _zz_333;
+  wire       [31:0]   _zz_334;
+  wire       [31:0]   _zz_335;
+  wire       [31:0]   _zz_336;
+  wire                _zz_337;
+  wire       [0:0]    _zz_338;
+  wire       [13:0]   _zz_339;
+  wire       [31:0]   _zz_340;
+  wire       [31:0]   _zz_341;
+  wire       [31:0]   _zz_342;
+  wire                _zz_343;
+  wire       [0:0]    _zz_344;
+  wire       [7:0]    _zz_345;
+  wire       [31:0]   _zz_346;
+  wire       [31:0]   _zz_347;
+  wire       [31:0]   _zz_348;
+  wire                _zz_349;
+  wire       [0:0]    _zz_350;
+  wire       [1:0]    _zz_351;
+  wire                _zz_352;
+  wire                _zz_353;
+  wire                _zz_354;
+  wire       [31:0]   _zz_355;
+  wire       [0:0]    _zz_356;
+  wire       [0:0]    _zz_357;
+  wire                _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [26:0]   _zz_360;
+  wire       [31:0]   _zz_361;
+  wire       [31:0]   _zz_362;
+  wire       [31:0]   _zz_363;
+  wire                _zz_364;
+  wire       [1:0]    _zz_365;
+  wire       [1:0]    _zz_366;
+  wire                _zz_367;
+  wire       [0:0]    _zz_368;
+  wire       [22:0]   _zz_369;
+  wire       [31:0]   _zz_370;
+  wire       [31:0]   _zz_371;
+  wire       [31:0]   _zz_372;
+  wire       [31:0]   _zz_373;
+  wire                _zz_374;
+  wire                _zz_375;
+  wire       [1:0]    _zz_376;
+  wire       [1:0]    _zz_377;
+  wire                _zz_378;
+  wire       [0:0]    _zz_379;
+  wire       [19:0]   _zz_380;
+  wire       [31:0]   _zz_381;
+  wire       [31:0]   _zz_382;
+  wire       [31:0]   _zz_383;
+  wire       [31:0]   _zz_384;
+  wire                _zz_385;
+  wire       [0:0]    _zz_386;
+  wire       [0:0]    _zz_387;
+  wire                _zz_388;
+  wire       [0:0]    _zz_389;
+  wire       [0:0]    _zz_390;
+  wire                _zz_391;
+  wire       [0:0]    _zz_392;
+  wire       [16:0]   _zz_393;
+  wire       [31:0]   _zz_394;
+  wire       [31:0]   _zz_395;
+  wire       [31:0]   _zz_396;
+  wire       [31:0]   _zz_397;
+  wire       [31:0]   _zz_398;
+  wire       [0:0]    _zz_399;
+  wire       [0:0]    _zz_400;
+  wire       [0:0]    _zz_401;
+  wire       [0:0]    _zz_402;
+  wire                _zz_403;
+  wire       [0:0]    _zz_404;
+  wire       [13:0]   _zz_405;
+  wire       [31:0]   _zz_406;
+  wire       [31:0]   _zz_407;
+  wire       [31:0]   _zz_408;
+  wire                _zz_409;
+  wire                _zz_410;
+  wire       [0:0]    _zz_411;
+  wire       [1:0]    _zz_412;
+  wire       [0:0]    _zz_413;
+  wire       [0:0]    _zz_414;
+  wire                _zz_415;
+  wire       [0:0]    _zz_416;
+  wire       [10:0]   _zz_417;
+  wire       [31:0]   _zz_418;
+  wire       [31:0]   _zz_419;
+  wire       [31:0]   _zz_420;
+  wire       [31:0]   _zz_421;
+  wire       [31:0]   _zz_422;
+  wire       [31:0]   _zz_423;
+  wire                _zz_424;
+  wire       [0:0]    _zz_425;
+  wire       [2:0]    _zz_426;
+  wire       [0:0]    _zz_427;
+  wire       [3:0]    _zz_428;
+  wire       [5:0]    _zz_429;
+  wire       [5:0]    _zz_430;
+  wire                _zz_431;
+  wire       [0:0]    _zz_432;
+  wire       [7:0]    _zz_433;
+  wire       [31:0]   _zz_434;
+  wire                _zz_435;
+  wire       [0:0]    _zz_436;
+  wire       [0:0]    _zz_437;
+  wire                _zz_438;
+  wire       [0:0]    _zz_439;
+  wire       [1:0]    _zz_440;
+  wire       [0:0]    _zz_441;
+  wire       [3:0]    _zz_442;
+  wire       [0:0]    _zz_443;
+  wire       [0:0]    _zz_444;
+  wire       [1:0]    _zz_445;
+  wire       [1:0]    _zz_446;
+  wire                _zz_447;
+  wire       [0:0]    _zz_448;
+  wire       [5:0]    _zz_449;
+  wire       [31:0]   _zz_450;
+  wire       [31:0]   _zz_451;
+  wire       [31:0]   _zz_452;
+  wire       [31:0]   _zz_453;
+  wire       [31:0]   _zz_454;
+  wire       [31:0]   _zz_455;
+  wire       [31:0]   _zz_456;
+  wire       [31:0]   _zz_457;
+  wire                _zz_458;
+  wire                _zz_459;
+  wire       [31:0]   _zz_460;
+  wire       [31:0]   _zz_461;
+  wire                _zz_462;
+  wire       [0:0]    _zz_463;
+  wire       [1:0]    _zz_464;
+  wire       [31:0]   _zz_465;
+  wire       [31:0]   _zz_466;
+  wire                _zz_467;
+  wire                _zz_468;
+  wire       [0:0]    _zz_469;
+  wire       [0:0]    _zz_470;
+  wire                _zz_471;
+  wire       [0:0]    _zz_472;
+  wire       [3:0]    _zz_473;
+  wire       [31:0]   _zz_474;
+  wire       [31:0]   _zz_475;
+  wire       [31:0]   _zz_476;
+  wire       [31:0]   _zz_477;
+  wire       [31:0]   _zz_478;
+  wire                _zz_479;
+  wire                _zz_480;
+  wire       [31:0]   _zz_481;
+  wire       [31:0]   _zz_482;
+  wire       [31:0]   _zz_483;
+  wire       [31:0]   _zz_484;
+  wire       [0:0]    _zz_485;
+  wire       [2:0]    _zz_486;
+  wire       [0:0]    _zz_487;
+  wire       [0:0]    _zz_488;
+  wire                _zz_489;
+  wire       [0:0]    _zz_490;
+  wire       [1:0]    _zz_491;
+  wire       [31:0]   _zz_492;
+  wire       [31:0]   _zz_493;
+  wire       [31:0]   _zz_494;
+  wire                _zz_495;
+  wire                _zz_496;
+  wire       [31:0]   _zz_497;
+  wire                _zz_498;
+  wire       [0:0]    _zz_499;
+  wire       [0:0]    _zz_500;
+  wire       [0:0]    _zz_501;
+  wire       [0:0]    _zz_502;
+  wire       [1:0]    _zz_503;
+  wire       [1:0]    _zz_504;
+  wire       [0:0]    _zz_505;
+  wire       [0:0]    _zz_506;
+  wire       [31:0]   _zz_507;
+  wire       [31:0]   _zz_508;
+  wire       [31:0]   _zz_509;
+  wire       [31:0]   _zz_510;
+  wire       [31:0]   _zz_511;
+  wire       [31:0]   _zz_512;
+  wire                _zz_513;
+  wire                _zz_514;
+  wire                _zz_515;
+  wire       [51:0]   memory_MUL_LOW;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
   wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_DO_EBREAK;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire       [33:0]   execute_MUL_LH;
-  wire                decode_CSR_READ_OPCODE;
-  wire       [51:0]   memory_MUL_LOW;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_2_;
-  wire                memory_MEMORY_WR;
-  wire                decode_MEMORY_WR;
-  wire       [31:0]   execute_SHIFT_RIGHT;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_3_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                decode_IS_RS1_SIGNED;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire                decode_DO_EBREAK;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       [31:0]   execute_MUL_LL;
-  wire       [33:0]   memory_MUL_HH;
-  wire       [33:0]   execute_MUL_HH;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire                decode_MEMORY_MANAGMENT;
   wire       [31:0]   memory_PC;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19_;
-  wire                memory_IS_MUL;
-  wire                execute_IS_MUL;
-  wire                decode_IS_MUL;
-  wire       [33:0]   execute_MUL_HL;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26_;
-  wire                decode_IS_CSR;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire                decode_IS_DIV;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire                decode_IS_RS2_SIGNED;
-  wire                execute_BRANCH_DO;
-  wire                decode_CSR_WRITE_OPCODE;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -1548,11 +546,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -1560,10 +558,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1573,49 +571,50 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49_;
-  reg        [31:0]   _zz_50_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
@@ -1624,15 +623,15 @@ module VexRiscv (
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_51_;
-  reg                 _zz_51__2;
-  reg                 _zz_51__1;
-  reg                 _zz_51__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53_;
-  reg        [31:0]   _zz_54_;
+  reg        [31:0]   _zz_52;
+  reg        [31:0]   _zz_53;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -1697,28 +696,47 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                DBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -1726,7 +744,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_55_;
+  reg                 _zz_54;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -1758,11 +776,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_56_;
-  wire       [3:0]    _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
-  wire                _zz_60_;
+  wire       [3:0]    _zz_55;
+  wire       [3:0]    _zz_56;
+  wire                _zz_57;
+  wire                _zz_58;
+  wire                _zz_59;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -1799,16 +817,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_61_;
-  wire                _zz_62_;
-  wire                _zz_63_;
+  wire                _zz_60;
+  wire                _zz_61;
+  wire                _zz_62;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_64_;
-  wire                _zz_65_;
-  reg                 _zz_66_;
-  wire                _zz_67_;
-  reg                 _zz_68_;
-  reg        [31:0]   _zz_69_;
+  wire                _zz_63;
+  wire                _zz_64;
+  reg                 _zz_65;
+  wire                _zz_66;
+  reg                 _zz_67;
+  reg        [31:0]   _zz_68;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1821,17 +839,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_70_;
-  reg        [18:0]   _zz_71_;
-  wire                _zz_72_;
-  reg        [10:0]   _zz_73_;
-  wire                _zz_74_;
-  reg        [18:0]   _zz_75_;
-  reg                 _zz_76_;
-  wire                _zz_77_;
-  reg        [10:0]   _zz_78_;
-  wire                _zz_79_;
-  reg        [18:0]   _zz_80_;
+  wire                _zz_69;
+  reg        [18:0]   _zz_70;
+  wire                _zz_71;
+  reg        [10:0]   _zz_72;
+  wire                _zz_73;
+  reg        [18:0]   _zz_74;
+  reg                 _zz_75;
+  wire                _zz_76;
+  reg        [10:0]   _zz_77;
+  wire                _zz_78;
+  reg        [18:0]   _zz_79;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1839,7 +857,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_81_;
+  wire       [31:0]   _zz_80;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1847,122 +865,115 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_82_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_81;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_83_;
+  reg        [31:0]   _zz_82;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_84_;
-  reg        [31:0]   _zz_85_;
-  wire                _zz_86_;
-  reg        [31:0]   _zz_87_;
+  wire                _zz_83;
+  reg        [31:0]   _zz_84;
+  wire                _zz_85;
+  reg        [31:0]   _zz_86;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [32:0]   _zz_88_;
-  wire                _zz_89_;
-  wire                _zz_90_;
-  wire                _zz_91_;
-  wire                _zz_92_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_93_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_94_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_95_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_96_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_97_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_98_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_99_;
+  wire       [32:0]   _zz_87;
+  wire                _zz_88;
+  wire                _zz_89;
+  wire                _zz_90;
+  wire                _zz_91;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_92;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_93;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_94;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_95;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_96;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_97;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_98;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_100_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_99;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_101_;
-  reg        [31:0]   _zz_102_;
-  wire                _zz_103_;
-  reg        [19:0]   _zz_104_;
-  wire                _zz_105_;
-  reg        [19:0]   _zz_106_;
-  reg        [31:0]   _zz_107_;
+  reg        [31:0]   _zz_100;
+  reg        [31:0]   _zz_101;
+  wire                _zz_102;
+  reg        [19:0]   _zz_103;
+  wire                _zz_104;
+  reg        [19:0]   _zz_105;
+  reg        [31:0]   _zz_106;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_108_;
+  reg        [31:0]   _zz_107;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_109_;
-  reg                 _zz_110_;
-  reg                 _zz_111_;
-  reg                 _zz_112_;
-  reg        [4:0]    _zz_113_;
-  reg        [31:0]   _zz_114_;
-  wire                _zz_115_;
-  wire                _zz_116_;
-  wire                _zz_117_;
-  wire                _zz_118_;
-  wire                _zz_119_;
-  wire                _zz_120_;
+  reg        [31:0]   _zz_108;
+  reg                 _zz_109;
+  reg                 _zz_110;
+  reg                 _zz_111;
+  reg        [4:0]    _zz_112;
+  reg        [31:0]   _zz_113;
+  wire                _zz_114;
+  wire                _zz_115;
+  wire                _zz_116;
+  wire                _zz_117;
+  wire                _zz_118;
+  wire                _zz_119;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_121_;
-  reg                 _zz_122_;
-  reg                 _zz_123_;
-  wire                _zz_124_;
-  reg        [19:0]   _zz_125_;
-  wire                _zz_126_;
-  reg        [10:0]   _zz_127_;
-  wire                _zz_128_;
-  reg        [18:0]   _zz_129_;
-  reg                 _zz_130_;
+  wire       [2:0]    _zz_120;
+  reg                 _zz_121;
+  reg                 _zz_122;
+  wire                _zz_123;
+  reg        [19:0]   _zz_124;
+  wire                _zz_125;
+  reg        [10:0]   _zz_126;
+  wire                _zz_127;
+  reg        [18:0]   _zz_128;
+  reg                 _zz_129;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_131_;
-  reg        [19:0]   _zz_132_;
-  wire                _zz_133_;
-  reg        [10:0]   _zz_134_;
-  wire                _zz_135_;
-  reg        [18:0]   _zz_136_;
+  wire                _zz_130;
+  reg        [19:0]   _zz_131;
+  wire                _zz_132;
+  reg        [10:0]   _zz_133;
+  wire                _zz_134;
+  reg        [18:0]   _zz_135;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
@@ -1983,9 +994,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_137_;
-  wire                _zz_138_;
-  wire                _zz_139_;
+  wire                _zz_136;
+  wire                _zz_137;
+  wire                _zz_138;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1998,8 +1009,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_140_;
-  wire                _zz_141_;
+  wire       [1:0]    _zz_139;
+  wire                _zz_140;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -2011,7 +1022,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2052,18 +1063,18 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_142_;
+  wire       [31:0]   _zz_141;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_143_;
-  wire                _zz_144_;
-  wire                _zz_145_;
-  reg        [32:0]   _zz_146_;
+  wire       [31:0]   _zz_142;
+  wire                _zz_143;
+  wire                _zz_144;
+  reg        [32:0]   _zz_145;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_147_;
-  wire       [31:0]   _zz_148_;
+  reg        [31:0]   _zz_146;
+  wire       [31:0]   _zz_147;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -2073,72 +1084,73 @@ module VexRiscv (
   reg                 DebugPlugin_godmode;
   reg                 DebugPlugin_haltedByBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_149_;
+  reg                 _zz_148;
   wire                DebugPlugin_allowEBreak;
   reg                 DebugPlugin_resetIt_regNext;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_PC;
+  reg        [31:0]   execute_to_memory_PC;
+  reg        [31:0]   memory_to_writeBack_PC;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
+  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
   reg                 decode_to_execute_IS_CSR;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg        [33:0]   execute_to_memory_MUL_HL;
   reg                 decode_to_execute_IS_MUL;
   reg                 execute_to_memory_IS_MUL;
   reg                 memory_to_writeBack_IS_MUL;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg        [31:0]   decode_to_execute_PC;
-  reg        [31:0]   execute_to_memory_PC;
-  reg        [31:0]   memory_to_writeBack_PC;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg        [31:0]   execute_to_memory_MUL_LL;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        [31:0]   decode_to_execute_INSTRUCTION;
-  reg        [31:0]   execute_to_memory_INSTRUCTION;
-  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg                 decode_to_execute_DO_EBREAK;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
   reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 decode_to_execute_MEMORY_WR;
-  reg                 execute_to_memory_MEMORY_WR;
-  reg                 memory_to_writeBack_MEMORY_WR;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [33:0]   execute_to_memory_MUL_LH;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_DO_EBREAK;
   reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
   reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg        [2:0]    _zz_150_;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  reg        [2:0]    _zz_149;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
@@ -2149,590 +1161,665 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_835;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_151_;
-  reg        [31:0]   _zz_152_;
-  reg        [31:0]   _zz_153_;
-  reg        [31:0]   _zz_154_;
-  reg        [31:0]   _zz_155_;
-  reg        [31:0]   _zz_156_;
-  reg        [31:0]   _zz_157_;
-  reg        [31:0]   _zz_158_;
-  reg        [31:0]   _zz_159_;
-  reg        [2:0]    _zz_160_;
-  reg                 _zz_161_;
+  reg        [31:0]   _zz_150;
+  reg        [31:0]   _zz_151;
+  reg        [31:0]   _zz_152;
+  reg        [31:0]   _zz_153;
+  reg        [31:0]   _zz_154;
+  reg        [31:0]   _zz_155;
+  reg        [31:0]   _zz_156;
+  reg        [31:0]   _zz_157;
+  reg        [31:0]   _zz_158;
+  reg        [2:0]    _zz_159;
+  reg                 _zz_160;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_162_;
-  wire                _zz_163_;
-  wire                _zz_164_;
-  wire                _zz_165_;
-  wire                _zz_166_;
-  wire                _zz_167_;
-  reg                 _zz_168_;
+  reg        [2:0]    _zz_161;
+  wire                _zz_162;
+  wire                _zz_163;
+  wire                _zz_164;
+  wire                _zz_165;
+  wire                _zz_166;
+  reg                 _zz_167;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [31:0] _zz_1__string;
-  reg [31:0] _zz_2__string;
-  reg [71:0] _zz_3__string;
-  reg [71:0] _zz_4__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_5__string;
-  reg [71:0] _zz_6__string;
-  reg [71:0] _zz_7__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_8__string;
-  reg [95:0] _zz_9__string;
-  reg [95:0] _zz_10__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_11__string;
-  reg [39:0] _zz_12__string;
-  reg [39:0] _zz_13__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_14__string;
-  reg [63:0] _zz_15__string;
-  reg [63:0] _zz_16__string;
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_17__string;
-  reg [23:0] _zz_18__string;
-  reg [23:0] _zz_19__string;
-  reg [39:0] _zz_20__string;
-  reg [39:0] _zz_21__string;
-  reg [39:0] _zz_22__string;
-  reg [39:0] _zz_23__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_24__string;
-  reg [39:0] _zz_25__string;
-  reg [39:0] _zz_26__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [39:0] _zz_43__string;
-  reg [39:0] _zz_44__string;
-  reg [23:0] _zz_45__string;
-  reg [63:0] _zz_46__string;
-  reg [71:0] _zz_47__string;
-  reg [31:0] _zz_48__string;
-  reg [95:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52__string;
-  reg [95:0] _zz_93__string;
-  reg [31:0] _zz_94__string;
-  reg [71:0] _zz_95__string;
-  reg [63:0] _zz_96__string;
-  reg [23:0] _zz_97__string;
-  reg [39:0] _zz_98__string;
-  reg [39:0] _zz_99__string;
-  reg [39:0] decode_to_execute_ENV_CTRL_string;
-  reg [39:0] execute_to_memory_ENV_CTRL_string;
-  reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [63:0] decode_to_execute_ALU_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [31:0] _zz_51_string;
+  reg [95:0] _zz_92_string;
+  reg [63:0] _zz_93_string;
+  reg [23:0] _zz_94_string;
+  reg [39:0] _zz_95_string;
+  reg [71:0] _zz_96_string;
+  reg [31:0] _zz_97_string;
+  reg [39:0] _zz_98_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
+  reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
   reg [71:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
+  reg [39:0] decode_to_execute_ENV_CTRL_string;
+  reg [39:0] execute_to_memory_ENV_CTRL_string;
+  reg [39:0] memory_to_writeBack_ENV_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_190_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_191_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_192_ = 1'b1;
-  assign _zz_193_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_194_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_195_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_196_ = ((_zz_173_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_51__2));
-  assign _zz_197_ = ((_zz_173_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_51__1));
-  assign _zz_198_ = ((_zz_173_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_51__0));
-  assign _zz_199_ = ((_zz_173_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_200_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_201_ = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_202_ = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00)) == 1'b0);
-  assign _zz_203_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_204_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_205_ = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_206_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_207_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_208_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_209_ = (1'b0 || (! 1'b1));
-  assign _zz_210_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_211_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_212_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_213_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_214_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_215_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_216_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_217_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_218_ = (! memory_arbitration_isStuck);
-  assign _zz_219_ = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_220_ = (iBus_cmd_valid || (_zz_160_ != (3'b000)));
-  assign _zz_221_ = (_zz_186_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_222_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_223_ = ((_zz_137_ && 1'b1) && (! 1'b0));
-  assign _zz_224_ = ((_zz_138_ && 1'b1) && (! 1'b0));
-  assign _zz_225_ = ((_zz_139_ && 1'b1) && (! 1'b0));
-  assign _zz_226_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_227_ = execute_INSTRUCTION[13];
-  assign _zz_228_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_229_ = ($signed(_zz_230_) + $signed(_zz_235_));
-  assign _zz_230_ = ($signed(_zz_231_) + $signed(_zz_233_));
-  assign _zz_231_ = 52'h0;
-  assign _zz_232_ = {1'b0,memory_MUL_LL};
-  assign _zz_233_ = {{19{_zz_232_[32]}}, _zz_232_};
-  assign _zz_234_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_235_ = {{2{_zz_234_[49]}}, _zz_234_};
-  assign _zz_236_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_237_ = {{2{_zz_236_[49]}}, _zz_236_};
-  assign _zz_238_ = _zz_88_[5 : 5];
-  assign _zz_239_ = ($signed(_zz_241_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_240_ = _zz_239_[31 : 0];
-  assign _zz_241_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_242_ = _zz_88_[10 : 10];
-  assign _zz_243_ = _zz_88_[9 : 9];
-  assign _zz_244_ = _zz_88_[8 : 8];
-  assign _zz_245_ = _zz_88_[6 : 6];
-  assign _zz_246_ = _zz_88_[17 : 17];
-  assign _zz_247_ = _zz_88_[13 : 13];
-  assign _zz_248_ = _zz_88_[24 : 24];
-  assign _zz_249_ = _zz_88_[14 : 14];
-  assign _zz_250_ = _zz_88_[12 : 12];
-  assign _zz_251_ = _zz_88_[18 : 18];
-  assign _zz_252_ = _zz_88_[4 : 4];
-  assign _zz_253_ = _zz_88_[29 : 29];
-  assign _zz_254_ = _zz_88_[3 : 3];
-  assign _zz_255_ = _zz_88_[11 : 11];
-  assign _zz_256_ = _zz_88_[23 : 23];
-  assign _zz_257_ = _zz_88_[32 : 32];
-  assign _zz_258_ = _zz_88_[0 : 0];
-  assign _zz_259_ = (_zz_56_ - (4'b0001));
-  assign _zz_260_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_261_ = {29'd0, _zz_260_};
-  assign _zz_262_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_263_ = {{_zz_71_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_264_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_265_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_266_ = {{_zz_73_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_267_ = {{_zz_75_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_268_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_269_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_270_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_271_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_272_ = execute_SRC_LESS;
-  assign _zz_273_ = (3'b100);
-  assign _zz_274_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_275_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_276_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_277_ = ($signed(_zz_278_) + $signed(_zz_281_));
-  assign _zz_278_ = ($signed(_zz_279_) + $signed(_zz_280_));
-  assign _zz_279_ = execute_SRC1;
-  assign _zz_280_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_281_ = (execute_SRC_USE_SUB_LESS ? _zz_282_ : _zz_283_);
-  assign _zz_282_ = 32'h00000001;
-  assign _zz_283_ = 32'h0;
-  assign _zz_284_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_285_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_286_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_287_ = {_zz_125_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_288_ = {{_zz_127_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_289_ = {{_zz_129_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_290_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_291_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_292_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_293_ = (3'b100);
-  assign _zz_294_ = (_zz_140_ & (~ _zz_295_));
-  assign _zz_295_ = (_zz_140_ - (2'b01));
-  assign _zz_296_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_297_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_298_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_299_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_300_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_301_ = {5'd0, _zz_300_};
-  assign _zz_302_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_303_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_304_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_305_ = {_zz_142_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_306_ = _zz_307_;
-  assign _zz_307_ = _zz_308_;
-  assign _zz_308_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_143_) : _zz_143_)} + _zz_310_);
-  assign _zz_309_ = memory_DivPlugin_div_needRevert;
-  assign _zz_310_ = {32'd0, _zz_309_};
-  assign _zz_311_ = _zz_145_;
-  assign _zz_312_ = {32'd0, _zz_311_};
-  assign _zz_313_ = _zz_144_;
-  assign _zz_314_ = {31'd0, _zz_313_};
-  assign _zz_315_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_316_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_317_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_318_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_319_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_320_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_321_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_322_ = 1'b1;
-  assign _zz_323_ = 1'b1;
-  assign _zz_324_ = {_zz_60_,_zz_59_};
-  assign _zz_325_ = 32'h0000107f;
-  assign _zz_326_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_327_ = 32'h00002073;
-  assign _zz_328_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_329_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_330_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_331_) == 32'h00000003),{(_zz_332_ == _zz_333_),{_zz_334_,{_zz_335_,_zz_336_}}}}}};
-  assign _zz_331_ = 32'h0000505f;
-  assign _zz_332_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_333_ = 32'h00000063;
-  assign _zz_334_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_335_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_336_ = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_337_) == 32'h00001013),{(_zz_338_ == _zz_339_),{_zz_340_,{_zz_341_,_zz_342_}}}}}};
-  assign _zz_337_ = 32'hfc00307f;
-  assign _zz_338_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_339_ = 32'h00005033;
-  assign _zz_340_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_341_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_342_ = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
-  assign _zz_343_ = decode_INSTRUCTION[31];
-  assign _zz_344_ = decode_INSTRUCTION[31];
-  assign _zz_345_ = decode_INSTRUCTION[7];
-  assign _zz_346_ = 32'h00000058;
-  assign _zz_347_ = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_348_ = 32'h00001000;
-  assign _zz_349_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_350_ = {(_zz_355_ == _zz_356_),{_zz_357_,{_zz_358_,_zz_359_}}};
-  assign _zz_351_ = (4'b0000);
-  assign _zz_352_ = ((_zz_360_ == _zz_361_) != (1'b0));
-  assign _zz_353_ = (_zz_362_ != (1'b0));
-  assign _zz_354_ = {(_zz_363_ != _zz_364_),{_zz_365_,{_zz_366_,_zz_367_}}};
-  assign _zz_355_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_356_ = 32'h0;
-  assign _zz_357_ = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_358_ = ((decode_INSTRUCTION & _zz_368_) == 32'h00002000);
-  assign _zz_359_ = ((decode_INSTRUCTION & _zz_369_) == 32'h00001000);
-  assign _zz_360_ = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz_361_ = 32'h00000050;
-  assign _zz_362_ = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz_363_ = {_zz_90_,(_zz_370_ == _zz_371_)};
-  assign _zz_364_ = (2'b00);
-  assign _zz_365_ = ({_zz_90_,_zz_372_} != (2'b00));
-  assign _zz_366_ = ({_zz_373_,_zz_374_} != (2'b00));
-  assign _zz_367_ = {(_zz_375_ != _zz_376_),{_zz_377_,{_zz_378_,_zz_379_}}};
-  assign _zz_368_ = 32'h00006004;
-  assign _zz_369_ = 32'h00005004;
-  assign _zz_370_ = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_371_ = 32'h00000020;
-  assign _zz_372_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz_373_ = ((decode_INSTRUCTION & _zz_380_) == 32'h00001050);
-  assign _zz_374_ = ((decode_INSTRUCTION & _zz_381_) == 32'h00002050);
-  assign _zz_375_ = {_zz_92_,{_zz_382_,{_zz_383_,_zz_384_}}};
-  assign _zz_376_ = 6'h0;
-  assign _zz_377_ = ((_zz_385_ == _zz_386_) != (1'b0));
-  assign _zz_378_ = (_zz_387_ != (1'b0));
-  assign _zz_379_ = {(_zz_388_ != _zz_389_),{_zz_390_,{_zz_391_,_zz_392_}}};
-  assign _zz_380_ = 32'h00001050;
-  assign _zz_381_ = 32'h00002050;
-  assign _zz_382_ = ((decode_INSTRUCTION & 32'h00001010) == 32'h00001010);
-  assign _zz_383_ = ((decode_INSTRUCTION & _zz_393_) == 32'h00002010);
-  assign _zz_384_ = {(_zz_394_ == _zz_395_),{_zz_396_,_zz_397_}};
-  assign _zz_385_ = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_386_ = 32'h00004010;
-  assign _zz_387_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz_388_ = {(_zz_398_ == _zz_399_),(_zz_400_ == _zz_401_)};
-  assign _zz_389_ = (2'b00);
-  assign _zz_390_ = ({_zz_402_,{_zz_403_,_zz_404_}} != (3'b000));
-  assign _zz_391_ = (_zz_405_ != (1'b0));
-  assign _zz_392_ = {(_zz_406_ != _zz_407_),{_zz_408_,{_zz_409_,_zz_410_}}};
-  assign _zz_393_ = 32'h00002010;
-  assign _zz_394_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_395_ = 32'h00000010;
-  assign _zz_396_ = ((decode_INSTRUCTION & _zz_411_) == 32'h00000004);
-  assign _zz_397_ = ((decode_INSTRUCTION & _zz_412_) == 32'h0);
-  assign _zz_398_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_399_ = 32'h00005010;
-  assign _zz_400_ = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_401_ = 32'h00005020;
-  assign _zz_402_ = ((decode_INSTRUCTION & _zz_413_) == 32'h40001010);
-  assign _zz_403_ = (_zz_414_ == _zz_415_);
-  assign _zz_404_ = (_zz_416_ == _zz_417_);
-  assign _zz_405_ = ((decode_INSTRUCTION & _zz_418_) == 32'h00100050);
-  assign _zz_406_ = (_zz_419_ == _zz_420_);
-  assign _zz_407_ = (1'b0);
-  assign _zz_408_ = ({_zz_421_,_zz_422_} != (2'b00));
-  assign _zz_409_ = (_zz_423_ != _zz_424_);
-  assign _zz_410_ = {_zz_425_,{_zz_426_,_zz_427_}};
-  assign _zz_411_ = 32'h0000000c;
-  assign _zz_412_ = 32'h00000028;
-  assign _zz_413_ = 32'h40003054;
-  assign _zz_414_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_415_ = 32'h00001010;
-  assign _zz_416_ = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_417_ = 32'h00001010;
-  assign _zz_418_ = 32'h10103050;
-  assign _zz_419_ = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz_420_ = 32'h00004008;
-  assign _zz_421_ = _zz_92_;
-  assign _zz_422_ = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_423_ = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_424_ = (1'b0);
-  assign _zz_425_ = (((decode_INSTRUCTION & _zz_428_) == 32'h02004020) != (1'b0));
-  assign _zz_426_ = ((_zz_429_ == _zz_430_) != (1'b0));
-  assign _zz_427_ = {(_zz_91_ != (1'b0)),{(_zz_431_ != _zz_432_),{_zz_433_,{_zz_434_,_zz_435_}}}};
-  assign _zz_428_ = 32'h02004064;
-  assign _zz_429_ = (decode_INSTRUCTION & 32'h02004074);
-  assign _zz_430_ = 32'h02000030;
-  assign _zz_431_ = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_432_ = (1'b0);
-  assign _zz_433_ = (_zz_91_ != (1'b0));
-  assign _zz_434_ = ({_zz_90_,{_zz_436_,{_zz_437_,_zz_438_}}} != 5'h0);
-  assign _zz_435_ = {({_zz_439_,{_zz_440_,_zz_441_}} != 5'h0),{({_zz_442_,_zz_443_} != (3'b000)),{(_zz_444_ != _zz_445_),{_zz_446_,{_zz_447_,_zz_448_}}}}};
-  assign _zz_436_ = ((decode_INSTRUCTION & _zz_449_) == 32'h00002010);
-  assign _zz_437_ = (_zz_450_ == _zz_451_);
-  assign _zz_438_ = {_zz_452_,_zz_453_};
-  assign _zz_439_ = ((decode_INSTRUCTION & _zz_454_) == 32'h00000040);
-  assign _zz_440_ = _zz_90_;
-  assign _zz_441_ = {_zz_455_,{_zz_456_,_zz_457_}};
-  assign _zz_442_ = (_zz_458_ == _zz_459_);
-  assign _zz_443_ = {_zz_460_,_zz_461_};
-  assign _zz_444_ = {_zz_462_,_zz_463_};
-  assign _zz_445_ = (2'b00);
-  assign _zz_446_ = (_zz_464_ != (1'b0));
-  assign _zz_447_ = (_zz_465_ != _zz_466_);
-  assign _zz_448_ = {_zz_467_,{_zz_468_,_zz_469_}};
-  assign _zz_449_ = 32'h00002030;
-  assign _zz_450_ = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_451_ = 32'h00000010;
-  assign _zz_452_ = ((decode_INSTRUCTION & _zz_470_) == 32'h00002020);
-  assign _zz_453_ = ((decode_INSTRUCTION & _zz_471_) == 32'h00000020);
-  assign _zz_454_ = 32'h00000040;
-  assign _zz_455_ = ((decode_INSTRUCTION & _zz_472_) == 32'h00004020);
-  assign _zz_456_ = (_zz_473_ == _zz_474_);
-  assign _zz_457_ = (_zz_475_ == _zz_476_);
-  assign _zz_458_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_459_ = 32'h00000040;
-  assign _zz_460_ = ((decode_INSTRUCTION & _zz_477_) == 32'h0);
-  assign _zz_461_ = ((decode_INSTRUCTION & _zz_478_) == 32'h00000040);
-  assign _zz_462_ = ((decode_INSTRUCTION & _zz_479_) == 32'h00002000);
-  assign _zz_463_ = ((decode_INSTRUCTION & _zz_480_) == 32'h00001000);
-  assign _zz_464_ = ((decode_INSTRUCTION & _zz_481_) == 32'h00000020);
-  assign _zz_465_ = {_zz_482_,_zz_483_};
-  assign _zz_466_ = (2'b00);
-  assign _zz_467_ = ({_zz_484_,_zz_485_} != (3'b000));
-  assign _zz_468_ = (_zz_486_ != _zz_487_);
-  assign _zz_469_ = {_zz_488_,_zz_489_};
-  assign _zz_470_ = 32'h02002060;
-  assign _zz_471_ = 32'h02003020;
-  assign _zz_472_ = 32'h00004020;
-  assign _zz_473_ = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_474_ = 32'h00000010;
-  assign _zz_475_ = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_476_ = 32'h00000020;
-  assign _zz_477_ = 32'h00000038;
-  assign _zz_478_ = 32'h00103040;
-  assign _zz_479_ = 32'h00002010;
-  assign _zz_480_ = 32'h00005000;
-  assign _zz_481_ = 32'h00000020;
-  assign _zz_482_ = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_483_ = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_484_ = ((decode_INSTRUCTION & _zz_490_) == 32'h00000040);
-  assign _zz_485_ = {(_zz_491_ == _zz_492_),(_zz_493_ == _zz_494_)};
-  assign _zz_486_ = {(_zz_495_ == _zz_496_),_zz_89_};
-  assign _zz_487_ = (2'b00);
-  assign _zz_488_ = ({_zz_497_,_zz_89_} != (2'b00));
-  assign _zz_489_ = ((_zz_498_ == _zz_499_) != (1'b0));
-  assign _zz_490_ = 32'h00000044;
-  assign _zz_491_ = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_492_ = 32'h00002010;
-  assign _zz_493_ = (decode_INSTRUCTION & 32'h40000034);
-  assign _zz_494_ = 32'h40000030;
-  assign _zz_495_ = (decode_INSTRUCTION & 32'h00000014);
-  assign _zz_496_ = 32'h00000004;
-  assign _zz_497_ = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_498_ = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz_499_ = 32'h00001008;
-  assign _zz_500_ = execute_INSTRUCTION[31];
-  assign _zz_501_ = execute_INSTRUCTION[31];
-  assign _zz_502_ = execute_INSTRUCTION[7];
+  assign _zz_199 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_200 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_201 = 1'b1;
+  assign _zz_202 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_203 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_204 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_205 = ((_zz_173 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_206 = ((_zz_173 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_207 = ((_zz_173 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_208 = ((_zz_173 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_209 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_210 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign _zz_211 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign _zz_212 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_213 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_214 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign _zz_215 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_216 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_217 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_218 = (1'b0 || (! 1'b1));
+  assign _zz_219 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_220 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_221 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_222 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_223 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_224 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_225 = execute_INSTRUCTION[13 : 12];
+  assign _zz_226 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_227 = (! memory_arbitration_isStuck);
+  assign _zz_228 = debug_bus_cmd_payload_address[7 : 2];
+  assign _zz_229 = (iBus_cmd_valid || (_zz_159 != 3'b000));
+  assign _zz_230 = (_zz_195 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_231 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_232 = ((_zz_136 && 1'b1) && (! 1'b0));
+  assign _zz_233 = ((_zz_137 && 1'b1) && (! 1'b0));
+  assign _zz_234 = ((_zz_138 && 1'b1) && (! 1'b0));
+  assign _zz_235 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_236 = execute_INSTRUCTION[13];
+  assign _zz_237 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_238 = ($signed(_zz_239) + $signed(_zz_244));
+  assign _zz_239 = ($signed(_zz_240) + $signed(_zz_242));
+  assign _zz_240 = 52'h0;
+  assign _zz_241 = {1'b0,memory_MUL_LL};
+  assign _zz_242 = {{19{_zz_241[32]}}, _zz_241};
+  assign _zz_243 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_244 = {{2{_zz_243[49]}}, _zz_243};
+  assign _zz_245 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_246 = {{2{_zz_245[49]}}, _zz_245};
+  assign _zz_247 = ($signed(_zz_249) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_248 = _zz_247[31 : 0];
+  assign _zz_249 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_250 = _zz_87[31 : 31];
+  assign _zz_251 = _zz_87[30 : 30];
+  assign _zz_252 = _zz_87[29 : 29];
+  assign _zz_253 = _zz_87[28 : 28];
+  assign _zz_254 = _zz_87[25 : 25];
+  assign _zz_255 = _zz_87[17 : 17];
+  assign _zz_256 = _zz_87[16 : 16];
+  assign _zz_257 = _zz_87[13 : 13];
+  assign _zz_258 = _zz_87[12 : 12];
+  assign _zz_259 = _zz_87[11 : 11];
+  assign _zz_260 = _zz_87[32 : 32];
+  assign _zz_261 = _zz_87[15 : 15];
+  assign _zz_262 = _zz_87[5 : 5];
+  assign _zz_263 = _zz_87[3 : 3];
+  assign _zz_264 = _zz_87[20 : 20];
+  assign _zz_265 = _zz_87[10 : 10];
+  assign _zz_266 = _zz_87[4 : 4];
+  assign _zz_267 = _zz_87[0 : 0];
+  assign _zz_268 = (_zz_55 - 4'b0001);
+  assign _zz_269 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_270 = {29'd0, _zz_269};
+  assign _zz_271 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_272 = {{_zz_70,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_273 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_274 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_275 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_276 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_277 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_278 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_279 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_280 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_281 = execute_SRC_LESS;
+  assign _zz_282 = 3'b100;
+  assign _zz_283 = execute_INSTRUCTION[19 : 15];
+  assign _zz_284 = execute_INSTRUCTION[31 : 20];
+  assign _zz_285 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_286 = ($signed(_zz_287) + $signed(_zz_290));
+  assign _zz_287 = ($signed(_zz_288) + $signed(_zz_289));
+  assign _zz_288 = execute_SRC1;
+  assign _zz_289 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_290 = (execute_SRC_USE_SUB_LESS ? _zz_291 : _zz_292);
+  assign _zz_291 = 32'h00000001;
+  assign _zz_292 = 32'h0;
+  assign _zz_293 = execute_INSTRUCTION[31 : 20];
+  assign _zz_294 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_295 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_296 = {_zz_124,execute_INSTRUCTION[31 : 20]};
+  assign _zz_297 = {{_zz_126,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_298 = {{_zz_128,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_299 = execute_INSTRUCTION[31 : 20];
+  assign _zz_300 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_301 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_302 = 3'b100;
+  assign _zz_303 = (_zz_139 & (~ _zz_304));
+  assign _zz_304 = (_zz_139 - 2'b01);
+  assign _zz_305 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_306 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_307 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_308 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_309 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_310 = {5'd0, _zz_309};
+  assign _zz_311 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_312 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_313 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_314 = {_zz_141,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_315 = _zz_316;
+  assign _zz_316 = _zz_317;
+  assign _zz_317 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_142) : _zz_142)} + _zz_319);
+  assign _zz_318 = memory_DivPlugin_div_needRevert;
+  assign _zz_319 = {32'd0, _zz_318};
+  assign _zz_320 = _zz_144;
+  assign _zz_321 = {32'd0, _zz_320};
+  assign _zz_322 = _zz_143;
+  assign _zz_323 = {31'd0, _zz_322};
+  assign _zz_324 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_325 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_326 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_327 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_328 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_329 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_330 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_331 = 1'b1;
+  assign _zz_332 = 1'b1;
+  assign _zz_333 = {_zz_59,_zz_58};
+  assign _zz_334 = 32'h0000107f;
+  assign _zz_335 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_336 = 32'h00002073;
+  assign _zz_337 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_338 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_339 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_340) == 32'h00000003),{(_zz_341 == _zz_342),{_zz_343,{_zz_344,_zz_345}}}}}};
+  assign _zz_340 = 32'h0000505f;
+  assign _zz_341 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_342 = 32'h00000063;
+  assign _zz_343 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_344 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_345 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_346) == 32'h00001013),{(_zz_347 == _zz_348),{_zz_349,{_zz_350,_zz_351}}}}}};
+  assign _zz_346 = 32'hfc00307f;
+  assign _zz_347 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_348 = 32'h00005033;
+  assign _zz_349 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_350 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_351 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
+  assign _zz_352 = decode_INSTRUCTION[31];
+  assign _zz_353 = decode_INSTRUCTION[31];
+  assign _zz_354 = decode_INSTRUCTION[7];
+  assign _zz_355 = 32'h10103050;
+  assign _zz_356 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz_357 = 1'b0;
+  assign _zz_358 = (((decode_INSTRUCTION & _zz_361) == 32'h02000030) != 1'b0);
+  assign _zz_359 = ((_zz_362 == _zz_363) != 1'b0);
+  assign _zz_360 = {(_zz_364 != 1'b0),{(_zz_365 != _zz_366),{_zz_367,{_zz_368,_zz_369}}}};
+  assign _zz_361 = 32'h02004074;
+  assign _zz_362 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz_363 = 32'h00000050;
+  assign _zz_364 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
+  assign _zz_365 = {(_zz_370 == _zz_371),(_zz_372 == _zz_373)};
+  assign _zz_366 = 2'b00;
+  assign _zz_367 = ({_zz_90,_zz_374} != 2'b00);
+  assign _zz_368 = (_zz_375 != 1'b0);
+  assign _zz_369 = {(_zz_376 != _zz_377),{_zz_378,{_zz_379,_zz_380}}};
+  assign _zz_370 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_371 = 32'h00001050;
+  assign _zz_372 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_373 = 32'h00002050;
+  assign _zz_374 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_375 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_376 = {(_zz_381 == _zz_382),(_zz_383 == _zz_384)};
+  assign _zz_377 = 2'b00;
+  assign _zz_378 = ({_zz_385,{_zz_386,_zz_387}} != 3'b000);
+  assign _zz_379 = (_zz_388 != 1'b0);
+  assign _zz_380 = {(_zz_389 != _zz_390),{_zz_391,{_zz_392,_zz_393}}};
+  assign _zz_381 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_382 = 32'h00005010;
+  assign _zz_383 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz_384 = 32'h00005020;
+  assign _zz_385 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz_386 = ((decode_INSTRUCTION & _zz_394) == 32'h00001010);
+  assign _zz_387 = ((decode_INSTRUCTION & _zz_395) == 32'h00001010);
+  assign _zz_388 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz_389 = ((decode_INSTRUCTION & _zz_396) == 32'h00001000);
+  assign _zz_390 = 1'b0;
+  assign _zz_391 = ((_zz_397 == _zz_398) != 1'b0);
+  assign _zz_392 = ({_zz_399,_zz_400} != 2'b00);
+  assign _zz_393 = {(_zz_401 != _zz_402),{_zz_403,{_zz_404,_zz_405}}};
+  assign _zz_394 = 32'h00007034;
+  assign _zz_395 = 32'h02007054;
+  assign _zz_396 = 32'h00001000;
+  assign _zz_397 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz_398 = 32'h00002000;
+  assign _zz_399 = ((decode_INSTRUCTION & _zz_406) == 32'h00002000);
+  assign _zz_400 = ((decode_INSTRUCTION & _zz_407) == 32'h00001000);
+  assign _zz_401 = ((decode_INSTRUCTION & _zz_408) == 32'h00004008);
+  assign _zz_402 = 1'b0;
+  assign _zz_403 = ({_zz_409,_zz_410} != 2'b00);
+  assign _zz_404 = ({_zz_411,_zz_412} != 3'b000);
+  assign _zz_405 = {(_zz_413 != _zz_414),{_zz_415,{_zz_416,_zz_417}}};
+  assign _zz_406 = 32'h00002010;
+  assign _zz_407 = 32'h00005000;
+  assign _zz_408 = 32'h00004048;
+  assign _zz_409 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz_410 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz_411 = ((decode_INSTRUCTION & _zz_418) == 32'h00000040);
+  assign _zz_412 = {(_zz_419 == _zz_420),(_zz_421 == _zz_422)};
+  assign _zz_413 = ((decode_INSTRUCTION & _zz_423) == 32'h00000020);
+  assign _zz_414 = 1'b0;
+  assign _zz_415 = ({_zz_424,{_zz_425,_zz_426}} != 5'h0);
+  assign _zz_416 = ({_zz_427,_zz_428} != 5'h0);
+  assign _zz_417 = {(_zz_429 != _zz_430),{_zz_431,{_zz_432,_zz_433}}};
+  assign _zz_418 = 32'h00000050;
+  assign _zz_419 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_420 = 32'h0;
+  assign _zz_421 = (decode_INSTRUCTION & 32'h00103040);
+  assign _zz_422 = 32'h00000040;
+  assign _zz_423 = 32'h00000020;
+  assign _zz_424 = ((decode_INSTRUCTION & _zz_434) == 32'h00000040);
+  assign _zz_425 = _zz_89;
+  assign _zz_426 = {_zz_435,{_zz_436,_zz_437}};
+  assign _zz_427 = _zz_89;
+  assign _zz_428 = {_zz_438,{_zz_439,_zz_440}};
+  assign _zz_429 = {_zz_90,{_zz_441,_zz_442}};
+  assign _zz_430 = 6'h0;
+  assign _zz_431 = ({_zz_443,_zz_444} != 2'b00);
+  assign _zz_432 = (_zz_445 != _zz_446);
+  assign _zz_433 = {_zz_447,{_zz_448,_zz_449}};
+  assign _zz_434 = 32'h00000040;
+  assign _zz_435 = ((decode_INSTRUCTION & _zz_450) == 32'h00004020);
+  assign _zz_436 = (_zz_451 == _zz_452);
+  assign _zz_437 = (_zz_453 == _zz_454);
+  assign _zz_438 = ((decode_INSTRUCTION & _zz_455) == 32'h00002010);
+  assign _zz_439 = (_zz_456 == _zz_457);
+  assign _zz_440 = {_zz_458,_zz_459};
+  assign _zz_441 = (_zz_460 == _zz_461);
+  assign _zz_442 = {_zz_462,{_zz_463,_zz_464}};
+  assign _zz_443 = _zz_89;
+  assign _zz_444 = (_zz_465 == _zz_466);
+  assign _zz_445 = {_zz_89,_zz_467};
+  assign _zz_446 = 2'b00;
+  assign _zz_447 = (_zz_468 != 1'b0);
+  assign _zz_448 = (_zz_469 != _zz_470);
+  assign _zz_449 = {_zz_471,{_zz_472,_zz_473}};
+  assign _zz_450 = 32'h00004020;
+  assign _zz_451 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_452 = 32'h00000010;
+  assign _zz_453 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz_454 = 32'h00000020;
+  assign _zz_455 = 32'h00002030;
+  assign _zz_456 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz_457 = 32'h00000010;
+  assign _zz_458 = ((decode_INSTRUCTION & _zz_474) == 32'h00002020);
+  assign _zz_459 = ((decode_INSTRUCTION & _zz_475) == 32'h00000020);
+  assign _zz_460 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_461 = 32'h00001010;
+  assign _zz_462 = ((decode_INSTRUCTION & _zz_476) == 32'h00002010);
+  assign _zz_463 = (_zz_477 == _zz_478);
+  assign _zz_464 = {_zz_479,_zz_480};
+  assign _zz_465 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_466 = 32'h00000020;
+  assign _zz_467 = ((decode_INSTRUCTION & _zz_481) == 32'h0);
+  assign _zz_468 = ((decode_INSTRUCTION & _zz_482) == 32'h00004010);
+  assign _zz_469 = (_zz_483 == _zz_484);
+  assign _zz_470 = 1'b0;
+  assign _zz_471 = ({_zz_485,_zz_486} != 4'b0000);
+  assign _zz_472 = (_zz_487 != _zz_488);
+  assign _zz_473 = {_zz_489,{_zz_490,_zz_491}};
+  assign _zz_474 = 32'h02002060;
+  assign _zz_475 = 32'h02003020;
+  assign _zz_476 = 32'h00002010;
+  assign _zz_477 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_478 = 32'h00000010;
+  assign _zz_479 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_480 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz_481 = 32'h00000020;
+  assign _zz_482 = 32'h00004014;
+  assign _zz_483 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_484 = 32'h00002010;
+  assign _zz_485 = ((decode_INSTRUCTION & _zz_492) == 32'h0);
+  assign _zz_486 = {(_zz_493 == _zz_494),{_zz_495,_zz_496}};
+  assign _zz_487 = ((decode_INSTRUCTION & _zz_497) == 32'h0);
+  assign _zz_488 = 1'b0;
+  assign _zz_489 = ({_zz_498,{_zz_499,_zz_500}} != 3'b000);
+  assign _zz_490 = ({_zz_501,_zz_502} != 2'b00);
+  assign _zz_491 = {(_zz_503 != _zz_504),(_zz_505 != _zz_506)};
+  assign _zz_492 = 32'h00000044;
+  assign _zz_493 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_494 = 32'h0;
+  assign _zz_495 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_496 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz_497 = 32'h00000058;
+  assign _zz_498 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_499 = ((decode_INSTRUCTION & _zz_507) == 32'h00002010);
+  assign _zz_500 = ((decode_INSTRUCTION & _zz_508) == 32'h40000030);
+  assign _zz_501 = ((decode_INSTRUCTION & _zz_509) == 32'h00000004);
+  assign _zz_502 = _zz_88;
+  assign _zz_503 = {(_zz_510 == _zz_511),_zz_88};
+  assign _zz_504 = 2'b00;
+  assign _zz_505 = ((decode_INSTRUCTION & _zz_512) == 32'h00001008);
+  assign _zz_506 = 1'b0;
+  assign _zz_507 = 32'h00002014;
+  assign _zz_508 = 32'h40000034;
+  assign _zz_509 = 32'h00000014;
+  assign _zz_510 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_511 = 32'h00000004;
+  assign _zz_512 = 32'h00005048;
+  assign _zz_513 = execute_INSTRUCTION[31];
+  assign _zz_514 = execute_INSTRUCTION[31];
+  assign _zz_515 = execute_INSTRUCTION[7];
   always @ (posedge clk) begin
-    if(_zz_322_) begin
-      _zz_187_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_331) begin
+      _zz_196 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_323_) begin
-      _zz_188_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_332) begin
+      _zz_197 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_169_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_170_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_171_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_172_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_173_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_174_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_175_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_176_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    ._zz_10_                                      (_zz_150_[2:0]                                                        ), //i
-    ._zz_11_                                      (IBusCachedPlugin_injectionPort_payload[31:0]                         ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_168                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_169                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_170                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_171                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_172                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_173                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_174                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_175                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_176                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    ._zz_9                                    (_zz_149[2:0]                                                ), //i
+    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_177_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_178_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (execute_MEMORY_WR                                           ), //i
-    .io_cpu_execute_args_data                      (_zz_83_[31:0]                                               ), //i
-    .io_cpu_execute_args_size                      (execute_DBusCachedPlugin_size[1:0]                          ), //i
-    .io_cpu_memory_isValid                         (_zz_179_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_180_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_181_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_182_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_183_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_184_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_185_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_186_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_177                                            ), //i
+    .io_cpu_execute_address                    (_zz_178[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
+    .io_cpu_execute_args_data                  (_zz_82[31:0]                                       ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_179                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_180[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_181                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_writeBack_isValid                  (_zz_182                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_183                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_184[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_185                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_186                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_187                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_188                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_189                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_190                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_191                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_192                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_193[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_194                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_195                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_324_)
+    case(_zz_333)
       2'b00 : begin
-        _zz_189_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_198 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_189_ = CsrPlugin_jumpInterface_payload;
+        _zz_198 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_189_ = BranchPlugin_jumpInterface_payload;
+        _zz_198 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_189_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_198 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_1__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_1__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_1__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_1__string = "JALR";
-      default : _zz_1__string = "????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_2__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_2__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_2__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_2__string = "JALR";
-      default : _zz_2__string = "????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_3__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_3__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_3__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_3__string = "SRA_1    ";
-      default : _zz_3__string = "?????????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_4__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_4__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_4__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_4__string = "SRA_1    ";
-      default : _zz_4__string = "?????????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
+      default : decode_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2745,66 +1832,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_5__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_5__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_5__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_5__string = "SRA_1    ";
-      default : _zz_5__string = "?????????";
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_6_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_6__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_6__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_6__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_6__string = "SRA_1    ";
-      default : _zz_6__string = "?????????";
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_7_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_7__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_7__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_7__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_7__string = "SRA_1    ";
-      default : _zz_7__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_8__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_8__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_8__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_8__string = "URS1        ";
-      default : _zz_8__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_9__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_9__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_9__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_9__string = "URS1        ";
-      default : _zz_9__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_10__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_10__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_10__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_10__string = "URS1        ";
-      default : _zz_10__string = "????????????";
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2816,59 +1867,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_11_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_11__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_11__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_11__string = "AND_1";
-      default : _zz_11__string = "?????";
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_12_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_12__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_12__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_12__string = "AND_1";
-      default : _zz_12__string = "?????";
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_13_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13__string = "AND_1";
-      default : _zz_13__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_14__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_14__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_14__string = "BITWISE ";
-      default : _zz_14__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_15__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_15__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_15__string = "BITWISE ";
-      default : _zz_15__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_16__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_16__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_16__string = "BITWISE ";
-      default : _zz_16__string = "????????";
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2881,94 +1900,98 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_17_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_17__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_17__string = "PC ";
-      default : _zz_17__string = "???";
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_18_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18__string = "PC ";
-      default : _zz_18__string = "???";
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19__string = "PC ";
-      default : _zz_19__string = "???";
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_20__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_20__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_20__string = "ECALL";
-      default : _zz_20__string = "?????";
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_21__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_21__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_21__string = "ECALL";
-      default : _zz_21__string = "?????";
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_22__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_22__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_22__string = "ECALL";
-      default : _zz_22__string = "?????";
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_23__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_23__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_23__string = "ECALL";
-      default : _zz_23__string = "?????";
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
     endcase
   end
   always @(*) begin
-    case(decode_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
-      default : decode_ENV_CTRL_string = "?????";
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_24__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_24__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_24__string = "ECALL";
-      default : _zz_24__string = "?????";
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_25__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_25__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_25__string = "ECALL";
-      default : _zz_25__string = "?????";
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26__string = "ECALL";
-      default : _zz_26__string = "?????";
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2980,11 +2003,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2996,11 +2019,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3012,11 +2035,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3029,12 +2052,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -3047,12 +2070,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3065,12 +2088,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3083,12 +2106,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -3101,12 +2124,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3118,11 +2141,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3134,71 +2157,71 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43__string = "AND_1";
-      default : _zz_43__string = "?????";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_44__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_44__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_44__string = "ECALL";
-      default : _zz_44__string = "?????";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_45__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_45__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_45__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_45__string = "PC ";
-      default : _zz_45__string = "???";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_46__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_46__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_46__string = "BITWISE ";
-      default : _zz_46__string = "????????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_47__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_47__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_47__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_47__string = "SRA_1    ";
-      default : _zz_47__string = "?????????";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_48__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_48__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_48__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_48__string = "JALR";
-      default : _zz_48__string = "????";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49__string = "URS1        ";
-      default : _zz_49__string = "????????????";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3211,96 +2234,89 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52__string = "JALR";
-      default : _zz_52__string = "????";
+    case(_zz_51)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
+      default : _zz_51_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_93_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_93__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_93__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_93__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_93__string = "URS1        ";
-      default : _zz_93__string = "????????????";
+    case(_zz_92)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_92_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_92_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_92_string = "URS1        ";
+      default : _zz_92_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_94_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_94__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_94__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_94__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_94__string = "JALR";
-      default : _zz_94__string = "????";
+    case(_zz_93)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_93_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_93_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_93_string = "BITWISE ";
+      default : _zz_93_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_95_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_95__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_95__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_95__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_95__string = "SRA_1    ";
-      default : _zz_95__string = "?????????";
+    case(_zz_94)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_94_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_94_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_94_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_94_string = "PC ";
+      default : _zz_94_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_96_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_96__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_96__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_96__string = "BITWISE ";
-      default : _zz_96__string = "????????";
+    case(_zz_95)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_95_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_95_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_95_string = "AND_1";
+      default : _zz_95_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_97_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_97__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_97__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_97__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_97__string = "PC ";
-      default : _zz_97__string = "???";
+    case(_zz_96)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_96_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_96_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_96_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_96_string = "SRA_1    ";
+      default : _zz_96_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_98_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_98__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_98__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_98__string = "ECALL";
-      default : _zz_98__string = "?????";
+    case(_zz_97)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_97_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_97_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_97_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_97_string = "JALR";
+      default : _zz_97_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_99_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_99__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_99__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_99__string = "AND_1";
-      default : _zz_99__string = "?????";
+    case(_zz_98)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_98_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_98_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_98_string = "ECALL";
+      default : _zz_98_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
-      default : decode_to_execute_ENV_CTRL_string = "?????";
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
-      default : execute_to_memory_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
-      default : memory_to_writeBack_ENV_CTRL_string = "?????";
+    case(decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3313,28 +2329,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
-      default : decode_to_execute_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
     case(decode_to_execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
       `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
       default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3364,62 +2363,87 @@ module VexRiscv (
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
+  always @(*) begin
+    case(decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : decode_to_execute_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : execute_to_memory_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : memory_to_writeBack_ENV_CTRL_string = "?????";
+    endcase
+  end
   `endif
 
+  assign memory_MUL_LOW = ($signed(_zz_238) + $signed(_zz_246));
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_SHIFT_RIGHT = _zz_248;
+  assign execute_REGFILE_WRITE_DATA = _zz_100;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_178_[1 : 0];
+  assign execute_MEMORY_ADDRESS_LOW = _zz_178[1 : 0];
+  assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_250[0];
+  assign decode_IS_RS1_SIGNED = _zz_251[0];
+  assign decode_IS_DIV = _zz_252[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_253[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_254[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_255[0];
+  assign decode_MEMORY_MANAGMENT = _zz_256[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_257[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_258[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_259[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign memory_MUL_LOW = ($signed(_zz_229_) + $signed(_zz_237_));
-  assign _zz_1_ = _zz_2_;
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_238_[0];
-  assign execute_SHIFT_RIGHT = _zz_240_;
-  assign _zz_3_ = _zz_4_;
-  assign decode_SHIFT_CTRL = _zz_5_;
-  assign _zz_6_ = _zz_7_;
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_IS_RS1_SIGNED = _zz_242_[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_243_[0];
-  assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
-  assign decode_SRC1_CTRL = _zz_8_;
-  assign _zz_9_ = _zz_10_;
-  assign decode_ALU_BITWISE_CTRL = _zz_11_;
-  assign _zz_12_ = _zz_13_;
-  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign memory_MUL_HH = execute_to_memory_MUL_HH;
-  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_244_[0];
-  assign decode_SRC_LESS_UNSIGNED = _zz_245_[0];
-  assign decode_MEMORY_MANAGMENT = _zz_246_[0];
   assign memory_PC = execute_to_memory_PC;
-  assign decode_ALU_CTRL = _zz_14_;
-  assign _zz_15_ = _zz_16_;
-  assign decode_SRC2_CTRL = _zz_17_;
-  assign _zz_18_ = _zz_19_;
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_247_[0];
-  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign execute_REGFILE_WRITE_DATA = _zz_101_;
-  assign _zz_20_ = _zz_21_;
-  assign _zz_22_ = _zz_23_;
-  assign decode_ENV_CTRL = _zz_24_;
-  assign _zz_25_ = _zz_26_;
-  assign decode_IS_CSR = _zz_248_[0];
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign decode_IS_DIV = _zz_249_[0];
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_250_[0];
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_251_[0];
+  assign decode_IS_EBREAK = _zz_260[0];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3433,22 +2457,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_123_;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_252_[0];
-  assign decode_RS1_USE = _zz_253_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_122;
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_261[0];
+  assign decode_RS1_USE = _zz_262[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_190_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_199)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
   end
 
@@ -3460,29 +2484,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_112_)begin
-      if((_zz_113_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_114_;
+    if(_zz_111)begin
+      if((_zz_112 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_113;
       end
     end
-    if(_zz_191_)begin
-      if(_zz_192_)begin
-        if(_zz_116_)begin
-          decode_RS2 = _zz_50_;
+    if(_zz_200)begin
+      if(_zz_201)begin
+        if(_zz_115)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_193_)begin
+    if(_zz_202)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_118_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_117)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_194_)begin
+    if(_zz_203)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_120_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_119)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -3490,29 +2514,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_112_)begin
-      if((_zz_113_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_114_;
+    if(_zz_111)begin
+      if((_zz_112 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_113;
       end
     end
-    if(_zz_191_)begin
-      if(_zz_192_)begin
-        if(_zz_115_)begin
-          decode_RS1 = _zz_50_;
+    if(_zz_200)begin
+      if(_zz_201)begin
+        if(_zz_114)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_193_)begin
+    if(_zz_202)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_117_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_116)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_194_)begin
+    if(_zz_203)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_119_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_118)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -3520,70 +2544,70 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_109_;
+          _zz_32 = _zz_108;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_195_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_204)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_254_[0];
-  assign decode_SRC_ADD_ZERO = _zz_255_[0];
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_263[0];
+  assign decode_SRC_ADD_ZERO = _zz_264[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_107_;
-  assign execute_SRC1 = _zz_102_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_106;
+  assign execute_SRC1 = _zz_101;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_256_[0];
+    decode_REGFILE_WRITE_VALID = _zz_265[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_325_) == 32'h00001073),{(_zz_326_ == _zz_327_),{_zz_328_,{_zz_329_,_zz_330_}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_334) == 32'h00001073),{(_zz_335 == _zz_336),{_zz_337,{_zz_338,_zz_339}}}}}}} != 21'h0);
   always @ (*) begin
-    _zz_50_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_228_)
+      case(_zz_237)
         2'b00 : begin
-          _zz_50_ = _zz_298_;
+          _zz_50 = _zz_307;
         end
         default : begin
-          _zz_50_ = _zz_299_;
+          _zz_50 = _zz_308;
         end
       endcase
     end
@@ -3595,55 +2619,56 @@ module VexRiscv (
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_257_[0];
-  assign decode_FLUSH_ALL = _zz_258_[0];
+  assign decode_MEMORY_ENABLE = _zz_266[0];
+  assign decode_FLUSH_ALL = _zz_267[0];
   always @ (*) begin
-    _zz_51_ = _zz_51__2;
-    if(_zz_196_)begin
-      _zz_51_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_205)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(_zz_197_)begin
-      _zz_51__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_206)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(_zz_198_)begin
-      _zz_51__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_207)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_199_)begin
-      _zz_51__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_208)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52_;
+  assign decode_BRANCH_CTRL = _zz_51;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_53_ = memory_FORMAL_PC_NEXT;
+    _zz_52 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_53_ = BranchPlugin_jumpInterface_payload;
+      _zz_52 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_54_ = decode_FORMAL_PC_NEXT;
+    _zz_53 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_54_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -3655,17 +2680,9 @@ module VexRiscv (
     if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_150_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_149)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
-      end
-      3'b011 : begin
-      end
-      3'b100 : begin
       end
       default : begin
       end
@@ -3674,20 +2691,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_110_ || _zz_111_)))begin
+    if((decode_arbitration_isValid && (_zz_109 || _zz_110)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_200_)begin
+    if(_zz_209)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3701,20 +2718,17 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_200_)begin
+    if(_zz_209)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_185_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_194 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_190_)begin
+    if(_zz_199)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -3723,7 +2737,10 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(_zz_201_)begin
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+    if(_zz_210)begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3740,8 +2757,8 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_201_)begin
-      if(_zz_202_)begin
+    if(_zz_210)begin
+      if(_zz_211)begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -3752,8 +2769,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_201_)begin
-      if(_zz_202_)begin
+    if(_zz_210)begin
+      if(_zz_211)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -3761,7 +2778,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_195_)begin
+    if(_zz_204)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -3792,7 +2809,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3823,10 +2840,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_203_)begin
+    if(_zz_212)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_204_)begin
+    if(_zz_213)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3837,24 +2854,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_203_)begin
+    if(_zz_212)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_204_)begin
+    if(_zz_213)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_201_)begin
-      if(_zz_202_)begin
+    if(_zz_210)begin
+      if(_zz_211)begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_205_)begin
+    if(_zz_214)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3867,9 +2884,9 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_55_ = 1'b0;
+    _zz_54 = 1'b0;
     if(DebugPlugin_godmode)begin
-      _zz_55_ = 1'b1;
+      _zz_54 = 1'b1;
     end
   end
 
@@ -3883,21 +2900,21 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_203_)begin
+    if(_zz_212)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_204_)begin
+    if(_zz_213)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_203_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_212)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_204_)begin
-      case(_zz_206_)
+    if(_zz_213)begin
+      case(_zz_215)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3928,14 +2945,14 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_56_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_57_ = (_zz_56_ & (~ _zz_259_));
-  assign _zz_58_ = _zz_57_[3];
-  assign _zz_59_ = (_zz_57_[1] || _zz_58_);
-  assign _zz_60_ = (_zz_57_[2] || _zz_58_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_189_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
+  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_56 = (_zz_55 & (~ _zz_268));
+  assign _zz_57 = _zz_56[3];
+  assign _zz_58 = (_zz_56[1] || _zz_57);
+  assign _zz_59 = (_zz_56[2] || _zz_57);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_198;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -3955,7 +2972,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_261_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_270);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -3995,44 +3012,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_61_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_61_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_61_);
+  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_62_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_62_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_62_);
+  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_51_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_63_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_63_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_63_);
+  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_64_;
-  assign _zz_64_ = ((1'b0 && (! _zz_65_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_65_ = _zz_66_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_65_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
+  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_64 = _zz_65;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_67_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_67_ = _zz_68_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_67_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_69_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_66 = _zz_67;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -4047,143 +3064,137 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @ (*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_150_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_149)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
       3'b011 : begin
         decode_arbitration_isValid = 1'b1;
       end
-      3'b100 : begin
-      end
       default : begin
       end
     endcase
   end
 
-  assign _zz_70_ = _zz_262_[11];
+  assign _zz_69 = _zz_271[11];
   always @ (*) begin
-    _zz_71_[18] = _zz_70_;
-    _zz_71_[17] = _zz_70_;
-    _zz_71_[16] = _zz_70_;
-    _zz_71_[15] = _zz_70_;
-    _zz_71_[14] = _zz_70_;
-    _zz_71_[13] = _zz_70_;
-    _zz_71_[12] = _zz_70_;
-    _zz_71_[11] = _zz_70_;
-    _zz_71_[10] = _zz_70_;
-    _zz_71_[9] = _zz_70_;
-    _zz_71_[8] = _zz_70_;
-    _zz_71_[7] = _zz_70_;
-    _zz_71_[6] = _zz_70_;
-    _zz_71_[5] = _zz_70_;
-    _zz_71_[4] = _zz_70_;
-    _zz_71_[3] = _zz_70_;
-    _zz_71_[2] = _zz_70_;
-    _zz_71_[1] = _zz_70_;
-    _zz_71_[0] = _zz_70_;
+    _zz_70[18] = _zz_69;
+    _zz_70[17] = _zz_69;
+    _zz_70[16] = _zz_69;
+    _zz_70[15] = _zz_69;
+    _zz_70[14] = _zz_69;
+    _zz_70[13] = _zz_69;
+    _zz_70[12] = _zz_69;
+    _zz_70[11] = _zz_69;
+    _zz_70[10] = _zz_69;
+    _zz_70[9] = _zz_69;
+    _zz_70[8] = _zz_69;
+    _zz_70[7] = _zz_69;
+    _zz_70[6] = _zz_69;
+    _zz_70[5] = _zz_69;
+    _zz_70[4] = _zz_69;
+    _zz_70[3] = _zz_69;
+    _zz_70[2] = _zz_69;
+    _zz_70[1] = _zz_69;
+    _zz_70[0] = _zz_69;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_263_[31]));
-    if(_zz_76_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_272[31]));
+    if(_zz_75)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_72_ = _zz_264_[19];
+  assign _zz_71 = _zz_273[19];
   always @ (*) begin
-    _zz_73_[10] = _zz_72_;
-    _zz_73_[9] = _zz_72_;
-    _zz_73_[8] = _zz_72_;
-    _zz_73_[7] = _zz_72_;
-    _zz_73_[6] = _zz_72_;
-    _zz_73_[5] = _zz_72_;
-    _zz_73_[4] = _zz_72_;
-    _zz_73_[3] = _zz_72_;
-    _zz_73_[2] = _zz_72_;
-    _zz_73_[1] = _zz_72_;
-    _zz_73_[0] = _zz_72_;
+    _zz_72[10] = _zz_71;
+    _zz_72[9] = _zz_71;
+    _zz_72[8] = _zz_71;
+    _zz_72[7] = _zz_71;
+    _zz_72[6] = _zz_71;
+    _zz_72[5] = _zz_71;
+    _zz_72[4] = _zz_71;
+    _zz_72[3] = _zz_71;
+    _zz_72[2] = _zz_71;
+    _zz_72[1] = _zz_71;
+    _zz_72[0] = _zz_71;
   end
 
-  assign _zz_74_ = _zz_265_[11];
+  assign _zz_73 = _zz_274[11];
   always @ (*) begin
-    _zz_75_[18] = _zz_74_;
-    _zz_75_[17] = _zz_74_;
-    _zz_75_[16] = _zz_74_;
-    _zz_75_[15] = _zz_74_;
-    _zz_75_[14] = _zz_74_;
-    _zz_75_[13] = _zz_74_;
-    _zz_75_[12] = _zz_74_;
-    _zz_75_[11] = _zz_74_;
-    _zz_75_[10] = _zz_74_;
-    _zz_75_[9] = _zz_74_;
-    _zz_75_[8] = _zz_74_;
-    _zz_75_[7] = _zz_74_;
-    _zz_75_[6] = _zz_74_;
-    _zz_75_[5] = _zz_74_;
-    _zz_75_[4] = _zz_74_;
-    _zz_75_[3] = _zz_74_;
-    _zz_75_[2] = _zz_74_;
-    _zz_75_[1] = _zz_74_;
-    _zz_75_[0] = _zz_74_;
+    _zz_74[18] = _zz_73;
+    _zz_74[17] = _zz_73;
+    _zz_74[16] = _zz_73;
+    _zz_74[15] = _zz_73;
+    _zz_74[14] = _zz_73;
+    _zz_74[13] = _zz_73;
+    _zz_74[12] = _zz_73;
+    _zz_74[11] = _zz_73;
+    _zz_74[10] = _zz_73;
+    _zz_74[9] = _zz_73;
+    _zz_74[8] = _zz_73;
+    _zz_74[7] = _zz_73;
+    _zz_74[6] = _zz_73;
+    _zz_74[5] = _zz_73;
+    _zz_74[4] = _zz_73;
+    _zz_74[3] = _zz_73;
+    _zz_74[2] = _zz_73;
+    _zz_74[1] = _zz_73;
+    _zz_74[0] = _zz_73;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_76_ = _zz_266_[1];
+        _zz_75 = _zz_275[1];
       end
       default : begin
-        _zz_76_ = _zz_267_[1];
+        _zz_75 = _zz_276[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_77_ = _zz_268_[19];
+  assign _zz_76 = _zz_277[19];
   always @ (*) begin
-    _zz_78_[10] = _zz_77_;
-    _zz_78_[9] = _zz_77_;
-    _zz_78_[8] = _zz_77_;
-    _zz_78_[7] = _zz_77_;
-    _zz_78_[6] = _zz_77_;
-    _zz_78_[5] = _zz_77_;
-    _zz_78_[4] = _zz_77_;
-    _zz_78_[3] = _zz_77_;
-    _zz_78_[2] = _zz_77_;
-    _zz_78_[1] = _zz_77_;
-    _zz_78_[0] = _zz_77_;
+    _zz_77[10] = _zz_76;
+    _zz_77[9] = _zz_76;
+    _zz_77[8] = _zz_76;
+    _zz_77[7] = _zz_76;
+    _zz_77[6] = _zz_76;
+    _zz_77[5] = _zz_76;
+    _zz_77[4] = _zz_76;
+    _zz_77[3] = _zz_76;
+    _zz_77[2] = _zz_76;
+    _zz_77[1] = _zz_76;
+    _zz_77[0] = _zz_76;
   end
 
-  assign _zz_79_ = _zz_269_[11];
+  assign _zz_78 = _zz_278[11];
   always @ (*) begin
-    _zz_80_[18] = _zz_79_;
-    _zz_80_[17] = _zz_79_;
-    _zz_80_[16] = _zz_79_;
-    _zz_80_[15] = _zz_79_;
-    _zz_80_[14] = _zz_79_;
-    _zz_80_[13] = _zz_79_;
-    _zz_80_[12] = _zz_79_;
-    _zz_80_[11] = _zz_79_;
-    _zz_80_[10] = _zz_79_;
-    _zz_80_[9] = _zz_79_;
-    _zz_80_[8] = _zz_79_;
-    _zz_80_[7] = _zz_79_;
-    _zz_80_[6] = _zz_79_;
-    _zz_80_[5] = _zz_79_;
-    _zz_80_[4] = _zz_79_;
-    _zz_80_[3] = _zz_79_;
-    _zz_80_[2] = _zz_79_;
-    _zz_80_[1] = _zz_79_;
-    _zz_80_[0] = _zz_79_;
+    _zz_79[18] = _zz_78;
+    _zz_79[17] = _zz_78;
+    _zz_79[16] = _zz_78;
+    _zz_79[15] = _zz_78;
+    _zz_79[14] = _zz_78;
+    _zz_79[13] = _zz_78;
+    _zz_79[12] = _zz_78;
+    _zz_79[11] = _zz_78;
+    _zz_79[10] = _zz_78;
+    _zz_79[9] = _zz_78;
+    _zz_79[8] = _zz_78;
+    _zz_79[7] = _zz_78;
+    _zz_79[6] = _zz_78;
+    _zz_79[5] = _zz_78;
+    _zz_79[4] = _zz_78;
+    _zz_79[3] = _zz_78;
+    _zz_79[2] = _zz_78;
+    _zz_79[1] = _zz_78;
+    _zz_79[0] = _zz_78;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_78_,{{{_zz_343_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_80_,{{{_zz_344_,_zz_345_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77,{{{_zz_352,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79,{{{_zz_353,_zz_354},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4192,123 +3203,128 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_170_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_171_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_172_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_173_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_174_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_175_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_169 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_170 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_171 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_170;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_173 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_174 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_175 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_199_)begin
+    if(_zz_208)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_197_)begin
+    if(_zz_206)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_176_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_197_)begin
-      _zz_176_ = 1'b1;
+    _zz_176 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_206)begin
+      _zz_176 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_198_)begin
+    if(_zz_207)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_196_)begin
+    if(_zz_205)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_198_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_207)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_196_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_205)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_169_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_186_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_168 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_195 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_177_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_178_ = execute_SRC_ADD;
+  assign _zz_177 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_178 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_83_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_82 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_83_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_82 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_83_ = execute_RS2[31 : 0];
+        _zz_82 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_185_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_179_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_180_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+  assign _zz_194 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_179 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_180 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_179;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_180;
+  assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @ (*) begin
-    _zz_181_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_55_ && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_181_ = 1'b1;
+    _zz_181 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((_zz_54 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_181 = 1'b1;
     end
   end
 
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_182_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_183_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_184_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_182 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_183 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_184 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_207_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_216)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -4317,17 +3333,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_207_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_216)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -4335,94 +3351,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_207_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_270_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_216)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_279};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_271_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_280};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_84_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_83 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_85_[31] = _zz_84_;
-    _zz_85_[30] = _zz_84_;
-    _zz_85_[29] = _zz_84_;
-    _zz_85_[28] = _zz_84_;
-    _zz_85_[27] = _zz_84_;
-    _zz_85_[26] = _zz_84_;
-    _zz_85_[25] = _zz_84_;
-    _zz_85_[24] = _zz_84_;
-    _zz_85_[23] = _zz_84_;
-    _zz_85_[22] = _zz_84_;
-    _zz_85_[21] = _zz_84_;
-    _zz_85_[20] = _zz_84_;
-    _zz_85_[19] = _zz_84_;
-    _zz_85_[18] = _zz_84_;
-    _zz_85_[17] = _zz_84_;
-    _zz_85_[16] = _zz_84_;
-    _zz_85_[15] = _zz_84_;
-    _zz_85_[14] = _zz_84_;
-    _zz_85_[13] = _zz_84_;
-    _zz_85_[12] = _zz_84_;
-    _zz_85_[11] = _zz_84_;
-    _zz_85_[10] = _zz_84_;
-    _zz_85_[9] = _zz_84_;
-    _zz_85_[8] = _zz_84_;
-    _zz_85_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_84[31] = _zz_83;
+    _zz_84[30] = _zz_83;
+    _zz_84[29] = _zz_83;
+    _zz_84[28] = _zz_83;
+    _zz_84[27] = _zz_83;
+    _zz_84[26] = _zz_83;
+    _zz_84[25] = _zz_83;
+    _zz_84[24] = _zz_83;
+    _zz_84[23] = _zz_83;
+    _zz_84[22] = _zz_83;
+    _zz_84[21] = _zz_83;
+    _zz_84[20] = _zz_83;
+    _zz_84[19] = _zz_83;
+    _zz_84[18] = _zz_83;
+    _zz_84[17] = _zz_83;
+    _zz_84[16] = _zz_83;
+    _zz_84[15] = _zz_83;
+    _zz_84[14] = _zz_83;
+    _zz_84[13] = _zz_83;
+    _zz_84[12] = _zz_83;
+    _zz_84[11] = _zz_83;
+    _zz_84[10] = _zz_83;
+    _zz_84[9] = _zz_83;
+    _zz_84[8] = _zz_83;
+    _zz_84[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_86_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_87_[31] = _zz_86_;
-    _zz_87_[30] = _zz_86_;
-    _zz_87_[29] = _zz_86_;
-    _zz_87_[28] = _zz_86_;
-    _zz_87_[27] = _zz_86_;
-    _zz_87_[26] = _zz_86_;
-    _zz_87_[25] = _zz_86_;
-    _zz_87_[24] = _zz_86_;
-    _zz_87_[23] = _zz_86_;
-    _zz_87_[22] = _zz_86_;
-    _zz_87_[21] = _zz_86_;
-    _zz_87_[20] = _zz_86_;
-    _zz_87_[19] = _zz_86_;
-    _zz_87_[18] = _zz_86_;
-    _zz_87_[17] = _zz_86_;
-    _zz_87_[16] = _zz_86_;
-    _zz_87_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_86[31] = _zz_85;
+    _zz_86[30] = _zz_85;
+    _zz_86[29] = _zz_85;
+    _zz_86[28] = _zz_85;
+    _zz_86[27] = _zz_85;
+    _zz_86[26] = _zz_85;
+    _zz_86[25] = _zz_85;
+    _zz_86[24] = _zz_85;
+    _zz_86[23] = _zz_85;
+    _zz_86[22] = _zz_85;
+    _zz_86[21] = _zz_85;
+    _zz_86[20] = _zz_85;
+    _zz_86[19] = _zz_85;
+    _zz_86[18] = _zz_85;
+    _zz_86[17] = _zz_85;
+    _zz_86[16] = _zz_85;
+    _zz_86[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_226_)
+    case(_zz_235)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_85_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_84;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_87_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -4430,57 +3446,71 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_89_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_90_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_91_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_92_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_88_ = {(((decode_INSTRUCTION & _zz_346_) == 32'h0) != (1'b0)),{((_zz_347_ == _zz_348_) != (1'b0)),{(_zz_349_ != (1'b0)),{(_zz_350_ != _zz_351_),{_zz_352_,{_zz_353_,_zz_354_}}}}}};
-  assign _zz_93_ = _zz_88_[2 : 1];
-  assign _zz_49_ = _zz_93_;
-  assign _zz_94_ = _zz_88_[16 : 15];
-  assign _zz_48_ = _zz_94_;
-  assign _zz_95_ = _zz_88_[20 : 19];
-  assign _zz_47_ = _zz_95_;
-  assign _zz_96_ = _zz_88_[22 : 21];
-  assign _zz_46_ = _zz_96_;
-  assign _zz_97_ = _zz_88_[26 : 25];
-  assign _zz_45_ = _zz_97_;
-  assign _zz_98_ = _zz_88_[28 : 27];
-  assign _zz_44_ = _zz_98_;
-  assign _zz_99_ = _zz_88_[31 : 30];
-  assign _zz_43_ = _zz_99_;
+  assign _zz_88 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_90 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_91 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_87 = {(((decode_INSTRUCTION & _zz_355) == 32'h00100050) != 1'b0),{(_zz_91 != 1'b0),{(_zz_91 != 1'b0),{(_zz_356 != _zz_357),{_zz_358,{_zz_359,_zz_360}}}}}};
+  assign _zz_92 = _zz_87[2 : 1];
+  assign _zz_49 = _zz_92;
+  assign _zz_93 = _zz_87[7 : 6];
+  assign _zz_48 = _zz_93;
+  assign _zz_94 = _zz_87[9 : 8];
+  assign _zz_47 = _zz_94;
+  assign _zz_95 = _zz_87[19 : 18];
+  assign _zz_46 = _zz_95;
+  assign _zz_96 = _zz_87[22 : 21];
+  assign _zz_45 = _zz_96;
+  assign _zz_97 = _zz_87[24 : 23];
+  assign _zz_44 = _zz_97;
+  assign _zz_98 = _zz_87[27 : 26];
+  assign _zz_43 = _zz_98;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_187_;
-  assign decode_RegFilePlugin_rs2Data = _zz_188_;
+  assign decode_RegFilePlugin_rs1Data = _zz_196;
+  assign decode_RegFilePlugin_rs2Data = _zz_197;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_100_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_99)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_50_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_99)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_99)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -4498,13 +3528,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_101_ = execute_IntAluPlugin_bitwise;
+        _zz_100 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_101_ = {31'd0, _zz_272_};
+        _zz_100 = {31'd0, _zz_281};
       end
       default : begin
-        _zz_101_ = execute_SRC_ADD_SUB;
+        _zz_100 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -4512,87 +3542,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_102_ = execute_RS1;
+        _zz_101 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_102_ = {29'd0, _zz_273_};
+        _zz_101 = {29'd0, _zz_282};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_102_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_101 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_102_ = {27'd0, _zz_274_};
+        _zz_101 = {27'd0, _zz_283};
       end
     endcase
   end
 
-  assign _zz_103_ = _zz_275_[11];
+  assign _zz_102 = _zz_284[11];
   always @ (*) begin
-    _zz_104_[19] = _zz_103_;
-    _zz_104_[18] = _zz_103_;
-    _zz_104_[17] = _zz_103_;
-    _zz_104_[16] = _zz_103_;
-    _zz_104_[15] = _zz_103_;
-    _zz_104_[14] = _zz_103_;
-    _zz_104_[13] = _zz_103_;
-    _zz_104_[12] = _zz_103_;
-    _zz_104_[11] = _zz_103_;
-    _zz_104_[10] = _zz_103_;
-    _zz_104_[9] = _zz_103_;
-    _zz_104_[8] = _zz_103_;
-    _zz_104_[7] = _zz_103_;
-    _zz_104_[6] = _zz_103_;
-    _zz_104_[5] = _zz_103_;
-    _zz_104_[4] = _zz_103_;
-    _zz_104_[3] = _zz_103_;
-    _zz_104_[2] = _zz_103_;
-    _zz_104_[1] = _zz_103_;
-    _zz_104_[0] = _zz_103_;
+    _zz_103[19] = _zz_102;
+    _zz_103[18] = _zz_102;
+    _zz_103[17] = _zz_102;
+    _zz_103[16] = _zz_102;
+    _zz_103[15] = _zz_102;
+    _zz_103[14] = _zz_102;
+    _zz_103[13] = _zz_102;
+    _zz_103[12] = _zz_102;
+    _zz_103[11] = _zz_102;
+    _zz_103[10] = _zz_102;
+    _zz_103[9] = _zz_102;
+    _zz_103[8] = _zz_102;
+    _zz_103[7] = _zz_102;
+    _zz_103[6] = _zz_102;
+    _zz_103[5] = _zz_102;
+    _zz_103[4] = _zz_102;
+    _zz_103[3] = _zz_102;
+    _zz_103[2] = _zz_102;
+    _zz_103[1] = _zz_102;
+    _zz_103[0] = _zz_102;
   end
 
-  assign _zz_105_ = _zz_276_[11];
+  assign _zz_104 = _zz_285[11];
   always @ (*) begin
-    _zz_106_[19] = _zz_105_;
-    _zz_106_[18] = _zz_105_;
-    _zz_106_[17] = _zz_105_;
-    _zz_106_[16] = _zz_105_;
-    _zz_106_[15] = _zz_105_;
-    _zz_106_[14] = _zz_105_;
-    _zz_106_[13] = _zz_105_;
-    _zz_106_[12] = _zz_105_;
-    _zz_106_[11] = _zz_105_;
-    _zz_106_[10] = _zz_105_;
-    _zz_106_[9] = _zz_105_;
-    _zz_106_[8] = _zz_105_;
-    _zz_106_[7] = _zz_105_;
-    _zz_106_[6] = _zz_105_;
-    _zz_106_[5] = _zz_105_;
-    _zz_106_[4] = _zz_105_;
-    _zz_106_[3] = _zz_105_;
-    _zz_106_[2] = _zz_105_;
-    _zz_106_[1] = _zz_105_;
-    _zz_106_[0] = _zz_105_;
+    _zz_105[19] = _zz_104;
+    _zz_105[18] = _zz_104;
+    _zz_105[17] = _zz_104;
+    _zz_105[16] = _zz_104;
+    _zz_105[15] = _zz_104;
+    _zz_105[14] = _zz_104;
+    _zz_105[13] = _zz_104;
+    _zz_105[12] = _zz_104;
+    _zz_105[11] = _zz_104;
+    _zz_105[10] = _zz_104;
+    _zz_105[9] = _zz_104;
+    _zz_105[8] = _zz_104;
+    _zz_105[7] = _zz_104;
+    _zz_105[6] = _zz_104;
+    _zz_105[5] = _zz_104;
+    _zz_105[4] = _zz_104;
+    _zz_105[3] = _zz_104;
+    _zz_105[2] = _zz_104;
+    _zz_105[1] = _zz_104;
+    _zz_105[0] = _zz_104;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_107_ = execute_RS2;
+        _zz_106 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_107_ = {_zz_104_,execute_INSTRUCTION[31 : 20]};
+        _zz_106 = {_zz_103,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_107_ = {_zz_106_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_106 = {_zz_105,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_107_ = _zz_35_;
+        _zz_106 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_277_;
+    execute_SrcPlugin_addSub = _zz_286;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -4601,246 +3631,246 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_108_[0] = execute_SRC1[31];
-    _zz_108_[1] = execute_SRC1[30];
-    _zz_108_[2] = execute_SRC1[29];
-    _zz_108_[3] = execute_SRC1[28];
-    _zz_108_[4] = execute_SRC1[27];
-    _zz_108_[5] = execute_SRC1[26];
-    _zz_108_[6] = execute_SRC1[25];
-    _zz_108_[7] = execute_SRC1[24];
-    _zz_108_[8] = execute_SRC1[23];
-    _zz_108_[9] = execute_SRC1[22];
-    _zz_108_[10] = execute_SRC1[21];
-    _zz_108_[11] = execute_SRC1[20];
-    _zz_108_[12] = execute_SRC1[19];
-    _zz_108_[13] = execute_SRC1[18];
-    _zz_108_[14] = execute_SRC1[17];
-    _zz_108_[15] = execute_SRC1[16];
-    _zz_108_[16] = execute_SRC1[15];
-    _zz_108_[17] = execute_SRC1[14];
-    _zz_108_[18] = execute_SRC1[13];
-    _zz_108_[19] = execute_SRC1[12];
-    _zz_108_[20] = execute_SRC1[11];
-    _zz_108_[21] = execute_SRC1[10];
-    _zz_108_[22] = execute_SRC1[9];
-    _zz_108_[23] = execute_SRC1[8];
-    _zz_108_[24] = execute_SRC1[7];
-    _zz_108_[25] = execute_SRC1[6];
-    _zz_108_[26] = execute_SRC1[5];
-    _zz_108_[27] = execute_SRC1[4];
-    _zz_108_[28] = execute_SRC1[3];
-    _zz_108_[29] = execute_SRC1[2];
-    _zz_108_[30] = execute_SRC1[1];
-    _zz_108_[31] = execute_SRC1[0];
+    _zz_107[0] = execute_SRC1[31];
+    _zz_107[1] = execute_SRC1[30];
+    _zz_107[2] = execute_SRC1[29];
+    _zz_107[3] = execute_SRC1[28];
+    _zz_107[4] = execute_SRC1[27];
+    _zz_107[5] = execute_SRC1[26];
+    _zz_107[6] = execute_SRC1[25];
+    _zz_107[7] = execute_SRC1[24];
+    _zz_107[8] = execute_SRC1[23];
+    _zz_107[9] = execute_SRC1[22];
+    _zz_107[10] = execute_SRC1[21];
+    _zz_107[11] = execute_SRC1[20];
+    _zz_107[12] = execute_SRC1[19];
+    _zz_107[13] = execute_SRC1[18];
+    _zz_107[14] = execute_SRC1[17];
+    _zz_107[15] = execute_SRC1[16];
+    _zz_107[16] = execute_SRC1[15];
+    _zz_107[17] = execute_SRC1[14];
+    _zz_107[18] = execute_SRC1[13];
+    _zz_107[19] = execute_SRC1[12];
+    _zz_107[20] = execute_SRC1[11];
+    _zz_107[21] = execute_SRC1[10];
+    _zz_107[22] = execute_SRC1[9];
+    _zz_107[23] = execute_SRC1[8];
+    _zz_107[24] = execute_SRC1[7];
+    _zz_107[25] = execute_SRC1[6];
+    _zz_107[26] = execute_SRC1[5];
+    _zz_107[27] = execute_SRC1[4];
+    _zz_107[28] = execute_SRC1[3];
+    _zz_107[29] = execute_SRC1[2];
+    _zz_107[30] = execute_SRC1[1];
+    _zz_107[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_108_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_107 : execute_SRC1);
   always @ (*) begin
-    _zz_109_[0] = memory_SHIFT_RIGHT[31];
-    _zz_109_[1] = memory_SHIFT_RIGHT[30];
-    _zz_109_[2] = memory_SHIFT_RIGHT[29];
-    _zz_109_[3] = memory_SHIFT_RIGHT[28];
-    _zz_109_[4] = memory_SHIFT_RIGHT[27];
-    _zz_109_[5] = memory_SHIFT_RIGHT[26];
-    _zz_109_[6] = memory_SHIFT_RIGHT[25];
-    _zz_109_[7] = memory_SHIFT_RIGHT[24];
-    _zz_109_[8] = memory_SHIFT_RIGHT[23];
-    _zz_109_[9] = memory_SHIFT_RIGHT[22];
-    _zz_109_[10] = memory_SHIFT_RIGHT[21];
-    _zz_109_[11] = memory_SHIFT_RIGHT[20];
-    _zz_109_[12] = memory_SHIFT_RIGHT[19];
-    _zz_109_[13] = memory_SHIFT_RIGHT[18];
-    _zz_109_[14] = memory_SHIFT_RIGHT[17];
-    _zz_109_[15] = memory_SHIFT_RIGHT[16];
-    _zz_109_[16] = memory_SHIFT_RIGHT[15];
-    _zz_109_[17] = memory_SHIFT_RIGHT[14];
-    _zz_109_[18] = memory_SHIFT_RIGHT[13];
-    _zz_109_[19] = memory_SHIFT_RIGHT[12];
-    _zz_109_[20] = memory_SHIFT_RIGHT[11];
-    _zz_109_[21] = memory_SHIFT_RIGHT[10];
-    _zz_109_[22] = memory_SHIFT_RIGHT[9];
-    _zz_109_[23] = memory_SHIFT_RIGHT[8];
-    _zz_109_[24] = memory_SHIFT_RIGHT[7];
-    _zz_109_[25] = memory_SHIFT_RIGHT[6];
-    _zz_109_[26] = memory_SHIFT_RIGHT[5];
-    _zz_109_[27] = memory_SHIFT_RIGHT[4];
-    _zz_109_[28] = memory_SHIFT_RIGHT[3];
-    _zz_109_[29] = memory_SHIFT_RIGHT[2];
-    _zz_109_[30] = memory_SHIFT_RIGHT[1];
-    _zz_109_[31] = memory_SHIFT_RIGHT[0];
+    _zz_108[0] = memory_SHIFT_RIGHT[31];
+    _zz_108[1] = memory_SHIFT_RIGHT[30];
+    _zz_108[2] = memory_SHIFT_RIGHT[29];
+    _zz_108[3] = memory_SHIFT_RIGHT[28];
+    _zz_108[4] = memory_SHIFT_RIGHT[27];
+    _zz_108[5] = memory_SHIFT_RIGHT[26];
+    _zz_108[6] = memory_SHIFT_RIGHT[25];
+    _zz_108[7] = memory_SHIFT_RIGHT[24];
+    _zz_108[8] = memory_SHIFT_RIGHT[23];
+    _zz_108[9] = memory_SHIFT_RIGHT[22];
+    _zz_108[10] = memory_SHIFT_RIGHT[21];
+    _zz_108[11] = memory_SHIFT_RIGHT[20];
+    _zz_108[12] = memory_SHIFT_RIGHT[19];
+    _zz_108[13] = memory_SHIFT_RIGHT[18];
+    _zz_108[14] = memory_SHIFT_RIGHT[17];
+    _zz_108[15] = memory_SHIFT_RIGHT[16];
+    _zz_108[16] = memory_SHIFT_RIGHT[15];
+    _zz_108[17] = memory_SHIFT_RIGHT[14];
+    _zz_108[18] = memory_SHIFT_RIGHT[13];
+    _zz_108[19] = memory_SHIFT_RIGHT[12];
+    _zz_108[20] = memory_SHIFT_RIGHT[11];
+    _zz_108[21] = memory_SHIFT_RIGHT[10];
+    _zz_108[22] = memory_SHIFT_RIGHT[9];
+    _zz_108[23] = memory_SHIFT_RIGHT[8];
+    _zz_108[24] = memory_SHIFT_RIGHT[7];
+    _zz_108[25] = memory_SHIFT_RIGHT[6];
+    _zz_108[26] = memory_SHIFT_RIGHT[5];
+    _zz_108[27] = memory_SHIFT_RIGHT[4];
+    _zz_108[28] = memory_SHIFT_RIGHT[3];
+    _zz_108[29] = memory_SHIFT_RIGHT[2];
+    _zz_108[30] = memory_SHIFT_RIGHT[1];
+    _zz_108[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_110_ = 1'b0;
-    if(_zz_208_)begin
-      if(_zz_209_)begin
-        if(_zz_115_)begin
-          _zz_110_ = 1'b1;
+    _zz_109 = 1'b0;
+    if(_zz_217)begin
+      if(_zz_218)begin
+        if(_zz_114)begin
+          _zz_109 = 1'b1;
         end
       end
     end
-    if(_zz_210_)begin
-      if(_zz_211_)begin
-        if(_zz_117_)begin
-          _zz_110_ = 1'b1;
+    if(_zz_219)begin
+      if(_zz_220)begin
+        if(_zz_116)begin
+          _zz_109 = 1'b1;
         end
       end
     end
-    if(_zz_212_)begin
-      if(_zz_213_)begin
-        if(_zz_119_)begin
-          _zz_110_ = 1'b1;
+    if(_zz_221)begin
+      if(_zz_222)begin
+        if(_zz_118)begin
+          _zz_109 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_110_ = 1'b0;
+      _zz_109 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_111_ = 1'b0;
-    if(_zz_208_)begin
-      if(_zz_209_)begin
-        if(_zz_116_)begin
-          _zz_111_ = 1'b1;
+    _zz_110 = 1'b0;
+    if(_zz_217)begin
+      if(_zz_218)begin
+        if(_zz_115)begin
+          _zz_110 = 1'b1;
         end
       end
     end
-    if(_zz_210_)begin
-      if(_zz_211_)begin
-        if(_zz_118_)begin
-          _zz_111_ = 1'b1;
+    if(_zz_219)begin
+      if(_zz_220)begin
+        if(_zz_117)begin
+          _zz_110 = 1'b1;
         end
       end
     end
-    if(_zz_212_)begin
-      if(_zz_213_)begin
-        if(_zz_120_)begin
-          _zz_111_ = 1'b1;
+    if(_zz_221)begin
+      if(_zz_222)begin
+        if(_zz_119)begin
+          _zz_110 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_111_ = 1'b0;
+      _zz_110 = 1'b0;
     end
   end
 
-  assign _zz_115_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_116_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_117_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_118_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_119_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_120_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_115 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_117 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_119 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_121_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_120 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_121_ == (3'b000))) begin
-        _zz_122_ = execute_BranchPlugin_eq;
-    end else if((_zz_121_ == (3'b001))) begin
-        _zz_122_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_121_ & (3'b101)) == (3'b101)))) begin
-        _zz_122_ = (! execute_SRC_LESS);
+    if((_zz_120 == 3'b000)) begin
+        _zz_121 = execute_BranchPlugin_eq;
+    end else if((_zz_120 == 3'b001)) begin
+        _zz_121 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_120 & 3'b101) == 3'b101))) begin
+        _zz_121 = (! execute_SRC_LESS);
     end else begin
-        _zz_122_ = execute_SRC_LESS;
+        _zz_121 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_123_ = 1'b0;
+        _zz_122 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_123_ = 1'b1;
+        _zz_122 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_123_ = 1'b1;
+        _zz_122 = 1'b1;
       end
       default : begin
-        _zz_123_ = _zz_122_;
+        _zz_122 = _zz_121;
       end
     endcase
   end
 
-  assign _zz_124_ = _zz_284_[11];
+  assign _zz_123 = _zz_293[11];
   always @ (*) begin
-    _zz_125_[19] = _zz_124_;
-    _zz_125_[18] = _zz_124_;
-    _zz_125_[17] = _zz_124_;
-    _zz_125_[16] = _zz_124_;
-    _zz_125_[15] = _zz_124_;
-    _zz_125_[14] = _zz_124_;
-    _zz_125_[13] = _zz_124_;
-    _zz_125_[12] = _zz_124_;
-    _zz_125_[11] = _zz_124_;
-    _zz_125_[10] = _zz_124_;
-    _zz_125_[9] = _zz_124_;
-    _zz_125_[8] = _zz_124_;
-    _zz_125_[7] = _zz_124_;
-    _zz_125_[6] = _zz_124_;
-    _zz_125_[5] = _zz_124_;
-    _zz_125_[4] = _zz_124_;
-    _zz_125_[3] = _zz_124_;
-    _zz_125_[2] = _zz_124_;
-    _zz_125_[1] = _zz_124_;
-    _zz_125_[0] = _zz_124_;
+    _zz_124[19] = _zz_123;
+    _zz_124[18] = _zz_123;
+    _zz_124[17] = _zz_123;
+    _zz_124[16] = _zz_123;
+    _zz_124[15] = _zz_123;
+    _zz_124[14] = _zz_123;
+    _zz_124[13] = _zz_123;
+    _zz_124[12] = _zz_123;
+    _zz_124[11] = _zz_123;
+    _zz_124[10] = _zz_123;
+    _zz_124[9] = _zz_123;
+    _zz_124[8] = _zz_123;
+    _zz_124[7] = _zz_123;
+    _zz_124[6] = _zz_123;
+    _zz_124[5] = _zz_123;
+    _zz_124[4] = _zz_123;
+    _zz_124[3] = _zz_123;
+    _zz_124[2] = _zz_123;
+    _zz_124[1] = _zz_123;
+    _zz_124[0] = _zz_123;
   end
 
-  assign _zz_126_ = _zz_285_[19];
+  assign _zz_125 = _zz_294[19];
   always @ (*) begin
-    _zz_127_[10] = _zz_126_;
-    _zz_127_[9] = _zz_126_;
-    _zz_127_[8] = _zz_126_;
-    _zz_127_[7] = _zz_126_;
-    _zz_127_[6] = _zz_126_;
-    _zz_127_[5] = _zz_126_;
-    _zz_127_[4] = _zz_126_;
-    _zz_127_[3] = _zz_126_;
-    _zz_127_[2] = _zz_126_;
-    _zz_127_[1] = _zz_126_;
-    _zz_127_[0] = _zz_126_;
+    _zz_126[10] = _zz_125;
+    _zz_126[9] = _zz_125;
+    _zz_126[8] = _zz_125;
+    _zz_126[7] = _zz_125;
+    _zz_126[6] = _zz_125;
+    _zz_126[5] = _zz_125;
+    _zz_126[4] = _zz_125;
+    _zz_126[3] = _zz_125;
+    _zz_126[2] = _zz_125;
+    _zz_126[1] = _zz_125;
+    _zz_126[0] = _zz_125;
   end
 
-  assign _zz_128_ = _zz_286_[11];
+  assign _zz_127 = _zz_295[11];
   always @ (*) begin
-    _zz_129_[18] = _zz_128_;
-    _zz_129_[17] = _zz_128_;
-    _zz_129_[16] = _zz_128_;
-    _zz_129_[15] = _zz_128_;
-    _zz_129_[14] = _zz_128_;
-    _zz_129_[13] = _zz_128_;
-    _zz_129_[12] = _zz_128_;
-    _zz_129_[11] = _zz_128_;
-    _zz_129_[10] = _zz_128_;
-    _zz_129_[9] = _zz_128_;
-    _zz_129_[8] = _zz_128_;
-    _zz_129_[7] = _zz_128_;
-    _zz_129_[6] = _zz_128_;
-    _zz_129_[5] = _zz_128_;
-    _zz_129_[4] = _zz_128_;
-    _zz_129_[3] = _zz_128_;
-    _zz_129_[2] = _zz_128_;
-    _zz_129_[1] = _zz_128_;
-    _zz_129_[0] = _zz_128_;
+    _zz_128[18] = _zz_127;
+    _zz_128[17] = _zz_127;
+    _zz_128[16] = _zz_127;
+    _zz_128[15] = _zz_127;
+    _zz_128[14] = _zz_127;
+    _zz_128[13] = _zz_127;
+    _zz_128[12] = _zz_127;
+    _zz_128[11] = _zz_127;
+    _zz_128[10] = _zz_127;
+    _zz_128[9] = _zz_127;
+    _zz_128[8] = _zz_127;
+    _zz_128[7] = _zz_127;
+    _zz_128[6] = _zz_127;
+    _zz_128[5] = _zz_127;
+    _zz_128[4] = _zz_127;
+    _zz_128[3] = _zz_127;
+    _zz_128[2] = _zz_127;
+    _zz_128[1] = _zz_127;
+    _zz_128[0] = _zz_127;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_130_ = (_zz_287_[1] ^ execute_RS1[1]);
+        _zz_129 = (_zz_296[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_130_ = _zz_288_[1];
+        _zz_129 = _zz_297[1];
       end
       default : begin
-        _zz_130_ = _zz_289_[1];
+        _zz_129 = _zz_298[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_130_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_129);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -4852,108 +3882,108 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_131_ = _zz_290_[11];
+  assign _zz_130 = _zz_299[11];
   always @ (*) begin
-    _zz_132_[19] = _zz_131_;
-    _zz_132_[18] = _zz_131_;
-    _zz_132_[17] = _zz_131_;
-    _zz_132_[16] = _zz_131_;
-    _zz_132_[15] = _zz_131_;
-    _zz_132_[14] = _zz_131_;
-    _zz_132_[13] = _zz_131_;
-    _zz_132_[12] = _zz_131_;
-    _zz_132_[11] = _zz_131_;
-    _zz_132_[10] = _zz_131_;
-    _zz_132_[9] = _zz_131_;
-    _zz_132_[8] = _zz_131_;
-    _zz_132_[7] = _zz_131_;
-    _zz_132_[6] = _zz_131_;
-    _zz_132_[5] = _zz_131_;
-    _zz_132_[4] = _zz_131_;
-    _zz_132_[3] = _zz_131_;
-    _zz_132_[2] = _zz_131_;
-    _zz_132_[1] = _zz_131_;
-    _zz_132_[0] = _zz_131_;
+    _zz_131[19] = _zz_130;
+    _zz_131[18] = _zz_130;
+    _zz_131[17] = _zz_130;
+    _zz_131[16] = _zz_130;
+    _zz_131[15] = _zz_130;
+    _zz_131[14] = _zz_130;
+    _zz_131[13] = _zz_130;
+    _zz_131[12] = _zz_130;
+    _zz_131[11] = _zz_130;
+    _zz_131[10] = _zz_130;
+    _zz_131[9] = _zz_130;
+    _zz_131[8] = _zz_130;
+    _zz_131[7] = _zz_130;
+    _zz_131[6] = _zz_130;
+    _zz_131[5] = _zz_130;
+    _zz_131[4] = _zz_130;
+    _zz_131[3] = _zz_130;
+    _zz_131[2] = _zz_130;
+    _zz_131[1] = _zz_130;
+    _zz_131[0] = _zz_130;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_132_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_131,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_134_,{{{_zz_500_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_136_,{{{_zz_501_,_zz_502_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_133,{{{_zz_513,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_135,{{{_zz_514,_zz_515},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_293_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_302};
         end
       end
     endcase
   end
 
-  assign _zz_133_ = _zz_291_[19];
+  assign _zz_132 = _zz_300[19];
   always @ (*) begin
-    _zz_134_[10] = _zz_133_;
-    _zz_134_[9] = _zz_133_;
-    _zz_134_[8] = _zz_133_;
-    _zz_134_[7] = _zz_133_;
-    _zz_134_[6] = _zz_133_;
-    _zz_134_[5] = _zz_133_;
-    _zz_134_[4] = _zz_133_;
-    _zz_134_[3] = _zz_133_;
-    _zz_134_[2] = _zz_133_;
-    _zz_134_[1] = _zz_133_;
-    _zz_134_[0] = _zz_133_;
+    _zz_133[10] = _zz_132;
+    _zz_133[9] = _zz_132;
+    _zz_133[8] = _zz_132;
+    _zz_133[7] = _zz_132;
+    _zz_133[6] = _zz_132;
+    _zz_133[5] = _zz_132;
+    _zz_133[4] = _zz_132;
+    _zz_133[3] = _zz_132;
+    _zz_133[2] = _zz_132;
+    _zz_133[1] = _zz_132;
+    _zz_133[0] = _zz_132;
   end
 
-  assign _zz_135_ = _zz_292_[11];
+  assign _zz_134 = _zz_301[11];
   always @ (*) begin
-    _zz_136_[18] = _zz_135_;
-    _zz_136_[17] = _zz_135_;
-    _zz_136_[16] = _zz_135_;
-    _zz_136_[15] = _zz_135_;
-    _zz_136_[14] = _zz_135_;
-    _zz_136_[13] = _zz_135_;
-    _zz_136_[12] = _zz_135_;
-    _zz_136_[11] = _zz_135_;
-    _zz_136_[10] = _zz_135_;
-    _zz_136_[9] = _zz_135_;
-    _zz_136_[8] = _zz_135_;
-    _zz_136_[7] = _zz_135_;
-    _zz_136_[6] = _zz_135_;
-    _zz_136_[5] = _zz_135_;
-    _zz_136_[4] = _zz_135_;
-    _zz_136_[3] = _zz_135_;
-    _zz_136_[2] = _zz_135_;
-    _zz_136_[1] = _zz_135_;
-    _zz_136_[0] = _zz_135_;
+    _zz_135[18] = _zz_134;
+    _zz_135[17] = _zz_134;
+    _zz_135[16] = _zz_134;
+    _zz_135[15] = _zz_134;
+    _zz_135[14] = _zz_134;
+    _zz_135[13] = _zz_134;
+    _zz_135[12] = _zz_134;
+    _zz_135[11] = _zz_134;
+    _zz_135[10] = _zz_134;
+    _zz_135[9] = _zz_134;
+    _zz_135[8] = _zz_134;
+    _zz_135[7] = _zz_134;
+    _zz_135[6] = _zz_134;
+    _zz_135[5] = _zz_134;
+    _zz_135[4] = _zz_134;
+    _zz_135[3] = _zz_134;
+    _zz_135[2] = _zz_134;
+    _zz_135[1] = _zz_134;
+    _zz_135[0] = _zz_134;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_137_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_138_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_139_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_136 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_137 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_138 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_140_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_141_ = _zz_294_[0];
+  assign _zz_139 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_140 = _zz_303[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_200_)begin
+    if(_zz_209)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -5000,7 +4030,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -5024,7 +4054,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -5046,7 +4076,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -5089,7 +4119,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_214_)begin
+    if(_zz_223)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -5108,20 +4138,20 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_215_)begin
+    if(_zz_224)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_215_)begin
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_224)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -5130,14 +4160,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_214_)begin
+    if(_zz_223)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_214_)begin
+    if(_zz_223)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5146,7 +4176,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_227_)
+    case(_zz_236)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -5160,7 +4190,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_216_)
+    case(_zz_225)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5174,7 +4204,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_216_)
+    case(_zz_225)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5193,12 +4223,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_296_) + $signed(_zz_297_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_305) + $signed(_zz_306));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_195_)begin
-      if(_zz_217_)begin
+    if(_zz_204)begin
+      if(_zz_226)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -5206,7 +4236,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_218_)begin
+    if(_zz_227)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -5217,35 +4247,33 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_301_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_310);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_142_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_142_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_302_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_303_ : _zz_304_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_305_[31:0];
-  assign _zz_143_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_144_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_145_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_141 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_141[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_311);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_312 : _zz_313);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_314[31:0];
+  assign _zz_142 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_143 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_144 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_146_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_146_[31 : 0] = execute_RS1;
+    _zz_145[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_145[31 : 0] = execute_RS1;
   end
 
-  assign _zz_148_ = (_zz_147_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_148_ != 32'h0);
+  assign _zz_147 = (_zz_146 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_147 != 32'h0);
   always @ (*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid)begin
-      case(_zz_219_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_228)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
@@ -5258,7 +4286,7 @@ module VexRiscv (
 
   always @ (*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_149_))begin
+    if((! _zz_148))begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -5270,10 +4298,8 @@ module VexRiscv (
   always @ (*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid)begin
-      case(_zz_219_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_228)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
@@ -5285,39 +4311,39 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == (2'b11));
+  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26_ = decode_ENV_CTRL;
-  assign _zz_23_ = execute_ENV_CTRL;
-  assign _zz_21_ = memory_ENV_CTRL;
-  assign _zz_24_ = _zz_44_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_19_ = decode_SRC2_CTRL;
-  assign _zz_17_ = _zz_45_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_16_ = decode_ALU_CTRL;
-  assign _zz_14_ = _zz_46_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign _zz_13_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_11_ = _zz_43_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_10_ = decode_SRC1_CTRL;
-  assign _zz_8_ = _zz_49_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_7_ = decode_SHIFT_CTRL;
-  assign _zz_4_ = execute_SHIFT_CTRL;
-  assign _zz_5_ = _zz_47_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_2_ = decode_BRANCH_CTRL;
-  assign _zz_52_ = _zz_48_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_51 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -5336,15 +4362,7 @@ module VexRiscv (
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_150_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
-      3'b010 : begin
-      end
-      3'b011 : begin
-      end
+    case(_zz_149)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -5354,116 +4372,116 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_151_ = 32'h0;
+    _zz_150 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_151_[12 : 0] = 13'h1000;
-      _zz_151_[25 : 20] = 6'h20;
+      _zz_150[12 : 0] = 13'h1000;
+      _zz_150[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_152_ = 32'h0;
+    _zz_151 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_152_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_152_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_152_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_151[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_151[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_151[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_153_ = 32'h0;
+    _zz_152 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_153_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_153_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_153_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_152[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_152[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_152[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_154_ = 32'h0;
+    _zz_153 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_154_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_154_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_154_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_153[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_153[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_153[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_155_ = 32'h0;
+    _zz_154 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_155_[31 : 0] = CsrPlugin_mepc;
+      _zz_154[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_156_ = 32'h0;
+    _zz_155 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_156_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_156_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_155[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_155[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_157_ = 32'h0;
+    _zz_156 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_157_[31 : 0] = CsrPlugin_mtval;
+      _zz_156[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_158_ = 32'h0;
+    _zz_157 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_158_[31 : 0] = _zz_147_;
+      _zz_157[31 : 0] = _zz_146;
     end
   end
 
   always @ (*) begin
-    _zz_159_ = 32'h0;
+    _zz_158 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_159_[31 : 0] = _zz_148_;
+      _zz_158[31 : 0] = _zz_147;
     end
   end
 
-  assign execute_CsrPlugin_readData = ((((_zz_151_ | _zz_152_) | (_zz_153_ | _zz_154_)) | ((_zz_155_ | _zz_156_) | (_zz_157_ | _zz_158_))) | _zz_159_);
-  assign iBusWishbone_ADR = {_zz_321_,_zz_160_};
-  assign iBusWishbone_CTI = ((_zz_160_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = ((((_zz_150 | _zz_151) | (_zz_152 | _zz_153)) | ((_zz_154 | _zz_155) | (_zz_156 | _zz_157))) | _zz_158);
+  assign iBusWishbone_ADR = {_zz_330,_zz_159};
+  assign iBusWishbone_CTI = ((_zz_159 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_220_)begin
+    if(_zz_229)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_220_)begin
+    if(_zz_229)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_161_;
+  assign iBus_rsp_valid = _zz_160;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_167_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_163_ = dBus_cmd_valid;
-  assign _zz_165_ = dBus_cmd_payload_wr;
-  assign _zz_166_ = (_zz_162_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_164_ && (_zz_165_ || _zz_166_));
-  assign dBusWishbone_ADR = ((_zz_167_ ? {{dBus_cmd_payload_address[31 : 5],_zz_162_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_167_ ? (_zz_166_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_165_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_165_;
+  assign _zz_166 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_162 = dBus_cmd_valid;
+  assign _zz_164 = dBus_cmd_payload_wr;
+  assign _zz_165 = (_zz_161 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_163 && (_zz_164 || _zz_165));
+  assign dBusWishbone_ADR = ((_zz_166 ? {{dBus_cmd_payload_address[31 : 5],_zz_161},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_166 ? (_zz_165 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_164 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_164;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_164_ = (_zz_163_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_163_;
-  assign dBusWishbone_STB = _zz_163_;
-  assign dBus_rsp_valid = _zz_168_;
+  assign _zz_163 = (_zz_162 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_162;
+  assign dBusWishbone_STB = _zz_162;
+  assign dBus_rsp_valid = _zz_167;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -5472,24 +4490,24 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_66_ <= 1'b0;
-      _zz_68_ <= 1'b0;
+      _zz_65 <= 1'b0;
+      _zz_67 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_81_;
+      IBusCachedPlugin_rspCounter <= _zz_80;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_82_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_81;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_100_ <= 1'b1;
-      _zz_112_ <= 1'b0;
+      _zz_99 <= 1'b1;
+      _zz_111 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -5504,17 +4522,15 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_147_ <= 32'h0;
+      _zz_146 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_150_ <= (3'b000);
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_160_ <= (3'b000);
-      _zz_161_ <= 1'b0;
-      _zz_162_ <= (3'b000);
-      _zz_168_ <= 1'b0;
+      _zz_149 <= 3'b000;
+      _zz_159 <= 3'b000;
+      _zz_160 <= 1'b0;
+      _zz_161 <= 3'b000;
+      _zz_167 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -5536,16 +4552,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_66_ <= 1'b0;
+        _zz_65 <= 1'b0;
       end
-      if(_zz_64_)begin
-        _zz_66_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_63)begin
+        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_68_ <= 1'b0;
+        _zz_67 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_68_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -5592,20 +4608,20 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_221_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_230)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_100_ <= 1'b0;
-      _zz_112_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_99 <= 1'b0;
+      _zz_111 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -5627,14 +4643,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_222_)begin
-        if(_zz_223_)begin
+      if(_zz_231)begin
+        if(_zz_232)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_224_)begin
+        if(_zz_233)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_225_)begin
+        if(_zz_234)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -5658,7 +4674,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_203_)begin
+      if(_zz_212)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5669,10 +4685,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_204_)begin
-        case(_zz_206_)
+      if(_zz_213)begin
+        case(_zz_215)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -5680,14 +4696,8 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_139_,{_zz_138_,_zz_137_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_138,{_zz_137,_zz_136}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -5706,25 +4716,25 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_150_)
+      case(_zz_149)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_150_ <= (3'b001);
+            _zz_149 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_150_ <= (3'b010);
+          _zz_149 <= 3'b010;
         end
         3'b010 : begin
-          _zz_150_ <= (3'b011);
+          _zz_149 <= 3'b011;
         end
         3'b011 : begin
           if((! decode_arbitration_isStuck))begin
-            _zz_150_ <= (3'b100);
+            _zz_149 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_150_ <= (3'b000);
+          _zz_149 <= 3'b000;
         end
         default : begin
         end
@@ -5732,41 +4742,41 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_315_[0];
-          CsrPlugin_mstatus_MIE <= _zz_316_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_324[0];
+          CsrPlugin_mstatus_MIE <= _zz_325[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_318_[0];
-          CsrPlugin_mie_MTIE <= _zz_319_[0];
-          CsrPlugin_mie_MSIE <= _zz_320_[0];
+          CsrPlugin_mie_MEIE <= _zz_327[0];
+          CsrPlugin_mie_MTIE <= _zz_328[0];
+          CsrPlugin_mie_MSIE <= _zz_329[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_147_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_146 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_220_)begin
+      if(_zz_229)begin
         if(iBusWishbone_ACK)begin
-          _zz_160_ <= (_zz_160_ + (3'b001));
+          _zz_159 <= (_zz_159 + 3'b001);
         end
       end
-      _zz_161_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_163_ && _zz_164_))begin
-        _zz_162_ <= (_zz_162_ + (3'b001));
-        if(_zz_166_)begin
-          _zz_162_ <= (3'b000);
+      _zz_160 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_162 && _zz_163))begin
+        _zz_161 <= (_zz_161 + 3'b001);
+        if(_zz_165)begin
+          _zz_161 <= 3'b000;
         end
       end
-      _zz_168_ <= ((_zz_163_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_167 <= ((_zz_162 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_69_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_68 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -5774,24 +4784,26 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_221_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_230)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_113_ <= _zz_40_[11 : 7];
-    _zz_114_ <= _zz_50_;
+    _zz_112 <= _zz_40[11 : 7];
+    _zz_113 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -5799,9 +4811,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_200_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_141_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_141_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_209)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -5815,21 +4827,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_222_)begin
-      if(_zz_223_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_231)begin
+      if(_zz_232)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_224_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_233)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_225_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_234)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_203_)begin
+    if(_zz_212)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5849,120 +4861,57 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_195_)begin
-      if(_zz_217_)begin
+    if(_zz_204)begin
+      if(_zz_226)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_306_[31:0];
+          memory_DivPlugin_div_result <= _zz_315[31:0];
         end
       end
     end
-    if(_zz_218_)begin
+    if(_zz_227)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_145_ ? (~ _zz_146_) : _zz_146_) + _zz_312_);
-      memory_DivPlugin_rs2 <= ((_zz_144_ ? (~ execute_RS2) : execute_RS2) + _zz_314_);
-      memory_DivPlugin_div_needRevert <= ((_zz_145_ ^ (_zz_144_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_144 ? (~ _zz_145) : _zz_145) + _zz_321);
+      memory_DivPlugin_rs2 <= ((_zz_143 ? (~ execute_RS2) : execute_RS2) + _zz_323);
+      memory_DivPlugin_div_needRevert <= ((_zz_144 ^ (_zz_143 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_25_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_22_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_20_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_18_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_15_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
+      execute_to_memory_PC <= _zz_35;
     end
     if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
       memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_25;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -5974,40 +4923,28 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_12_;
+      decode_to_execute_ALU_CTRL <= _zz_22;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_9_;
+      decode_to_execute_SRC2_CTRL <= _zz_19;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_6_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_3_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
@@ -6019,31 +4956,115 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_1_;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
-    end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_54_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53_;
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -6077,7 +5098,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_317_[0];
+        CsrPlugin_mip_MSIP <= _zz_326[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -6101,12 +5122,12 @@ module VexRiscv (
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
-    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != (4'b0000)) || IBusCachedPlugin_incomingInstruction);
+    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
     if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50_;
+      DebugPlugin_busReadDataReg <= _zz_50;
     end
-    _zz_149_ <= debug_bus_cmd_payload_address[2];
-    if(_zz_201_)begin
+    _zz_148 <= debug_bus_cmd_payload_address[2];
+    if(_zz_210)begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -6124,8 +5145,8 @@ module VexRiscv (
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid)begin
-        case(_zz_219_)
-          6'b000000 : begin
+        case(_zz_228)
+          6'h0 : begin
             if(debug_bus_cmd_payload_wr)begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
               if(debug_bus_cmd_payload_data[16])begin
@@ -6148,23 +5169,1112 @@ module VexRiscv (
               end
             end
           end
-          6'b000001 : begin
-          end
           default : begin
           end
         endcase
       end
-      if(_zz_201_)begin
-        if(_zz_202_)begin
+      if(_zz_210)begin
+        if(_zz_211)begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_205_)begin
+      if(_zz_214)begin
         if(decode_arbitration_isValid)begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
+    end
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire       [0:0]    _zz_19;
+  wire       [0:0]    _zz_20;
+  wire       [9:0]    _zz_21;
+  wire       [9:0]    _zz_22;
+  wire       [0:0]    _zz_23;
+  wire       [0:0]    _zz_24;
+  wire       [2:0]    _zz_25;
+  wire       [1:0]    _zz_26;
+  wire       [21:0]   _zz_27;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  wire                stage0_isAmo;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire                stageA_isAmo;
+  wire                stageA_isLrsc;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  wire                stageB_isAmo;
+  wire                stageB_isAmoCached;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  wire       [31:0]   stageB_requestDataBypass;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_28;
+  reg [7:0] _zz_29;
+  reg [7:0] _zz_30;
+  reg [7:0] _zz_31;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign _zz_17 = (! stageB_flusher_hold);
+  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_19 = _zz_4[0 : 0];
+  assign _zz_20 = _zz_4[1 : 1];
+  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_23 = 1'b1;
+  assign _zz_24 = loader_counter_willIncrement;
+  assign _zz_25 = {2'd0, _zz_24};
+  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_19[0];
+  assign ways_0_tagsReadRsp_error = _zz_20[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_23[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign stage0_isAmo = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign stageA_isAmo = 1'b0;
+  assign stageA_isLrsc = 1'b0;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_16)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isAmo = 1'b0;
+  assign stageB_isAmoCached = 1'b0;
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  assign stageB_requestDataBypass = stageB_request_data;
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          io_mem_cmd_valid = (! memCmdSent);
+        end else begin
+          if(_zz_16)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_14)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_25);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_17)begin
+        if(_zz_18)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_17)begin
+          if(! _zz_18) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_14)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_26[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input      [2:0]    _zz_9,
+  input      [31:0]   _zz_10,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_11;
+  reg        [21:0]   _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire       [0:0]    _zz_15;
+  wire       [0:0]    _zz_16;
+  wire       [21:0]   _zz_17;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_13 = (! lineLoader_flushCounter[7]);
+  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_15 = _zz_8[0 : 0];
+  assign _zz_16 = _zz_8[1 : 1];
+  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_11 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_12 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_13)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_12;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_14)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_13)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_14)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
+    if((_zz_9 != 3'b000))begin
+      io_cpu_fetch_data_regNextWhen <= _zz_10;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Full.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Full.v
@@ -1,19 +1,19 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:38:40
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
+
+`define EnvCtrlEnum_defaultEncoding_type [1:0]
+`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
+`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
+`define EnvCtrlEnum_defaultEncoding_WFI 2'b10
+`define EnvCtrlEnum_defaultEncoding_ECALL 2'b11
 
 `define BranchCtrlEnum_defaultEncoding_type [1:0]
 `define BranchCtrlEnum_defaultEncoding_INC 2'b00
 `define BranchCtrlEnum_defaultEncoding_B 2'b01
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
-
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
 `define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
@@ -26,1030 +26,23 @@
 `define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
 `define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
 
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
-
-`define EnvCtrlEnum_defaultEncoding_type [1:0]
-`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
-`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
-`define EnvCtrlEnum_defaultEncoding_WFI 2'b10
-`define EnvCtrlEnum_defaultEncoding_ECALL 2'b11
-
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
 `define Src2CtrlEnum_defaultEncoding_IMI 2'b01
 `define Src2CtrlEnum_defaultEncoding_IMS 2'b10
 `define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire       [0:0]    _zz_14_;
-  wire       [0:0]    _zz_15_;
-  wire       [21:0]   _zz_16_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* syn_keep , keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* syn_keep , keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-  assign _zz_12_ = (! lineLoader_flushCounter[7]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [0:0]    _zz_18_;
-  wire       [0:0]    _zz_19_;
-  wire       [2:0]    _zz_20_;
-  wire       [1:0]    _zz_21_;
-  wire       [21:0]   _zz_22_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  wire       [31:0]   stageB_requestDataBypass;
-  wire                stageB_isAmo;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_23_;
-  reg [7:0] _zz_24_;
-  reg [7:0] _zz_25_;
-  reg [7:0] _zz_26_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmo)));
-  assign _zz_15_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_16_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_17_ = _zz_4_[0 : 0];
-  assign _zz_18_ = _zz_4_[1 : 1];
-  assign _zz_19_ = loader_counter_willIncrement;
-  assign _zz_20_ = {2'd0, _zz_19_};
-  assign _zz_21_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_22_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_22_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_26_, _zz_25_, _zz_24_, _zz_23_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_23_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_24_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_25_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_26_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_17_[0];
-  assign ways_0_tagsReadRsp_error = _zz_18_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  assign stageB_requestDataBypass = stageB_request_data;
-  assign stageB_isAmo = 1'b0;
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((((! stageB_request_wr) || stageB_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0))))begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_15_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_20_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_16_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_16_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_15_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_21_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1065,8 +58,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1076,40 +69,45 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset 
+  input               reset
 );
-  wire                _zz_180_;
-  wire                _zz_181_;
-  wire                _zz_182_;
-  wire                _zz_183_;
-  wire                _zz_184_;
-  wire                _zz_185_;
-  wire                _zz_186_;
-  reg                 _zz_187_;
-  wire                _zz_188_;
-  wire       [31:0]   _zz_189_;
-  wire                _zz_190_;
-  wire       [31:0]   _zz_191_;
-  reg                 _zz_192_;
-  wire                _zz_193_;
-  wire                _zz_194_;
-  wire       [31:0]   _zz_195_;
-  wire                _zz_196_;
-  wire                _zz_197_;
-  reg        [31:0]   _zz_198_;
-  reg        [31:0]   _zz_199_;
-  reg        [31:0]   _zz_200_;
+  wire                _zz_179;
+  wire                _zz_180;
+  wire                _zz_181;
+  wire                _zz_182;
+  wire                _zz_183;
+  wire                _zz_184;
+  wire                _zz_185;
+  wire                _zz_186;
+  reg                 _zz_187;
+  wire                _zz_188;
+  wire       [31:0]   _zz_189;
+  wire                _zz_190;
+  wire       [31:0]   _zz_191;
+  reg                 _zz_192;
+  wire                _zz_193;
+  wire                _zz_194;
+  wire       [31:0]   _zz_195;
+  wire                _zz_196;
+  wire                _zz_197;
+  wire                _zz_198;
+  wire                _zz_199;
+  wire                _zz_200;
+  wire                _zz_201;
+  wire                _zz_202;
+  wire                _zz_203;
+  wire       [3:0]    _zz_204;
+  wire                _zz_205;
+  wire                _zz_206;
+  reg        [31:0]   _zz_207;
+  reg        [31:0]   _zz_208;
+  reg        [31:0]   _zz_209;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -1119,401 +117,416 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire                _zz_203_;
-  wire                _zz_204_;
-  wire                _zz_205_;
-  wire                _zz_206_;
-  wire                _zz_207_;
-  wire                _zz_208_;
-  wire                _zz_209_;
-  wire                _zz_210_;
-  wire                _zz_211_;
-  wire                _zz_212_;
-  wire                _zz_213_;
-  wire                _zz_214_;
-  wire       [1:0]    _zz_215_;
-  wire                _zz_216_;
-  wire                _zz_217_;
-  wire                _zz_218_;
-  wire                _zz_219_;
-  wire                _zz_220_;
-  wire                _zz_221_;
-  wire                _zz_222_;
-  wire                _zz_223_;
-  wire                _zz_224_;
-  wire                _zz_225_;
-  wire       [1:0]    _zz_226_;
-  wire                _zz_227_;
-  wire                _zz_228_;
-  wire                _zz_229_;
-  wire                _zz_230_;
-  wire                _zz_231_;
-  wire                _zz_232_;
-  wire                _zz_233_;
-  wire                _zz_234_;
-  wire       [1:0]    _zz_235_;
-  wire                _zz_236_;
-  wire       [1:0]    _zz_237_;
-  wire       [51:0]   _zz_238_;
-  wire       [51:0]   _zz_239_;
-  wire       [51:0]   _zz_240_;
-  wire       [32:0]   _zz_241_;
-  wire       [51:0]   _zz_242_;
-  wire       [49:0]   _zz_243_;
-  wire       [51:0]   _zz_244_;
-  wire       [49:0]   _zz_245_;
-  wire       [51:0]   _zz_246_;
-  wire       [0:0]    _zz_247_;
-  wire       [0:0]    _zz_248_;
-  wire       [0:0]    _zz_249_;
-  wire       [0:0]    _zz_250_;
-  wire       [32:0]   _zz_251_;
-  wire       [31:0]   _zz_252_;
-  wire       [32:0]   _zz_253_;
-  wire       [0:0]    _zz_254_;
-  wire       [0:0]    _zz_255_;
-  wire       [0:0]    _zz_256_;
-  wire       [0:0]    _zz_257_;
-  wire       [0:0]    _zz_258_;
-  wire       [0:0]    _zz_259_;
-  wire       [0:0]    _zz_260_;
-  wire       [0:0]    _zz_261_;
-  wire       [0:0]    _zz_262_;
-  wire       [0:0]    _zz_263_;
-  wire       [0:0]    _zz_264_;
-  wire       [0:0]    _zz_265_;
-  wire       [0:0]    _zz_266_;
-  wire       [3:0]    _zz_267_;
-  wire       [2:0]    _zz_268_;
-  wire       [31:0]   _zz_269_;
-  wire       [11:0]   _zz_270_;
-  wire       [31:0]   _zz_271_;
-  wire       [19:0]   _zz_272_;
-  wire       [11:0]   _zz_273_;
-  wire       [31:0]   _zz_274_;
-  wire       [31:0]   _zz_275_;
-  wire       [19:0]   _zz_276_;
-  wire       [11:0]   _zz_277_;
-  wire       [2:0]    _zz_278_;
-  wire       [2:0]    _zz_279_;
-  wire       [0:0]    _zz_280_;
-  wire       [2:0]    _zz_281_;
-  wire       [4:0]    _zz_282_;
-  wire       [11:0]   _zz_283_;
-  wire       [11:0]   _zz_284_;
-  wire       [31:0]   _zz_285_;
-  wire       [31:0]   _zz_286_;
-  wire       [31:0]   _zz_287_;
-  wire       [31:0]   _zz_288_;
-  wire       [31:0]   _zz_289_;
-  wire       [31:0]   _zz_290_;
-  wire       [31:0]   _zz_291_;
-  wire       [11:0]   _zz_292_;
-  wire       [19:0]   _zz_293_;
-  wire       [11:0]   _zz_294_;
-  wire       [31:0]   _zz_295_;
-  wire       [31:0]   _zz_296_;
-  wire       [31:0]   _zz_297_;
-  wire       [11:0]   _zz_298_;
-  wire       [19:0]   _zz_299_;
-  wire       [11:0]   _zz_300_;
-  wire       [2:0]    _zz_301_;
-  wire       [1:0]    _zz_302_;
-  wire       [1:0]    _zz_303_;
-  wire       [65:0]   _zz_304_;
-  wire       [65:0]   _zz_305_;
-  wire       [31:0]   _zz_306_;
-  wire       [31:0]   _zz_307_;
-  wire       [0:0]    _zz_308_;
-  wire       [5:0]    _zz_309_;
-  wire       [32:0]   _zz_310_;
-  wire       [31:0]   _zz_311_;
-  wire       [31:0]   _zz_312_;
-  wire       [32:0]   _zz_313_;
-  wire       [32:0]   _zz_314_;
-  wire       [32:0]   _zz_315_;
-  wire       [32:0]   _zz_316_;
-  wire       [0:0]    _zz_317_;
-  wire       [32:0]   _zz_318_;
-  wire       [0:0]    _zz_319_;
-  wire       [32:0]   _zz_320_;
-  wire       [0:0]    _zz_321_;
-  wire       [31:0]   _zz_322_;
-  wire       [0:0]    _zz_323_;
-  wire       [0:0]    _zz_324_;
-  wire       [0:0]    _zz_325_;
-  wire       [0:0]    _zz_326_;
-  wire       [0:0]    _zz_327_;
-  wire       [0:0]    _zz_328_;
-  wire       [0:0]    _zz_329_;
-  wire       [26:0]   _zz_330_;
-  wire                _zz_331_;
-  wire                _zz_332_;
-  wire       [1:0]    _zz_333_;
-  wire       [31:0]   _zz_334_;
-  wire       [31:0]   _zz_335_;
-  wire       [31:0]   _zz_336_;
-  wire                _zz_337_;
-  wire       [0:0]    _zz_338_;
-  wire       [13:0]   _zz_339_;
-  wire       [31:0]   _zz_340_;
-  wire       [31:0]   _zz_341_;
-  wire       [31:0]   _zz_342_;
-  wire                _zz_343_;
-  wire       [0:0]    _zz_344_;
-  wire       [7:0]    _zz_345_;
-  wire       [31:0]   _zz_346_;
-  wire       [31:0]   _zz_347_;
-  wire       [31:0]   _zz_348_;
-  wire                _zz_349_;
-  wire       [0:0]    _zz_350_;
-  wire       [1:0]    _zz_351_;
-  wire                _zz_352_;
-  wire                _zz_353_;
-  wire                _zz_354_;
-  wire       [31:0]   _zz_355_;
-  wire       [31:0]   _zz_356_;
-  wire                _zz_357_;
-  wire                _zz_358_;
-  wire       [0:0]    _zz_359_;
-  wire       [0:0]    _zz_360_;
-  wire                _zz_361_;
-  wire       [0:0]    _zz_362_;
-  wire       [25:0]   _zz_363_;
-  wire       [31:0]   _zz_364_;
-  wire                _zz_365_;
-  wire       [0:0]    _zz_366_;
-  wire       [0:0]    _zz_367_;
-  wire       [0:0]    _zz_368_;
-  wire       [0:0]    _zz_369_;
-  wire       [1:0]    _zz_370_;
-  wire       [1:0]    _zz_371_;
-  wire                _zz_372_;
-  wire       [0:0]    _zz_373_;
-  wire       [21:0]   _zz_374_;
-  wire       [31:0]   _zz_375_;
-  wire       [31:0]   _zz_376_;
-  wire       [31:0]   _zz_377_;
-  wire       [31:0]   _zz_378_;
-  wire       [31:0]   _zz_379_;
-  wire       [1:0]    _zz_380_;
-  wire       [1:0]    _zz_381_;
-  wire                _zz_382_;
-  wire       [0:0]    _zz_383_;
-  wire       [18:0]   _zz_384_;
-  wire       [31:0]   _zz_385_;
-  wire       [31:0]   _zz_386_;
-  wire       [31:0]   _zz_387_;
-  wire       [31:0]   _zz_388_;
-  wire       [31:0]   _zz_389_;
-  wire       [0:0]    _zz_390_;
-  wire       [0:0]    _zz_391_;
-  wire       [0:0]    _zz_392_;
-  wire       [0:0]    _zz_393_;
-  wire                _zz_394_;
-  wire       [0:0]    _zz_395_;
-  wire       [14:0]   _zz_396_;
-  wire       [31:0]   _zz_397_;
-  wire       [31:0]   _zz_398_;
-  wire       [31:0]   _zz_399_;
-  wire       [0:0]    _zz_400_;
-  wire       [0:0]    _zz_401_;
-  wire       [1:0]    _zz_402_;
-  wire       [1:0]    _zz_403_;
-  wire                _zz_404_;
-  wire       [0:0]    _zz_405_;
-  wire       [10:0]   _zz_406_;
-  wire       [31:0]   _zz_407_;
-  wire       [31:0]   _zz_408_;
-  wire       [31:0]   _zz_409_;
-  wire       [31:0]   _zz_410_;
-  wire       [31:0]   _zz_411_;
-  wire       [31:0]   _zz_412_;
-  wire                _zz_413_;
-  wire       [0:0]    _zz_414_;
-  wire       [0:0]    _zz_415_;
-  wire       [0:0]    _zz_416_;
-  wire       [0:0]    _zz_417_;
-  wire       [0:0]    _zz_418_;
-  wire       [0:0]    _zz_419_;
-  wire                _zz_420_;
-  wire       [0:0]    _zz_421_;
-  wire       [7:0]    _zz_422_;
-  wire       [31:0]   _zz_423_;
-  wire       [31:0]   _zz_424_;
-  wire       [31:0]   _zz_425_;
-  wire       [31:0]   _zz_426_;
-  wire       [31:0]   _zz_427_;
-  wire       [31:0]   _zz_428_;
-  wire       [31:0]   _zz_429_;
-  wire       [31:0]   _zz_430_;
-  wire       [31:0]   _zz_431_;
-  wire       [31:0]   _zz_432_;
-  wire       [31:0]   _zz_433_;
-  wire       [0:0]    _zz_434_;
-  wire       [3:0]    _zz_435_;
-  wire       [4:0]    _zz_436_;
-  wire       [4:0]    _zz_437_;
-  wire                _zz_438_;
-  wire       [0:0]    _zz_439_;
-  wire       [5:0]    _zz_440_;
-  wire       [31:0]   _zz_441_;
-  wire       [31:0]   _zz_442_;
-  wire                _zz_443_;
-  wire       [0:0]    _zz_444_;
-  wire       [0:0]    _zz_445_;
-  wire       [31:0]   _zz_446_;
-  wire       [31:0]   _zz_447_;
-  wire       [0:0]    _zz_448_;
-  wire       [1:0]    _zz_449_;
-  wire       [31:0]   _zz_450_;
-  wire       [31:0]   _zz_451_;
-  wire                _zz_452_;
-  wire       [4:0]    _zz_453_;
-  wire       [4:0]    _zz_454_;
-  wire                _zz_455_;
-  wire       [0:0]    _zz_456_;
-  wire       [2:0]    _zz_457_;
-  wire       [31:0]   _zz_458_;
-  wire       [31:0]   _zz_459_;
-  wire       [31:0]   _zz_460_;
-  wire       [31:0]   _zz_461_;
-  wire       [31:0]   _zz_462_;
-  wire       [31:0]   _zz_463_;
-  wire       [31:0]   _zz_464_;
-  wire                _zz_465_;
-  wire                _zz_466_;
-  wire       [31:0]   _zz_467_;
-  wire                _zz_468_;
-  wire       [0:0]    _zz_469_;
-  wire       [2:0]    _zz_470_;
-  wire                _zz_471_;
-  wire       [0:0]    _zz_472_;
-  wire       [0:0]    _zz_473_;
-  wire                _zz_474_;
-  wire       [0:0]    _zz_475_;
-  wire       [0:0]    _zz_476_;
-  wire       [31:0]   _zz_477_;
-  wire       [31:0]   _zz_478_;
-  wire       [31:0]   _zz_479_;
-  wire       [31:0]   _zz_480_;
-  wire       [31:0]   _zz_481_;
-  wire                _zz_482_;
-  wire       [0:0]    _zz_483_;
-  wire       [0:0]    _zz_484_;
-  wire       [31:0]   _zz_485_;
-  wire       [31:0]   _zz_486_;
-  wire       [31:0]   _zz_487_;
-  wire       [0:0]    _zz_488_;
-  wire       [2:0]    _zz_489_;
-  wire       [0:0]    _zz_490_;
-  wire       [0:0]    _zz_491_;
-  wire       [5:0]    _zz_492_;
-  wire       [5:0]    _zz_493_;
-  wire       [31:0]   _zz_494_;
-  wire       [31:0]   _zz_495_;
-  wire       [31:0]   _zz_496_;
-  wire       [31:0]   _zz_497_;
-  wire       [31:0]   _zz_498_;
-  wire                _zz_499_;
-  wire                _zz_500_;
-  wire       [31:0]   _zz_501_;
-  wire                _zz_502_;
-  wire       [0:0]    _zz_503_;
-  wire       [2:0]    _zz_504_;
-  wire                _zz_505_;
-  wire                _zz_506_;
-  wire                _zz_507_;
-  wire       [31:0]   _zz_508_;
-  wire       [33:0]   execute_MUL_LH;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_210;
+  wire                _zz_211;
+  wire                _zz_212;
+  wire                _zz_213;
+  wire                _zz_214;
+  wire                _zz_215;
+  wire                _zz_216;
+  wire                _zz_217;
+  wire                _zz_218;
+  wire                _zz_219;
+  wire                _zz_220;
+  wire                _zz_221;
+  wire                _zz_222;
+  wire                _zz_223;
+  wire       [1:0]    _zz_224;
+  wire                _zz_225;
+  wire                _zz_226;
+  wire                _zz_227;
+  wire                _zz_228;
+  wire                _zz_229;
+  wire                _zz_230;
+  wire                _zz_231;
+  wire                _zz_232;
+  wire                _zz_233;
+  wire                _zz_234;
+  wire       [1:0]    _zz_235;
+  wire                _zz_236;
+  wire                _zz_237;
+  wire                _zz_238;
+  wire                _zz_239;
+  wire                _zz_240;
+  wire                _zz_241;
+  wire                _zz_242;
+  wire                _zz_243;
+  wire       [1:0]    _zz_244;
+  wire                _zz_245;
+  wire       [1:0]    _zz_246;
+  wire       [51:0]   _zz_247;
+  wire       [51:0]   _zz_248;
+  wire       [51:0]   _zz_249;
+  wire       [32:0]   _zz_250;
+  wire       [51:0]   _zz_251;
+  wire       [49:0]   _zz_252;
+  wire       [51:0]   _zz_253;
+  wire       [49:0]   _zz_254;
+  wire       [51:0]   _zz_255;
+  wire       [32:0]   _zz_256;
+  wire       [31:0]   _zz_257;
+  wire       [32:0]   _zz_258;
+  wire       [0:0]    _zz_259;
+  wire       [0:0]    _zz_260;
+  wire       [0:0]    _zz_261;
+  wire       [0:0]    _zz_262;
+  wire       [0:0]    _zz_263;
+  wire       [0:0]    _zz_264;
+  wire       [0:0]    _zz_265;
+  wire       [0:0]    _zz_266;
+  wire       [0:0]    _zz_267;
+  wire       [0:0]    _zz_268;
+  wire       [0:0]    _zz_269;
+  wire       [0:0]    _zz_270;
+  wire       [0:0]    _zz_271;
+  wire       [0:0]    _zz_272;
+  wire       [0:0]    _zz_273;
+  wire       [0:0]    _zz_274;
+  wire       [0:0]    _zz_275;
+  wire       [3:0]    _zz_276;
+  wire       [2:0]    _zz_277;
+  wire       [31:0]   _zz_278;
+  wire       [11:0]   _zz_279;
+  wire       [31:0]   _zz_280;
+  wire       [19:0]   _zz_281;
+  wire       [11:0]   _zz_282;
+  wire       [31:0]   _zz_283;
+  wire       [31:0]   _zz_284;
+  wire       [19:0]   _zz_285;
+  wire       [11:0]   _zz_286;
+  wire       [2:0]    _zz_287;
+  wire       [2:0]    _zz_288;
+  wire       [0:0]    _zz_289;
+  wire       [2:0]    _zz_290;
+  wire       [4:0]    _zz_291;
+  wire       [11:0]   _zz_292;
+  wire       [11:0]   _zz_293;
+  wire       [31:0]   _zz_294;
+  wire       [31:0]   _zz_295;
+  wire       [31:0]   _zz_296;
+  wire       [31:0]   _zz_297;
+  wire       [31:0]   _zz_298;
+  wire       [31:0]   _zz_299;
+  wire       [31:0]   _zz_300;
+  wire       [11:0]   _zz_301;
+  wire       [19:0]   _zz_302;
+  wire       [11:0]   _zz_303;
+  wire       [31:0]   _zz_304;
+  wire       [31:0]   _zz_305;
+  wire       [31:0]   _zz_306;
+  wire       [11:0]   _zz_307;
+  wire       [19:0]   _zz_308;
+  wire       [11:0]   _zz_309;
+  wire       [2:0]    _zz_310;
+  wire       [1:0]    _zz_311;
+  wire       [1:0]    _zz_312;
+  wire       [65:0]   _zz_313;
+  wire       [65:0]   _zz_314;
+  wire       [31:0]   _zz_315;
+  wire       [31:0]   _zz_316;
+  wire       [0:0]    _zz_317;
+  wire       [5:0]    _zz_318;
+  wire       [32:0]   _zz_319;
+  wire       [31:0]   _zz_320;
+  wire       [31:0]   _zz_321;
+  wire       [32:0]   _zz_322;
+  wire       [32:0]   _zz_323;
+  wire       [32:0]   _zz_324;
+  wire       [32:0]   _zz_325;
+  wire       [0:0]    _zz_326;
+  wire       [32:0]   _zz_327;
+  wire       [0:0]    _zz_328;
+  wire       [32:0]   _zz_329;
+  wire       [0:0]    _zz_330;
+  wire       [31:0]   _zz_331;
+  wire       [0:0]    _zz_332;
+  wire       [0:0]    _zz_333;
+  wire       [0:0]    _zz_334;
+  wire       [0:0]    _zz_335;
+  wire       [0:0]    _zz_336;
+  wire       [0:0]    _zz_337;
+  wire       [0:0]    _zz_338;
+  wire       [26:0]   _zz_339;
+  wire                _zz_340;
+  wire                _zz_341;
+  wire       [1:0]    _zz_342;
+  wire       [31:0]   _zz_343;
+  wire       [31:0]   _zz_344;
+  wire       [31:0]   _zz_345;
+  wire                _zz_346;
+  wire       [0:0]    _zz_347;
+  wire       [13:0]   _zz_348;
+  wire       [31:0]   _zz_349;
+  wire       [31:0]   _zz_350;
+  wire       [31:0]   _zz_351;
+  wire                _zz_352;
+  wire       [0:0]    _zz_353;
+  wire       [7:0]    _zz_354;
+  wire       [31:0]   _zz_355;
+  wire       [31:0]   _zz_356;
+  wire       [31:0]   _zz_357;
+  wire                _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [1:0]    _zz_360;
+  wire                _zz_361;
+  wire                _zz_362;
+  wire                _zz_363;
+  wire       [31:0]   _zz_364;
+  wire       [31:0]   _zz_365;
+  wire                _zz_366;
+  wire       [0:0]    _zz_367;
+  wire       [0:0]    _zz_368;
+  wire                _zz_369;
+  wire       [0:0]    _zz_370;
+  wire       [24:0]   _zz_371;
+  wire       [31:0]   _zz_372;
+  wire                _zz_373;
+  wire                _zz_374;
+  wire       [0:0]    _zz_375;
+  wire       [0:0]    _zz_376;
+  wire       [0:0]    _zz_377;
+  wire       [0:0]    _zz_378;
+  wire                _zz_379;
+  wire       [0:0]    _zz_380;
+  wire       [20:0]   _zz_381;
+  wire       [31:0]   _zz_382;
+  wire       [31:0]   _zz_383;
+  wire                _zz_384;
+  wire                _zz_385;
+  wire       [0:0]    _zz_386;
+  wire       [1:0]    _zz_387;
+  wire       [0:0]    _zz_388;
+  wire       [0:0]    _zz_389;
+  wire                _zz_390;
+  wire       [0:0]    _zz_391;
+  wire       [17:0]   _zz_392;
+  wire       [31:0]   _zz_393;
+  wire       [31:0]   _zz_394;
+  wire       [31:0]   _zz_395;
+  wire       [31:0]   _zz_396;
+  wire       [31:0]   _zz_397;
+  wire       [31:0]   _zz_398;
+  wire       [31:0]   _zz_399;
+  wire       [31:0]   _zz_400;
+  wire                _zz_401;
+  wire       [1:0]    _zz_402;
+  wire       [1:0]    _zz_403;
+  wire                _zz_404;
+  wire       [0:0]    _zz_405;
+  wire       [14:0]   _zz_406;
+  wire       [31:0]   _zz_407;
+  wire       [31:0]   _zz_408;
+  wire       [31:0]   _zz_409;
+  wire       [31:0]   _zz_410;
+  wire       [31:0]   _zz_411;
+  wire       [31:0]   _zz_412;
+  wire       [0:0]    _zz_413;
+  wire       [0:0]    _zz_414;
+  wire       [4:0]    _zz_415;
+  wire       [4:0]    _zz_416;
+  wire                _zz_417;
+  wire       [0:0]    _zz_418;
+  wire       [11:0]   _zz_419;
+  wire       [31:0]   _zz_420;
+  wire       [31:0]   _zz_421;
+  wire       [31:0]   _zz_422;
+  wire       [31:0]   _zz_423;
+  wire                _zz_424;
+  wire       [0:0]    _zz_425;
+  wire       [1:0]    _zz_426;
+  wire       [31:0]   _zz_427;
+  wire       [31:0]   _zz_428;
+  wire       [0:0]    _zz_429;
+  wire       [3:0]    _zz_430;
+  wire       [4:0]    _zz_431;
+  wire       [4:0]    _zz_432;
+  wire                _zz_433;
+  wire       [0:0]    _zz_434;
+  wire       [8:0]    _zz_435;
+  wire       [31:0]   _zz_436;
+  wire       [31:0]   _zz_437;
+  wire       [31:0]   _zz_438;
+  wire                _zz_439;
+  wire                _zz_440;
+  wire       [31:0]   _zz_441;
+  wire       [31:0]   _zz_442;
+  wire       [0:0]    _zz_443;
+  wire       [1:0]    _zz_444;
+  wire       [0:0]    _zz_445;
+  wire       [2:0]    _zz_446;
+  wire       [0:0]    _zz_447;
+  wire       [4:0]    _zz_448;
+  wire       [1:0]    _zz_449;
+  wire       [1:0]    _zz_450;
+  wire                _zz_451;
+  wire       [0:0]    _zz_452;
+  wire       [6:0]    _zz_453;
+  wire       [31:0]   _zz_454;
+  wire       [31:0]   _zz_455;
+  wire       [31:0]   _zz_456;
+  wire       [31:0]   _zz_457;
+  wire                _zz_458;
+  wire                _zz_459;
+  wire       [31:0]   _zz_460;
+  wire       [31:0]   _zz_461;
+  wire                _zz_462;
+  wire       [0:0]    _zz_463;
+  wire       [0:0]    _zz_464;
+  wire                _zz_465;
+  wire       [0:0]    _zz_466;
+  wire       [2:0]    _zz_467;
+  wire                _zz_468;
+  wire       [0:0]    _zz_469;
+  wire       [0:0]    _zz_470;
+  wire       [0:0]    _zz_471;
+  wire       [0:0]    _zz_472;
+  wire                _zz_473;
+  wire       [0:0]    _zz_474;
+  wire       [4:0]    _zz_475;
+  wire       [31:0]   _zz_476;
+  wire       [31:0]   _zz_477;
+  wire       [31:0]   _zz_478;
+  wire       [31:0]   _zz_479;
+  wire       [31:0]   _zz_480;
+  wire       [31:0]   _zz_481;
+  wire       [31:0]   _zz_482;
+  wire       [31:0]   _zz_483;
+  wire       [31:0]   _zz_484;
+  wire       [31:0]   _zz_485;
+  wire                _zz_486;
+  wire       [0:0]    _zz_487;
+  wire       [0:0]    _zz_488;
+  wire       [31:0]   _zz_489;
+  wire       [31:0]   _zz_490;
+  wire       [31:0]   _zz_491;
+  wire       [31:0]   _zz_492;
+  wire       [31:0]   _zz_493;
+  wire                _zz_494;
+  wire       [3:0]    _zz_495;
+  wire       [3:0]    _zz_496;
+  wire                _zz_497;
+  wire       [0:0]    _zz_498;
+  wire       [2:0]    _zz_499;
+  wire       [31:0]   _zz_500;
+  wire       [31:0]   _zz_501;
+  wire       [31:0]   _zz_502;
+  wire       [31:0]   _zz_503;
+  wire       [31:0]   _zz_504;
+  wire       [31:0]   _zz_505;
+  wire                _zz_506;
+  wire       [0:0]    _zz_507;
+  wire       [1:0]    _zz_508;
+  wire                _zz_509;
+  wire       [2:0]    _zz_510;
+  wire       [2:0]    _zz_511;
+  wire                _zz_512;
+  wire       [0:0]    _zz_513;
+  wire       [0:0]    _zz_514;
+  wire       [31:0]   _zz_515;
+  wire       [31:0]   _zz_516;
+  wire       [31:0]   _zz_517;
+  wire       [31:0]   _zz_518;
+  wire       [31:0]   _zz_519;
+  wire       [31:0]   _zz_520;
+  wire       [31:0]   _zz_521;
+  wire                _zz_522;
+  wire                _zz_523;
+  wire                _zz_524;
+  wire       [0:0]    _zz_525;
+  wire       [0:0]    _zz_526;
+  wire                _zz_527;
+  wire                _zz_528;
+  wire                _zz_529;
+  wire                _zz_530;
+  wire       [31:0]   _zz_531;
   wire       [51:0]   memory_MUL_LOW;
-  wire                memory_MEMORY_WR;
-  wire                decode_MEMORY_WR;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [31:0]   memory_PC;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_2_;
-  wire                decode_IS_DIV;
-  wire                decode_IS_RS2_SIGNED;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       [31:0]   execute_SHIFT_RIGHT;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_3_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_5_;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10_;
-  wire                decode_MEMORY_MANAGMENT;
-  wire                decode_IS_CSR;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
   wire       [31:0]   execute_MUL_LL;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
   wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire                decode_CSR_READ_OPCODE;
-  wire                execute_BRANCH_DO;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_16_;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire                decode_IS_RS1_SIGNED;
-  wire                memory_IS_MUL;
-  wire                execute_IS_MUL;
-  wire                decode_IS_MUL;
-  wire       [33:0]   memory_MUL_HH;
-  wire       [33:0]   execute_MUL_HH;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_26_;
-  wire       [33:0]   execute_MUL_HL;
+  wire       [31:0]   memory_PC;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -1528,22 +541,22 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* syn_keep , keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1553,66 +566,67 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_49_;
-  reg        [31:0]   _zz_50_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
-  (* syn_keep , keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_51_;
-  reg                 _zz_51__2;
-  reg                 _zz_51__1;
-  reg                 _zz_51__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53_;
-  reg        [31:0]   _zz_54_;
+  reg        [31:0]   _zz_52;
+  reg        [31:0]   _zz_53;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -1628,7 +642,7 @@ module VexRiscv (
   wire                decode_arbitration_isMoving;
   wire                decode_arbitration_isFiring;
   reg                 execute_arbitration_haltItself;
-  wire                execute_arbitration_haltByOther;
+  reg                 execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
   wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
@@ -1667,7 +681,7 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetcherHalt;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
-  (* syn_keep , keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
   reg                 IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   wire                IBusCachedPlugin_decodePrediction_rsp_wasWrong;
   wire                IBusCachedPlugin_pcValids_0;
@@ -1677,28 +691,47 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                DBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -1734,11 +767,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55_;
-  wire       [3:0]    _zz_56_;
-  wire                _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
+  wire       [3:0]    _zz_54;
+  wire       [3:0]    _zz_55;
+  wire                _zz_56;
+  wire                _zz_57;
+  wire                _zz_58;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -1775,16 +808,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_60_;
-  wire                _zz_61_;
-  wire                _zz_62_;
+  wire                _zz_59;
+  wire                _zz_60;
+  wire                _zz_61;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63_;
-  wire                _zz_64_;
-  reg                 _zz_65_;
-  wire                _zz_66_;
-  reg                 _zz_67_;
-  reg        [31:0]   _zz_68_;
+  wire                _zz_62;
+  wire                _zz_63;
+  reg                 _zz_64;
+  wire                _zz_65;
+  reg                 _zz_66;
+  reg        [31:0]   _zz_67;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1797,17 +830,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_69_;
-  reg        [18:0]   _zz_70_;
-  wire                _zz_71_;
-  reg        [10:0]   _zz_72_;
-  wire                _zz_73_;
-  reg        [18:0]   _zz_74_;
-  reg                 _zz_75_;
-  wire                _zz_76_;
-  reg        [10:0]   _zz_77_;
-  wire                _zz_78_;
-  reg        [18:0]   _zz_79_;
+  wire                _zz_68;
+  reg        [18:0]   _zz_69;
+  wire                _zz_70;
+  reg        [10:0]   _zz_71;
+  wire                _zz_72;
+  reg        [18:0]   _zz_73;
+  reg                 _zz_74;
+  wire                _zz_75;
+  reg        [10:0]   _zz_76;
+  wire                _zz_77;
+  reg        [18:0]   _zz_78;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1815,7 +848,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_80_;
+  wire       [31:0]   _zz_79;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1823,122 +856,115 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_81_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_80;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_82_;
+  reg        [31:0]   _zz_81;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_83_;
-  reg        [31:0]   _zz_84_;
-  wire                _zz_85_;
-  reg        [31:0]   _zz_86_;
+  wire                _zz_82;
+  reg        [31:0]   _zz_83;
+  wire                _zz_84;
+  reg        [31:0]   _zz_85;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [31:0]   _zz_87_;
-  wire                _zz_88_;
-  wire                _zz_89_;
-  wire                _zz_90_;
-  wire                _zz_91_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_92_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_93_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_94_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_95_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_96_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_97_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_98_;
+  wire       [31:0]   _zz_86;
+  wire                _zz_87;
+  wire                _zz_88;
+  wire                _zz_89;
+  wire                _zz_90;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_91;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_92;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_93;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_94;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_95;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_96;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_97;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_99_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_98;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_100_;
-  reg        [31:0]   _zz_101_;
-  wire                _zz_102_;
-  reg        [19:0]   _zz_103_;
-  wire                _zz_104_;
-  reg        [19:0]   _zz_105_;
-  reg        [31:0]   _zz_106_;
+  reg        [31:0]   _zz_99;
+  reg        [31:0]   _zz_100;
+  wire                _zz_101;
+  reg        [19:0]   _zz_102;
+  wire                _zz_103;
+  reg        [19:0]   _zz_104;
+  reg        [31:0]   _zz_105;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_107_;
+  reg        [31:0]   _zz_106;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_108_;
-  reg                 _zz_109_;
-  reg                 _zz_110_;
-  reg                 _zz_111_;
-  reg        [4:0]    _zz_112_;
-  reg        [31:0]   _zz_113_;
-  wire                _zz_114_;
-  wire                _zz_115_;
-  wire                _zz_116_;
-  wire                _zz_117_;
-  wire                _zz_118_;
-  wire                _zz_119_;
+  reg        [31:0]   _zz_107;
+  reg                 _zz_108;
+  reg                 _zz_109;
+  reg                 _zz_110;
+  reg        [4:0]    _zz_111;
+  reg        [31:0]   _zz_112;
+  wire                _zz_113;
+  wire                _zz_114;
+  wire                _zz_115;
+  wire                _zz_116;
+  wire                _zz_117;
+  wire                _zz_118;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_120_;
-  reg                 _zz_121_;
-  reg                 _zz_122_;
-  wire                _zz_123_;
-  reg        [19:0]   _zz_124_;
-  wire                _zz_125_;
-  reg        [10:0]   _zz_126_;
-  wire                _zz_127_;
-  reg        [18:0]   _zz_128_;
-  reg                 _zz_129_;
+  wire       [2:0]    _zz_119;
+  reg                 _zz_120;
+  reg                 _zz_121;
+  wire                _zz_122;
+  reg        [19:0]   _zz_123;
+  wire                _zz_124;
+  reg        [10:0]   _zz_125;
+  wire                _zz_126;
+  reg        [18:0]   _zz_127;
+  reg                 _zz_128;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_130_;
-  reg        [19:0]   _zz_131_;
-  wire                _zz_132_;
-  reg        [10:0]   _zz_133_;
-  wire                _zz_134_;
-  reg        [18:0]   _zz_135_;
+  wire                _zz_129;
+  reg        [19:0]   _zz_130;
+  wire                _zz_131;
+  reg        [10:0]   _zz_132;
+  wire                _zz_133;
+  reg        [18:0]   _zz_134;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -1960,9 +986,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_136_;
-  wire                _zz_137_;
-  wire                _zz_138_;
+  wire                _zz_135;
+  wire                _zz_136;
+  wire                _zz_137;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1975,8 +1001,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_139_;
-  wire                _zz_140_;
+  wire       [1:0]    _zz_138;
+  wire                _zz_139;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -1988,7 +1014,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2029,79 +1055,80 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_141_;
+  wire       [31:0]   _zz_140;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_142_;
-  wire                _zz_143_;
-  wire                _zz_144_;
-  reg        [32:0]   _zz_145_;
+  wire       [31:0]   _zz_141;
+  wire                _zz_142;
+  wire                _zz_143;
+  reg        [32:0]   _zz_144;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_146_;
-  wire       [31:0]   _zz_147_;
-  reg        [33:0]   execute_to_memory_MUL_HL;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg        [31:0]   decode_to_execute_INSTRUCTION;
-  reg        [31:0]   execute_to_memory_INSTRUCTION;
-  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 memory_to_writeBack_IS_MUL;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg        [31:0]   execute_to_memory_MUL_LL;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg                 decode_to_execute_IS_CSR;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg        [31:0]   _zz_145;
+  wire       [31:0]   _zz_146;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   reg                 decode_to_execute_MEMORY_WR;
   reg                 execute_to_memory_MEMORY_WR;
   reg                 memory_to_writeBack_MEMORY_WR;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 memory_to_writeBack_IS_MUL;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
   reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_3857;
   reg                 execute_CsrPlugin_csr_3858;
@@ -2126,769 +1153,618 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_3202;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_148_;
-  reg        [31:0]   _zz_149_;
-  reg        [31:0]   _zz_150_;
-  reg        [31:0]   _zz_151_;
-  reg        [31:0]   _zz_152_;
-  reg        [31:0]   _zz_153_;
-  reg        [31:0]   _zz_154_;
-  reg        [31:0]   _zz_155_;
-  reg        [31:0]   _zz_156_;
-  reg        [31:0]   _zz_157_;
-  reg        [31:0]   _zz_158_;
-  reg        [31:0]   _zz_159_;
-  reg        [31:0]   _zz_160_;
-  reg        [31:0]   _zz_161_;
-  reg        [31:0]   _zz_162_;
-  reg        [31:0]   _zz_163_;
-  reg        [31:0]   _zz_164_;
-  reg        [31:0]   _zz_165_;
-  reg        [31:0]   _zz_166_;
-  reg        [31:0]   _zz_167_;
-  reg        [31:0]   _zz_168_;
-  reg        [31:0]   _zz_169_;
-  reg        [31:0]   _zz_170_;
-  reg        [2:0]    _zz_171_;
-  reg                 _zz_172_;
+  reg        [31:0]   _zz_147;
+  reg        [31:0]   _zz_148;
+  reg        [31:0]   _zz_149;
+  reg        [31:0]   _zz_150;
+  reg        [31:0]   _zz_151;
+  reg        [31:0]   _zz_152;
+  reg        [31:0]   _zz_153;
+  reg        [31:0]   _zz_154;
+  reg        [31:0]   _zz_155;
+  reg        [31:0]   _zz_156;
+  reg        [31:0]   _zz_157;
+  reg        [31:0]   _zz_158;
+  reg        [31:0]   _zz_159;
+  reg        [31:0]   _zz_160;
+  reg        [31:0]   _zz_161;
+  reg        [31:0]   _zz_162;
+  reg        [31:0]   _zz_163;
+  reg        [31:0]   _zz_164;
+  reg        [31:0]   _zz_165;
+  reg        [31:0]   _zz_166;
+  reg        [31:0]   _zz_167;
+  reg        [31:0]   _zz_168;
+  reg        [31:0]   _zz_169;
+  reg        [2:0]    _zz_170;
+  reg                 _zz_171;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_173_;
-  wire                _zz_174_;
-  wire                _zz_175_;
-  wire                _zz_176_;
-  wire                _zz_177_;
-  wire                _zz_178_;
-  reg                 _zz_179_;
+  reg        [2:0]    _zz_172;
+  wire                _zz_173;
+  wire                _zz_174;
+  wire                _zz_175;
+  wire                _zz_176;
+  wire                _zz_177;
+  reg                 _zz_178;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [31:0] _zz_1__string;
-  reg [31:0] _zz_2__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_3__string;
-  reg [95:0] _zz_4__string;
-  reg [95:0] _zz_5__string;
-  reg [71:0] _zz_6__string;
-  reg [71:0] _zz_7__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_8__string;
-  reg [71:0] _zz_9__string;
-  reg [71:0] _zz_10__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_11__string;
-  reg [39:0] _zz_12__string;
-  reg [39:0] _zz_13__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_14__string;
-  reg [63:0] _zz_15__string;
-  reg [63:0] _zz_16__string;
-  reg [39:0] _zz_17__string;
-  reg [39:0] _zz_18__string;
-  reg [39:0] _zz_19__string;
-  reg [39:0] _zz_20__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_21__string;
-  reg [39:0] _zz_22__string;
-  reg [39:0] _zz_23__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_24__string;
-  reg [23:0] _zz_25__string;
-  reg [23:0] _zz_26__string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [23:0] _zz_43__string;
-  reg [39:0] _zz_44__string;
-  reg [95:0] _zz_45__string;
-  reg [31:0] _zz_46__string;
-  reg [63:0] _zz_47__string;
-  reg [71:0] _zz_48__string;
-  reg [39:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52__string;
-  reg [39:0] _zz_92__string;
-  reg [71:0] _zz_93__string;
-  reg [63:0] _zz_94__string;
-  reg [31:0] _zz_95__string;
-  reg [95:0] _zz_96__string;
-  reg [39:0] _zz_97__string;
-  reg [23:0] _zz_98__string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [39:0] decode_to_execute_ENV_CTRL_string;
-  reg [39:0] execute_to_memory_ENV_CTRL_string;
-  reg [39:0] memory_to_writeBack_ENV_CTRL_string;
+  reg [31:0] _zz_51_string;
+  reg [95:0] _zz_91_string;
+  reg [63:0] _zz_92_string;
+  reg [23:0] _zz_93_string;
+  reg [39:0] _zz_94_string;
+  reg [71:0] _zz_95_string;
+  reg [31:0] _zz_96_string;
+  reg [39:0] _zz_97_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
   reg [71:0] execute_to_memory_SHIFT_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
+  reg [39:0] decode_to_execute_ENV_CTRL_string;
+  reg [39:0] execute_to_memory_ENV_CTRL_string;
+  reg [39:0] memory_to_writeBack_ENV_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_201_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_202_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_203_ = 1'b1;
-  assign _zz_204_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_205_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_206_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_207_ = ((_zz_184_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_51__2));
-  assign _zz_208_ = ((_zz_184_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_51__1));
-  assign _zz_209_ = ((_zz_184_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_51__0));
-  assign _zz_210_ = ((_zz_184_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_211_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_212_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_213_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_214_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_215_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_216_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_217_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_218_ = (1'b0 || (! 1'b1));
-  assign _zz_219_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_220_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_221_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_222_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_223_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_224_ = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_225_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_226_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_227_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_228_ = (! memory_arbitration_isStuck);
-  assign _zz_229_ = (iBus_cmd_valid || (_zz_171_ != (3'b000)));
-  assign _zz_230_ = (_zz_197_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_231_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_232_ = ((_zz_136_ && 1'b1) && (! 1'b0));
-  assign _zz_233_ = ((_zz_137_ && 1'b1) && (! 1'b0));
-  assign _zz_234_ = ((_zz_138_ && 1'b1) && (! 1'b0));
-  assign _zz_235_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_236_ = execute_INSTRUCTION[13];
-  assign _zz_237_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_238_ = ($signed(_zz_239_) + $signed(_zz_244_));
-  assign _zz_239_ = ($signed(_zz_240_) + $signed(_zz_242_));
-  assign _zz_240_ = 52'h0;
-  assign _zz_241_ = {1'b0,memory_MUL_LL};
-  assign _zz_242_ = {{19{_zz_241_[32]}}, _zz_241_};
-  assign _zz_243_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_244_ = {{2{_zz_243_[49]}}, _zz_243_};
-  assign _zz_245_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_246_ = {{2{_zz_245_[49]}}, _zz_245_};
-  assign _zz_247_ = _zz_87_[10 : 10];
-  assign _zz_248_ = _zz_87_[7 : 7];
-  assign _zz_249_ = _zz_87_[23 : 23];
-  assign _zz_250_ = _zz_87_[9 : 9];
-  assign _zz_251_ = ($signed(_zz_253_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_252_ = _zz_251_[31 : 0];
-  assign _zz_253_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_254_ = _zz_87_[6 : 6];
-  assign _zz_255_ = _zz_87_[11 : 11];
-  assign _zz_256_ = _zz_87_[8 : 8];
-  assign _zz_257_ = _zz_87_[22 : 22];
-  assign _zz_258_ = _zz_87_[29 : 29];
-  assign _zz_259_ = _zz_87_[21 : 21];
-  assign _zz_260_ = _zz_87_[14 : 14];
-  assign _zz_261_ = _zz_87_[2 : 2];
-  assign _zz_262_ = _zz_87_[26 : 26];
-  assign _zz_263_ = _zz_87_[19 : 19];
-  assign _zz_264_ = _zz_87_[0 : 0];
-  assign _zz_265_ = _zz_87_[20 : 20];
-  assign _zz_266_ = _zz_87_[1 : 1];
-  assign _zz_267_ = (_zz_55_ - (4'b0001));
-  assign _zz_268_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_269_ = {29'd0, _zz_268_};
-  assign _zz_270_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_271_ = {{_zz_70_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_272_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_273_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_274_ = {{_zz_72_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_275_ = {{_zz_74_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_276_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_277_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_278_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_279_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_280_ = execute_SRC_LESS;
-  assign _zz_281_ = (3'b100);
-  assign _zz_282_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_283_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_284_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_285_ = ($signed(_zz_286_) + $signed(_zz_289_));
-  assign _zz_286_ = ($signed(_zz_287_) + $signed(_zz_288_));
-  assign _zz_287_ = execute_SRC1;
-  assign _zz_288_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_289_ = (execute_SRC_USE_SUB_LESS ? _zz_290_ : _zz_291_);
-  assign _zz_290_ = 32'h00000001;
-  assign _zz_291_ = 32'h0;
-  assign _zz_292_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_293_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_294_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_295_ = {_zz_124_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_296_ = {{_zz_126_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_297_ = {{_zz_128_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_298_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_299_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_300_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_301_ = (3'b100);
-  assign _zz_302_ = (_zz_139_ & (~ _zz_303_));
-  assign _zz_303_ = (_zz_139_ - (2'b01));
-  assign _zz_304_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_305_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_306_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_307_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_308_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_309_ = {5'd0, _zz_308_};
-  assign _zz_310_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_311_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_312_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_313_ = {_zz_141_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_314_ = _zz_315_;
-  assign _zz_315_ = _zz_316_;
-  assign _zz_316_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_142_) : _zz_142_)} + _zz_318_);
-  assign _zz_317_ = memory_DivPlugin_div_needRevert;
-  assign _zz_318_ = {32'd0, _zz_317_};
-  assign _zz_319_ = _zz_144_;
-  assign _zz_320_ = {32'd0, _zz_319_};
-  assign _zz_321_ = _zz_143_;
-  assign _zz_322_ = {31'd0, _zz_321_};
-  assign _zz_323_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_324_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_325_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_326_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_327_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_328_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_329_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_330_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_331_ = 1'b1;
-  assign _zz_332_ = 1'b1;
-  assign _zz_333_ = {_zz_59_,_zz_58_};
-  assign _zz_334_ = 32'h0000107f;
-  assign _zz_335_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_336_ = 32'h00002073;
-  assign _zz_337_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_338_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_339_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_340_) == 32'h00000003),{(_zz_341_ == _zz_342_),{_zz_343_,{_zz_344_,_zz_345_}}}}}};
-  assign _zz_340_ = 32'h0000505f;
-  assign _zz_341_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_342_ = 32'h00000063;
-  assign _zz_343_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_344_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_345_ = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_346_) == 32'h00001013),{(_zz_347_ == _zz_348_),{_zz_349_,{_zz_350_,_zz_351_}}}}}};
-  assign _zz_346_ = 32'hfc00307f;
-  assign _zz_347_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_348_ = 32'h00005033;
-  assign _zz_349_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_350_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_351_ = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_352_ = decode_INSTRUCTION[31];
-  assign _zz_353_ = decode_INSTRUCTION[31];
-  assign _zz_354_ = decode_INSTRUCTION[7];
-  assign _zz_355_ = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_356_ = 32'h00000020;
-  assign _zz_357_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz_358_ = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_359_ = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
-  assign _zz_360_ = (1'b0);
-  assign _zz_361_ = (((decode_INSTRUCTION & _zz_364_) == 32'h00000050) != (1'b0));
-  assign _zz_362_ = ({_zz_365_,{_zz_366_,_zz_367_}} != (3'b000));
-  assign _zz_363_ = {({_zz_368_,_zz_369_} != (2'b00)),{(_zz_370_ != _zz_371_),{_zz_372_,{_zz_373_,_zz_374_}}}};
-  assign _zz_364_ = 32'h00403050;
-  assign _zz_365_ = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_366_ = ((decode_INSTRUCTION & _zz_375_) == 32'h00002010);
-  assign _zz_367_ = ((decode_INSTRUCTION & _zz_376_) == 32'h40000030);
-  assign _zz_368_ = ((decode_INSTRUCTION & _zz_377_) == 32'h00000004);
-  assign _zz_369_ = _zz_91_;
-  assign _zz_370_ = {(_zz_378_ == _zz_379_),_zz_91_};
-  assign _zz_371_ = (2'b00);
-  assign _zz_372_ = (_zz_90_ != (1'b0));
-  assign _zz_373_ = (_zz_90_ != (1'b0));
-  assign _zz_374_ = {(_zz_380_ != _zz_381_),{_zz_382_,{_zz_383_,_zz_384_}}};
-  assign _zz_375_ = 32'h00002014;
-  assign _zz_376_ = 32'h40000034;
-  assign _zz_377_ = 32'h00000014;
-  assign _zz_378_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_379_ = 32'h00000004;
-  assign _zz_380_ = {((decode_INSTRUCTION & _zz_385_) == 32'h00002000),((decode_INSTRUCTION & _zz_386_) == 32'h00001000)};
-  assign _zz_381_ = (2'b00);
-  assign _zz_382_ = (((decode_INSTRUCTION & _zz_387_) == 32'h0) != (1'b0));
-  assign _zz_383_ = ((_zz_388_ == _zz_389_) != (1'b0));
-  assign _zz_384_ = {({_zz_390_,_zz_391_} != (2'b00)),{(_zz_392_ != _zz_393_),{_zz_394_,{_zz_395_,_zz_396_}}}};
-  assign _zz_385_ = 32'h00002010;
-  assign _zz_386_ = 32'h00005000;
-  assign _zz_387_ = 32'h00000058;
-  assign _zz_388_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_389_ = 32'h00000024;
-  assign _zz_390_ = _zz_88_;
-  assign _zz_391_ = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_392_ = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_393_ = (1'b0);
-  assign _zz_394_ = (((decode_INSTRUCTION & _zz_397_) == 32'h00004010) != (1'b0));
-  assign _zz_395_ = ((_zz_398_ == _zz_399_) != (1'b0));
-  assign _zz_396_ = {({_zz_400_,_zz_401_} != (2'b00)),{(_zz_402_ != _zz_403_),{_zz_404_,{_zz_405_,_zz_406_}}}};
-  assign _zz_397_ = 32'h00004014;
-  assign _zz_398_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_399_ = 32'h00002010;
-  assign _zz_400_ = ((decode_INSTRUCTION & _zz_407_) == 32'h00000020);
-  assign _zz_401_ = ((decode_INSTRUCTION & _zz_408_) == 32'h00000020);
-  assign _zz_402_ = {(_zz_409_ == _zz_410_),(_zz_411_ == _zz_412_)};
-  assign _zz_403_ = (2'b00);
-  assign _zz_404_ = ({_zz_413_,{_zz_414_,_zz_415_}} != (3'b000));
-  assign _zz_405_ = ({_zz_416_,_zz_417_} != (2'b00));
-  assign _zz_406_ = {(_zz_418_ != _zz_419_),{_zz_420_,{_zz_421_,_zz_422_}}};
-  assign _zz_407_ = 32'h00000034;
-  assign _zz_408_ = 32'h00000064;
-  assign _zz_409_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_410_ = 32'h00005010;
-  assign _zz_411_ = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_412_ = 32'h00005020;
-  assign _zz_413_ = ((decode_INSTRUCTION & _zz_423_) == 32'h40001010);
-  assign _zz_414_ = (_zz_424_ == _zz_425_);
-  assign _zz_415_ = (_zz_426_ == _zz_427_);
-  assign _zz_416_ = (_zz_428_ == _zz_429_);
-  assign _zz_417_ = (_zz_430_ == _zz_431_);
-  assign _zz_418_ = (_zz_432_ == _zz_433_);
-  assign _zz_419_ = (1'b0);
-  assign _zz_420_ = ({_zz_434_,_zz_435_} != 5'h0);
-  assign _zz_421_ = (_zz_436_ != _zz_437_);
-  assign _zz_422_ = {_zz_438_,{_zz_439_,_zz_440_}};
-  assign _zz_423_ = 32'h40003054;
-  assign _zz_424_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_425_ = 32'h00001010;
-  assign _zz_426_ = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_427_ = 32'h00001010;
-  assign _zz_428_ = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_429_ = 32'h00001050;
-  assign _zz_430_ = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_431_ = 32'h00002050;
-  assign _zz_432_ = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_433_ = 32'h00000020;
-  assign _zz_434_ = _zz_89_;
-  assign _zz_435_ = {(_zz_441_ == _zz_442_),{_zz_443_,{_zz_444_,_zz_445_}}};
-  assign _zz_436_ = {(_zz_446_ == _zz_447_),{_zz_89_,{_zz_448_,_zz_449_}}};
-  assign _zz_437_ = 5'h0;
-  assign _zz_438_ = ((_zz_450_ == _zz_451_) != (1'b0));
-  assign _zz_439_ = (_zz_452_ != (1'b0));
-  assign _zz_440_ = {(_zz_453_ != _zz_454_),{_zz_455_,{_zz_456_,_zz_457_}}};
-  assign _zz_441_ = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_442_ = 32'h00002010;
-  assign _zz_443_ = ((decode_INSTRUCTION & _zz_458_) == 32'h00000010);
-  assign _zz_444_ = (_zz_459_ == _zz_460_);
-  assign _zz_445_ = (_zz_461_ == _zz_462_);
-  assign _zz_446_ = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_447_ = 32'h00000040;
-  assign _zz_448_ = (_zz_463_ == _zz_464_);
-  assign _zz_449_ = {_zz_465_,_zz_466_};
-  assign _zz_450_ = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_451_ = 32'h02004020;
-  assign _zz_452_ = ((decode_INSTRUCTION & _zz_467_) == 32'h00004008);
-  assign _zz_453_ = {_zz_468_,{_zz_469_,_zz_470_}};
-  assign _zz_454_ = 5'h0;
-  assign _zz_455_ = (_zz_471_ != (1'b0));
-  assign _zz_456_ = (_zz_472_ != _zz_473_);
-  assign _zz_457_ = {_zz_474_,{_zz_475_,_zz_476_}};
-  assign _zz_458_ = 32'h00001030;
-  assign _zz_459_ = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz_460_ = 32'h00002020;
-  assign _zz_461_ = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_462_ = 32'h00000020;
-  assign _zz_463_ = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_464_ = 32'h00004020;
-  assign _zz_465_ = ((decode_INSTRUCTION & _zz_477_) == 32'h00000010);
-  assign _zz_466_ = ((decode_INSTRUCTION & _zz_478_) == 32'h00000020);
-  assign _zz_467_ = 32'h00004048;
-  assign _zz_468_ = ((decode_INSTRUCTION & _zz_479_) == 32'h00002040);
-  assign _zz_469_ = (_zz_480_ == _zz_481_);
-  assign _zz_470_ = {_zz_482_,{_zz_483_,_zz_484_}};
-  assign _zz_471_ = ((decode_INSTRUCTION & _zz_485_) == 32'h00001000);
-  assign _zz_472_ = (_zz_486_ == _zz_487_);
-  assign _zz_473_ = (1'b0);
-  assign _zz_474_ = ({_zz_488_,_zz_489_} != (4'b0000));
-  assign _zz_475_ = (_zz_490_ != _zz_491_);
-  assign _zz_476_ = (_zz_492_ != _zz_493_);
-  assign _zz_477_ = 32'h00000030;
-  assign _zz_478_ = 32'h02000020;
-  assign _zz_479_ = 32'h00002040;
-  assign _zz_480_ = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_481_ = 32'h00001040;
-  assign _zz_482_ = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_483_ = ((decode_INSTRUCTION & _zz_494_) == 32'h00000040);
-  assign _zz_484_ = ((decode_INSTRUCTION & _zz_495_) == 32'h0);
-  assign _zz_485_ = 32'h00001000;
-  assign _zz_486_ = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_487_ = 32'h00002000;
-  assign _zz_488_ = ((decode_INSTRUCTION & _zz_496_) == 32'h0);
-  assign _zz_489_ = {(_zz_497_ == _zz_498_),{_zz_499_,_zz_500_}};
-  assign _zz_490_ = ((decode_INSTRUCTION & _zz_501_) == 32'h00001008);
-  assign _zz_491_ = (1'b0);
-  assign _zz_492_ = {_zz_88_,{_zz_502_,{_zz_503_,_zz_504_}}};
-  assign _zz_493_ = 6'h0;
-  assign _zz_494_ = 32'h00400040;
-  assign _zz_495_ = 32'h00000038;
-  assign _zz_496_ = 32'h00000044;
-  assign _zz_497_ = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_498_ = 32'h0;
-  assign _zz_499_ = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_500_ = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_501_ = 32'h00005048;
-  assign _zz_502_ = ((decode_INSTRUCTION & 32'h00001010) == 32'h00001010);
-  assign _zz_503_ = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
-  assign _zz_504_ = {((decode_INSTRUCTION & 32'h00000050) == 32'h00000010),{((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004),((decode_INSTRUCTION & 32'h00000028) == 32'h0)}};
-  assign _zz_505_ = execute_INSTRUCTION[31];
-  assign _zz_506_ = execute_INSTRUCTION[31];
-  assign _zz_507_ = execute_INSTRUCTION[7];
-  assign _zz_508_ = 32'h0;
+  assign _zz_210 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_211 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_212 = 1'b1;
+  assign _zz_213 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_214 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_215 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_216 = ((_zz_184 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_217 = ((_zz_184 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_218 = ((_zz_184 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_219 = ((_zz_184 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_220 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_221 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_222 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_223 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_224 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_225 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_226 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_227 = (1'b0 || (! 1'b1));
+  assign _zz_228 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_229 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_230 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_231 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_232 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_233 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_234 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_235 = execute_INSTRUCTION[13 : 12];
+  assign _zz_236 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_237 = (! memory_arbitration_isStuck);
+  assign _zz_238 = (iBus_cmd_valid || (_zz_170 != 3'b000));
+  assign _zz_239 = (_zz_206 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_240 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_241 = ((_zz_135 && 1'b1) && (! 1'b0));
+  assign _zz_242 = ((_zz_136 && 1'b1) && (! 1'b0));
+  assign _zz_243 = ((_zz_137 && 1'b1) && (! 1'b0));
+  assign _zz_244 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_245 = execute_INSTRUCTION[13];
+  assign _zz_246 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_247 = ($signed(_zz_248) + $signed(_zz_253));
+  assign _zz_248 = ($signed(_zz_249) + $signed(_zz_251));
+  assign _zz_249 = 52'h0;
+  assign _zz_250 = {1'b0,memory_MUL_LL};
+  assign _zz_251 = {{19{_zz_250[32]}}, _zz_250};
+  assign _zz_252 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_253 = {{2{_zz_252[49]}}, _zz_252};
+  assign _zz_254 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_255 = {{2{_zz_254[49]}}, _zz_254};
+  assign _zz_256 = ($signed(_zz_258) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_257 = _zz_256[31 : 0];
+  assign _zz_258 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_259 = _zz_86[31 : 31];
+  assign _zz_260 = _zz_86[30 : 30];
+  assign _zz_261 = _zz_86[29 : 29];
+  assign _zz_262 = _zz_86[28 : 28];
+  assign _zz_263 = _zz_86[25 : 25];
+  assign _zz_264 = _zz_86[17 : 17];
+  assign _zz_265 = _zz_86[16 : 16];
+  assign _zz_266 = _zz_86[13 : 13];
+  assign _zz_267 = _zz_86[12 : 12];
+  assign _zz_268 = _zz_86[11 : 11];
+  assign _zz_269 = _zz_86[15 : 15];
+  assign _zz_270 = _zz_86[5 : 5];
+  assign _zz_271 = _zz_86[3 : 3];
+  assign _zz_272 = _zz_86[20 : 20];
+  assign _zz_273 = _zz_86[10 : 10];
+  assign _zz_274 = _zz_86[4 : 4];
+  assign _zz_275 = _zz_86[0 : 0];
+  assign _zz_276 = (_zz_54 - 4'b0001);
+  assign _zz_277 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_278 = {29'd0, _zz_277};
+  assign _zz_279 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_280 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_281 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_282 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_283 = {{_zz_71,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_284 = {{_zz_73,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_285 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_286 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_287 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_288 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_289 = execute_SRC_LESS;
+  assign _zz_290 = 3'b100;
+  assign _zz_291 = execute_INSTRUCTION[19 : 15];
+  assign _zz_292 = execute_INSTRUCTION[31 : 20];
+  assign _zz_293 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_294 = ($signed(_zz_295) + $signed(_zz_298));
+  assign _zz_295 = ($signed(_zz_296) + $signed(_zz_297));
+  assign _zz_296 = execute_SRC1;
+  assign _zz_297 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_298 = (execute_SRC_USE_SUB_LESS ? _zz_299 : _zz_300);
+  assign _zz_299 = 32'h00000001;
+  assign _zz_300 = 32'h0;
+  assign _zz_301 = execute_INSTRUCTION[31 : 20];
+  assign _zz_302 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_303 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_304 = {_zz_123,execute_INSTRUCTION[31 : 20]};
+  assign _zz_305 = {{_zz_125,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_306 = {{_zz_127,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_307 = execute_INSTRUCTION[31 : 20];
+  assign _zz_308 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_309 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_310 = 3'b100;
+  assign _zz_311 = (_zz_138 & (~ _zz_312));
+  assign _zz_312 = (_zz_138 - 2'b01);
+  assign _zz_313 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_314 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_315 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_316 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_317 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_318 = {5'd0, _zz_317};
+  assign _zz_319 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_320 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_321 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_322 = {_zz_140,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_323 = _zz_324;
+  assign _zz_324 = _zz_325;
+  assign _zz_325 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_141) : _zz_141)} + _zz_327);
+  assign _zz_326 = memory_DivPlugin_div_needRevert;
+  assign _zz_327 = {32'd0, _zz_326};
+  assign _zz_328 = _zz_143;
+  assign _zz_329 = {32'd0, _zz_328};
+  assign _zz_330 = _zz_142;
+  assign _zz_331 = {31'd0, _zz_330};
+  assign _zz_332 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_333 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_334 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_335 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_336 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_337 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_338 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_339 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_340 = 1'b1;
+  assign _zz_341 = 1'b1;
+  assign _zz_342 = {_zz_58,_zz_57};
+  assign _zz_343 = 32'h0000107f;
+  assign _zz_344 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_345 = 32'h00002073;
+  assign _zz_346 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_347 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_348 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_349) == 32'h00000003),{(_zz_350 == _zz_351),{_zz_352,{_zz_353,_zz_354}}}}}};
+  assign _zz_349 = 32'h0000505f;
+  assign _zz_350 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_351 = 32'h00000063;
+  assign _zz_352 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_353 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_354 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_355) == 32'h00001013),{(_zz_356 == _zz_357),{_zz_358,{_zz_359,_zz_360}}}}}};
+  assign _zz_355 = 32'hfc00307f;
+  assign _zz_356 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_357 = 32'h00005033;
+  assign _zz_358 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_359 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_360 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_361 = decode_INSTRUCTION[31];
+  assign _zz_362 = decode_INSTRUCTION[31];
+  assign _zz_363 = decode_INSTRUCTION[7];
+  assign _zz_364 = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz_365 = 32'h02004020;
+  assign _zz_366 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz_367 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
+  assign _zz_368 = 1'b0;
+  assign _zz_369 = (((decode_INSTRUCTION & _zz_372) == 32'h00000050) != 1'b0);
+  assign _zz_370 = ({_zz_373,_zz_374} != 2'b00);
+  assign _zz_371 = {({_zz_375,_zz_376} != 2'b00),{(_zz_377 != _zz_378),{_zz_379,{_zz_380,_zz_381}}}};
+  assign _zz_372 = 32'h00403050;
+  assign _zz_373 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz_374 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz_375 = _zz_89;
+  assign _zz_376 = ((decode_INSTRUCTION & _zz_382) == 32'h00000004);
+  assign _zz_377 = ((decode_INSTRUCTION & _zz_383) == 32'h00000040);
+  assign _zz_378 = 1'b0;
+  assign _zz_379 = ({_zz_384,_zz_385} != 2'b00);
+  assign _zz_380 = ({_zz_386,_zz_387} != 3'b000);
+  assign _zz_381 = {(_zz_388 != _zz_389),{_zz_390,{_zz_391,_zz_392}}};
+  assign _zz_382 = 32'h0000001c;
+  assign _zz_383 = 32'h00000058;
+  assign _zz_384 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz_385 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz_386 = ((decode_INSTRUCTION & _zz_393) == 32'h40001010);
+  assign _zz_387 = {(_zz_394 == _zz_395),(_zz_396 == _zz_397)};
+  assign _zz_388 = ((decode_INSTRUCTION & _zz_398) == 32'h00000024);
+  assign _zz_389 = 1'b0;
+  assign _zz_390 = ((_zz_399 == _zz_400) != 1'b0);
+  assign _zz_391 = (_zz_401 != 1'b0);
+  assign _zz_392 = {(_zz_402 != _zz_403),{_zz_404,{_zz_405,_zz_406}}};
+  assign _zz_393 = 32'h40003054;
+  assign _zz_394 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_395 = 32'h00001010;
+  assign _zz_396 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz_397 = 32'h00001010;
+  assign _zz_398 = 32'h00000064;
+  assign _zz_399 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz_400 = 32'h00001000;
+  assign _zz_401 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_402 = {(_zz_407 == _zz_408),(_zz_409 == _zz_410)};
+  assign _zz_403 = 2'b00;
+  assign _zz_404 = ((_zz_411 == _zz_412) != 1'b0);
+  assign _zz_405 = ({_zz_413,_zz_414} != 2'b00);
+  assign _zz_406 = {(_zz_415 != _zz_416),{_zz_417,{_zz_418,_zz_419}}};
+  assign _zz_407 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_408 = 32'h00002000;
+  assign _zz_409 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz_410 = 32'h00001000;
+  assign _zz_411 = (decode_INSTRUCTION & 32'h00004048);
+  assign _zz_412 = 32'h00004008;
+  assign _zz_413 = ((decode_INSTRUCTION & _zz_420) == 32'h00000020);
+  assign _zz_414 = ((decode_INSTRUCTION & _zz_421) == 32'h00000020);
+  assign _zz_415 = {(_zz_422 == _zz_423),{_zz_424,{_zz_425,_zz_426}}};
+  assign _zz_416 = 5'h0;
+  assign _zz_417 = ((_zz_427 == _zz_428) != 1'b0);
+  assign _zz_418 = ({_zz_429,_zz_430} != 5'h0);
+  assign _zz_419 = {(_zz_431 != _zz_432),{_zz_433,{_zz_434,_zz_435}}};
+  assign _zz_420 = 32'h00000034;
+  assign _zz_421 = 32'h00000064;
+  assign _zz_422 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz_423 = 32'h00002040;
+  assign _zz_424 = ((decode_INSTRUCTION & _zz_436) == 32'h00001040);
+  assign _zz_425 = (_zz_437 == _zz_438);
+  assign _zz_426 = {_zz_439,_zz_440};
+  assign _zz_427 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_428 = 32'h00000020;
+  assign _zz_429 = (_zz_441 == _zz_442);
+  assign _zz_430 = {_zz_88,{_zz_443,_zz_444}};
+  assign _zz_431 = {_zz_88,{_zz_445,_zz_446}};
+  assign _zz_432 = 5'h0;
+  assign _zz_433 = ({_zz_447,_zz_448} != 6'h0);
+  assign _zz_434 = (_zz_449 != _zz_450);
+  assign _zz_435 = {_zz_451,{_zz_452,_zz_453}};
+  assign _zz_436 = 32'h00001040;
+  assign _zz_437 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_438 = 32'h00000040;
+  assign _zz_439 = ((decode_INSTRUCTION & _zz_454) == 32'h00000040);
+  assign _zz_440 = ((decode_INSTRUCTION & _zz_455) == 32'h0);
+  assign _zz_441 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_442 = 32'h00000040;
+  assign _zz_443 = (_zz_456 == _zz_457);
+  assign _zz_444 = {_zz_458,_zz_459};
+  assign _zz_445 = (_zz_460 == _zz_461);
+  assign _zz_446 = {_zz_462,{_zz_463,_zz_464}};
+  assign _zz_447 = _zz_89;
+  assign _zz_448 = {_zz_465,{_zz_466,_zz_467}};
+  assign _zz_449 = {_zz_88,_zz_468};
+  assign _zz_450 = 2'b00;
+  assign _zz_451 = ({_zz_469,_zz_470} != 2'b00);
+  assign _zz_452 = (_zz_471 != _zz_472);
+  assign _zz_453 = {_zz_473,{_zz_474,_zz_475}};
+  assign _zz_454 = 32'h00400040;
+  assign _zz_455 = 32'h00000038;
+  assign _zz_456 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz_457 = 32'h00004020;
+  assign _zz_458 = ((decode_INSTRUCTION & _zz_476) == 32'h00000010);
+  assign _zz_459 = ((decode_INSTRUCTION & _zz_477) == 32'h00000020);
+  assign _zz_460 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz_461 = 32'h00002010;
+  assign _zz_462 = ((decode_INSTRUCTION & _zz_478) == 32'h00000010);
+  assign _zz_463 = (_zz_479 == _zz_480);
+  assign _zz_464 = (_zz_481 == _zz_482);
+  assign _zz_465 = ((decode_INSTRUCTION & _zz_483) == 32'h00001010);
+  assign _zz_466 = (_zz_484 == _zz_485);
+  assign _zz_467 = {_zz_486,{_zz_487,_zz_488}};
+  assign _zz_468 = ((decode_INSTRUCTION & _zz_489) == 32'h00000020);
+  assign _zz_469 = _zz_88;
+  assign _zz_470 = (_zz_490 == _zz_491);
+  assign _zz_471 = (_zz_492 == _zz_493);
+  assign _zz_472 = 1'b0;
+  assign _zz_473 = (_zz_494 != 1'b0);
+  assign _zz_474 = (_zz_495 != _zz_496);
+  assign _zz_475 = {_zz_497,{_zz_498,_zz_499}};
+  assign _zz_476 = 32'h00000030;
+  assign _zz_477 = 32'h02000020;
+  assign _zz_478 = 32'h00001030;
+  assign _zz_479 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz_480 = 32'h00002020;
+  assign _zz_481 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz_482 = 32'h00000020;
+  assign _zz_483 = 32'h00001010;
+  assign _zz_484 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_485 = 32'h00002010;
+  assign _zz_486 = ((decode_INSTRUCTION & _zz_500) == 32'h00000010);
+  assign _zz_487 = (_zz_501 == _zz_502);
+  assign _zz_488 = (_zz_503 == _zz_504);
+  assign _zz_489 = 32'h00000070;
+  assign _zz_490 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_491 = 32'h0;
+  assign _zz_492 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz_493 = 32'h00004010;
+  assign _zz_494 = ((decode_INSTRUCTION & _zz_505) == 32'h00002010);
+  assign _zz_495 = {_zz_506,{_zz_507,_zz_508}};
+  assign _zz_496 = 4'b0000;
+  assign _zz_497 = (_zz_509 != 1'b0);
+  assign _zz_498 = (_zz_510 != _zz_511);
+  assign _zz_499 = {_zz_512,{_zz_513,_zz_514}};
+  assign _zz_500 = 32'h00000050;
+  assign _zz_501 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz_502 = 32'h00000004;
+  assign _zz_503 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_504 = 32'h0;
+  assign _zz_505 = 32'h00006014;
+  assign _zz_506 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz_507 = ((decode_INSTRUCTION & _zz_515) == 32'h0);
+  assign _zz_508 = {(_zz_516 == _zz_517),(_zz_518 == _zz_519)};
+  assign _zz_509 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz_510 = {(_zz_520 == _zz_521),{_zz_522,_zz_523}};
+  assign _zz_511 = 3'b000;
+  assign _zz_512 = ({_zz_524,_zz_87} != 2'b00);
+  assign _zz_513 = ({_zz_525,_zz_526} != 2'b00);
+  assign _zz_514 = (_zz_527 != 1'b0);
+  assign _zz_515 = 32'h00000018;
+  assign _zz_516 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz_517 = 32'h00002000;
+  assign _zz_518 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz_519 = 32'h00001000;
+  assign _zz_520 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_521 = 32'h00000040;
+  assign _zz_522 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_523 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz_524 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz_525 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_526 = _zz_87;
+  assign _zz_527 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_528 = execute_INSTRUCTION[31];
+  assign _zz_529 = execute_INSTRUCTION[31];
+  assign _zz_530 = execute_INSTRUCTION[7];
+  assign _zz_531 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_331_) begin
-      _zz_198_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_340) begin
+      _zz_207 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_332_) begin
-      _zz_199_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_341) begin
+      _zz_208 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_180_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_181_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_182_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_183_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_184_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_185_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_186_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_187_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_179                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_180                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_181                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_182                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_183                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_184                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_185                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_186                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_187                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_188_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_189_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (execute_MEMORY_WR                                           ), //i
-    .io_cpu_execute_args_data                      (_zz_82_[31:0]                                               ), //i
-    .io_cpu_execute_args_size                      (execute_DBusCachedPlugin_size[1:0]                          ), //i
-    .io_cpu_memory_isValid                         (_zz_190_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_191_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_192_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_193_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_194_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_195_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_196_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_197_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_188                                            ), //i
+    .io_cpu_execute_address                    (_zz_189[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
+    .io_cpu_execute_args_data                  (_zz_81[31:0]                                       ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_190                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_191[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_192                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_writeBack_isValid                  (_zz_193                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_194                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_195[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_196                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_197                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_198                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_199                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_200                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_201                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_202                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_203                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_204[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_205                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_206                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_333_)
+    case(_zz_342)
       2'b00 : begin
-        _zz_200_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_209 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_200_ = CsrPlugin_jumpInterface_payload;
+        _zz_209 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_200_ = BranchPlugin_jumpInterface_payload;
+        _zz_209 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_200_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_209 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_1__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_1__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_1__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_1__string = "JALR";
-      default : _zz_1__string = "????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_2__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_2__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_2__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_2__string = "JALR";
-      default : _zz_2__string = "????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_3__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_3__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_3__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_3__string = "URS1        ";
-      default : _zz_3__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_4__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_4__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_4__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_4__string = "URS1        ";
-      default : _zz_4__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_5__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_5__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_5__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_5__string = "URS1        ";
-      default : _zz_5__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_6__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_6__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_6__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_6__string = "SRA_1    ";
-      default : _zz_6__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_7__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_7__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_7__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_7__string = "SRA_1    ";
-      default : _zz_7__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_8__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_8__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_8__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_8__string = "SRA_1    ";
-      default : _zz_8__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_9__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_9__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_9__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_9__string = "SRA_1    ";
-      default : _zz_9__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10__string = "SRA_1    ";
-      default : _zz_10__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_11_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_11__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_11__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_11__string = "AND_1";
-      default : _zz_11__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_12__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_12__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_12__string = "AND_1";
-      default : _zz_12__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13__string = "AND_1";
-      default : _zz_13__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_14__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_14__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_14__string = "BITWISE ";
-      default : _zz_14__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_15__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_15__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_15__string = "BITWISE ";
-      default : _zz_15__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_16__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_16__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_16__string = "BITWISE ";
-      default : _zz_16__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_17__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_17__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_17__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_17__string = "ECALL";
-      default : _zz_17__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_18__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_18__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_18__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_18__string = "ECALL";
-      default : _zz_18__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_19__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_19__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_19__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_19__string = "ECALL";
-      default : _zz_19__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_20__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_20__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_20__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_20__string = "ECALL";
-      default : _zz_20__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2901,30 +1777,134 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_21__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_21__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_21__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_21__string = "ECALL";
-      default : _zz_21__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_22__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_22__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_22__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_22__string = "ECALL";
-      default : _zz_22__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_23__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_23__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_23__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_23__string = "ECALL";
-      default : _zz_23__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2937,30 +1917,98 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_24__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_24__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_24__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_24__string = "PC ";
-      default : _zz_24__string = "???";
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_25__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_25__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_25__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_25__string = "PC ";
-      default : _zz_25__string = "???";
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_26__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_26__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_26__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_26__string = "PC ";
-      default : _zz_26__string = "???";
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2973,12 +2021,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2991,12 +2039,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3009,12 +2057,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3027,12 +2075,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -3045,12 +2093,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3063,12 +2111,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3081,12 +2129,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -3099,12 +2147,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3116,11 +2164,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3132,72 +2180,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_43__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_43__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_43__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_43__string = "PC ";
-      default : _zz_43__string = "???";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_44__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_44__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_44__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_44__string = "ECALL";
-      default : _zz_44__string = "?????";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_45__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_45__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_45__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_45__string = "URS1        ";
-      default : _zz_45__string = "????????????";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_46__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_46__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_46__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_46__string = "JALR";
-      default : _zz_46__string = "????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_47__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_47__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_47__string = "BITWISE ";
-      default : _zz_47__string = "????????";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_48__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_48__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_48__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_48__string = "SRA_1    ";
-      default : _zz_48__string = "?????????";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_49__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_49__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_49__string = "AND_1";
-      default : _zz_49__string = "?????";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3210,73 +2258,90 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52__string = "JALR";
-      default : _zz_52__string = "????";
+    case(_zz_51)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
+      default : _zz_51_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_92_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_92__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_92__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_92__string = "AND_1";
-      default : _zz_92__string = "?????";
+    case(_zz_91)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_91_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_91_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_91_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_91_string = "URS1        ";
+      default : _zz_91_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_93__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_93__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_93__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_93__string = "SRA_1    ";
-      default : _zz_93__string = "?????????";
+    case(_zz_92)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_92_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_92_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_92_string = "BITWISE ";
+      default : _zz_92_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_94_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_94__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_94__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_94__string = "BITWISE ";
-      default : _zz_94__string = "????????";
+    case(_zz_93)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_93_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_93_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_93_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_93_string = "PC ";
+      default : _zz_93_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_95__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_95__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_95__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_95__string = "JALR";
-      default : _zz_95__string = "????";
+    case(_zz_94)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_94_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_94_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_94_string = "AND_1";
+      default : _zz_94_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_96_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_96__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_96__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_96__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_96__string = "URS1        ";
-      default : _zz_96__string = "????????????";
+    case(_zz_95)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_95_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_95_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_95_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_95_string = "SRA_1    ";
+      default : _zz_95_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_97_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_97__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_97__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_97__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_97__string = "ECALL";
-      default : _zz_97__string = "?????";
+    case(_zz_96)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_96_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_96_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_96_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_96_string = "JALR";
+      default : _zz_96_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_98_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_98__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_98__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_98__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_98__string = "PC ";
-      default : _zz_98__string = "???";
+    case(_zz_97)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_97_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_97_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_97_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_97_string = "ECALL";
+      default : _zz_97_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3286,41 +2351,6 @@ module VexRiscv (
       `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
       `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
       default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
-      default : decode_to_execute_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_to_memory_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
-      default : execute_to_memory_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(memory_to_writeBack_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
-      default : memory_to_writeBack_ENV_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
-      default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3350,15 +2380,6 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
     case(decode_to_execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
       `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
@@ -3367,59 +2388,87 @@ module VexRiscv (
       default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
+  always @(*) begin
+    case(decode_to_execute_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_to_execute_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_to_execute_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : decode_to_execute_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_to_execute_ENV_CTRL_string = "ECALL";
+      default : decode_to_execute_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : execute_to_memory_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : execute_to_memory_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : execute_to_memory_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : execute_to_memory_ENV_CTRL_string = "ECALL";
+      default : execute_to_memory_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(memory_to_writeBack_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : memory_to_writeBack_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : memory_to_writeBack_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : memory_to_writeBack_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : memory_to_writeBack_ENV_CTRL_string = "ECALL";
+      default : memory_to_writeBack_ENV_CTRL_string = "?????";
+    endcase
+  end
   `endif
 
+  assign memory_MUL_LOW = ($signed(_zz_247) + $signed(_zz_255));
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
   assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign memory_MUL_LOW = ($signed(_zz_238_) + $signed(_zz_246_));
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_247_[0];
-  assign execute_REGFILE_WRITE_DATA = _zz_100_;
-  assign memory_PC = execute_to_memory_PC;
-  assign _zz_1_ = _zz_2_;
-  assign decode_IS_DIV = _zz_248_[0];
-  assign decode_IS_RS2_SIGNED = _zz_249_[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_250_[0];
-  assign execute_SHIFT_RIGHT = _zz_252_;
-  assign decode_SRC1_CTRL = _zz_3_;
-  assign _zz_4_ = _zz_5_;
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign _zz_6_ = _zz_7_;
-  assign decode_SHIFT_CTRL = _zz_8_;
-  assign _zz_9_ = _zz_10_;
-  assign decode_MEMORY_MANAGMENT = _zz_254_[0];
-  assign decode_IS_CSR = _zz_255_[0];
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_256_[0];
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_SHIFT_RIGHT = _zz_257;
+  assign execute_REGFILE_WRITE_DATA = _zz_99;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_189_[1 : 0];
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign decode_ALU_BITWISE_CTRL = _zz_11_;
-  assign _zz_12_ = _zz_13_;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_189[1 : 0];
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_259[0];
+  assign decode_IS_RS1_SIGNED = _zz_260[0];
+  assign decode_IS_DIV = _zz_261[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_262[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_263[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_264[0];
+  assign decode_MEMORY_MANAGMENT = _zz_265[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_266[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_267[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_268[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign decode_ALU_CTRL = _zz_14_;
-  assign _zz_15_ = _zz_16_;
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS1_SIGNED = _zz_257_[0];
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_258_[0];
-  assign memory_MUL_HH = execute_to_memory_MUL_HH;
-  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_SRC_LESS_UNSIGNED = _zz_259_[0];
-  assign _zz_17_ = _zz_18_;
-  assign _zz_19_ = _zz_20_;
-  assign decode_ENV_CTRL = _zz_21_;
-  assign _zz_22_ = _zz_23_;
-  assign decode_SRC2_CTRL = _zz_24_;
-  assign _zz_25_ = _zz_26_;
-  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign memory_PC = execute_to_memory_PC;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3433,22 +2482,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_122_;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_260_[0];
-  assign decode_RS1_USE = _zz_261_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_121;
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_269[0];
+  assign decode_RS1_USE = _zz_270[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_201_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_210)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
   end
 
@@ -3460,29 +2509,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_111_)begin
-      if((_zz_112_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_113_;
+    if(_zz_110)begin
+      if((_zz_111 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_112;
       end
     end
-    if(_zz_202_)begin
-      if(_zz_203_)begin
-        if(_zz_115_)begin
-          decode_RS2 = _zz_50_;
+    if(_zz_211)begin
+      if(_zz_212)begin
+        if(_zz_114)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_204_)begin
+    if(_zz_213)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_117_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_116)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_205_)begin
+    if(_zz_214)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_119_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_118)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -3490,29 +2539,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_111_)begin
-      if((_zz_112_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_113_;
+    if(_zz_110)begin
+      if((_zz_111 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_112;
       end
     end
-    if(_zz_202_)begin
-      if(_zz_203_)begin
-        if(_zz_114_)begin
-          decode_RS1 = _zz_50_;
+    if(_zz_211)begin
+      if(_zz_212)begin
+        if(_zz_113)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_204_)begin
+    if(_zz_213)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_115)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_205_)begin
+    if(_zz_214)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_117)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -3520,70 +2569,70 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_108_;
+          _zz_32 = _zz_107;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_206_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_215)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_262_[0];
-  assign decode_SRC_ADD_ZERO = _zz_263_[0];
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_271[0];
+  assign decode_SRC_ADD_ZERO = _zz_272[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_106_;
-  assign execute_SRC1 = _zz_101_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_105;
+  assign execute_SRC1 = _zz_100;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_264_[0];
+    decode_REGFILE_WRITE_VALID = _zz_273[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_334_) == 32'h00001073),{(_zz_335_ == _zz_336_),{_zz_337_,{_zz_338_,_zz_339_}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_343) == 32'h00001073),{(_zz_344 == _zz_345),{_zz_346,{_zz_347,_zz_348}}}}}}} != 21'h0);
   always @ (*) begin
-    _zz_50_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_237_)
+      case(_zz_246)
         2'b00 : begin
-          _zz_50_ = _zz_306_;
+          _zz_50 = _zz_315;
         end
         default : begin
-          _zz_50_ = _zz_307_;
+          _zz_50 = _zz_316;
         end
       endcase
     end
@@ -3595,55 +2644,56 @@ module VexRiscv (
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_265_[0];
-  assign decode_FLUSH_ALL = _zz_266_[0];
+  assign decode_MEMORY_ENABLE = _zz_274[0];
+  assign decode_FLUSH_ALL = _zz_275[0];
   always @ (*) begin
-    _zz_51_ = _zz_51__2;
-    if(_zz_207_)begin
-      _zz_51_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_216)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(_zz_208_)begin
-      _zz_51__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_217)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(_zz_209_)begin
-      _zz_51__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_218)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_210_)begin
-      _zz_51__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_219)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52_;
+  assign decode_BRANCH_CTRL = _zz_51;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_53_ = memory_FORMAL_PC_NEXT;
+    _zz_52 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_53_ = BranchPlugin_jumpInterface_payload;
+      _zz_52 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_54_ = decode_FORMAL_PC_NEXT;
+    _zz_53 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_54_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -3659,20 +2709,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_109_ || _zz_110_)))begin
+    if((decode_arbitration_isValid && (_zz_108 || _zz_109)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_211_)begin
+    if(_zz_220)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3686,32 +2736,35 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_211_)begin
+    if(_zz_220)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_196_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_205 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_212_)begin
+    if(_zz_221)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_201_)begin
+    if(_zz_210)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  assign execute_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    execute_arbitration_haltByOther = 1'b0;
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+  end
+
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
     if(CsrPlugin_selfException_valid)begin
@@ -3732,7 +2785,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_206_)begin
+    if(_zz_215)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -3763,7 +2816,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3794,10 +2847,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_213_)begin
+    if(_zz_222)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_214_)begin
+    if(_zz_223)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3808,13 +2861,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_213_)begin
+    if(_zz_222)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_214_)begin
+    if(_zz_223)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3828,7 +2881,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_212_)begin
+    if(_zz_221)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3836,21 +2889,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_213_)begin
+    if(_zz_222)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_214_)begin
+    if(_zz_223)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_213_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_222)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_214_)begin
-      case(_zz_215_)
+    if(_zz_223)begin
+      case(_zz_224)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3863,14 +2916,14 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_55_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56_ = (_zz_55_ & (~ _zz_267_));
-  assign _zz_57_ = _zz_56_[3];
-  assign _zz_58_ = (_zz_56_[1] || _zz_57_);
-  assign _zz_59_ = (_zz_56_[2] || _zz_57_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_200_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
+  assign _zz_54 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_55 = (_zz_54 & (~ _zz_276));
+  assign _zz_56 = _zz_55[3];
+  assign _zz_57 = (_zz_55[1] || _zz_56);
+  assign _zz_58 = (_zz_55[2] || _zz_56);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_209;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -3890,7 +2943,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_269_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_278);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -3930,44 +2983,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_60_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60_);
+  assign _zz_59 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_59);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_59);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_61_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61_);
+  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_60);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_60);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_51_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_62_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62_);
+  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_61);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_61);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63_;
-  assign _zz_63_ = ((1'b0 && (! _zz_64_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64_ = _zz_65_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62;
+  assign _zz_62 = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_63 = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_66_ = _zz_67_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_65)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_65 = _zz_66;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_65;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_67;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -3981,125 +3034,125 @@ module VexRiscv (
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_69_ = _zz_270_[11];
+  assign _zz_68 = _zz_279[11];
   always @ (*) begin
-    _zz_70_[18] = _zz_69_;
-    _zz_70_[17] = _zz_69_;
-    _zz_70_[16] = _zz_69_;
-    _zz_70_[15] = _zz_69_;
-    _zz_70_[14] = _zz_69_;
-    _zz_70_[13] = _zz_69_;
-    _zz_70_[12] = _zz_69_;
-    _zz_70_[11] = _zz_69_;
-    _zz_70_[10] = _zz_69_;
-    _zz_70_[9] = _zz_69_;
-    _zz_70_[8] = _zz_69_;
-    _zz_70_[7] = _zz_69_;
-    _zz_70_[6] = _zz_69_;
-    _zz_70_[5] = _zz_69_;
-    _zz_70_[4] = _zz_69_;
-    _zz_70_[3] = _zz_69_;
-    _zz_70_[2] = _zz_69_;
-    _zz_70_[1] = _zz_69_;
-    _zz_70_[0] = _zz_69_;
+    _zz_69[18] = _zz_68;
+    _zz_69[17] = _zz_68;
+    _zz_69[16] = _zz_68;
+    _zz_69[15] = _zz_68;
+    _zz_69[14] = _zz_68;
+    _zz_69[13] = _zz_68;
+    _zz_69[12] = _zz_68;
+    _zz_69[11] = _zz_68;
+    _zz_69[10] = _zz_68;
+    _zz_69[9] = _zz_68;
+    _zz_69[8] = _zz_68;
+    _zz_69[7] = _zz_68;
+    _zz_69[6] = _zz_68;
+    _zz_69[5] = _zz_68;
+    _zz_69[4] = _zz_68;
+    _zz_69[3] = _zz_68;
+    _zz_69[2] = _zz_68;
+    _zz_69[1] = _zz_68;
+    _zz_69[0] = _zz_68;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_271_[31]));
-    if(_zz_75_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_280[31]));
+    if(_zz_74)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_71_ = _zz_272_[19];
+  assign _zz_70 = _zz_281[19];
   always @ (*) begin
-    _zz_72_[10] = _zz_71_;
-    _zz_72_[9] = _zz_71_;
-    _zz_72_[8] = _zz_71_;
-    _zz_72_[7] = _zz_71_;
-    _zz_72_[6] = _zz_71_;
-    _zz_72_[5] = _zz_71_;
-    _zz_72_[4] = _zz_71_;
-    _zz_72_[3] = _zz_71_;
-    _zz_72_[2] = _zz_71_;
-    _zz_72_[1] = _zz_71_;
-    _zz_72_[0] = _zz_71_;
+    _zz_71[10] = _zz_70;
+    _zz_71[9] = _zz_70;
+    _zz_71[8] = _zz_70;
+    _zz_71[7] = _zz_70;
+    _zz_71[6] = _zz_70;
+    _zz_71[5] = _zz_70;
+    _zz_71[4] = _zz_70;
+    _zz_71[3] = _zz_70;
+    _zz_71[2] = _zz_70;
+    _zz_71[1] = _zz_70;
+    _zz_71[0] = _zz_70;
   end
 
-  assign _zz_73_ = _zz_273_[11];
+  assign _zz_72 = _zz_282[11];
   always @ (*) begin
-    _zz_74_[18] = _zz_73_;
-    _zz_74_[17] = _zz_73_;
-    _zz_74_[16] = _zz_73_;
-    _zz_74_[15] = _zz_73_;
-    _zz_74_[14] = _zz_73_;
-    _zz_74_[13] = _zz_73_;
-    _zz_74_[12] = _zz_73_;
-    _zz_74_[11] = _zz_73_;
-    _zz_74_[10] = _zz_73_;
-    _zz_74_[9] = _zz_73_;
-    _zz_74_[8] = _zz_73_;
-    _zz_74_[7] = _zz_73_;
-    _zz_74_[6] = _zz_73_;
-    _zz_74_[5] = _zz_73_;
-    _zz_74_[4] = _zz_73_;
-    _zz_74_[3] = _zz_73_;
-    _zz_74_[2] = _zz_73_;
-    _zz_74_[1] = _zz_73_;
-    _zz_74_[0] = _zz_73_;
+    _zz_73[18] = _zz_72;
+    _zz_73[17] = _zz_72;
+    _zz_73[16] = _zz_72;
+    _zz_73[15] = _zz_72;
+    _zz_73[14] = _zz_72;
+    _zz_73[13] = _zz_72;
+    _zz_73[12] = _zz_72;
+    _zz_73[11] = _zz_72;
+    _zz_73[10] = _zz_72;
+    _zz_73[9] = _zz_72;
+    _zz_73[8] = _zz_72;
+    _zz_73[7] = _zz_72;
+    _zz_73[6] = _zz_72;
+    _zz_73[5] = _zz_72;
+    _zz_73[4] = _zz_72;
+    _zz_73[3] = _zz_72;
+    _zz_73[2] = _zz_72;
+    _zz_73[1] = _zz_72;
+    _zz_73[0] = _zz_72;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_75_ = _zz_274_[1];
+        _zz_74 = _zz_283[1];
       end
       default : begin
-        _zz_75_ = _zz_275_[1];
+        _zz_74 = _zz_284[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_76_ = _zz_276_[19];
+  assign _zz_75 = _zz_285[19];
   always @ (*) begin
-    _zz_77_[10] = _zz_76_;
-    _zz_77_[9] = _zz_76_;
-    _zz_77_[8] = _zz_76_;
-    _zz_77_[7] = _zz_76_;
-    _zz_77_[6] = _zz_76_;
-    _zz_77_[5] = _zz_76_;
-    _zz_77_[4] = _zz_76_;
-    _zz_77_[3] = _zz_76_;
-    _zz_77_[2] = _zz_76_;
-    _zz_77_[1] = _zz_76_;
-    _zz_77_[0] = _zz_76_;
+    _zz_76[10] = _zz_75;
+    _zz_76[9] = _zz_75;
+    _zz_76[8] = _zz_75;
+    _zz_76[7] = _zz_75;
+    _zz_76[6] = _zz_75;
+    _zz_76[5] = _zz_75;
+    _zz_76[4] = _zz_75;
+    _zz_76[3] = _zz_75;
+    _zz_76[2] = _zz_75;
+    _zz_76[1] = _zz_75;
+    _zz_76[0] = _zz_75;
   end
 
-  assign _zz_78_ = _zz_277_[11];
+  assign _zz_77 = _zz_286[11];
   always @ (*) begin
-    _zz_79_[18] = _zz_78_;
-    _zz_79_[17] = _zz_78_;
-    _zz_79_[16] = _zz_78_;
-    _zz_79_[15] = _zz_78_;
-    _zz_79_[14] = _zz_78_;
-    _zz_79_[13] = _zz_78_;
-    _zz_79_[12] = _zz_78_;
-    _zz_79_[11] = _zz_78_;
-    _zz_79_[10] = _zz_78_;
-    _zz_79_[9] = _zz_78_;
-    _zz_79_[8] = _zz_78_;
-    _zz_79_[7] = _zz_78_;
-    _zz_79_[6] = _zz_78_;
-    _zz_79_[5] = _zz_78_;
-    _zz_79_[4] = _zz_78_;
-    _zz_79_[3] = _zz_78_;
-    _zz_79_[2] = _zz_78_;
-    _zz_79_[1] = _zz_78_;
-    _zz_79_[0] = _zz_78_;
+    _zz_78[18] = _zz_77;
+    _zz_78[17] = _zz_77;
+    _zz_78[16] = _zz_77;
+    _zz_78[15] = _zz_77;
+    _zz_78[14] = _zz_77;
+    _zz_78[13] = _zz_77;
+    _zz_78[12] = _zz_77;
+    _zz_78[11] = _zz_77;
+    _zz_78[10] = _zz_77;
+    _zz_78[9] = _zz_77;
+    _zz_78[8] = _zz_77;
+    _zz_78[7] = _zz_77;
+    _zz_78[6] = _zz_77;
+    _zz_78[5] = _zz_77;
+    _zz_78[4] = _zz_77;
+    _zz_78[3] = _zz_77;
+    _zz_78[2] = _zz_77;
+    _zz_78[1] = _zz_77;
+    _zz_78[0] = _zz_77;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77_,{{{_zz_352_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79_,{{{_zz_353_,_zz_354_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_76,{{{_zz_361,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_78,{{{_zz_362,_zz_363},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4108,123 +3161,128 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_181_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_182_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_183_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_184_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_185_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_186_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_180 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_181 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_182 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_181;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_184 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_185 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_186 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_210_)begin
+    if(_zz_219)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_208_)begin
+    if(_zz_217)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_187_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_208_)begin
-      _zz_187_ = 1'b1;
+    _zz_187 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_217)begin
+      _zz_187 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_209_)begin
+    if(_zz_218)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_207_)begin
+    if(_zz_216)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_209_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_218)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_207_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_216)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_180_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_197_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_179 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_206 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_188_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_189_ = execute_SRC_ADD;
+  assign _zz_188 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_189 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_82_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_81 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_82_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_81 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_82_ = execute_RS2[31 : 0];
+        _zz_81 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_196_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_190_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_191_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+  assign _zz_205 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_190 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_191 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_190;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_191;
+  assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @ (*) begin
-    _zz_192_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_192_ = 1'b1;
+    _zz_192 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_192 = 1'b1;
     end
   end
 
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_193_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_194_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_195_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_193 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_194 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_195 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_216_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_225)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -4233,17 +3291,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_216_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_225)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -4251,94 +3309,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_216_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_278_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_225)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_287};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_279_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_288};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_83_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_82 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_84_[31] = _zz_83_;
-    _zz_84_[30] = _zz_83_;
-    _zz_84_[29] = _zz_83_;
-    _zz_84_[28] = _zz_83_;
-    _zz_84_[27] = _zz_83_;
-    _zz_84_[26] = _zz_83_;
-    _zz_84_[25] = _zz_83_;
-    _zz_84_[24] = _zz_83_;
-    _zz_84_[23] = _zz_83_;
-    _zz_84_[22] = _zz_83_;
-    _zz_84_[21] = _zz_83_;
-    _zz_84_[20] = _zz_83_;
-    _zz_84_[19] = _zz_83_;
-    _zz_84_[18] = _zz_83_;
-    _zz_84_[17] = _zz_83_;
-    _zz_84_[16] = _zz_83_;
-    _zz_84_[15] = _zz_83_;
-    _zz_84_[14] = _zz_83_;
-    _zz_84_[13] = _zz_83_;
-    _zz_84_[12] = _zz_83_;
-    _zz_84_[11] = _zz_83_;
-    _zz_84_[10] = _zz_83_;
-    _zz_84_[9] = _zz_83_;
-    _zz_84_[8] = _zz_83_;
-    _zz_84_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_83[31] = _zz_82;
+    _zz_83[30] = _zz_82;
+    _zz_83[29] = _zz_82;
+    _zz_83[28] = _zz_82;
+    _zz_83[27] = _zz_82;
+    _zz_83[26] = _zz_82;
+    _zz_83[25] = _zz_82;
+    _zz_83[24] = _zz_82;
+    _zz_83[23] = _zz_82;
+    _zz_83[22] = _zz_82;
+    _zz_83[21] = _zz_82;
+    _zz_83[20] = _zz_82;
+    _zz_83[19] = _zz_82;
+    _zz_83[18] = _zz_82;
+    _zz_83[17] = _zz_82;
+    _zz_83[16] = _zz_82;
+    _zz_83[15] = _zz_82;
+    _zz_83[14] = _zz_82;
+    _zz_83[13] = _zz_82;
+    _zz_83[12] = _zz_82;
+    _zz_83[11] = _zz_82;
+    _zz_83[10] = _zz_82;
+    _zz_83[9] = _zz_82;
+    _zz_83[8] = _zz_82;
+    _zz_83[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_85_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_84 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_86_[31] = _zz_85_;
-    _zz_86_[30] = _zz_85_;
-    _zz_86_[29] = _zz_85_;
-    _zz_86_[28] = _zz_85_;
-    _zz_86_[27] = _zz_85_;
-    _zz_86_[26] = _zz_85_;
-    _zz_86_[25] = _zz_85_;
-    _zz_86_[24] = _zz_85_;
-    _zz_86_[23] = _zz_85_;
-    _zz_86_[22] = _zz_85_;
-    _zz_86_[21] = _zz_85_;
-    _zz_86_[20] = _zz_85_;
-    _zz_86_[19] = _zz_85_;
-    _zz_86_[18] = _zz_85_;
-    _zz_86_[17] = _zz_85_;
-    _zz_86_[16] = _zz_85_;
-    _zz_86_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_85[31] = _zz_84;
+    _zz_85[30] = _zz_84;
+    _zz_85[29] = _zz_84;
+    _zz_85[28] = _zz_84;
+    _zz_85[27] = _zz_84;
+    _zz_85[26] = _zz_84;
+    _zz_85[25] = _zz_84;
+    _zz_85[24] = _zz_84;
+    _zz_85[23] = _zz_84;
+    _zz_85[22] = _zz_84;
+    _zz_85[21] = _zz_84;
+    _zz_85[20] = _zz_84;
+    _zz_85[19] = _zz_84;
+    _zz_85[18] = _zz_84;
+    _zz_85[17] = _zz_84;
+    _zz_85[16] = _zz_84;
+    _zz_85[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_235_)
+    case(_zz_244)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_84_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_83;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_85;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -4346,57 +3404,71 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_88_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_89_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_90_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_91_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_87_ = {({_zz_89_,(_zz_355_ == _zz_356_)} != (2'b00)),{({_zz_89_,_zz_357_} != (2'b00)),{(_zz_358_ != (1'b0)),{(_zz_359_ != _zz_360_),{_zz_361_,{_zz_362_,_zz_363_}}}}}};
-  assign _zz_92_ = _zz_87_[4 : 3];
-  assign _zz_49_ = _zz_92_;
-  assign _zz_93_ = _zz_87_[13 : 12];
-  assign _zz_48_ = _zz_93_;
-  assign _zz_94_ = _zz_87_[16 : 15];
-  assign _zz_47_ = _zz_94_;
-  assign _zz_95_ = _zz_87_[18 : 17];
-  assign _zz_46_ = _zz_95_;
-  assign _zz_96_ = _zz_87_[25 : 24];
-  assign _zz_45_ = _zz_96_;
-  assign _zz_97_ = _zz_87_[28 : 27];
-  assign _zz_44_ = _zz_97_;
-  assign _zz_98_ = _zz_87_[31 : 30];
-  assign _zz_43_ = _zz_98_;
+  assign _zz_87 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_88 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_90 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_86 = {(_zz_90 != 1'b0),{(_zz_90 != 1'b0),{((_zz_364 == _zz_365) != 1'b0),{(_zz_366 != 1'b0),{(_zz_367 != _zz_368),{_zz_369,{_zz_370,_zz_371}}}}}}};
+  assign _zz_91 = _zz_86[2 : 1];
+  assign _zz_49 = _zz_91;
+  assign _zz_92 = _zz_86[7 : 6];
+  assign _zz_48 = _zz_92;
+  assign _zz_93 = _zz_86[9 : 8];
+  assign _zz_47 = _zz_93;
+  assign _zz_94 = _zz_86[19 : 18];
+  assign _zz_46 = _zz_94;
+  assign _zz_95 = _zz_86[22 : 21];
+  assign _zz_45 = _zz_95;
+  assign _zz_96 = _zz_86[24 : 23];
+  assign _zz_44 = _zz_96;
+  assign _zz_97 = _zz_86[27 : 26];
+  assign _zz_43 = _zz_97;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_198_;
-  assign decode_RegFilePlugin_rs2Data = _zz_199_;
+  assign decode_RegFilePlugin_rs1Data = _zz_207;
+  assign decode_RegFilePlugin_rs2Data = _zz_208;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_99_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_98)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_50_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_98)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_98)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -4414,13 +3486,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_100_ = execute_IntAluPlugin_bitwise;
+        _zz_99 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_100_ = {31'd0, _zz_280_};
+        _zz_99 = {31'd0, _zz_289};
       end
       default : begin
-        _zz_100_ = execute_SRC_ADD_SUB;
+        _zz_99 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -4428,87 +3500,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_101_ = execute_RS1;
+        _zz_100 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_101_ = {29'd0, _zz_281_};
+        _zz_100 = {29'd0, _zz_290};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_101_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_100 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_101_ = {27'd0, _zz_282_};
+        _zz_100 = {27'd0, _zz_291};
       end
     endcase
   end
 
-  assign _zz_102_ = _zz_283_[11];
+  assign _zz_101 = _zz_292[11];
   always @ (*) begin
-    _zz_103_[19] = _zz_102_;
-    _zz_103_[18] = _zz_102_;
-    _zz_103_[17] = _zz_102_;
-    _zz_103_[16] = _zz_102_;
-    _zz_103_[15] = _zz_102_;
-    _zz_103_[14] = _zz_102_;
-    _zz_103_[13] = _zz_102_;
-    _zz_103_[12] = _zz_102_;
-    _zz_103_[11] = _zz_102_;
-    _zz_103_[10] = _zz_102_;
-    _zz_103_[9] = _zz_102_;
-    _zz_103_[8] = _zz_102_;
-    _zz_103_[7] = _zz_102_;
-    _zz_103_[6] = _zz_102_;
-    _zz_103_[5] = _zz_102_;
-    _zz_103_[4] = _zz_102_;
-    _zz_103_[3] = _zz_102_;
-    _zz_103_[2] = _zz_102_;
-    _zz_103_[1] = _zz_102_;
-    _zz_103_[0] = _zz_102_;
+    _zz_102[19] = _zz_101;
+    _zz_102[18] = _zz_101;
+    _zz_102[17] = _zz_101;
+    _zz_102[16] = _zz_101;
+    _zz_102[15] = _zz_101;
+    _zz_102[14] = _zz_101;
+    _zz_102[13] = _zz_101;
+    _zz_102[12] = _zz_101;
+    _zz_102[11] = _zz_101;
+    _zz_102[10] = _zz_101;
+    _zz_102[9] = _zz_101;
+    _zz_102[8] = _zz_101;
+    _zz_102[7] = _zz_101;
+    _zz_102[6] = _zz_101;
+    _zz_102[5] = _zz_101;
+    _zz_102[4] = _zz_101;
+    _zz_102[3] = _zz_101;
+    _zz_102[2] = _zz_101;
+    _zz_102[1] = _zz_101;
+    _zz_102[0] = _zz_101;
   end
 
-  assign _zz_104_ = _zz_284_[11];
+  assign _zz_103 = _zz_293[11];
   always @ (*) begin
-    _zz_105_[19] = _zz_104_;
-    _zz_105_[18] = _zz_104_;
-    _zz_105_[17] = _zz_104_;
-    _zz_105_[16] = _zz_104_;
-    _zz_105_[15] = _zz_104_;
-    _zz_105_[14] = _zz_104_;
-    _zz_105_[13] = _zz_104_;
-    _zz_105_[12] = _zz_104_;
-    _zz_105_[11] = _zz_104_;
-    _zz_105_[10] = _zz_104_;
-    _zz_105_[9] = _zz_104_;
-    _zz_105_[8] = _zz_104_;
-    _zz_105_[7] = _zz_104_;
-    _zz_105_[6] = _zz_104_;
-    _zz_105_[5] = _zz_104_;
-    _zz_105_[4] = _zz_104_;
-    _zz_105_[3] = _zz_104_;
-    _zz_105_[2] = _zz_104_;
-    _zz_105_[1] = _zz_104_;
-    _zz_105_[0] = _zz_104_;
+    _zz_104[19] = _zz_103;
+    _zz_104[18] = _zz_103;
+    _zz_104[17] = _zz_103;
+    _zz_104[16] = _zz_103;
+    _zz_104[15] = _zz_103;
+    _zz_104[14] = _zz_103;
+    _zz_104[13] = _zz_103;
+    _zz_104[12] = _zz_103;
+    _zz_104[11] = _zz_103;
+    _zz_104[10] = _zz_103;
+    _zz_104[9] = _zz_103;
+    _zz_104[8] = _zz_103;
+    _zz_104[7] = _zz_103;
+    _zz_104[6] = _zz_103;
+    _zz_104[5] = _zz_103;
+    _zz_104[4] = _zz_103;
+    _zz_104[3] = _zz_103;
+    _zz_104[2] = _zz_103;
+    _zz_104[1] = _zz_103;
+    _zz_104[0] = _zz_103;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_106_ = execute_RS2;
+        _zz_105 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_106_ = {_zz_103_,execute_INSTRUCTION[31 : 20]};
+        _zz_105 = {_zz_102,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_106_ = {_zz_105_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_105 = {_zz_104,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_106_ = _zz_35_;
+        _zz_105 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_285_;
+    execute_SrcPlugin_addSub = _zz_294;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -4517,246 +3589,246 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_107_[0] = execute_SRC1[31];
-    _zz_107_[1] = execute_SRC1[30];
-    _zz_107_[2] = execute_SRC1[29];
-    _zz_107_[3] = execute_SRC1[28];
-    _zz_107_[4] = execute_SRC1[27];
-    _zz_107_[5] = execute_SRC1[26];
-    _zz_107_[6] = execute_SRC1[25];
-    _zz_107_[7] = execute_SRC1[24];
-    _zz_107_[8] = execute_SRC1[23];
-    _zz_107_[9] = execute_SRC1[22];
-    _zz_107_[10] = execute_SRC1[21];
-    _zz_107_[11] = execute_SRC1[20];
-    _zz_107_[12] = execute_SRC1[19];
-    _zz_107_[13] = execute_SRC1[18];
-    _zz_107_[14] = execute_SRC1[17];
-    _zz_107_[15] = execute_SRC1[16];
-    _zz_107_[16] = execute_SRC1[15];
-    _zz_107_[17] = execute_SRC1[14];
-    _zz_107_[18] = execute_SRC1[13];
-    _zz_107_[19] = execute_SRC1[12];
-    _zz_107_[20] = execute_SRC1[11];
-    _zz_107_[21] = execute_SRC1[10];
-    _zz_107_[22] = execute_SRC1[9];
-    _zz_107_[23] = execute_SRC1[8];
-    _zz_107_[24] = execute_SRC1[7];
-    _zz_107_[25] = execute_SRC1[6];
-    _zz_107_[26] = execute_SRC1[5];
-    _zz_107_[27] = execute_SRC1[4];
-    _zz_107_[28] = execute_SRC1[3];
-    _zz_107_[29] = execute_SRC1[2];
-    _zz_107_[30] = execute_SRC1[1];
-    _zz_107_[31] = execute_SRC1[0];
+    _zz_106[0] = execute_SRC1[31];
+    _zz_106[1] = execute_SRC1[30];
+    _zz_106[2] = execute_SRC1[29];
+    _zz_106[3] = execute_SRC1[28];
+    _zz_106[4] = execute_SRC1[27];
+    _zz_106[5] = execute_SRC1[26];
+    _zz_106[6] = execute_SRC1[25];
+    _zz_106[7] = execute_SRC1[24];
+    _zz_106[8] = execute_SRC1[23];
+    _zz_106[9] = execute_SRC1[22];
+    _zz_106[10] = execute_SRC1[21];
+    _zz_106[11] = execute_SRC1[20];
+    _zz_106[12] = execute_SRC1[19];
+    _zz_106[13] = execute_SRC1[18];
+    _zz_106[14] = execute_SRC1[17];
+    _zz_106[15] = execute_SRC1[16];
+    _zz_106[16] = execute_SRC1[15];
+    _zz_106[17] = execute_SRC1[14];
+    _zz_106[18] = execute_SRC1[13];
+    _zz_106[19] = execute_SRC1[12];
+    _zz_106[20] = execute_SRC1[11];
+    _zz_106[21] = execute_SRC1[10];
+    _zz_106[22] = execute_SRC1[9];
+    _zz_106[23] = execute_SRC1[8];
+    _zz_106[24] = execute_SRC1[7];
+    _zz_106[25] = execute_SRC1[6];
+    _zz_106[26] = execute_SRC1[5];
+    _zz_106[27] = execute_SRC1[4];
+    _zz_106[28] = execute_SRC1[3];
+    _zz_106[29] = execute_SRC1[2];
+    _zz_106[30] = execute_SRC1[1];
+    _zz_106[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_107_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_106 : execute_SRC1);
   always @ (*) begin
-    _zz_108_[0] = memory_SHIFT_RIGHT[31];
-    _zz_108_[1] = memory_SHIFT_RIGHT[30];
-    _zz_108_[2] = memory_SHIFT_RIGHT[29];
-    _zz_108_[3] = memory_SHIFT_RIGHT[28];
-    _zz_108_[4] = memory_SHIFT_RIGHT[27];
-    _zz_108_[5] = memory_SHIFT_RIGHT[26];
-    _zz_108_[6] = memory_SHIFT_RIGHT[25];
-    _zz_108_[7] = memory_SHIFT_RIGHT[24];
-    _zz_108_[8] = memory_SHIFT_RIGHT[23];
-    _zz_108_[9] = memory_SHIFT_RIGHT[22];
-    _zz_108_[10] = memory_SHIFT_RIGHT[21];
-    _zz_108_[11] = memory_SHIFT_RIGHT[20];
-    _zz_108_[12] = memory_SHIFT_RIGHT[19];
-    _zz_108_[13] = memory_SHIFT_RIGHT[18];
-    _zz_108_[14] = memory_SHIFT_RIGHT[17];
-    _zz_108_[15] = memory_SHIFT_RIGHT[16];
-    _zz_108_[16] = memory_SHIFT_RIGHT[15];
-    _zz_108_[17] = memory_SHIFT_RIGHT[14];
-    _zz_108_[18] = memory_SHIFT_RIGHT[13];
-    _zz_108_[19] = memory_SHIFT_RIGHT[12];
-    _zz_108_[20] = memory_SHIFT_RIGHT[11];
-    _zz_108_[21] = memory_SHIFT_RIGHT[10];
-    _zz_108_[22] = memory_SHIFT_RIGHT[9];
-    _zz_108_[23] = memory_SHIFT_RIGHT[8];
-    _zz_108_[24] = memory_SHIFT_RIGHT[7];
-    _zz_108_[25] = memory_SHIFT_RIGHT[6];
-    _zz_108_[26] = memory_SHIFT_RIGHT[5];
-    _zz_108_[27] = memory_SHIFT_RIGHT[4];
-    _zz_108_[28] = memory_SHIFT_RIGHT[3];
-    _zz_108_[29] = memory_SHIFT_RIGHT[2];
-    _zz_108_[30] = memory_SHIFT_RIGHT[1];
-    _zz_108_[31] = memory_SHIFT_RIGHT[0];
+    _zz_107[0] = memory_SHIFT_RIGHT[31];
+    _zz_107[1] = memory_SHIFT_RIGHT[30];
+    _zz_107[2] = memory_SHIFT_RIGHT[29];
+    _zz_107[3] = memory_SHIFT_RIGHT[28];
+    _zz_107[4] = memory_SHIFT_RIGHT[27];
+    _zz_107[5] = memory_SHIFT_RIGHT[26];
+    _zz_107[6] = memory_SHIFT_RIGHT[25];
+    _zz_107[7] = memory_SHIFT_RIGHT[24];
+    _zz_107[8] = memory_SHIFT_RIGHT[23];
+    _zz_107[9] = memory_SHIFT_RIGHT[22];
+    _zz_107[10] = memory_SHIFT_RIGHT[21];
+    _zz_107[11] = memory_SHIFT_RIGHT[20];
+    _zz_107[12] = memory_SHIFT_RIGHT[19];
+    _zz_107[13] = memory_SHIFT_RIGHT[18];
+    _zz_107[14] = memory_SHIFT_RIGHT[17];
+    _zz_107[15] = memory_SHIFT_RIGHT[16];
+    _zz_107[16] = memory_SHIFT_RIGHT[15];
+    _zz_107[17] = memory_SHIFT_RIGHT[14];
+    _zz_107[18] = memory_SHIFT_RIGHT[13];
+    _zz_107[19] = memory_SHIFT_RIGHT[12];
+    _zz_107[20] = memory_SHIFT_RIGHT[11];
+    _zz_107[21] = memory_SHIFT_RIGHT[10];
+    _zz_107[22] = memory_SHIFT_RIGHT[9];
+    _zz_107[23] = memory_SHIFT_RIGHT[8];
+    _zz_107[24] = memory_SHIFT_RIGHT[7];
+    _zz_107[25] = memory_SHIFT_RIGHT[6];
+    _zz_107[26] = memory_SHIFT_RIGHT[5];
+    _zz_107[27] = memory_SHIFT_RIGHT[4];
+    _zz_107[28] = memory_SHIFT_RIGHT[3];
+    _zz_107[29] = memory_SHIFT_RIGHT[2];
+    _zz_107[30] = memory_SHIFT_RIGHT[1];
+    _zz_107[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_109_ = 1'b0;
-    if(_zz_217_)begin
-      if(_zz_218_)begin
-        if(_zz_114_)begin
-          _zz_109_ = 1'b1;
+    _zz_108 = 1'b0;
+    if(_zz_226)begin
+      if(_zz_227)begin
+        if(_zz_113)begin
+          _zz_108 = 1'b1;
         end
       end
     end
-    if(_zz_219_)begin
-      if(_zz_220_)begin
-        if(_zz_116_)begin
-          _zz_109_ = 1'b1;
+    if(_zz_228)begin
+      if(_zz_229)begin
+        if(_zz_115)begin
+          _zz_108 = 1'b1;
         end
       end
     end
-    if(_zz_221_)begin
-      if(_zz_222_)begin
-        if(_zz_118_)begin
-          _zz_109_ = 1'b1;
+    if(_zz_230)begin
+      if(_zz_231)begin
+        if(_zz_117)begin
+          _zz_108 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_109_ = 1'b0;
+      _zz_108 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_110_ = 1'b0;
-    if(_zz_217_)begin
-      if(_zz_218_)begin
-        if(_zz_115_)begin
-          _zz_110_ = 1'b1;
+    _zz_109 = 1'b0;
+    if(_zz_226)begin
+      if(_zz_227)begin
+        if(_zz_114)begin
+          _zz_109 = 1'b1;
         end
       end
     end
-    if(_zz_219_)begin
-      if(_zz_220_)begin
-        if(_zz_117_)begin
-          _zz_110_ = 1'b1;
+    if(_zz_228)begin
+      if(_zz_229)begin
+        if(_zz_116)begin
+          _zz_109 = 1'b1;
         end
       end
     end
-    if(_zz_221_)begin
-      if(_zz_222_)begin
-        if(_zz_119_)begin
-          _zz_110_ = 1'b1;
+    if(_zz_230)begin
+      if(_zz_231)begin
+        if(_zz_118)begin
+          _zz_109 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_110_ = 1'b0;
+      _zz_109 = 1'b0;
     end
   end
 
-  assign _zz_114_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_115_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_116_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_117_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_118_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_119_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_113 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_115 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_117 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_120_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_119 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_120_ == (3'b000))) begin
-        _zz_121_ = execute_BranchPlugin_eq;
-    end else if((_zz_120_ == (3'b001))) begin
-        _zz_121_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_120_ & (3'b101)) == (3'b101)))) begin
-        _zz_121_ = (! execute_SRC_LESS);
+    if((_zz_119 == 3'b000)) begin
+        _zz_120 = execute_BranchPlugin_eq;
+    end else if((_zz_119 == 3'b001)) begin
+        _zz_120 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_119 & 3'b101) == 3'b101))) begin
+        _zz_120 = (! execute_SRC_LESS);
     end else begin
-        _zz_121_ = execute_SRC_LESS;
+        _zz_120 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_122_ = 1'b0;
+        _zz_121 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_122_ = 1'b1;
+        _zz_121 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_122_ = 1'b1;
+        _zz_121 = 1'b1;
       end
       default : begin
-        _zz_122_ = _zz_121_;
+        _zz_121 = _zz_120;
       end
     endcase
   end
 
-  assign _zz_123_ = _zz_292_[11];
+  assign _zz_122 = _zz_301[11];
   always @ (*) begin
-    _zz_124_[19] = _zz_123_;
-    _zz_124_[18] = _zz_123_;
-    _zz_124_[17] = _zz_123_;
-    _zz_124_[16] = _zz_123_;
-    _zz_124_[15] = _zz_123_;
-    _zz_124_[14] = _zz_123_;
-    _zz_124_[13] = _zz_123_;
-    _zz_124_[12] = _zz_123_;
-    _zz_124_[11] = _zz_123_;
-    _zz_124_[10] = _zz_123_;
-    _zz_124_[9] = _zz_123_;
-    _zz_124_[8] = _zz_123_;
-    _zz_124_[7] = _zz_123_;
-    _zz_124_[6] = _zz_123_;
-    _zz_124_[5] = _zz_123_;
-    _zz_124_[4] = _zz_123_;
-    _zz_124_[3] = _zz_123_;
-    _zz_124_[2] = _zz_123_;
-    _zz_124_[1] = _zz_123_;
-    _zz_124_[0] = _zz_123_;
+    _zz_123[19] = _zz_122;
+    _zz_123[18] = _zz_122;
+    _zz_123[17] = _zz_122;
+    _zz_123[16] = _zz_122;
+    _zz_123[15] = _zz_122;
+    _zz_123[14] = _zz_122;
+    _zz_123[13] = _zz_122;
+    _zz_123[12] = _zz_122;
+    _zz_123[11] = _zz_122;
+    _zz_123[10] = _zz_122;
+    _zz_123[9] = _zz_122;
+    _zz_123[8] = _zz_122;
+    _zz_123[7] = _zz_122;
+    _zz_123[6] = _zz_122;
+    _zz_123[5] = _zz_122;
+    _zz_123[4] = _zz_122;
+    _zz_123[3] = _zz_122;
+    _zz_123[2] = _zz_122;
+    _zz_123[1] = _zz_122;
+    _zz_123[0] = _zz_122;
   end
 
-  assign _zz_125_ = _zz_293_[19];
+  assign _zz_124 = _zz_302[19];
   always @ (*) begin
-    _zz_126_[10] = _zz_125_;
-    _zz_126_[9] = _zz_125_;
-    _zz_126_[8] = _zz_125_;
-    _zz_126_[7] = _zz_125_;
-    _zz_126_[6] = _zz_125_;
-    _zz_126_[5] = _zz_125_;
-    _zz_126_[4] = _zz_125_;
-    _zz_126_[3] = _zz_125_;
-    _zz_126_[2] = _zz_125_;
-    _zz_126_[1] = _zz_125_;
-    _zz_126_[0] = _zz_125_;
+    _zz_125[10] = _zz_124;
+    _zz_125[9] = _zz_124;
+    _zz_125[8] = _zz_124;
+    _zz_125[7] = _zz_124;
+    _zz_125[6] = _zz_124;
+    _zz_125[5] = _zz_124;
+    _zz_125[4] = _zz_124;
+    _zz_125[3] = _zz_124;
+    _zz_125[2] = _zz_124;
+    _zz_125[1] = _zz_124;
+    _zz_125[0] = _zz_124;
   end
 
-  assign _zz_127_ = _zz_294_[11];
+  assign _zz_126 = _zz_303[11];
   always @ (*) begin
-    _zz_128_[18] = _zz_127_;
-    _zz_128_[17] = _zz_127_;
-    _zz_128_[16] = _zz_127_;
-    _zz_128_[15] = _zz_127_;
-    _zz_128_[14] = _zz_127_;
-    _zz_128_[13] = _zz_127_;
-    _zz_128_[12] = _zz_127_;
-    _zz_128_[11] = _zz_127_;
-    _zz_128_[10] = _zz_127_;
-    _zz_128_[9] = _zz_127_;
-    _zz_128_[8] = _zz_127_;
-    _zz_128_[7] = _zz_127_;
-    _zz_128_[6] = _zz_127_;
-    _zz_128_[5] = _zz_127_;
-    _zz_128_[4] = _zz_127_;
-    _zz_128_[3] = _zz_127_;
-    _zz_128_[2] = _zz_127_;
-    _zz_128_[1] = _zz_127_;
-    _zz_128_[0] = _zz_127_;
+    _zz_127[18] = _zz_126;
+    _zz_127[17] = _zz_126;
+    _zz_127[16] = _zz_126;
+    _zz_127[15] = _zz_126;
+    _zz_127[14] = _zz_126;
+    _zz_127[13] = _zz_126;
+    _zz_127[12] = _zz_126;
+    _zz_127[11] = _zz_126;
+    _zz_127[10] = _zz_126;
+    _zz_127[9] = _zz_126;
+    _zz_127[8] = _zz_126;
+    _zz_127[7] = _zz_126;
+    _zz_127[6] = _zz_126;
+    _zz_127[5] = _zz_126;
+    _zz_127[4] = _zz_126;
+    _zz_127[3] = _zz_126;
+    _zz_127[2] = _zz_126;
+    _zz_127[1] = _zz_126;
+    _zz_127[0] = _zz_126;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_129_ = (_zz_295_[1] ^ execute_RS1[1]);
+        _zz_128 = (_zz_304[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_129_ = _zz_296_[1];
+        _zz_128 = _zz_305[1];
       end
       default : begin
-        _zz_129_ = _zz_297_[1];
+        _zz_128 = _zz_306[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_129_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_128);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -4768,106 +3840,106 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_130_ = _zz_298_[11];
+  assign _zz_129 = _zz_307[11];
   always @ (*) begin
-    _zz_131_[19] = _zz_130_;
-    _zz_131_[18] = _zz_130_;
-    _zz_131_[17] = _zz_130_;
-    _zz_131_[16] = _zz_130_;
-    _zz_131_[15] = _zz_130_;
-    _zz_131_[14] = _zz_130_;
-    _zz_131_[13] = _zz_130_;
-    _zz_131_[12] = _zz_130_;
-    _zz_131_[11] = _zz_130_;
-    _zz_131_[10] = _zz_130_;
-    _zz_131_[9] = _zz_130_;
-    _zz_131_[8] = _zz_130_;
-    _zz_131_[7] = _zz_130_;
-    _zz_131_[6] = _zz_130_;
-    _zz_131_[5] = _zz_130_;
-    _zz_131_[4] = _zz_130_;
-    _zz_131_[3] = _zz_130_;
-    _zz_131_[2] = _zz_130_;
-    _zz_131_[1] = _zz_130_;
-    _zz_131_[0] = _zz_130_;
+    _zz_130[19] = _zz_129;
+    _zz_130[18] = _zz_129;
+    _zz_130[17] = _zz_129;
+    _zz_130[16] = _zz_129;
+    _zz_130[15] = _zz_129;
+    _zz_130[14] = _zz_129;
+    _zz_130[13] = _zz_129;
+    _zz_130[12] = _zz_129;
+    _zz_130[11] = _zz_129;
+    _zz_130[10] = _zz_129;
+    _zz_130[9] = _zz_129;
+    _zz_130[8] = _zz_129;
+    _zz_130[7] = _zz_129;
+    _zz_130[6] = _zz_129;
+    _zz_130[5] = _zz_129;
+    _zz_130[4] = _zz_129;
+    _zz_130[3] = _zz_129;
+    _zz_130[2] = _zz_129;
+    _zz_130[1] = _zz_129;
+    _zz_130[0] = _zz_129;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_131_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_130,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_133_,{{{_zz_505_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_135_,{{{_zz_506_,_zz_507_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_132,{{{_zz_528,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_134,{{{_zz_529,_zz_530},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_301_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_310};
         end
       end
     endcase
   end
 
-  assign _zz_132_ = _zz_299_[19];
+  assign _zz_131 = _zz_308[19];
   always @ (*) begin
-    _zz_133_[10] = _zz_132_;
-    _zz_133_[9] = _zz_132_;
-    _zz_133_[8] = _zz_132_;
-    _zz_133_[7] = _zz_132_;
-    _zz_133_[6] = _zz_132_;
-    _zz_133_[5] = _zz_132_;
-    _zz_133_[4] = _zz_132_;
-    _zz_133_[3] = _zz_132_;
-    _zz_133_[2] = _zz_132_;
-    _zz_133_[1] = _zz_132_;
-    _zz_133_[0] = _zz_132_;
+    _zz_132[10] = _zz_131;
+    _zz_132[9] = _zz_131;
+    _zz_132[8] = _zz_131;
+    _zz_132[7] = _zz_131;
+    _zz_132[6] = _zz_131;
+    _zz_132[5] = _zz_131;
+    _zz_132[4] = _zz_131;
+    _zz_132[3] = _zz_131;
+    _zz_132[2] = _zz_131;
+    _zz_132[1] = _zz_131;
+    _zz_132[0] = _zz_131;
   end
 
-  assign _zz_134_ = _zz_300_[11];
+  assign _zz_133 = _zz_309[11];
   always @ (*) begin
-    _zz_135_[18] = _zz_134_;
-    _zz_135_[17] = _zz_134_;
-    _zz_135_[16] = _zz_134_;
-    _zz_135_[15] = _zz_134_;
-    _zz_135_[14] = _zz_134_;
-    _zz_135_[13] = _zz_134_;
-    _zz_135_[12] = _zz_134_;
-    _zz_135_[11] = _zz_134_;
-    _zz_135_[10] = _zz_134_;
-    _zz_135_[9] = _zz_134_;
-    _zz_135_[8] = _zz_134_;
-    _zz_135_[7] = _zz_134_;
-    _zz_135_[6] = _zz_134_;
-    _zz_135_[5] = _zz_134_;
-    _zz_135_[4] = _zz_134_;
-    _zz_135_[3] = _zz_134_;
-    _zz_135_[2] = _zz_134_;
-    _zz_135_[1] = _zz_134_;
-    _zz_135_[0] = _zz_134_;
+    _zz_134[18] = _zz_133;
+    _zz_134[17] = _zz_133;
+    _zz_134[16] = _zz_133;
+    _zz_134[15] = _zz_133;
+    _zz_134[14] = _zz_133;
+    _zz_134[13] = _zz_133;
+    _zz_134[12] = _zz_133;
+    _zz_134[11] = _zz_133;
+    _zz_134[10] = _zz_133;
+    _zz_134[9] = _zz_133;
+    _zz_134[8] = _zz_133;
+    _zz_134[7] = _zz_133;
+    _zz_134[6] = _zz_133;
+    _zz_134[5] = _zz_133;
+    _zz_134[4] = _zz_133;
+    _zz_134[3] = _zz_133;
+    _zz_134[2] = _zz_133;
+    _zz_134[1] = _zz_133;
+    _zz_134[0] = _zz_133;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_136_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_137_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_138_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_135 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_136 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_137 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_139_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_140_ = _zz_302_[0];
+  assign _zz_138 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_139 = _zz_311[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_211_)begin
+    if(_zz_220)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -4913,7 +3985,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -4937,7 +4009,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -4959,7 +4031,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -5054,7 +4126,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_223_)begin
+    if(_zz_232)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -5073,26 +4145,26 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_224_)begin
+    if(_zz_233)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_225_)begin
+    if(_zz_234)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_224_)begin
-      CsrPlugin_selfException_payload_code = (4'b0010);
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_233)begin
+      CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_225_)begin
+    if(_zz_234)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -5101,14 +4173,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_223_)begin
+    if(_zz_232)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_223_)begin
+    if(_zz_232)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5117,7 +4189,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_236_)
+    case(_zz_245)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -5131,7 +4203,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_226_)
+    case(_zz_235)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5145,7 +4217,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_226_)
+    case(_zz_235)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5164,12 +4236,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_304_) + $signed(_zz_305_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_313) + $signed(_zz_314));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_206_)begin
-      if(_zz_227_)begin
+    if(_zz_215)begin
+      if(_zz_236)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -5177,7 +4249,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_228_)begin
+    if(_zz_237)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -5188,59 +4260,59 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_309_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_318);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_141_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_141_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_310_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_311_ : _zz_312_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_313_[31:0];
-  assign _zz_142_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_143_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_144_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_140 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_140[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_319);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_320 : _zz_321);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_322[31:0];
+  assign _zz_141 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_142 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_143 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_145_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_145_[31 : 0] = execute_RS1;
+    _zz_144[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_144[31 : 0] = execute_RS1;
   end
 
-  assign _zz_147_ = (_zz_146_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_147_ != 32'h0);
-  assign _zz_26_ = decode_SRC2_CTRL;
-  assign _zz_24_ = _zz_43_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_23_ = decode_ENV_CTRL;
-  assign _zz_20_ = execute_ENV_CTRL;
-  assign _zz_18_ = memory_ENV_CTRL;
-  assign _zz_21_ = _zz_44_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_16_ = decode_ALU_CTRL;
-  assign _zz_14_ = _zz_47_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign _zz_13_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_11_ = _zz_49_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_10_ = decode_SHIFT_CTRL;
-  assign _zz_7_ = execute_SHIFT_CTRL;
-  assign _zz_8_ = _zz_48_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_5_ = decode_SRC1_CTRL;
-  assign _zz_3_ = _zz_45_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_2_ = decode_BRANCH_CTRL;
-  assign _zz_52_ = _zz_46_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_146 = (_zz_145 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_146 != 32'h0);
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_51 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -5258,216 +4330,216 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_148_ = 32'h0;
+    _zz_147 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_148_[12 : 0] = 13'h1000;
-      _zz_148_[25 : 20] = 6'h20;
+      _zz_147[12 : 0] = 13'h1000;
+      _zz_147[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_149_ = 32'h0;
+    _zz_148 = 32'h0;
     if(execute_CsrPlugin_csr_3857)begin
-      _zz_149_[3 : 0] = (4'b1011);
+      _zz_148[3 : 0] = 4'b1011;
     end
   end
 
   always @ (*) begin
-    _zz_150_ = 32'h0;
+    _zz_149 = 32'h0;
     if(execute_CsrPlugin_csr_3858)begin
-      _zz_150_[4 : 0] = 5'h16;
+      _zz_149[4 : 0] = 5'h16;
     end
   end
 
   always @ (*) begin
-    _zz_151_ = 32'h0;
+    _zz_150 = 32'h0;
     if(execute_CsrPlugin_csr_3859)begin
-      _zz_151_[5 : 0] = 6'h21;
+      _zz_150[5 : 0] = 6'h21;
     end
   end
 
   always @ (*) begin
-    _zz_152_ = 32'h0;
+    _zz_151 = 32'h0;
     if(execute_CsrPlugin_csr_769)begin
-      _zz_152_[31 : 30] = CsrPlugin_misa_base;
-      _zz_152_[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_151[31 : 30] = CsrPlugin_misa_base;
+      _zz_151[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
   always @ (*) begin
-    _zz_153_ = 32'h0;
+    _zz_152 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_153_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_153_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_153_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_152[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_152[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_152[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_154_ = 32'h0;
+    _zz_153 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_154_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_154_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_154_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_153[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_153[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_153[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_155_ = 32'h0;
+    _zz_154 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_155_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_155_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_155_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_154[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_154[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_154[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_156_ = 32'h0;
+    _zz_155 = 32'h0;
     if(execute_CsrPlugin_csr_773)begin
-      _zz_156_[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_156_[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_155[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_155[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
   always @ (*) begin
-    _zz_157_ = 32'h0;
+    _zz_156 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_157_[31 : 0] = CsrPlugin_mepc;
+      _zz_156[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_158_ = 32'h0;
+    _zz_157 = 32'h0;
     if(execute_CsrPlugin_csr_832)begin
-      _zz_158_[31 : 0] = CsrPlugin_mscratch;
+      _zz_157[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
-    _zz_159_ = 32'h0;
+    _zz_158 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_159_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_159_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_158[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_158[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_160_ = 32'h0;
+    _zz_159 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_160_[31 : 0] = CsrPlugin_mtval;
+      _zz_159[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_161_ = 32'h0;
+    _zz_160 = 32'h0;
     if(execute_CsrPlugin_csr_2816)begin
-      _zz_161_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_160[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_162_ = 32'h0;
+    _zz_161 = 32'h0;
     if(execute_CsrPlugin_csr_2944)begin
-      _zz_162_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_161[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_163_ = 32'h0;
+    _zz_162 = 32'h0;
     if(execute_CsrPlugin_csr_2818)begin
-      _zz_163_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_162[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_164_ = 32'h0;
+    _zz_163 = 32'h0;
     if(execute_CsrPlugin_csr_2946)begin
-      _zz_164_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_163[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_165_ = 32'h0;
+    _zz_164 = 32'h0;
     if(execute_CsrPlugin_csr_3072)begin
-      _zz_165_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_164[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_166_ = 32'h0;
+    _zz_165 = 32'h0;
     if(execute_CsrPlugin_csr_3200)begin
-      _zz_166_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_165[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_167_ = 32'h0;
+    _zz_166 = 32'h0;
     if(execute_CsrPlugin_csr_3074)begin
-      _zz_167_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_166[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_168_ = 32'h0;
+    _zz_167 = 32'h0;
     if(execute_CsrPlugin_csr_3202)begin
-      _zz_168_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_167[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_169_ = 32'h0;
+    _zz_168 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_169_[31 : 0] = _zz_146_;
+      _zz_168[31 : 0] = _zz_145;
     end
   end
 
   always @ (*) begin
-    _zz_170_ = 32'h0;
+    _zz_169 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_170_[31 : 0] = _zz_147_;
+      _zz_169[31 : 0] = _zz_146;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_148_ | _zz_149_) | (_zz_150_ | _zz_151_)) | ((_zz_508_ | _zz_152_) | (_zz_153_ | _zz_154_))) | (((_zz_155_ | _zz_156_) | (_zz_157_ | _zz_158_)) | ((_zz_159_ | _zz_160_) | (_zz_161_ | _zz_162_)))) | (((_zz_163_ | _zz_164_) | (_zz_165_ | _zz_166_)) | ((_zz_167_ | _zz_168_) | (_zz_169_ | _zz_170_))));
-  assign iBusWishbone_ADR = {_zz_330_,_zz_171_};
-  assign iBusWishbone_CTI = ((_zz_171_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((((_zz_147 | _zz_148) | (_zz_149 | _zz_150)) | ((_zz_531 | _zz_151) | (_zz_152 | _zz_153))) | (((_zz_154 | _zz_155) | (_zz_156 | _zz_157)) | ((_zz_158 | _zz_159) | (_zz_160 | _zz_161)))) | (((_zz_162 | _zz_163) | (_zz_164 | _zz_165)) | ((_zz_166 | _zz_167) | (_zz_168 | _zz_169))));
+  assign iBusWishbone_ADR = {_zz_339,_zz_170};
+  assign iBusWishbone_CTI = ((_zz_170 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_229_)begin
+    if(_zz_238)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_229_)begin
+    if(_zz_238)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_172_;
+  assign iBus_rsp_valid = _zz_171;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_178_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_174_ = dBus_cmd_valid;
-  assign _zz_176_ = dBus_cmd_payload_wr;
-  assign _zz_177_ = (_zz_173_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_175_ && (_zz_176_ || _zz_177_));
-  assign dBusWishbone_ADR = ((_zz_178_ ? {{dBus_cmd_payload_address[31 : 5],_zz_173_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_178_ ? (_zz_177_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_176_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_176_;
+  assign _zz_177 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_173 = dBus_cmd_valid;
+  assign _zz_175 = dBus_cmd_payload_wr;
+  assign _zz_176 = (_zz_172 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_174 && (_zz_175 || _zz_176));
+  assign dBusWishbone_ADR = ((_zz_177 ? {{dBus_cmd_payload_address[31 : 5],_zz_172},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_177 ? (_zz_176 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_175 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_175;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_175_ = (_zz_174_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_174_;
-  assign dBusWishbone_STB = _zz_174_;
-  assign dBus_rsp_valid = _zz_179_;
+  assign _zz_174 = (_zz_173 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_173;
+  assign dBusWishbone_STB = _zz_173;
+  assign dBus_rsp_valid = _zz_178;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -5476,26 +4548,26 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_65_ <= 1'b0;
-      _zz_67_ <= 1'b0;
+      _zz_64 <= 1'b0;
+      _zz_66 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_80_;
+      IBusCachedPlugin_rspCounter <= _zz_79;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_81_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_80;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_99_ <= 1'b1;
-      _zz_111_ <= 1'b0;
-      CsrPlugin_misa_base <= (2'b01);
+      _zz_98 <= 1'b1;
+      _zz_110 <= 1'b0;
+      CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -5511,16 +4583,14 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_146_ <= 32'h0;
+      _zz_145 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_171_ <= (3'b000);
-      _zz_172_ <= 1'b0;
-      _zz_173_ <= (3'b000);
-      _zz_179_ <= 1'b0;
+      _zz_170 <= 3'b000;
+      _zz_171 <= 1'b0;
+      _zz_172 <= 3'b000;
+      _zz_178 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -5542,16 +4612,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65_ <= 1'b0;
+        _zz_64 <= 1'b0;
       end
-      if(_zz_63_)begin
-        _zz_65_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_62)begin
+        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67_ <= 1'b0;
+        _zz_66 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_67_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_66 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -5598,20 +4668,20 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_230_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_239)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_99_ <= 1'b0;
-      _zz_111_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_98 <= 1'b0;
+      _zz_110 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -5633,14 +4703,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_231_)begin
-        if(_zz_232_)begin
+      if(_zz_240)begin
+        if(_zz_241)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_233_)begin
+        if(_zz_242)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_234_)begin
+        if(_zz_243)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -5665,7 +4735,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_213_)begin
+      if(_zz_222)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5676,10 +4746,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_214_)begin
-        case(_zz_215_)
+      if(_zz_223)begin
+        case(_zz_224)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -5687,14 +4757,8 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_138_,{_zz_137_,_zz_136_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_137,{_zz_136,_zz_135}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -5722,41 +4786,41 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_323_[0];
-          CsrPlugin_mstatus_MIE <= _zz_324_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_332[0];
+          CsrPlugin_mstatus_MIE <= _zz_333[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_326_[0];
-          CsrPlugin_mie_MTIE <= _zz_327_[0];
-          CsrPlugin_mie_MSIE <= _zz_328_[0];
+          CsrPlugin_mie_MEIE <= _zz_335[0];
+          CsrPlugin_mie_MTIE <= _zz_336[0];
+          CsrPlugin_mie_MSIE <= _zz_337[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_146_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_145 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_229_)begin
+      if(_zz_238)begin
         if(iBusWishbone_ACK)begin
-          _zz_171_ <= (_zz_171_ + (3'b001));
+          _zz_170 <= (_zz_170 + 3'b001);
         end
       end
-      _zz_172_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_174_ && _zz_175_))begin
-        _zz_173_ <= (_zz_173_ + (3'b001));
-        if(_zz_177_)begin
-          _zz_173_ <= (3'b000);
+      _zz_171 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_173 && _zz_174))begin
+        _zz_172 <= (_zz_172 + 3'b001);
+        if(_zz_176)begin
+          _zz_172 <= 3'b000;
         end
       end
-      _zz_179_ <= ((_zz_174_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_178 <= ((_zz_173 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_68_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_67 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -5764,24 +4828,26 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_230_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_239)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_112_ <= _zz_40_[11 : 7];
-    _zz_113_ <= _zz_50_;
+    _zz_111 <= _zz_40[11 : 7];
+    _zz_112 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -5789,9 +4855,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_211_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_140_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_140_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_220)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -5805,21 +4871,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_231_)begin
-      if(_zz_232_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_240)begin
+      if(_zz_241)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_233_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_242)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_234_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_243)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_213_)begin
+    if(_zz_222)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5839,57 +4905,30 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_206_)begin
-      if(_zz_227_)begin
+    if(_zz_215)begin
+      if(_zz_236)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_314_[31:0];
+          memory_DivPlugin_div_result <= _zz_323[31:0];
         end
       end
     end
-    if(_zz_228_)begin
+    if(_zz_237)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_144_ ? (~ _zz_145_) : _zz_145_) + _zz_320_);
-      memory_DivPlugin_rs2 <= ((_zz_143_ ? (~ execute_RS2) : execute_RS2) + _zz_322_);
-      memory_DivPlugin_div_needRevert <= ((_zz_144_ ^ (_zz_143_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_143 ? (~ _zz_144) : _zz_144) + _zz_329);
+      memory_DivPlugin_rs2 <= ((_zz_142 ? (~ execute_RS2) : execute_RS2) + _zz_331);
+      memory_DivPlugin_div_needRevert <= ((_zz_143 ^ (_zz_142 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      execute_to_memory_PC <= _zz_35;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_25_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_22_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_19_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_17_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
@@ -5897,77 +4936,26 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
-    end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_15_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_54_;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53_;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_12_;
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      decode_to_execute_SRC1_CTRL <= _zz_25;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_9_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_6_;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -5979,43 +4967,28 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      decode_to_execute_ALU_CTRL <= _zz_22;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_4_;
+      decode_to_execute_SRC2_CTRL <= _zz_19;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_1_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
@@ -6026,11 +4999,113 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -6106,7 +5181,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_325_[0];
+        CsrPlugin_mip_MSIP <= _zz_334[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -6127,7 +5202,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_834)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_329_[0];
+        CsrPlugin_mcause_interrupt <= _zz_338[0];
         CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -6158,6 +5233,1092 @@ module VexRiscv (
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire       [0:0]    _zz_19;
+  wire       [0:0]    _zz_20;
+  wire       [9:0]    _zz_21;
+  wire       [9:0]    _zz_22;
+  wire       [0:0]    _zz_23;
+  wire       [0:0]    _zz_24;
+  wire       [2:0]    _zz_25;
+  wire       [1:0]    _zz_26;
+  wire       [21:0]   _zz_27;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  wire                stage0_isAmo;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire                stageA_isAmo;
+  wire                stageA_isLrsc;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  wire                stageB_isAmo;
+  wire                stageB_isAmoCached;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  wire       [31:0]   stageB_requestDataBypass;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_28;
+  reg [7:0] _zz_29;
+  reg [7:0] _zz_30;
+  reg [7:0] _zz_31;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign _zz_17 = (! stageB_flusher_hold);
+  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_19 = _zz_4[0 : 0];
+  assign _zz_20 = _zz_4[1 : 1];
+  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_23 = 1'b1;
+  assign _zz_24 = loader_counter_willIncrement;
+  assign _zz_25 = {2'd0, _zz_24};
+  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_19[0];
+  assign ways_0_tagsReadRsp_error = _zz_20[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_23[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign stage0_isAmo = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign stageA_isAmo = 1'b0;
+  assign stageA_isLrsc = 1'b0;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_16)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isAmo = 1'b0;
+  assign stageB_isAmoCached = 1'b0;
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  assign stageB_requestDataBypass = stageB_request_data;
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          io_mem_cmd_valid = (! memCmdSent);
+        end else begin
+          if(_zz_16)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_14)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_25);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_17)begin
+        if(_zz_18)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_17)begin
+          if(! _zz_18) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_14)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_26[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_9;
+  reg        [21:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [21:0]   _zz_15;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_11 = (! lineLoader_flushCounter[7]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_9 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_10 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_11)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_12)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_11)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_12)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
   end
 
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfu.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfu.v
@@ -3,6 +3,10 @@
 // Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
 
+`define Input2Kind_defaultEncoding_type [0:0]
+`define Input2Kind_defaultEncoding_RS 1'b0
+`define Input2Kind_defaultEncoding_IMM_I 1'b1
+
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
 `define EnvCtrlEnum_defaultEncoding_XRET 2'b01
@@ -49,13 +53,15 @@ module VexRiscv (
   input               timerInterrupt,
   input               softwareInterrupt,
   input      [31:0]   externalInterruptArray,
-  input               debug_bus_cmd_valid,
-  output reg          debug_bus_cmd_ready,
-  input               debug_bus_cmd_payload_wr,
-  input      [7:0]    debug_bus_cmd_payload_address,
-  input      [31:0]   debug_bus_cmd_payload_data,
-  output reg [31:0]   debug_bus_rsp_data,
-  output              debug_resetOut,
+  output              CfuPlugin_bus_cmd_valid,
+  input               CfuPlugin_bus_cmd_ready,
+  output     [9:0]    CfuPlugin_bus_cmd_payload_function_id,
+  output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_0,
+  output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_1,
+  input               CfuPlugin_bus_rsp_valid,
+  output              CfuPlugin_bus_rsp_ready,
+  input               CfuPlugin_bus_rsp_payload_response_ok,
+  input      [31:0]   CfuPlugin_bus_rsp_payload_outputs_0,
   output reg          iBusWishbone_CYC,
   output reg          iBusWishbone_STB,
   input               iBusWishbone_ACK,
@@ -79,40 +85,39 @@ module VexRiscv (
   output     [2:0]    dBusWishbone_CTI,
   output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset,
-  input               debugReset
+  input               reset
 );
-  wire                _zz_182;
-  wire                _zz_183;
-  wire                _zz_184;
-  wire                _zz_185;
-  wire                _zz_186;
-  wire                _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  reg                 _zz_190;
-  wire                _zz_191;
-  wire       [31:0]   _zz_192;
   wire                _zz_193;
-  wire       [31:0]   _zz_194;
-  reg                 _zz_195;
+  wire                _zz_194;
+  wire                _zz_195;
   wire                _zz_196;
   wire                _zz_197;
-  wire       [31:0]   _zz_198;
+  wire                _zz_198;
   wire                _zz_199;
   wire                _zz_200;
-  wire                _zz_201;
+  reg                 _zz_201;
   wire                _zz_202;
-  wire                _zz_203;
+  wire       [31:0]   _zz_203;
   wire                _zz_204;
-  wire                _zz_205;
-  wire                _zz_206;
-  wire       [3:0]    _zz_207;
+  wire       [31:0]   _zz_205;
+  reg                 _zz_206;
+  wire                _zz_207;
   wire                _zz_208;
-  wire                _zz_209;
-  reg        [31:0]   _zz_210;
-  reg        [31:0]   _zz_211;
-  reg        [31:0]   _zz_212;
+  wire       [31:0]   _zz_209;
+  wire                _zz_210;
+  wire                _zz_211;
+  wire                _zz_212;
+  wire                _zz_213;
+  wire                _zz_214;
+  wire                _zz_215;
+  wire                _zz_216;
+  wire                _zz_217;
+  wire       [3:0]    _zz_218;
+  wire                _zz_219;
+  wire                _zz_220;
+  reg        [31:0]   _zz_221;
+  reg        [31:0]   _zz_222;
+  reg        [31:0]   _zz_223;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -145,24 +150,13 @@ module VexRiscv (
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
   wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
   wire                _zz_224;
   wire                _zz_225;
   wire                _zz_226;
   wire                _zz_227;
   wire                _zz_228;
   wire                _zz_229;
-  wire       [1:0]    _zz_230;
+  wire                _zz_230;
   wire                _zz_231;
   wire                _zz_232;
   wire                _zz_233;
@@ -171,42 +165,42 @@ module VexRiscv (
   wire                _zz_236;
   wire                _zz_237;
   wire                _zz_238;
-  wire                _zz_239;
+  wire       [1:0]    _zz_239;
   wire                _zz_240;
-  wire       [1:0]    _zz_241;
+  wire                _zz_241;
   wire                _zz_242;
   wire                _zz_243;
-  wire       [5:0]    _zz_244;
+  wire                _zz_244;
   wire                _zz_245;
   wire                _zz_246;
   wire                _zz_247;
   wire                _zz_248;
   wire                _zz_249;
-  wire                _zz_250;
-  wire       [1:0]    _zz_251;
+  wire       [1:0]    _zz_250;
+  wire                _zz_251;
   wire                _zz_252;
-  wire       [1:0]    _zz_253;
-  wire       [51:0]   _zz_254;
-  wire       [51:0]   _zz_255;
-  wire       [51:0]   _zz_256;
-  wire       [32:0]   _zz_257;
-  wire       [51:0]   _zz_258;
-  wire       [49:0]   _zz_259;
-  wire       [51:0]   _zz_260;
-  wire       [49:0]   _zz_261;
-  wire       [51:0]   _zz_262;
-  wire       [32:0]   _zz_263;
-  wire       [31:0]   _zz_264;
-  wire       [32:0]   _zz_265;
-  wire       [0:0]    _zz_266;
-  wire       [0:0]    _zz_267;
-  wire       [0:0]    _zz_268;
-  wire       [0:0]    _zz_269;
-  wire       [0:0]    _zz_270;
-  wire       [0:0]    _zz_271;
-  wire       [0:0]    _zz_272;
-  wire       [0:0]    _zz_273;
-  wire       [0:0]    _zz_274;
+  wire                _zz_253;
+  wire                _zz_254;
+  wire                _zz_255;
+  wire                _zz_256;
+  wire                _zz_257;
+  wire                _zz_258;
+  wire                _zz_259;
+  wire       [1:0]    _zz_260;
+  wire                _zz_261;
+  wire       [1:0]    _zz_262;
+  wire       [51:0]   _zz_263;
+  wire       [51:0]   _zz_264;
+  wire       [51:0]   _zz_265;
+  wire       [32:0]   _zz_266;
+  wire       [51:0]   _zz_267;
+  wire       [49:0]   _zz_268;
+  wire       [51:0]   _zz_269;
+  wire       [49:0]   _zz_270;
+  wire       [51:0]   _zz_271;
+  wire       [32:0]   _zz_272;
+  wire       [31:0]   _zz_273;
+  wire       [32:0]   _zz_274;
   wire       [0:0]    _zz_275;
   wire       [0:0]    _zz_276;
   wire       [0:0]    _zz_277;
@@ -216,306 +210,326 @@ module VexRiscv (
   wire       [0:0]    _zz_281;
   wire       [0:0]    _zz_282;
   wire       [0:0]    _zz_283;
-  wire       [3:0]    _zz_284;
-  wire       [2:0]    _zz_285;
-  wire       [31:0]   _zz_286;
-  wire       [11:0]   _zz_287;
-  wire       [31:0]   _zz_288;
-  wire       [19:0]   _zz_289;
-  wire       [11:0]   _zz_290;
-  wire       [31:0]   _zz_291;
-  wire       [31:0]   _zz_292;
-  wire       [19:0]   _zz_293;
-  wire       [11:0]   _zz_294;
-  wire       [2:0]    _zz_295;
-  wire       [2:0]    _zz_296;
-  wire       [0:0]    _zz_297;
-  wire       [2:0]    _zz_298;
-  wire       [4:0]    _zz_299;
-  wire       [11:0]   _zz_300;
-  wire       [11:0]   _zz_301;
-  wire       [31:0]   _zz_302;
-  wire       [31:0]   _zz_303;
-  wire       [31:0]   _zz_304;
-  wire       [31:0]   _zz_305;
-  wire       [31:0]   _zz_306;
-  wire       [31:0]   _zz_307;
-  wire       [31:0]   _zz_308;
+  wire       [0:0]    _zz_284;
+  wire       [0:0]    _zz_285;
+  wire       [0:0]    _zz_286;
+  wire       [0:0]    _zz_287;
+  wire       [0:0]    _zz_288;
+  wire       [0:0]    _zz_289;
+  wire       [0:0]    _zz_290;
+  wire       [0:0]    _zz_291;
+  wire       [0:0]    _zz_292;
+  wire       [3:0]    _zz_293;
+  wire       [2:0]    _zz_294;
+  wire       [31:0]   _zz_295;
+  wire       [11:0]   _zz_296;
+  wire       [31:0]   _zz_297;
+  wire       [19:0]   _zz_298;
+  wire       [11:0]   _zz_299;
+  wire       [31:0]   _zz_300;
+  wire       [31:0]   _zz_301;
+  wire       [19:0]   _zz_302;
+  wire       [11:0]   _zz_303;
+  wire       [2:0]    _zz_304;
+  wire       [2:0]    _zz_305;
+  wire       [0:0]    _zz_306;
+  wire       [2:0]    _zz_307;
+  wire       [4:0]    _zz_308;
   wire       [11:0]   _zz_309;
-  wire       [19:0]   _zz_310;
-  wire       [11:0]   _zz_311;
+  wire       [11:0]   _zz_310;
+  wire       [31:0]   _zz_311;
   wire       [31:0]   _zz_312;
   wire       [31:0]   _zz_313;
   wire       [31:0]   _zz_314;
-  wire       [11:0]   _zz_315;
-  wire       [19:0]   _zz_316;
-  wire       [11:0]   _zz_317;
-  wire       [2:0]    _zz_318;
-  wire       [1:0]    _zz_319;
-  wire       [1:0]    _zz_320;
-  wire       [65:0]   _zz_321;
-  wire       [65:0]   _zz_322;
+  wire       [31:0]   _zz_315;
+  wire       [31:0]   _zz_316;
+  wire       [31:0]   _zz_317;
+  wire       [11:0]   _zz_318;
+  wire       [19:0]   _zz_319;
+  wire       [11:0]   _zz_320;
+  wire       [31:0]   _zz_321;
+  wire       [31:0]   _zz_322;
   wire       [31:0]   _zz_323;
-  wire       [31:0]   _zz_324;
-  wire       [0:0]    _zz_325;
-  wire       [5:0]    _zz_326;
-  wire       [32:0]   _zz_327;
-  wire       [31:0]   _zz_328;
-  wire       [31:0]   _zz_329;
-  wire       [32:0]   _zz_330;
-  wire       [32:0]   _zz_331;
-  wire       [32:0]   _zz_332;
-  wire       [32:0]   _zz_333;
-  wire       [0:0]    _zz_334;
-  wire       [32:0]   _zz_335;
+  wire       [11:0]   _zz_324;
+  wire       [19:0]   _zz_325;
+  wire       [11:0]   _zz_326;
+  wire       [2:0]    _zz_327;
+  wire       [1:0]    _zz_328;
+  wire       [1:0]    _zz_329;
+  wire       [1:0]    _zz_330;
+  wire       [1:0]    _zz_331;
+  wire       [65:0]   _zz_332;
+  wire       [65:0]   _zz_333;
+  wire       [31:0]   _zz_334;
+  wire       [31:0]   _zz_335;
   wire       [0:0]    _zz_336;
-  wire       [32:0]   _zz_337;
-  wire       [0:0]    _zz_338;
+  wire       [5:0]    _zz_337;
+  wire       [32:0]   _zz_338;
   wire       [31:0]   _zz_339;
-  wire       [0:0]    _zz_340;
-  wire       [0:0]    _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [0:0]    _zz_343;
-  wire       [0:0]    _zz_344;
+  wire       [31:0]   _zz_340;
+  wire       [32:0]   _zz_341;
+  wire       [32:0]   _zz_342;
+  wire       [32:0]   _zz_343;
+  wire       [32:0]   _zz_344;
   wire       [0:0]    _zz_345;
-  wire       [0:0]    _zz_346;
-  wire       [26:0]   _zz_347;
-  wire                _zz_348;
-  wire                _zz_349;
-  wire       [1:0]    _zz_350;
-  wire       [31:0]   _zz_351;
-  wire       [31:0]   _zz_352;
-  wire       [31:0]   _zz_353;
-  wire                _zz_354;
+  wire       [32:0]   _zz_346;
+  wire       [0:0]    _zz_347;
+  wire       [32:0]   _zz_348;
+  wire       [0:0]    _zz_349;
+  wire       [31:0]   _zz_350;
+  wire       [9:0]    _zz_351;
+  wire       [7:0]    _zz_352;
+  wire       [0:0]    _zz_353;
+  wire       [0:0]    _zz_354;
   wire       [0:0]    _zz_355;
-  wire       [13:0]   _zz_356;
-  wire       [31:0]   _zz_357;
-  wire       [31:0]   _zz_358;
-  wire       [31:0]   _zz_359;
-  wire                _zz_360;
-  wire       [0:0]    _zz_361;
-  wire       [7:0]    _zz_362;
-  wire       [31:0]   _zz_363;
+  wire       [0:0]    _zz_356;
+  wire       [0:0]    _zz_357;
+  wire       [0:0]    _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [26:0]   _zz_360;
+  wire                _zz_361;
+  wire                _zz_362;
+  wire       [1:0]    _zz_363;
   wire       [31:0]   _zz_364;
   wire       [31:0]   _zz_365;
-  wire                _zz_366;
-  wire       [0:0]    _zz_367;
-  wire       [1:0]    _zz_368;
-  wire                _zz_369;
-  wire                _zz_370;
-  wire                _zz_371;
+  wire       [31:0]   _zz_366;
+  wire                _zz_367;
+  wire       [0:0]    _zz_368;
+  wire       [14:0]   _zz_369;
+  wire       [31:0]   _zz_370;
+  wire       [31:0]   _zz_371;
   wire       [31:0]   _zz_372;
-  wire       [0:0]    _zz_373;
+  wire                _zz_373;
   wire       [0:0]    _zz_374;
-  wire                _zz_375;
-  wire       [0:0]    _zz_376;
-  wire       [26:0]   _zz_377;
+  wire       [8:0]    _zz_375;
+  wire       [31:0]   _zz_376;
+  wire       [31:0]   _zz_377;
   wire       [31:0]   _zz_378;
   wire                _zz_379;
-  wire                _zz_380;
-  wire                _zz_381;
-  wire       [1:0]    _zz_382;
-  wire       [1:0]    _zz_383;
+  wire       [0:0]    _zz_380;
+  wire       [2:0]    _zz_381;
+  wire                _zz_382;
+  wire                _zz_383;
   wire                _zz_384;
   wire       [0:0]    _zz_385;
-  wire       [22:0]   _zz_386;
-  wire       [31:0]   _zz_387;
-  wire       [31:0]   _zz_388;
-  wire       [31:0]   _zz_389;
+  wire       [0:0]    _zz_386;
+  wire                _zz_387;
+  wire       [0:0]    _zz_388;
+  wire       [26:0]   _zz_389;
   wire       [31:0]   _zz_390;
-  wire                _zz_391;
-  wire                _zz_392;
-  wire       [1:0]    _zz_393;
+  wire       [31:0]   _zz_391;
+  wire       [31:0]   _zz_392;
+  wire                _zz_393;
   wire       [1:0]    _zz_394;
-  wire                _zz_395;
-  wire       [0:0]    _zz_396;
-  wire       [19:0]   _zz_397;
-  wire       [31:0]   _zz_398;
+  wire       [1:0]    _zz_395;
+  wire                _zz_396;
+  wire       [0:0]    _zz_397;
+  wire       [22:0]   _zz_398;
   wire       [31:0]   _zz_399;
   wire       [31:0]   _zz_400;
   wire       [31:0]   _zz_401;
-  wire                _zz_402;
-  wire       [0:0]    _zz_403;
-  wire       [0:0]    _zz_404;
-  wire                _zz_405;
-  wire       [0:0]    _zz_406;
-  wire       [0:0]    _zz_407;
-  wire                _zz_408;
-  wire       [0:0]    _zz_409;
-  wire       [16:0]   _zz_410;
+  wire       [31:0]   _zz_402;
+  wire                _zz_403;
+  wire                _zz_404;
+  wire       [1:0]    _zz_405;
+  wire       [1:0]    _zz_406;
+  wire                _zz_407;
+  wire       [0:0]    _zz_408;
+  wire       [19:0]   _zz_409;
+  wire       [31:0]   _zz_410;
   wire       [31:0]   _zz_411;
   wire       [31:0]   _zz_412;
   wire       [31:0]   _zz_413;
-  wire       [31:0]   _zz_414;
-  wire       [31:0]   _zz_415;
+  wire                _zz_414;
+  wire       [0:0]    _zz_415;
   wire       [0:0]    _zz_416;
-  wire       [0:0]    _zz_417;
+  wire                _zz_417;
   wire       [0:0]    _zz_418;
   wire       [0:0]    _zz_419;
   wire                _zz_420;
   wire       [0:0]    _zz_421;
-  wire       [13:0]   _zz_422;
+  wire       [16:0]   _zz_422;
   wire       [31:0]   _zz_423;
   wire       [31:0]   _zz_424;
   wire       [31:0]   _zz_425;
-  wire                _zz_426;
-  wire                _zz_427;
+  wire       [31:0]   _zz_426;
+  wire       [31:0]   _zz_427;
   wire       [0:0]    _zz_428;
-  wire       [3:0]    _zz_429;
+  wire       [0:0]    _zz_429;
   wire       [0:0]    _zz_430;
   wire       [0:0]    _zz_431;
   wire                _zz_432;
   wire       [0:0]    _zz_433;
-  wire       [10:0]   _zz_434;
+  wire       [13:0]   _zz_434;
   wire       [31:0]   _zz_435;
   wire       [31:0]   _zz_436;
   wire       [31:0]   _zz_437;
-  wire                _zz_438;
+  wire       [0:0]    _zz_438;
   wire       [0:0]    _zz_439;
   wire       [0:0]    _zz_440;
-  wire       [31:0]   _zz_441;
-  wire                _zz_442;
+  wire       [3:0]    _zz_441;
+  wire       [0:0]    _zz_442;
   wire       [0:0]    _zz_443;
-  wire       [2:0]    _zz_444;
+  wire                _zz_444;
   wire       [0:0]    _zz_445;
-  wire       [3:0]    _zz_446;
-  wire       [5:0]    _zz_447;
-  wire       [5:0]    _zz_448;
-  wire                _zz_449;
-  wire       [0:0]    _zz_450;
-  wire       [7:0]    _zz_451;
-  wire       [31:0]   _zz_452;
-  wire       [31:0]   _zz_453;
-  wire       [31:0]   _zz_454;
+  wire       [10:0]   _zz_446;
+  wire       [31:0]   _zz_447;
+  wire       [31:0]   _zz_448;
+  wire       [31:0]   _zz_449;
+  wire       [31:0]   _zz_450;
+  wire       [31:0]   _zz_451;
+  wire                _zz_452;
+  wire       [0:0]    _zz_453;
+  wire       [0:0]    _zz_454;
   wire       [31:0]   _zz_455;
-  wire       [31:0]   _zz_456;
-  wire       [31:0]   _zz_457;
-  wire                _zz_458;
+  wire                _zz_456;
+  wire       [0:0]    _zz_457;
+  wire       [3:0]    _zz_458;
   wire       [0:0]    _zz_459;
-  wire       [0:0]    _zz_460;
-  wire                _zz_461;
-  wire       [0:0]    _zz_462;
-  wire       [1:0]    _zz_463;
+  wire       [3:0]    _zz_460;
+  wire       [5:0]    _zz_461;
+  wire       [5:0]    _zz_462;
+  wire                _zz_463;
   wire       [0:0]    _zz_464;
-  wire       [3:0]    _zz_465;
-  wire       [0:0]    _zz_466;
-  wire       [0:0]    _zz_467;
-  wire       [1:0]    _zz_468;
-  wire       [1:0]    _zz_469;
-  wire                _zz_470;
-  wire       [0:0]    _zz_471;
-  wire       [5:0]    _zz_472;
+  wire       [7:0]    _zz_465;
+  wire       [31:0]   _zz_466;
+  wire       [31:0]   _zz_467;
+  wire       [31:0]   _zz_468;
+  wire       [31:0]   _zz_469;
+  wire       [31:0]   _zz_470;
+  wire       [31:0]   _zz_471;
+  wire       [31:0]   _zz_472;
   wire       [31:0]   _zz_473;
-  wire       [31:0]   _zz_474;
-  wire       [31:0]   _zz_475;
-  wire       [31:0]   _zz_476;
-  wire       [31:0]   _zz_477;
-  wire       [31:0]   _zz_478;
-  wire       [31:0]   _zz_479;
-  wire       [31:0]   _zz_480;
-  wire                _zz_481;
-  wire                _zz_482;
-  wire       [31:0]   _zz_483;
-  wire       [31:0]   _zz_484;
+  wire       [0:0]    _zz_474;
+  wire       [1:0]    _zz_475;
+  wire                _zz_476;
+  wire       [0:0]    _zz_477;
+  wire       [1:0]    _zz_478;
+  wire       [0:0]    _zz_479;
+  wire       [3:0]    _zz_480;
+  wire       [0:0]    _zz_481;
+  wire       [0:0]    _zz_482;
+  wire       [1:0]    _zz_483;
+  wire       [1:0]    _zz_484;
   wire                _zz_485;
   wire       [0:0]    _zz_486;
-  wire       [1:0]    _zz_487;
+  wire       [5:0]    _zz_487;
   wire       [31:0]   _zz_488;
   wire       [31:0]   _zz_489;
   wire                _zz_490;
   wire                _zz_491;
-  wire       [0:0]    _zz_492;
-  wire       [0:0]    _zz_493;
-  wire                _zz_494;
-  wire       [0:0]    _zz_495;
-  wire       [3:0]    _zz_496;
+  wire       [31:0]   _zz_492;
+  wire       [31:0]   _zz_493;
+  wire       [31:0]   _zz_494;
+  wire                _zz_495;
+  wire                _zz_496;
   wire       [31:0]   _zz_497;
   wire       [31:0]   _zz_498;
-  wire       [31:0]   _zz_499;
-  wire       [31:0]   _zz_500;
-  wire       [31:0]   _zz_501;
-  wire                _zz_502;
-  wire                _zz_503;
-  wire       [31:0]   _zz_504;
-  wire       [31:0]   _zz_505;
-  wire       [31:0]   _zz_506;
-  wire       [31:0]   _zz_507;
-  wire       [0:0]    _zz_508;
-  wire       [2:0]    _zz_509;
-  wire       [0:0]    _zz_510;
-  wire       [0:0]    _zz_511;
-  wire                _zz_512;
-  wire       [0:0]    _zz_513;
-  wire       [1:0]    _zz_514;
+  wire                _zz_499;
+  wire       [0:0]    _zz_500;
+  wire       [1:0]    _zz_501;
+  wire       [31:0]   _zz_502;
+  wire       [31:0]   _zz_503;
+  wire                _zz_504;
+  wire                _zz_505;
+  wire       [0:0]    _zz_506;
+  wire       [0:0]    _zz_507;
+  wire                _zz_508;
+  wire       [0:0]    _zz_509;
+  wire       [3:0]    _zz_510;
+  wire       [31:0]   _zz_511;
+  wire       [31:0]   _zz_512;
+  wire       [31:0]   _zz_513;
+  wire       [31:0]   _zz_514;
   wire       [31:0]   _zz_515;
   wire       [31:0]   _zz_516;
   wire       [31:0]   _zz_517;
   wire                _zz_518;
   wire                _zz_519;
   wire       [31:0]   _zz_520;
-  wire                _zz_521;
-  wire       [0:0]    _zz_522;
-  wire       [0:0]    _zz_523;
+  wire       [31:0]   _zz_521;
+  wire       [31:0]   _zz_522;
+  wire       [31:0]   _zz_523;
   wire       [0:0]    _zz_524;
-  wire       [0:0]    _zz_525;
-  wire       [1:0]    _zz_526;
-  wire       [1:0]    _zz_527;
-  wire       [0:0]    _zz_528;
+  wire       [2:0]    _zz_525;
+  wire       [0:0]    _zz_526;
+  wire       [0:0]    _zz_527;
+  wire                _zz_528;
   wire       [0:0]    _zz_529;
-  wire       [31:0]   _zz_530;
+  wire       [1:0]    _zz_530;
   wire       [31:0]   _zz_531;
   wire       [31:0]   _zz_532;
   wire       [31:0]   _zz_533;
-  wire       [31:0]   _zz_534;
-  wire       [31:0]   _zz_535;
-  wire                _zz_536;
+  wire                _zz_534;
+  wire                _zz_535;
+  wire       [31:0]   _zz_536;
   wire                _zz_537;
-  wire                _zz_538;
-  wire       [31:0]   _zz_539;
+  wire       [0:0]    _zz_538;
+  wire       [0:0]    _zz_539;
+  wire       [0:0]    _zz_540;
+  wire       [0:0]    _zz_541;
+  wire       [1:0]    _zz_542;
+  wire       [1:0]    _zz_543;
+  wire       [0:0]    _zz_544;
+  wire       [0:0]    _zz_545;
+  wire       [31:0]   _zz_546;
+  wire       [31:0]   _zz_547;
+  wire       [31:0]   _zz_548;
+  wire       [31:0]   _zz_549;
+  wire       [31:0]   _zz_550;
+  wire       [31:0]   _zz_551;
+  wire                _zz_552;
+  wire                _zz_553;
+  wire                _zz_554;
+  wire       [31:0]   _zz_555;
   wire       [51:0]   memory_MUL_LOW;
+  wire                writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                execute_CfuPlugin_CFU_IN_FLIGHT;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
   wire       [33:0]   execute_MUL_HL;
   wire       [33:0]   execute_MUL_LH;
   wire       [31:0]   execute_MUL_LL;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
   wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire                decode_DO_EBREAK;
   wire                decode_CSR_READ_OPCODE;
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
+  wire       `Input2Kind_defaultEncoding_type decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       `Input2Kind_defaultEncoding_type _zz_1;
+  wire       `Input2Kind_defaultEncoding_type _zz_2;
+  wire       `Input2Kind_defaultEncoding_type _zz_3;
+  wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
   wire                decode_IS_DIV;
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_12;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_19;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_20;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -524,25 +538,29 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_24;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_25;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_26;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_28;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_29;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
   wire       [31:0]   memory_PC;
-  wire                execute_DO_EBREAK;
-  wire                decode_IS_EBREAK;
+  reg                 _zz_30;
+  reg                 _zz_31;
+  wire                memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire       `Input2Kind_defaultEncoding_type execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       `Input2Kind_defaultEncoding_type _zz_32;
+  wire                execute_CfuPlugin_CFU_ENABLE;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -557,22 +575,22 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_33;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_34;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
-  wire       [31:0]   memory_BRANCH_CALC;
-  wire                memory_BRANCH_DO;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_35;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_36;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_37;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -582,43 +600,44 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_38;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_39;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_40;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_41;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_42;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_43;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_44;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_45;
+  wire       [31:0]   _zz_46;
+  wire                _zz_47;
+  reg                 _zz_48;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
+  wire       `Input2Kind_defaultEncoding_type _zz_49;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_50;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_52;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_53;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_54;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_55;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_56;
+  reg        [31:0]   _zz_57;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
@@ -639,10 +658,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_58;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_52;
-  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_59;
+  reg        [31:0]   _zz_60;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -651,7 +670,7 @@ module VexRiscv (
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
   reg                 decode_arbitration_flushNext;
-  reg                 decode_arbitration_isValid;
+  wire                decode_arbitration_isValid;
   wire                decode_arbitration_isStuck;
   wire                decode_arbitration_isStuckByOthers;
   wire                decode_arbitration_isFlushed;
@@ -660,7 +679,7 @@ module VexRiscv (
   reg                 execute_arbitration_haltItself;
   reg                 execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
-  reg                 execute_arbitration_flushIt;
+  wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
   reg                 execute_arbitration_isValid;
   wire                execute_arbitration_isStuck;
@@ -755,17 +774,16 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_54;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
   wire                BranchPlugin_jumpInterface_valid;
   wire       [31:0]   BranchPlugin_jumpInterface_payload;
-  wire                BranchPlugin_branchExceptionPort_valid;
+  reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
-  reg                 CsrPlugin_thirdPartyWake;
+  wire                CsrPlugin_thirdPartyWake;
   reg                 CsrPlugin_jumpInterface_valid;
   reg        [31:0]   CsrPlugin_jumpInterface_payload;
   wire                CsrPlugin_exceptionPendings_0;
@@ -775,23 +793,23 @@ module VexRiscv (
   wire                externalInterrupt;
   wire                contextSwitching;
   reg        [1:0]    CsrPlugin_privilege;
-  reg                 CsrPlugin_forceMachineWire;
+  wire                CsrPlugin_forceMachineWire;
   reg                 CsrPlugin_selfException_valid;
   reg        [3:0]    CsrPlugin_selfException_payload_code;
   wire       [31:0]   CsrPlugin_selfException_payload_badAddr;
-  reg                 CsrPlugin_allowInterrupts;
-  reg                 CsrPlugin_allowException;
-  reg                 IBusCachedPlugin_injectionPort_valid;
-  reg                 IBusCachedPlugin_injectionPort_ready;
-  wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  wire                CsrPlugin_allowInterrupts;
+  wire                CsrPlugin_allowException;
+  reg                 CfuPlugin_joinException_valid;
+  wire       [3:0]    CfuPlugin_joinException_payload_code;
+  wire       [31:0]   CfuPlugin_joinException_payload_badAddr;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55;
-  wire       [3:0]    _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
+  wire       [3:0]    _zz_61;
+  wire       [3:0]    _zz_62;
+  wire                _zz_63;
+  wire                _zz_64;
+  wire                _zz_65;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -828,16 +846,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_60;
-  wire                _zz_61;
-  wire                _zz_62;
-  wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63;
-  wire                _zz_64;
-  reg                 _zz_65;
   wire                _zz_66;
-  reg                 _zz_67;
-  reg        [31:0]   _zz_68;
+  wire                _zz_67;
+  wire                _zz_68;
+  wire                IBusCachedPlugin_iBusRsp_flush;
+  wire                _zz_69;
+  wire                _zz_70;
+  reg                 _zz_71;
+  wire                _zz_72;
+  reg                 _zz_73;
+  reg        [31:0]   _zz_74;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -850,17 +868,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_69;
-  reg        [18:0]   _zz_70;
-  wire                _zz_71;
-  reg        [10:0]   _zz_72;
-  wire                _zz_73;
-  reg        [18:0]   _zz_74;
-  reg                 _zz_75;
-  wire                _zz_76;
-  reg        [10:0]   _zz_77;
-  wire                _zz_78;
-  reg        [18:0]   _zz_79;
+  wire                _zz_75;
+  reg        [18:0]   _zz_76;
+  wire                _zz_77;
+  reg        [10:0]   _zz_78;
+  wire                _zz_79;
+  reg        [18:0]   _zz_80;
+  reg                 _zz_81;
+  wire                _zz_82;
+  reg        [10:0]   _zz_83;
+  wire                _zz_84;
+  reg        [18:0]   _zz_85;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -868,7 +886,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_80;
+  wire       [31:0]   _zz_86;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -910,28 +928,30 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_81;
+  wire       [31:0]   _zz_87;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_82;
+  reg        [31:0]   _zz_88;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_83;
-  reg        [31:0]   _zz_84;
-  wire                _zz_85;
-  reg        [31:0]   _zz_86;
-  reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [32:0]   _zz_87;
-  wire                _zz_88;
   wire                _zz_89;
-  wire                _zz_90;
+  reg        [31:0]   _zz_90;
   wire                _zz_91;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_92;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_93;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_94;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_95;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_96;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_97;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_98;
+  reg        [31:0]   _zz_92;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
+  wire       [33:0]   _zz_93;
+  wire                _zz_94;
+  wire                _zz_95;
+  wire                _zz_96;
+  wire                _zz_97;
+  wire                _zz_98;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_99;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_100;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_101;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_102;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_103;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_104;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_105;
+  wire       `Input2Kind_defaultEncoding_type _zz_106;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -939,52 +959,52 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_99;
+  reg                 _zz_107;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_100;
-  reg        [31:0]   _zz_101;
-  wire                _zz_102;
-  reg        [19:0]   _zz_103;
-  wire                _zz_104;
-  reg        [19:0]   _zz_105;
-  reg        [31:0]   _zz_106;
+  reg        [31:0]   _zz_108;
+  reg        [31:0]   _zz_109;
+  wire                _zz_110;
+  reg        [19:0]   _zz_111;
+  wire                _zz_112;
+  reg        [19:0]   _zz_113;
+  reg        [31:0]   _zz_114;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_107;
+  reg        [31:0]   _zz_115;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_108;
-  reg                 _zz_109;
-  reg                 _zz_110;
-  reg                 _zz_111;
-  reg        [4:0]    _zz_112;
-  reg        [31:0]   _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
-  wire                _zz_117;
-  wire                _zz_118;
-  wire                _zz_119;
-  wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_120;
-  reg                 _zz_121;
-  reg                 _zz_122;
+  reg        [31:0]   _zz_116;
+  reg                 _zz_117;
+  reg                 _zz_118;
+  reg                 _zz_119;
+  reg        [4:0]    _zz_120;
+  reg        [31:0]   _zz_121;
+  wire                _zz_122;
   wire                _zz_123;
-  reg        [19:0]   _zz_124;
+  wire                _zz_124;
   wire                _zz_125;
-  reg        [10:0]   _zz_126;
+  wire                _zz_126;
   wire                _zz_127;
-  reg        [18:0]   _zz_128;
+  wire                execute_BranchPlugin_eq;
+  wire       [2:0]    _zz_128;
   reg                 _zz_129;
+  reg                 _zz_130;
+  wire                _zz_131;
+  reg        [19:0]   _zz_132;
+  wire                _zz_133;
+  reg        [10:0]   _zz_134;
+  wire                _zz_135;
+  reg        [18:0]   _zz_136;
+  reg                 _zz_137;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_130;
-  reg        [19:0]   _zz_131;
-  wire                _zz_132;
-  reg        [10:0]   _zz_133;
-  wire                _zz_134;
-  reg        [18:0]   _zz_135;
+  wire                _zz_138;
+  reg        [19:0]   _zz_139;
+  wire                _zz_140;
+  reg        [10:0]   _zz_141;
+  wire                _zz_142;
+  reg        [18:0]   _zz_143;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -1006,9 +1026,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
+  wire                _zz_144;
+  wire                _zz_145;
+  wire                _zz_146;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1021,8 +1041,10 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_139;
-  wire                _zz_140;
+  wire       [1:0]    _zz_147;
+  wire                _zz_148;
+  wire       [1:0]    _zz_149;
+  wire                _zz_150;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -1075,30 +1097,32 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_141;
+  wire       [31:0]   _zz_151;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_142;
-  wire                _zz_143;
-  wire                _zz_144;
-  reg        [32:0]   _zz_145;
+  wire       [31:0]   _zz_152;
+  wire                _zz_153;
+  wire                _zz_154;
+  reg        [32:0]   _zz_155;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_146;
-  wire       [31:0]   _zz_147;
-  reg                 DebugPlugin_firstCycle;
-  reg                 DebugPlugin_secondCycle;
-  reg                 DebugPlugin_resetIt;
-  reg                 DebugPlugin_haltIt;
-  reg                 DebugPlugin_stepIt;
-  reg                 DebugPlugin_isPipBusy;
-  reg                 DebugPlugin_godmode;
-  reg                 DebugPlugin_haltedByBreak;
-  reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_148;
-  wire                DebugPlugin_allowEBreak;
-  reg                 DebugPlugin_resetIt_regNext;
+  reg        [31:0]   _zz_156;
+  wire       [31:0]   _zz_157;
+  wire                execute_CfuPlugin_schedule;
+  reg                 execute_CfuPlugin_hold;
+  reg                 execute_CfuPlugin_fired;
+  wire       [9:0]    execute_CfuPlugin_functionsIds_0;
+  wire                _zz_158;
+  reg        [23:0]   _zz_159;
+  reg        [31:0]   _zz_160;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire                memory_CfuPlugin_rsp_payload_response_ok;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
+  reg                 CfuPlugin_bus_rsp_s2mPipe_rValid;
+  reg                 CfuPlugin_bus_rsp_s2mPipe_rData_response_ok;
+  reg        [31:0]   CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
@@ -1142,27 +1166,27 @@ module VexRiscv (
   reg                 execute_to_memory_IS_DIV;
   reg                 decode_to_execute_IS_RS1_SIGNED;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg        `Input2Kind_defaultEncoding_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   reg        [31:0]   decode_to_execute_RS1;
   reg        [31:0]   decode_to_execute_RS2;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
   reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
   reg                 decode_to_execute_CSR_WRITE_OPCODE;
   reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg                 decode_to_execute_DO_EBREAK;
   reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
   reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
   reg        [31:0]   execute_to_memory_MUL_LL;
   reg        [33:0]   execute_to_memory_MUL_LH;
   reg        [33:0]   execute_to_memory_MUL_HL;
   reg        [33:0]   execute_to_memory_MUL_HH;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [2:0]    _zz_149;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_3857;
   reg                 execute_CsrPlugin_csr_3858;
@@ -1187,17 +1211,6 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_3202;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_150;
-  reg        [31:0]   _zz_151;
-  reg        [31:0]   _zz_152;
-  reg        [31:0]   _zz_153;
-  reg        [31:0]   _zz_154;
-  reg        [31:0]   _zz_155;
-  reg        [31:0]   _zz_156;
-  reg        [31:0]   _zz_157;
-  reg        [31:0]   _zz_158;
-  reg        [31:0]   _zz_159;
-  reg        [31:0]   _zz_160;
   reg        [31:0]   _zz_161;
   reg        [31:0]   _zz_162;
   reg        [31:0]   _zz_163;
@@ -1210,86 +1223,105 @@ module VexRiscv (
   reg        [31:0]   _zz_170;
   reg        [31:0]   _zz_171;
   reg        [31:0]   _zz_172;
-  reg        [2:0]    _zz_173;
-  reg                 _zz_174;
+  reg        [31:0]   _zz_173;
+  reg        [31:0]   _zz_174;
+  reg        [31:0]   _zz_175;
+  reg        [31:0]   _zz_176;
+  reg        [31:0]   _zz_177;
+  reg        [31:0]   _zz_178;
+  reg        [31:0]   _zz_179;
+  reg        [31:0]   _zz_180;
+  reg        [31:0]   _zz_181;
+  reg        [31:0]   _zz_182;
+  reg        [31:0]   _zz_183;
+  reg        [2:0]    _zz_184;
+  reg                 _zz_185;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_175;
-  wire                _zz_176;
-  wire                _zz_177;
-  wire                _zz_178;
-  wire                _zz_179;
-  wire                _zz_180;
-  reg                 _zz_181;
+  reg        [2:0]    _zz_186;
+  wire                _zz_187;
+  wire                _zz_188;
+  wire                _zz_189;
+  wire                _zz_190;
+  wire                _zz_191;
+  reg                 _zz_192;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
+  reg [39:0] decode_CfuPlugin_CFU_INPUT_2_KIND_string;
   reg [39:0] _zz_1_string;
   reg [39:0] _zz_2_string;
   reg [39:0] _zz_3_string;
   reg [39:0] _zz_4_string;
-  reg [39:0] decode_ENV_CTRL_string;
   reg [39:0] _zz_5_string;
   reg [39:0] _zz_6_string;
   reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
+  reg [39:0] decode_ENV_CTRL_string;
+  reg [39:0] _zz_8_string;
+  reg [39:0] _zz_9_string;
+  reg [39:0] _zz_10_string;
+  reg [31:0] _zz_11_string;
+  reg [31:0] _zz_12_string;
   reg [71:0] _zz_13_string;
   reg [71:0] _zz_14_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_15_string;
+  reg [71:0] _zz_16_string;
+  reg [71:0] _zz_17_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_18_string;
+  reg [39:0] _zz_19_string;
+  reg [39:0] _zz_20_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_21_string;
+  reg [23:0] _zz_22_string;
+  reg [23:0] _zz_23_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_24_string;
+  reg [63:0] _zz_25_string;
+  reg [63:0] _zz_26_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_27_string;
+  reg [95:0] _zz_28_string;
+  reg [95:0] _zz_29_string;
+  reg [39:0] execute_CfuPlugin_CFU_INPUT_2_KIND_string;
+  reg [39:0] _zz_32_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_33_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_34_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_35_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
+  reg [31:0] _zz_36_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
+  reg [71:0] _zz_39_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [71:0] _zz_40_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_42_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_43_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
+  reg [63:0] _zz_44_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
-  reg [31:0] decode_BRANCH_CTRL_string;
+  reg [39:0] _zz_45_string;
+  reg [39:0] _zz_49_string;
+  reg [39:0] _zz_50_string;
   reg [31:0] _zz_51_string;
-  reg [95:0] _zz_92_string;
-  reg [63:0] _zz_93_string;
-  reg [23:0] _zz_94_string;
-  reg [39:0] _zz_95_string;
-  reg [71:0] _zz_96_string;
-  reg [31:0] _zz_97_string;
-  reg [39:0] _zz_98_string;
+  reg [71:0] _zz_52_string;
+  reg [39:0] _zz_53_string;
+  reg [23:0] _zz_54_string;
+  reg [63:0] _zz_55_string;
+  reg [95:0] _zz_56_string;
+  reg [31:0] decode_BRANCH_CTRL_string;
+  reg [31:0] _zz_58_string;
+  reg [95:0] _zz_99_string;
+  reg [63:0] _zz_100_string;
+  reg [23:0] _zz_101_string;
+  reg [39:0] _zz_102_string;
+  reg [71:0] _zz_103_string;
+  reg [31:0] _zz_104_string;
+  reg [39:0] _zz_105_string;
+  reg [39:0] _zz_106_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1300,363 +1332,369 @@ module VexRiscv (
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_213 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_214 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_215 = 1'b1;
-  assign _zz_216 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_217 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_218 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_219 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_220 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_221 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_222 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_223 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_224 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_225 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_226 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_227 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_228 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_229 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_230 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_231 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_232 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_233 = (1'b0 || (! 1'b1));
-  assign _zz_234 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_235 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_236 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_237 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_238 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_239 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_240 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_241 = execute_INSTRUCTION[13 : 12];
-  assign _zz_242 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_243 = (! memory_arbitration_isStuck);
-  assign _zz_244 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_245 = (iBus_cmd_valid || (_zz_173 != 3'b000));
-  assign _zz_246 = (_zz_209 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_247 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_248 = ((_zz_136 && 1'b1) && (! 1'b0));
-  assign _zz_249 = ((_zz_137 && 1'b1) && (! 1'b0));
-  assign _zz_250 = ((_zz_138 && 1'b1) && (! 1'b0));
-  assign _zz_251 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_252 = execute_INSTRUCTION[13];
-  assign _zz_253 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_254 = ($signed(_zz_255) + $signed(_zz_260));
-  assign _zz_255 = ($signed(_zz_256) + $signed(_zz_258));
-  assign _zz_256 = 52'h0;
-  assign _zz_257 = {1'b0,memory_MUL_LL};
-  assign _zz_258 = {{19{_zz_257[32]}}, _zz_257};
-  assign _zz_259 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_260 = {{2{_zz_259[49]}}, _zz_259};
-  assign _zz_261 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_262 = {{2{_zz_261[49]}}, _zz_261};
-  assign _zz_263 = ($signed(_zz_265) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_264 = _zz_263[31 : 0];
-  assign _zz_265 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_266 = _zz_87[31 : 31];
-  assign _zz_267 = _zz_87[30 : 30];
-  assign _zz_268 = _zz_87[29 : 29];
-  assign _zz_269 = _zz_87[28 : 28];
-  assign _zz_270 = _zz_87[25 : 25];
-  assign _zz_271 = _zz_87[17 : 17];
-  assign _zz_272 = _zz_87[16 : 16];
-  assign _zz_273 = _zz_87[13 : 13];
-  assign _zz_274 = _zz_87[12 : 12];
-  assign _zz_275 = _zz_87[11 : 11];
-  assign _zz_276 = _zz_87[32 : 32];
-  assign _zz_277 = _zz_87[15 : 15];
-  assign _zz_278 = _zz_87[5 : 5];
-  assign _zz_279 = _zz_87[3 : 3];
-  assign _zz_280 = _zz_87[20 : 20];
-  assign _zz_281 = _zz_87[10 : 10];
-  assign _zz_282 = _zz_87[4 : 4];
-  assign _zz_283 = _zz_87[0 : 0];
-  assign _zz_284 = (_zz_55 - 4'b0001);
-  assign _zz_285 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_286 = {29'd0, _zz_285};
-  assign _zz_287 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_288 = {{_zz_70,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_289 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_290 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_291 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_292 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_293 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_294 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_295 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_296 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_297 = execute_SRC_LESS;
-  assign _zz_298 = 3'b100;
-  assign _zz_299 = execute_INSTRUCTION[19 : 15];
-  assign _zz_300 = execute_INSTRUCTION[31 : 20];
-  assign _zz_301 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_302 = ($signed(_zz_303) + $signed(_zz_306));
-  assign _zz_303 = ($signed(_zz_304) + $signed(_zz_305));
-  assign _zz_304 = execute_SRC1;
-  assign _zz_305 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_306 = (execute_SRC_USE_SUB_LESS ? _zz_307 : _zz_308);
-  assign _zz_307 = 32'h00000001;
-  assign _zz_308 = 32'h0;
+  assign _zz_224 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_225 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_226 = 1'b1;
+  assign _zz_227 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_228 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_229 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_230 = ((_zz_198 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_231 = ((_zz_198 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_232 = ((_zz_198 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_233 = ((_zz_198 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_234 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_235 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_236 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
+  assign _zz_237 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_238 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_239 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_240 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_241 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_242 = (1'b0 || (! 1'b1));
+  assign _zz_243 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_244 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_245 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_246 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_247 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_248 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_249 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_250 = execute_INSTRUCTION[13 : 12];
+  assign _zz_251 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_252 = (! memory_arbitration_isStuck);
+  assign _zz_253 = (iBus_cmd_valid || (_zz_184 != 3'b000));
+  assign _zz_254 = (_zz_220 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_255 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_256 = ((_zz_144 && 1'b1) && (! 1'b0));
+  assign _zz_257 = ((_zz_145 && 1'b1) && (! 1'b0));
+  assign _zz_258 = ((_zz_146 && 1'b1) && (! 1'b0));
+  assign _zz_259 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
+  assign _zz_260 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_261 = execute_INSTRUCTION[13];
+  assign _zz_262 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_263 = ($signed(_zz_264) + $signed(_zz_269));
+  assign _zz_264 = ($signed(_zz_265) + $signed(_zz_267));
+  assign _zz_265 = 52'h0;
+  assign _zz_266 = {1'b0,memory_MUL_LL};
+  assign _zz_267 = {{19{_zz_266[32]}}, _zz_266};
+  assign _zz_268 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_269 = {{2{_zz_268[49]}}, _zz_268};
+  assign _zz_270 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_271 = {{2{_zz_270[49]}}, _zz_270};
+  assign _zz_272 = ($signed(_zz_274) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_273 = _zz_272[31 : 0];
+  assign _zz_274 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_275 = _zz_93[32 : 32];
+  assign _zz_276 = _zz_93[31 : 31];
+  assign _zz_277 = _zz_93[30 : 30];
+  assign _zz_278 = _zz_93[29 : 29];
+  assign _zz_279 = _zz_93[28 : 28];
+  assign _zz_280 = _zz_93[25 : 25];
+  assign _zz_281 = _zz_93[17 : 17];
+  assign _zz_282 = _zz_93[16 : 16];
+  assign _zz_283 = _zz_93[13 : 13];
+  assign _zz_284 = _zz_93[12 : 12];
+  assign _zz_285 = _zz_93[11 : 11];
+  assign _zz_286 = _zz_93[15 : 15];
+  assign _zz_287 = _zz_93[5 : 5];
+  assign _zz_288 = _zz_93[3 : 3];
+  assign _zz_289 = _zz_93[20 : 20];
+  assign _zz_290 = _zz_93[10 : 10];
+  assign _zz_291 = _zz_93[4 : 4];
+  assign _zz_292 = _zz_93[0 : 0];
+  assign _zz_293 = (_zz_61 - 4'b0001);
+  assign _zz_294 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_295 = {29'd0, _zz_294};
+  assign _zz_296 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_297 = {{_zz_76,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_298 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_299 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_300 = {{_zz_78,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_301 = {{_zz_80,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_302 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_303 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_304 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_305 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_306 = execute_SRC_LESS;
+  assign _zz_307 = 3'b100;
+  assign _zz_308 = execute_INSTRUCTION[19 : 15];
   assign _zz_309 = execute_INSTRUCTION[31 : 20];
-  assign _zz_310 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_311 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_312 = {_zz_124,execute_INSTRUCTION[31 : 20]};
-  assign _zz_313 = {{_zz_126,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_314 = {{_zz_128,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_315 = execute_INSTRUCTION[31 : 20];
-  assign _zz_316 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_317 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_318 = 3'b100;
-  assign _zz_319 = (_zz_139 & (~ _zz_320));
-  assign _zz_320 = (_zz_139 - 2'b01);
-  assign _zz_321 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_322 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_323 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_324 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_325 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_326 = {5'd0, _zz_325};
-  assign _zz_327 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_328 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_329 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_330 = {_zz_141,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_331 = _zz_332;
-  assign _zz_332 = _zz_333;
-  assign _zz_333 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_142) : _zz_142)} + _zz_335);
-  assign _zz_334 = memory_DivPlugin_div_needRevert;
-  assign _zz_335 = {32'd0, _zz_334};
-  assign _zz_336 = _zz_144;
-  assign _zz_337 = {32'd0, _zz_336};
-  assign _zz_338 = _zz_143;
-  assign _zz_339 = {31'd0, _zz_338};
-  assign _zz_340 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_341 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_342 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_343 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_344 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_345 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_346 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_347 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_348 = 1'b1;
-  assign _zz_349 = 1'b1;
-  assign _zz_350 = {_zz_59,_zz_58};
-  assign _zz_351 = 32'h0000107f;
-  assign _zz_352 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_353 = 32'h00002073;
-  assign _zz_354 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_355 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_356 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_357) == 32'h00000003),{(_zz_358 == _zz_359),{_zz_360,{_zz_361,_zz_362}}}}}};
-  assign _zz_357 = 32'h0000505f;
-  assign _zz_358 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_359 = 32'h00000063;
-  assign _zz_360 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_361 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_362 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_363) == 32'h00001013),{(_zz_364 == _zz_365),{_zz_366,{_zz_367,_zz_368}}}}}};
-  assign _zz_363 = 32'hfc00307f;
-  assign _zz_364 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_365 = 32'h00005033;
-  assign _zz_366 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_367 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_368 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
-  assign _zz_369 = decode_INSTRUCTION[31];
-  assign _zz_370 = decode_INSTRUCTION[31];
-  assign _zz_371 = decode_INSTRUCTION[7];
-  assign _zz_372 = 32'h10103050;
-  assign _zz_373 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_374 = 1'b0;
-  assign _zz_375 = (((decode_INSTRUCTION & _zz_378) == 32'h02000030) != 1'b0);
-  assign _zz_376 = ({_zz_379,_zz_380} != 2'b00);
-  assign _zz_377 = {(_zz_381 != 1'b0),{(_zz_382 != _zz_383),{_zz_384,{_zz_385,_zz_386}}}};
-  assign _zz_378 = 32'h02004074;
-  assign _zz_379 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz_380 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_381 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz_382 = {(_zz_387 == _zz_388),(_zz_389 == _zz_390)};
-  assign _zz_383 = 2'b00;
-  assign _zz_384 = ({_zz_90,_zz_391} != 2'b00);
-  assign _zz_385 = (_zz_392 != 1'b0);
-  assign _zz_386 = {(_zz_393 != _zz_394),{_zz_395,{_zz_396,_zz_397}}};
-  assign _zz_387 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_388 = 32'h00001050;
-  assign _zz_389 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_390 = 32'h00002050;
-  assign _zz_391 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_392 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_393 = {(_zz_398 == _zz_399),(_zz_400 == _zz_401)};
-  assign _zz_394 = 2'b00;
-  assign _zz_395 = ({_zz_402,{_zz_403,_zz_404}} != 3'b000);
-  assign _zz_396 = (_zz_405 != 1'b0);
-  assign _zz_397 = {(_zz_406 != _zz_407),{_zz_408,{_zz_409,_zz_410}}};
-  assign _zz_398 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_399 = 32'h00005010;
-  assign _zz_400 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_401 = 32'h00005020;
-  assign _zz_402 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_403 = ((decode_INSTRUCTION & _zz_411) == 32'h00001010);
-  assign _zz_404 = ((decode_INSTRUCTION & _zz_412) == 32'h00001010);
-  assign _zz_405 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_406 = ((decode_INSTRUCTION & _zz_413) == 32'h00001000);
-  assign _zz_407 = 1'b0;
-  assign _zz_408 = ((_zz_414 == _zz_415) != 1'b0);
-  assign _zz_409 = ({_zz_416,_zz_417} != 2'b00);
-  assign _zz_410 = {(_zz_418 != _zz_419),{_zz_420,{_zz_421,_zz_422}}};
-  assign _zz_411 = 32'h00007034;
-  assign _zz_412 = 32'h02007054;
-  assign _zz_413 = 32'h00001000;
-  assign _zz_414 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_415 = 32'h00002000;
-  assign _zz_416 = ((decode_INSTRUCTION & _zz_423) == 32'h00002000);
-  assign _zz_417 = ((decode_INSTRUCTION & _zz_424) == 32'h00001000);
-  assign _zz_418 = ((decode_INSTRUCTION & _zz_425) == 32'h00004008);
+  assign _zz_310 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_311 = ($signed(_zz_312) + $signed(_zz_315));
+  assign _zz_312 = ($signed(_zz_313) + $signed(_zz_314));
+  assign _zz_313 = execute_SRC1;
+  assign _zz_314 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_315 = (execute_SRC_USE_SUB_LESS ? _zz_316 : _zz_317);
+  assign _zz_316 = 32'h00000001;
+  assign _zz_317 = 32'h0;
+  assign _zz_318 = execute_INSTRUCTION[31 : 20];
+  assign _zz_319 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_320 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_321 = {_zz_132,execute_INSTRUCTION[31 : 20]};
+  assign _zz_322 = {{_zz_134,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_323 = {{_zz_136,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_324 = execute_INSTRUCTION[31 : 20];
+  assign _zz_325 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_326 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_327 = 3'b100;
+  assign _zz_328 = (_zz_147 & (~ _zz_329));
+  assign _zz_329 = (_zz_147 - 2'b01);
+  assign _zz_330 = (_zz_149 & (~ _zz_331));
+  assign _zz_331 = (_zz_149 - 2'b01);
+  assign _zz_332 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_333 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_334 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_335 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_336 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_337 = {5'd0, _zz_336};
+  assign _zz_338 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_339 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_340 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_341 = {_zz_151,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_342 = _zz_343;
+  assign _zz_343 = _zz_344;
+  assign _zz_344 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_152) : _zz_152)} + _zz_346);
+  assign _zz_345 = memory_DivPlugin_div_needRevert;
+  assign _zz_346 = {32'd0, _zz_345};
+  assign _zz_347 = _zz_154;
+  assign _zz_348 = {32'd0, _zz_347};
+  assign _zz_349 = _zz_153;
+  assign _zz_350 = {31'd0, _zz_349};
+  assign _zz_351 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
+  assign _zz_352 = execute_INSTRUCTION[31 : 24];
+  assign _zz_353 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_354 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_355 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_356 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_357 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_358 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_359 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_360 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_361 = 1'b1;
+  assign _zz_362 = 1'b1;
+  assign _zz_363 = {_zz_65,_zz_64};
+  assign _zz_364 = 32'h0000106f;
+  assign _zz_365 = (decode_INSTRUCTION & 32'h0000107f);
+  assign _zz_366 = 32'h00001073;
+  assign _zz_367 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
+  assign _zz_368 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_369 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_370) == 32'h00000003),{(_zz_371 == _zz_372),{_zz_373,{_zz_374,_zz_375}}}}}};
+  assign _zz_370 = 32'h0000207f;
+  assign _zz_371 = (decode_INSTRUCTION & 32'h0000505f);
+  assign _zz_372 = 32'h00000003;
+  assign _zz_373 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
+  assign _zz_374 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_375 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_376) == 32'h00005013),{(_zz_377 == _zz_378),{_zz_379,{_zz_380,_zz_381}}}}}};
+  assign _zz_376 = 32'hbc00707f;
+  assign _zz_377 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_378 = 32'h00001013;
+  assign _zz_379 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_380 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_381 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}};
+  assign _zz_382 = decode_INSTRUCTION[31];
+  assign _zz_383 = decode_INSTRUCTION[31];
+  assign _zz_384 = decode_INSTRUCTION[7];
+  assign _zz_385 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz_386 = 1'b0;
+  assign _zz_387 = (((decode_INSTRUCTION & _zz_390) == 32'h02000030) != 1'b0);
+  assign _zz_388 = ((_zz_391 == _zz_392) != 1'b0);
+  assign _zz_389 = {(_zz_393 != 1'b0),{(_zz_394 != _zz_395),{_zz_396,{_zz_397,_zz_398}}}};
+  assign _zz_390 = 32'h02004074;
+  assign _zz_391 = (decode_INSTRUCTION & 32'h00203050);
+  assign _zz_392 = 32'h00000050;
+  assign _zz_393 = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
+  assign _zz_394 = {(_zz_399 == _zz_400),(_zz_401 == _zz_402)};
+  assign _zz_395 = 2'b00;
+  assign _zz_396 = ({_zz_96,_zz_403} != 2'b00);
+  assign _zz_397 = (_zz_404 != 1'b0);
+  assign _zz_398 = {(_zz_405 != _zz_406),{_zz_407,{_zz_408,_zz_409}}};
+  assign _zz_399 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_400 = 32'h00001050;
+  assign _zz_401 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_402 = 32'h00002050;
+  assign _zz_403 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_404 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_405 = {(_zz_410 == _zz_411),(_zz_412 == _zz_413)};
+  assign _zz_406 = 2'b00;
+  assign _zz_407 = ({_zz_414,{_zz_415,_zz_416}} != 3'b000);
+  assign _zz_408 = (_zz_417 != 1'b0);
+  assign _zz_409 = {(_zz_418 != _zz_419),{_zz_420,{_zz_421,_zz_422}}};
+  assign _zz_410 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_411 = 32'h00005010;
+  assign _zz_412 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz_413 = 32'h00005020;
+  assign _zz_414 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz_415 = ((decode_INSTRUCTION & _zz_423) == 32'h00001010);
+  assign _zz_416 = ((decode_INSTRUCTION & _zz_424) == 32'h00001010);
+  assign _zz_417 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz_418 = ((decode_INSTRUCTION & _zz_425) == 32'h00001000);
   assign _zz_419 = 1'b0;
-  assign _zz_420 = ({_zz_426,_zz_427} != 2'b00);
-  assign _zz_421 = ({_zz_428,_zz_429} != 5'h0);
+  assign _zz_420 = ((_zz_426 == _zz_427) != 1'b0);
+  assign _zz_421 = ({_zz_428,_zz_429} != 2'b00);
   assign _zz_422 = {(_zz_430 != _zz_431),{_zz_432,{_zz_433,_zz_434}}};
-  assign _zz_423 = 32'h00002010;
-  assign _zz_424 = 32'h00005000;
-  assign _zz_425 = 32'h00004048;
-  assign _zz_426 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_427 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_428 = ((decode_INSTRUCTION & _zz_435) == 32'h00002040);
-  assign _zz_429 = {(_zz_436 == _zz_437),{_zz_438,{_zz_439,_zz_440}}};
-  assign _zz_430 = ((decode_INSTRUCTION & _zz_441) == 32'h00000020);
+  assign _zz_423 = 32'h00007034;
+  assign _zz_424 = 32'h02007054;
+  assign _zz_425 = 32'h00001000;
+  assign _zz_426 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz_427 = 32'h00002000;
+  assign _zz_428 = ((decode_INSTRUCTION & _zz_435) == 32'h00002000);
+  assign _zz_429 = ((decode_INSTRUCTION & _zz_436) == 32'h00001000);
+  assign _zz_430 = ((decode_INSTRUCTION & _zz_437) == 32'h00004004);
   assign _zz_431 = 1'b0;
-  assign _zz_432 = ({_zz_442,{_zz_443,_zz_444}} != 5'h0);
-  assign _zz_433 = ({_zz_445,_zz_446} != 5'h0);
-  assign _zz_434 = {(_zz_447 != _zz_448),{_zz_449,{_zz_450,_zz_451}}};
-  assign _zz_435 = 32'h00002040;
-  assign _zz_436 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_437 = 32'h00001040;
-  assign _zz_438 = ((decode_INSTRUCTION & _zz_452) == 32'h00000040);
-  assign _zz_439 = (_zz_453 == _zz_454);
-  assign _zz_440 = (_zz_455 == _zz_456);
-  assign _zz_441 = 32'h00000020;
-  assign _zz_442 = ((decode_INSTRUCTION & _zz_457) == 32'h00000040);
-  assign _zz_443 = _zz_89;
-  assign _zz_444 = {_zz_458,{_zz_459,_zz_460}};
-  assign _zz_445 = _zz_89;
-  assign _zz_446 = {_zz_461,{_zz_462,_zz_463}};
-  assign _zz_447 = {_zz_90,{_zz_464,_zz_465}};
-  assign _zz_448 = 6'h0;
-  assign _zz_449 = ({_zz_466,_zz_467} != 2'b00);
-  assign _zz_450 = (_zz_468 != _zz_469);
-  assign _zz_451 = {_zz_470,{_zz_471,_zz_472}};
-  assign _zz_452 = 32'h00100040;
-  assign _zz_453 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_454 = 32'h00000040;
-  assign _zz_455 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_456 = 32'h0;
-  assign _zz_457 = 32'h00000040;
-  assign _zz_458 = ((decode_INSTRUCTION & _zz_473) == 32'h00004020);
-  assign _zz_459 = (_zz_474 == _zz_475);
-  assign _zz_460 = (_zz_476 == _zz_477);
-  assign _zz_461 = ((decode_INSTRUCTION & _zz_478) == 32'h00002010);
-  assign _zz_462 = (_zz_479 == _zz_480);
-  assign _zz_463 = {_zz_481,_zz_482};
-  assign _zz_464 = (_zz_483 == _zz_484);
+  assign _zz_432 = ({_zz_97,{_zz_438,_zz_439}} != 3'b000);
+  assign _zz_433 = ({_zz_440,_zz_441} != 5'h0);
+  assign _zz_434 = {(_zz_442 != _zz_443),{_zz_444,{_zz_445,_zz_446}}};
+  assign _zz_435 = 32'h00002010;
+  assign _zz_436 = 32'h00005000;
+  assign _zz_437 = 32'h00004054;
+  assign _zz_438 = ((decode_INSTRUCTION & _zz_447) == 32'h00000020);
+  assign _zz_439 = ((decode_INSTRUCTION & _zz_448) == 32'h00000020);
+  assign _zz_440 = ((decode_INSTRUCTION & _zz_449) == 32'h00002040);
+  assign _zz_441 = {(_zz_450 == _zz_451),{_zz_452,{_zz_453,_zz_454}}};
+  assign _zz_442 = ((decode_INSTRUCTION & _zz_455) == 32'h00000020);
+  assign _zz_443 = 1'b0;
+  assign _zz_444 = ({_zz_456,{_zz_457,_zz_458}} != 6'h0);
+  assign _zz_445 = ({_zz_459,_zz_460} != 5'h0);
+  assign _zz_446 = {(_zz_461 != _zz_462),{_zz_463,{_zz_464,_zz_465}}};
+  assign _zz_447 = 32'h00000034;
+  assign _zz_448 = 32'h00000064;
+  assign _zz_449 = 32'h00002040;
+  assign _zz_450 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz_451 = 32'h00001040;
+  assign _zz_452 = ((decode_INSTRUCTION & _zz_466) == 32'h00000040);
+  assign _zz_453 = (_zz_467 == _zz_468);
+  assign _zz_454 = (_zz_469 == _zz_470);
+  assign _zz_455 = 32'h00000020;
+  assign _zz_456 = ((decode_INSTRUCTION & _zz_471) == 32'h00000008);
+  assign _zz_457 = (_zz_472 == _zz_473);
+  assign _zz_458 = {_zz_95,{_zz_474,_zz_475}};
+  assign _zz_459 = _zz_95;
+  assign _zz_460 = {_zz_476,{_zz_477,_zz_478}};
+  assign _zz_461 = {_zz_96,{_zz_479,_zz_480}};
+  assign _zz_462 = 6'h0;
+  assign _zz_463 = ({_zz_481,_zz_482} != 2'b00);
+  assign _zz_464 = (_zz_483 != _zz_484);
   assign _zz_465 = {_zz_485,{_zz_486,_zz_487}};
-  assign _zz_466 = _zz_89;
-  assign _zz_467 = (_zz_488 == _zz_489);
-  assign _zz_468 = {_zz_89,_zz_490};
-  assign _zz_469 = 2'b00;
-  assign _zz_470 = (_zz_491 != 1'b0);
-  assign _zz_471 = (_zz_492 != _zz_493);
-  assign _zz_472 = {_zz_494,{_zz_495,_zz_496}};
-  assign _zz_473 = 32'h00004020;
-  assign _zz_474 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_475 = 32'h00000010;
-  assign _zz_476 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_477 = 32'h00000020;
-  assign _zz_478 = 32'h00002030;
-  assign _zz_479 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_480 = 32'h00000010;
-  assign _zz_481 = ((decode_INSTRUCTION & _zz_497) == 32'h00002020);
-  assign _zz_482 = ((decode_INSTRUCTION & _zz_498) == 32'h00000020);
-  assign _zz_483 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_484 = 32'h00001010;
-  assign _zz_485 = ((decode_INSTRUCTION & _zz_499) == 32'h00002010);
-  assign _zz_486 = (_zz_500 == _zz_501);
-  assign _zz_487 = {_zz_502,_zz_503};
-  assign _zz_488 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_489 = 32'h00000020;
-  assign _zz_490 = ((decode_INSTRUCTION & _zz_504) == 32'h0);
-  assign _zz_491 = ((decode_INSTRUCTION & _zz_505) == 32'h00004010);
-  assign _zz_492 = (_zz_506 == _zz_507);
-  assign _zz_493 = 1'b0;
-  assign _zz_494 = ({_zz_508,_zz_509} != 4'b0000);
-  assign _zz_495 = (_zz_510 != _zz_511);
-  assign _zz_496 = {_zz_512,{_zz_513,_zz_514}};
-  assign _zz_497 = 32'h02002060;
-  assign _zz_498 = 32'h02003020;
-  assign _zz_499 = 32'h00002010;
-  assign _zz_500 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_501 = 32'h00000010;
-  assign _zz_502 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_503 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz_504 = 32'h00000020;
-  assign _zz_505 = 32'h00004014;
-  assign _zz_506 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_507 = 32'h00002010;
-  assign _zz_508 = ((decode_INSTRUCTION & _zz_515) == 32'h0);
-  assign _zz_509 = {(_zz_516 == _zz_517),{_zz_518,_zz_519}};
-  assign _zz_510 = ((decode_INSTRUCTION & _zz_520) == 32'h0);
-  assign _zz_511 = 1'b0;
-  assign _zz_512 = ({_zz_521,{_zz_522,_zz_523}} != 3'b000);
-  assign _zz_513 = ({_zz_524,_zz_525} != 2'b00);
-  assign _zz_514 = {(_zz_526 != _zz_527),(_zz_528 != _zz_529)};
-  assign _zz_515 = 32'h00000044;
-  assign _zz_516 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_517 = 32'h0;
-  assign _zz_518 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_519 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_520 = 32'h00000058;
-  assign _zz_521 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_522 = ((decode_INSTRUCTION & _zz_530) == 32'h00002010);
-  assign _zz_523 = ((decode_INSTRUCTION & _zz_531) == 32'h40000030);
-  assign _zz_524 = ((decode_INSTRUCTION & _zz_532) == 32'h00000004);
-  assign _zz_525 = _zz_88;
-  assign _zz_526 = {(_zz_533 == _zz_534),_zz_88};
-  assign _zz_527 = 2'b00;
-  assign _zz_528 = ((decode_INSTRUCTION & _zz_535) == 32'h00001008);
-  assign _zz_529 = 1'b0;
-  assign _zz_530 = 32'h00002014;
-  assign _zz_531 = 32'h40000034;
-  assign _zz_532 = 32'h00000014;
-  assign _zz_533 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_534 = 32'h00000004;
-  assign _zz_535 = 32'h00005048;
-  assign _zz_536 = execute_INSTRUCTION[31];
-  assign _zz_537 = execute_INSTRUCTION[31];
-  assign _zz_538 = execute_INSTRUCTION[7];
-  assign _zz_539 = 32'h0;
+  assign _zz_466 = 32'h00000050;
+  assign _zz_467 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz_468 = 32'h00000040;
+  assign _zz_469 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_470 = 32'h0;
+  assign _zz_471 = 32'h00000008;
+  assign _zz_472 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_473 = 32'h00000040;
+  assign _zz_474 = (_zz_488 == _zz_489);
+  assign _zz_475 = {_zz_490,_zz_491};
+  assign _zz_476 = ((decode_INSTRUCTION & _zz_492) == 32'h00002010);
+  assign _zz_477 = (_zz_493 == _zz_494);
+  assign _zz_478 = {_zz_495,_zz_496};
+  assign _zz_479 = (_zz_497 == _zz_498);
+  assign _zz_480 = {_zz_499,{_zz_500,_zz_501}};
+  assign _zz_481 = _zz_95;
+  assign _zz_482 = (_zz_502 == _zz_503);
+  assign _zz_483 = {_zz_95,_zz_504};
+  assign _zz_484 = 2'b00;
+  assign _zz_485 = (_zz_505 != 1'b0);
+  assign _zz_486 = (_zz_506 != _zz_507);
+  assign _zz_487 = {_zz_508,{_zz_509,_zz_510}};
+  assign _zz_488 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz_489 = 32'h00004020;
+  assign _zz_490 = ((decode_INSTRUCTION & _zz_511) == 32'h00000010);
+  assign _zz_491 = ((decode_INSTRUCTION & _zz_512) == 32'h00000020);
+  assign _zz_492 = 32'h00002030;
+  assign _zz_493 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz_494 = 32'h00000010;
+  assign _zz_495 = ((decode_INSTRUCTION & _zz_513) == 32'h00002020);
+  assign _zz_496 = ((decode_INSTRUCTION & _zz_514) == 32'h00000020);
+  assign _zz_497 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_498 = 32'h00001010;
+  assign _zz_499 = ((decode_INSTRUCTION & _zz_515) == 32'h00002010);
+  assign _zz_500 = (_zz_516 == _zz_517);
+  assign _zz_501 = {_zz_518,_zz_519};
+  assign _zz_502 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_503 = 32'h00000020;
+  assign _zz_504 = ((decode_INSTRUCTION & _zz_520) == 32'h0);
+  assign _zz_505 = ((decode_INSTRUCTION & _zz_521) == 32'h00004010);
+  assign _zz_506 = (_zz_522 == _zz_523);
+  assign _zz_507 = 1'b0;
+  assign _zz_508 = ({_zz_524,_zz_525} != 4'b0000);
+  assign _zz_509 = (_zz_526 != _zz_527);
+  assign _zz_510 = {_zz_528,{_zz_529,_zz_530}};
+  assign _zz_511 = 32'h00000030;
+  assign _zz_512 = 32'h02000020;
+  assign _zz_513 = 32'h02002060;
+  assign _zz_514 = 32'h02003020;
+  assign _zz_515 = 32'h00002010;
+  assign _zz_516 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_517 = 32'h00000010;
+  assign _zz_518 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_519 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz_520 = 32'h00000020;
+  assign _zz_521 = 32'h00004014;
+  assign _zz_522 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_523 = 32'h00002010;
+  assign _zz_524 = ((decode_INSTRUCTION & _zz_531) == 32'h0);
+  assign _zz_525 = {(_zz_532 == _zz_533),{_zz_534,_zz_535}};
+  assign _zz_526 = ((decode_INSTRUCTION & _zz_536) == 32'h0);
+  assign _zz_527 = 1'b0;
+  assign _zz_528 = ({_zz_537,{_zz_538,_zz_539}} != 3'b000);
+  assign _zz_529 = ({_zz_540,_zz_541} != 2'b00);
+  assign _zz_530 = {(_zz_542 != _zz_543),(_zz_544 != _zz_545)};
+  assign _zz_531 = 32'h00000044;
+  assign _zz_532 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_533 = 32'h0;
+  assign _zz_534 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_535 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz_536 = 32'h00000058;
+  assign _zz_537 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_538 = ((decode_INSTRUCTION & _zz_546) == 32'h00002010);
+  assign _zz_539 = ((decode_INSTRUCTION & _zz_547) == 32'h40000030);
+  assign _zz_540 = ((decode_INSTRUCTION & _zz_548) == 32'h00000004);
+  assign _zz_541 = _zz_94;
+  assign _zz_542 = {(_zz_549 == _zz_550),_zz_94};
+  assign _zz_543 = 2'b00;
+  assign _zz_544 = ((decode_INSTRUCTION & _zz_551) == 32'h00001004);
+  assign _zz_545 = 1'b0;
+  assign _zz_546 = 32'h00002014;
+  assign _zz_547 = 32'h40000034;
+  assign _zz_548 = 32'h00000014;
+  assign _zz_549 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_550 = 32'h00000004;
+  assign _zz_551 = 32'h00005054;
+  assign _zz_552 = execute_INSTRUCTION[31];
+  assign _zz_553 = execute_INSTRUCTION[31];
+  assign _zz_554 = execute_INSTRUCTION[7];
+  assign _zz_555 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_348) begin
-      _zz_210 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_361) begin
+      _zz_221 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_349) begin
-      _zz_211 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_362) begin
+      _zz_222 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42) begin
+    if(_zz_48) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_182                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_183                                                     ), //i
+    .io_flush                                 (_zz_193                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_194                                                     ), //i
     .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
     .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_184                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_185                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_186                                                     ), //i
+    .io_cpu_fetch_isValid                     (_zz_195                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_196                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_197                                                     ), //i
     .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
     .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
     .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
@@ -1669,8 +1707,8 @@ module VexRiscv (
     .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
     .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
     .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_187                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_188                                                     ), //i
+    .io_cpu_decode_isValid                    (_zz_198                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_199                                                     ), //i
     .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
     .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
     .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
@@ -1678,8 +1716,8 @@ module VexRiscv (
     .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
     .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
     .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_189                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_190                                                     ), //i
+    .io_cpu_decode_isUser                     (_zz_200                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_201                                                     ), //i
     .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
     .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
     .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
@@ -1688,26 +1726,24 @@ module VexRiscv (
     .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
     .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
     .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    ._zz_9                                    (_zz_149[2:0]                                                ), //i
-    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
     .clk                                      (clk                                                         ), //i
     .reset                                    (reset                                                       )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_191                                            ), //i
-    .io_cpu_execute_address                    (_zz_192[31:0]                                      ), //i
+    .io_cpu_execute_isValid                    (_zz_202                                            ), //i
+    .io_cpu_execute_address                    (_zz_203[31:0]                                      ), //i
     .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
     .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_82[31:0]                                       ), //i
+    .io_cpu_execute_args_data                  (_zz_88[31:0]                                       ), //i
     .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
     .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
     .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_193                                            ), //i
+    .io_cpu_memory_isValid                     (_zz_204                                            ), //i
     .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
     .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_194[31:0]                                      ), //i
+    .io_cpu_memory_address                     (_zz_205[31:0]                                      ), //i
     .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_195                                            ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_206                                            ), //i
     .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
     .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
     .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
@@ -1715,31 +1751,31 @@ module VexRiscv (
     .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
     .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
     .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_196                                            ), //i
+    .io_cpu_writeBack_isValid                  (_zz_207                                            ), //i
     .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_197                                            ), //i
+    .io_cpu_writeBack_isUser                   (_zz_208                                            ), //i
     .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
     .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
     .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_198[31:0]                                      ), //i
+    .io_cpu_writeBack_address                  (_zz_209[31:0]                                      ), //i
     .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
     .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
     .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
     .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_199                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_200                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_201                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_202                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_203                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_204                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_205                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_206                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_207[3:0]                                       ), //i
+    .io_cpu_writeBack_fence_SW                 (_zz_210                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_211                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_212                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_213                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_214                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_215                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_216                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_217                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_218[3:0]                                       ), //i
     .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_208                                            ), //i
+    .io_cpu_flush_valid                        (_zz_219                                            ), //i
     .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
     .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_209                                            ), //i
+    .io_mem_cmd_ready                          (_zz_220                                            ), //i
     .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
     .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
     .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
@@ -1755,47 +1791,48 @@ module VexRiscv (
     .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_350)
+    case(_zz_363)
       2'b00 : begin
-        _zz_212 = DBusCachedPlugin_redoBranch_payload;
+        _zz_223 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_212 = CsrPlugin_jumpInterface_payload;
+        _zz_223 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_212 = BranchPlugin_jumpInterface_payload;
+        _zz_223 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_212 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_223 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
+    case(decode_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      `Input2Kind_defaultEncoding_RS : _zz_1_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_1_string = "IMM_I";
       default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      `Input2Kind_defaultEncoding_RS : _zz_2_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_2_string = "IMM_I";
       default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      `Input2Kind_defaultEncoding_RS : _zz_3_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_3_string = "IMM_I";
       default : _zz_3_string = "?????";
     endcase
   end
@@ -1806,15 +1843,6 @@ module VexRiscv (
       `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
       `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
       default : _zz_4_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
-      default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1845,57 +1873,57 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
+      default : decode_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_8_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8_string = "ECALL";
+      default : _zz_8_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_9_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9_string = "ECALL";
+      default : _zz_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_10_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10_string = "ECALL";
+      default : _zz_10_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_11_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_11_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_11_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_11_string = "JALR";
+      default : _zz_11_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_12_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_12_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_12_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_12_string = "JALR";
+      default : _zz_12_string = "????";
     endcase
   end
   always @(*) begin
@@ -1917,6 +1945,42 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15_string = "SRA_1    ";
+      default : _zz_15_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_16_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_16_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_16_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_16_string = "SRA_1    ";
+      default : _zz_16_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17_string = "SRA_1    ";
+      default : _zz_17_string = "?????????";
+    endcase
+  end
+  always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
       `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
@@ -1925,27 +1989,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_18)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
+      default : _zz_18_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_19)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_19_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_19_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_19_string = "AND_1";
+      default : _zz_19_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_20)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_20_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_20_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_20_string = "AND_1";
+      default : _zz_20_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1958,30 +2022,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_21)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_21_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_21_string = "PC ";
+      default : _zz_21_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_22)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_22_string = "PC ";
+      default : _zz_22_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_23)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_23_string = "PC ";
+      default : _zz_23_string = "???";
     endcase
   end
   always @(*) begin
@@ -1993,27 +2057,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_24)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24_string = "BITWISE ";
+      default : _zz_24_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_25)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_25_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_25_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_25_string = "BITWISE ";
+      default : _zz_25_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_26)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_26_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_26_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_26_string = "BITWISE ";
+      default : _zz_26_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2026,30 +2090,44 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_27)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27_string = "URS1        ";
+      default : _zz_27_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_28)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_28_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_28_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_28_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_28_string = "URS1        ";
+      default : _zz_28_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_29)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_29_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_29_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_29_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_29_string = "URS1        ";
+      default : _zz_29_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_32)
+      `Input2Kind_defaultEncoding_RS : _zz_32_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_32_string = "IMM_I";
+      default : _zz_32_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2062,12 +2140,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_33)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_33_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_33_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_33_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_33_string = "ECALL";
+      default : _zz_33_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2080,12 +2158,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_34)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_34_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_34_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_34_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_34_string = "ECALL";
+      default : _zz_34_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2098,12 +2176,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_35)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_35_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_35_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_35_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_35_string = "ECALL";
+      default : _zz_35_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2116,12 +2194,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_36)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_36_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_36_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_36_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_36_string = "JALR";
+      default : _zz_36_string = "????";
     endcase
   end
   always @(*) begin
@@ -2134,12 +2212,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_39)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_39_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_39_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_39_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_39_string = "SRA_1    ";
+      default : _zz_39_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2152,12 +2230,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_40)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_40_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_40_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_40_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_40_string = "SRA_1    ";
+      default : _zz_40_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2170,12 +2248,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_42)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_42_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_42_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_42_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_42_string = "PC ";
+      default : _zz_42_string = "???";
     endcase
   end
   always @(*) begin
@@ -2188,12 +2266,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_43)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_43_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_43_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_43_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_43_string = "URS1        ";
+      default : _zz_43_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2205,11 +2283,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_44)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_44_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_44_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_44_string = "BITWISE ";
+      default : _zz_44_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2221,81 +2299,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_45_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_45_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_45_string = "AND_1";
+      default : _zz_45_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+      `Input2Kind_defaultEncoding_RS : _zz_49_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_49_string = "IMM_I";
+      default : _zz_49_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_BRANCH_CTRL_string = "JALR";
-      default : decode_BRANCH_CTRL_string = "????";
+    case(_zz_50)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_50_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_50_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_50_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_50_string = "ECALL";
+      default : _zz_50_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2308,64 +2332,132 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_92)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_92_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_92_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_92_string = "URS1        ";
-      default : _zz_92_string = "????????????";
+    case(_zz_52)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_52_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_52_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_52_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_52_string = "SRA_1    ";
+      default : _zz_52_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_93_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_93_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_93_string = "BITWISE ";
-      default : _zz_93_string = "????????";
+    case(_zz_53)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_53_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_53_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_53_string = "AND_1";
+      default : _zz_53_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_94)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_94_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_94_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_94_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_94_string = "PC ";
-      default : _zz_94_string = "???";
+    case(_zz_54)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_54_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_54_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_54_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_54_string = "PC ";
+      default : _zz_54_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_95_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_95_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_95_string = "AND_1";
-      default : _zz_95_string = "?????";
+    case(_zz_55)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_55_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_55_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_55_string = "BITWISE ";
+      default : _zz_55_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_96)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_96_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_96_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_96_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_96_string = "SRA_1    ";
-      default : _zz_96_string = "?????????";
+    case(_zz_56)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_56_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_56_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_56_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_56_string = "URS1        ";
+      default : _zz_56_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_97)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_97_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_97_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_97_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_97_string = "JALR";
-      default : _zz_97_string = "????";
+    case(decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_BRANCH_CTRL_string = "JALR";
+      default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_98)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_98_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_98_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_98_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_98_string = "ECALL";
-      default : _zz_98_string = "?????";
+    case(_zz_58)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_58_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_58_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_58_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_58_string = "JALR";
+      default : _zz_58_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_99)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_99_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_99_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_99_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_99_string = "URS1        ";
+      default : _zz_99_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_100)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_100_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_100_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_100_string = "BITWISE ";
+      default : _zz_100_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_101)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_101_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_101_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_101_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_101_string = "PC ";
+      default : _zz_101_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_102)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_102_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_102_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_102_string = "AND_1";
+      default : _zz_102_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_103)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_103_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_103_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_103_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_103_string = "SRA_1    ";
+      default : _zz_103_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_104)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_104_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_104_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_104_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_104_string = "JALR";
+      default : _zz_104_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_105)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_105_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_105_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_105_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_105_string = "ECALL";
+      default : _zz_105_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_106)
+      `Input2Kind_defaultEncoding_RS : _zz_106_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_106_string = "IMM_I";
+      default : _zz_106_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2456,63 +2548,87 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
+  always @(*) begin
+    case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
+    endcase
+  end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_254) + $signed(_zz_262));
+  assign memory_MUL_LOW = ($signed(_zz_263) + $signed(_zz_271));
+  assign writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
   assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_264;
-  assign execute_REGFILE_WRITE_DATA = _zz_100;
+  assign execute_SHIFT_RIGHT = _zz_273;
+  assign execute_REGFILE_WRITE_DATA = _zz_108;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_192[1 : 0];
-  assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
+  assign execute_MEMORY_ADDRESS_LOW = _zz_203[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_266[0];
-  assign decode_IS_RS1_SIGNED = _zz_267[0];
-  assign decode_IS_DIV = _zz_268[0];
+  assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_1;
+  assign _zz_2 = _zz_3;
+  assign decode_CfuPlugin_CFU_ENABLE = _zz_275[0];
+  assign decode_IS_RS2_SIGNED = _zz_276[0];
+  assign decode_IS_RS1_SIGNED = _zz_277[0];
+  assign decode_IS_DIV = _zz_278[0];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_269[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
+  assign decode_IS_MUL = _zz_279[0];
+  assign _zz_4 = _zz_5;
   assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_270[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
+  assign decode_ENV_CTRL = _zz_8;
+  assign _zz_9 = _zz_10;
+  assign decode_IS_CSR = _zz_280[0];
+  assign _zz_11 = _zz_12;
   assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign decode_SHIFT_CTRL = _zz_15;
   assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_271[0];
-  assign decode_MEMORY_MANAGMENT = _zz_272[0];
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_273[0];
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_274[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_275[0];
-  assign decode_SRC2_CTRL = _zz_18;
+  assign decode_ALU_BITWISE_CTRL = _zz_18;
   assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
+  assign decode_SRC_LESS_UNSIGNED = _zz_281[0];
+  assign decode_MEMORY_MANAGMENT = _zz_282[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_283[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_284[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_285[0];
+  assign decode_SRC2_CTRL = _zz_21;
   assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
+  assign decode_ALU_CTRL = _zz_24;
   assign _zz_25 = _zz_26;
+  assign decode_SRC1_CTRL = _zz_27;
+  assign _zz_28 = _zz_29;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
-  assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_276[0];
+  always @ (*) begin
+    _zz_30 = memory_CfuPlugin_CFU_IN_FLIGHT;
+    if(memory_arbitration_isStuck)begin
+      _zz_30 = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    _zz_31 = execute_CfuPlugin_CFU_IN_FLIGHT;
+    if(execute_arbitration_isStuck)begin
+      _zz_31 = 1'b0;
+    end
+  end
+
+  assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_32;
+  assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2526,22 +2642,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
-  assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
-  assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
+  assign memory_ENV_CTRL = _zz_33;
+  assign execute_ENV_CTRL = _zz_34;
+  assign writeBack_ENV_CTRL = _zz_35;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_122;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_277[0];
-  assign decode_RS1_USE = _zz_278[0];
+  assign execute_BRANCH_COND_RESULT = _zz_130;
+  assign execute_BRANCH_CTRL = _zz_36;
+  assign decode_RS2_USE = _zz_286[0];
+  assign decode_RS1_USE = _zz_287[0];
   always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_213)begin
-      _zz_31 = execute_CsrPlugin_readData;
+    _zz_37 = execute_REGFILE_WRITE_DATA;
+    if(_zz_224)begin
+      _zz_37 = execute_CsrPlugin_readData;
     end
   end
 
@@ -2553,29 +2669,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_111)begin
-      if((_zz_112 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_113;
+    if(_zz_119)begin
+      if((_zz_120 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_121;
       end
     end
-    if(_zz_214)begin
-      if(_zz_215)begin
-        if(_zz_115)begin
-          decode_RS2 = _zz_50;
+    if(_zz_225)begin
+      if(_zz_226)begin
+        if(_zz_123)begin
+          decode_RS2 = _zz_57;
         end
       end
     end
-    if(_zz_216)begin
+    if(_zz_227)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_117)begin
-          decode_RS2 = _zz_32;
+        if(_zz_125)begin
+          decode_RS2 = _zz_38;
         end
       end
     end
-    if(_zz_217)begin
+    if(_zz_228)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_119)begin
-          decode_RS2 = _zz_31;
+        if(_zz_127)begin
+          decode_RS2 = _zz_37;
         end
       end
     end
@@ -2583,29 +2699,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_111)begin
-      if((_zz_112 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_113;
+    if(_zz_119)begin
+      if((_zz_120 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_121;
       end
     end
-    if(_zz_214)begin
-      if(_zz_215)begin
-        if(_zz_114)begin
-          decode_RS1 = _zz_50;
+    if(_zz_225)begin
+      if(_zz_226)begin
+        if(_zz_122)begin
+          decode_RS1 = _zz_57;
         end
       end
     end
-    if(_zz_216)begin
+    if(_zz_227)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116)begin
-          decode_RS1 = _zz_32;
+        if(_zz_124)begin
+          decode_RS1 = _zz_38;
         end
       end
     end
-    if(_zz_217)begin
+    if(_zz_228)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118)begin
-          decode_RS1 = _zz_31;
+        if(_zz_126)begin
+          decode_RS1 = _zz_37;
         end
       end
     end
@@ -2613,70 +2729,73 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
+    _zz_38 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_108;
+          _zz_38 = _zz_116;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+          _zz_38 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_218)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(_zz_229)begin
+      _zz_38 = memory_DivPlugin_div_result;
+    end
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      _zz_38 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_39;
+  assign execute_SHIFT_CTRL = _zz_40;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_279[0];
-  assign decode_SRC_ADD_ZERO = _zz_280[0];
+  assign _zz_41 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_42;
+  assign execute_SRC1_CTRL = _zz_43;
+  assign decode_SRC_USE_SUB_LESS = _zz_288[0];
+  assign decode_SRC_ADD_ZERO = _zz_289[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_106;
-  assign execute_SRC1 = _zz_101;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_44;
+  assign execute_SRC2 = _zz_114;
+  assign execute_SRC1 = _zz_109;
+  assign execute_ALU_BITWISE_CTRL = _zz_45;
+  assign _zz_46 = writeBack_INSTRUCTION;
+  assign _zz_47 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42 = 1'b0;
+    _zz_48 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+      _zz_48 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_281[0];
+    decode_REGFILE_WRITE_VALID = _zz_290[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_351) == 32'h00001073),{(_zz_352 == _zz_353),{_zz_354,{_zz_355,_zz_356}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_364) == 32'h00000003),{(_zz_365 == _zz_366),{_zz_367,{_zz_368,_zz_369}}}}}}} != 22'h0);
   always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
+    _zz_57 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_57 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_253)
+      case(_zz_262)
         2'b00 : begin
-          _zz_50 = _zz_323;
+          _zz_57 = _zz_334;
         end
         default : begin
-          _zz_50 = _zz_324;
+          _zz_57 = _zz_335;
         end
       endcase
     end
@@ -2695,49 +2814,49 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_282[0];
-  assign decode_FLUSH_ALL = _zz_283[0];
+  assign decode_MEMORY_ENABLE = _zz_291[0];
+  assign decode_FLUSH_ALL = _zz_292[0];
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_219)begin
+    if(_zz_230)begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_220)begin
+    if(_zz_231)begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_221)begin
+    if(_zz_232)begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_222)begin
+    if(_zz_233)begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_51;
+  assign decode_BRANCH_CTRL = _zz_58;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_52 = memory_FORMAL_PC_NEXT;
+    _zz_59 = execute_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_52 = BranchPlugin_jumpInterface_payload;
+      _zz_59 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_53 = decode_FORMAL_PC_NEXT;
+    _zz_60 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_60 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -2749,18 +2868,11 @@ module VexRiscv (
     if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_149)
-      3'b010 : begin
-        decode_arbitration_haltItself = 1'b1;
-      end
-      default : begin
-      end
-    endcase
   end
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_109 || _zz_110)))begin
+    if((decode_arbitration_isValid && (_zz_117 || _zz_118)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
@@ -2773,7 +2885,7 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_223)begin
+    if(_zz_234)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -2787,25 +2899,28 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_223)begin
+    if(_zz_234)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_208 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(((_zz_219 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_224)begin
+    if(_zz_235)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_213)begin
+    if(_zz_224)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
+    end
+    if((CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready)))begin
+      execute_arbitration_haltItself = 1'b1;
     end
   end
 
@@ -2814,14 +2929,11 @@ module VexRiscv (
     if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(_zz_225)begin
-      execute_arbitration_haltByOther = 1'b1;
-    end
   end
 
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(_zz_236)begin
       execute_arbitration_removeIt = 1'b1;
     end
     if(execute_arbitration_isFlushed)begin
@@ -2829,31 +2941,26 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
-    execute_arbitration_flushIt = 1'b0;
-    if(_zz_225)begin
-      if(_zz_226)begin
-        execute_arbitration_flushIt = 1'b1;
-      end
-    end
-  end
-
+  assign execute_arbitration_flushIt = 1'b0;
   always @ (*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(BranchPlugin_jumpInterface_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_225)begin
-      if(_zz_226)begin
-        execute_arbitration_flushNext = 1'b1;
-      end
+    if(_zz_236)begin
+      execute_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_218)begin
+    if(_zz_229)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+        memory_arbitration_haltItself = 1'b1;
+      end
+    end
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      if((! memory_CfuPlugin_rsp_valid))begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -2862,7 +2969,7 @@ module VexRiscv (
   assign memory_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(CfuPlugin_joinException_valid)begin
       memory_arbitration_removeIt = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -2873,10 +2980,7 @@ module VexRiscv (
   assign memory_arbitration_flushIt = 1'b0;
   always @ (*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
-      memory_arbitration_flushNext = 1'b1;
-    end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(CfuPlugin_joinException_valid)begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
@@ -2914,10 +3018,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_227)begin
+    if(_zz_237)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_228)begin
+    if(_zz_238)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2931,21 +3035,10 @@ module VexRiscv (
     if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_227)begin
+    if(_zz_237)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_228)begin
-      IBusCachedPlugin_fetcherHalt = 1'b1;
-    end
-    if(_zz_225)begin
-      if(_zz_226)begin
-        IBusCachedPlugin_fetcherHalt = 1'b1;
-      end
-    end
-    if(DebugPlugin_haltIt)begin
-      IBusCachedPlugin_fetcherHalt = 1'b1;
-    end
-    if(_zz_229)begin
+    if(_zz_238)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2958,43 +3051,30 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_54 = 1'b0;
-    if(DebugPlugin_godmode)begin
-      _zz_54 = 1'b1;
-    end
-  end
-
-  always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_224)begin
+    if(_zz_235)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_thirdPartyWake = 1'b0;
-    if(DebugPlugin_haltIt)begin
-      CsrPlugin_thirdPartyWake = 1'b1;
-    end
-  end
-
+  assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_227)begin
+    if(_zz_237)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_228)begin
+    if(_zz_238)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_227)begin
+    if(_zz_237)begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_228)begin
-      case(_zz_230)
+    if(_zz_238)begin
+      case(_zz_239)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3004,35 +3084,17 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
-    CsrPlugin_forceMachineWire = 1'b0;
-    if(DebugPlugin_godmode)begin
-      CsrPlugin_forceMachineWire = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    CsrPlugin_allowInterrupts = 1'b1;
-    if((DebugPlugin_haltIt || DebugPlugin_stepIt))begin
-      CsrPlugin_allowInterrupts = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    CsrPlugin_allowException = 1'b1;
-    if(DebugPlugin_godmode)begin
-      CsrPlugin_allowException = 1'b0;
-    end
-  end
-
+  assign CsrPlugin_forceMachineWire = 1'b0;
+  assign CsrPlugin_allowInterrupts = 1'b1;
+  assign CsrPlugin_allowException = 1'b1;
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56 = (_zz_55 & (~ _zz_284));
-  assign _zz_57 = _zz_56[3];
-  assign _zz_58 = (_zz_56[1] || _zz_57);
-  assign _zz_59 = (_zz_56[2] || _zz_57);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_212;
+  assign _zz_61 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_62 = (_zz_61 & (~ _zz_293));
+  assign _zz_63 = _zz_62[3];
+  assign _zz_64 = (_zz_62[1] || _zz_63);
+  assign _zz_65 = (_zz_62[2] || _zz_63);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_223;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -3052,7 +3114,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_286);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_295);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -3092,9 +3154,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
+  assign _zz_66 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_66);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_66);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
@@ -3103,9 +3165,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
+  assign _zz_67 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_67);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_67);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
@@ -3114,22 +3176,22 @@ module VexRiscv (
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
+  assign _zz_68 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_68);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_68);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
-  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64 = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_69;
+  assign _zz_69 = ((1'b0 && (! _zz_70)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_70 = _zz_71;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_70;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_66 = _zz_67;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_72)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_72 = _zz_73;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_72;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_74;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -3142,139 +3204,126 @@ module VexRiscv (
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
+  assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
+  assign _zz_75 = _zz_296[11];
   always @ (*) begin
-    decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_149)
-      3'b010 : begin
-        decode_arbitration_isValid = 1'b1;
-      end
-      3'b011 : begin
-        decode_arbitration_isValid = 1'b1;
-      end
-      default : begin
-      end
-    endcase
-  end
-
-  assign _zz_69 = _zz_287[11];
-  always @ (*) begin
-    _zz_70[18] = _zz_69;
-    _zz_70[17] = _zz_69;
-    _zz_70[16] = _zz_69;
-    _zz_70[15] = _zz_69;
-    _zz_70[14] = _zz_69;
-    _zz_70[13] = _zz_69;
-    _zz_70[12] = _zz_69;
-    _zz_70[11] = _zz_69;
-    _zz_70[10] = _zz_69;
-    _zz_70[9] = _zz_69;
-    _zz_70[8] = _zz_69;
-    _zz_70[7] = _zz_69;
-    _zz_70[6] = _zz_69;
-    _zz_70[5] = _zz_69;
-    _zz_70[4] = _zz_69;
-    _zz_70[3] = _zz_69;
-    _zz_70[2] = _zz_69;
-    _zz_70[1] = _zz_69;
-    _zz_70[0] = _zz_69;
+    _zz_76[18] = _zz_75;
+    _zz_76[17] = _zz_75;
+    _zz_76[16] = _zz_75;
+    _zz_76[15] = _zz_75;
+    _zz_76[14] = _zz_75;
+    _zz_76[13] = _zz_75;
+    _zz_76[12] = _zz_75;
+    _zz_76[11] = _zz_75;
+    _zz_76[10] = _zz_75;
+    _zz_76[9] = _zz_75;
+    _zz_76[8] = _zz_75;
+    _zz_76[7] = _zz_75;
+    _zz_76[6] = _zz_75;
+    _zz_76[5] = _zz_75;
+    _zz_76[4] = _zz_75;
+    _zz_76[3] = _zz_75;
+    _zz_76[2] = _zz_75;
+    _zz_76[1] = _zz_75;
+    _zz_76[0] = _zz_75;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_288[31]));
-    if(_zz_75)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_297[31]));
+    if(_zz_81)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_71 = _zz_289[19];
+  assign _zz_77 = _zz_298[19];
   always @ (*) begin
-    _zz_72[10] = _zz_71;
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
+    _zz_78[10] = _zz_77;
+    _zz_78[9] = _zz_77;
+    _zz_78[8] = _zz_77;
+    _zz_78[7] = _zz_77;
+    _zz_78[6] = _zz_77;
+    _zz_78[5] = _zz_77;
+    _zz_78[4] = _zz_77;
+    _zz_78[3] = _zz_77;
+    _zz_78[2] = _zz_77;
+    _zz_78[1] = _zz_77;
+    _zz_78[0] = _zz_77;
   end
 
-  assign _zz_73 = _zz_290[11];
+  assign _zz_79 = _zz_299[11];
   always @ (*) begin
-    _zz_74[18] = _zz_73;
-    _zz_74[17] = _zz_73;
-    _zz_74[16] = _zz_73;
-    _zz_74[15] = _zz_73;
-    _zz_74[14] = _zz_73;
-    _zz_74[13] = _zz_73;
-    _zz_74[12] = _zz_73;
-    _zz_74[11] = _zz_73;
-    _zz_74[10] = _zz_73;
-    _zz_74[9] = _zz_73;
-    _zz_74[8] = _zz_73;
-    _zz_74[7] = _zz_73;
-    _zz_74[6] = _zz_73;
-    _zz_74[5] = _zz_73;
-    _zz_74[4] = _zz_73;
-    _zz_74[3] = _zz_73;
-    _zz_74[2] = _zz_73;
-    _zz_74[1] = _zz_73;
-    _zz_74[0] = _zz_73;
+    _zz_80[18] = _zz_79;
+    _zz_80[17] = _zz_79;
+    _zz_80[16] = _zz_79;
+    _zz_80[15] = _zz_79;
+    _zz_80[14] = _zz_79;
+    _zz_80[13] = _zz_79;
+    _zz_80[12] = _zz_79;
+    _zz_80[11] = _zz_79;
+    _zz_80[10] = _zz_79;
+    _zz_80[9] = _zz_79;
+    _zz_80[8] = _zz_79;
+    _zz_80[7] = _zz_79;
+    _zz_80[6] = _zz_79;
+    _zz_80[5] = _zz_79;
+    _zz_80[4] = _zz_79;
+    _zz_80[3] = _zz_79;
+    _zz_80[2] = _zz_79;
+    _zz_80[1] = _zz_79;
+    _zz_80[0] = _zz_79;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_75 = _zz_291[1];
+        _zz_81 = _zz_300[1];
       end
       default : begin
-        _zz_75 = _zz_292[1];
+        _zz_81 = _zz_301[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_76 = _zz_293[19];
+  assign _zz_82 = _zz_302[19];
   always @ (*) begin
-    _zz_77[10] = _zz_76;
-    _zz_77[9] = _zz_76;
-    _zz_77[8] = _zz_76;
-    _zz_77[7] = _zz_76;
-    _zz_77[6] = _zz_76;
-    _zz_77[5] = _zz_76;
-    _zz_77[4] = _zz_76;
-    _zz_77[3] = _zz_76;
-    _zz_77[2] = _zz_76;
-    _zz_77[1] = _zz_76;
-    _zz_77[0] = _zz_76;
+    _zz_83[10] = _zz_82;
+    _zz_83[9] = _zz_82;
+    _zz_83[8] = _zz_82;
+    _zz_83[7] = _zz_82;
+    _zz_83[6] = _zz_82;
+    _zz_83[5] = _zz_82;
+    _zz_83[4] = _zz_82;
+    _zz_83[3] = _zz_82;
+    _zz_83[2] = _zz_82;
+    _zz_83[1] = _zz_82;
+    _zz_83[0] = _zz_82;
   end
 
-  assign _zz_78 = _zz_294[11];
+  assign _zz_84 = _zz_303[11];
   always @ (*) begin
-    _zz_79[18] = _zz_78;
-    _zz_79[17] = _zz_78;
-    _zz_79[16] = _zz_78;
-    _zz_79[15] = _zz_78;
-    _zz_79[14] = _zz_78;
-    _zz_79[13] = _zz_78;
-    _zz_79[12] = _zz_78;
-    _zz_79[11] = _zz_78;
-    _zz_79[10] = _zz_78;
-    _zz_79[9] = _zz_78;
-    _zz_79[8] = _zz_78;
-    _zz_79[7] = _zz_78;
-    _zz_79[6] = _zz_78;
-    _zz_79[5] = _zz_78;
-    _zz_79[4] = _zz_78;
-    _zz_79[3] = _zz_78;
-    _zz_79[2] = _zz_78;
-    _zz_79[1] = _zz_78;
-    _zz_79[0] = _zz_78;
+    _zz_85[18] = _zz_84;
+    _zz_85[17] = _zz_84;
+    _zz_85[16] = _zz_84;
+    _zz_85[15] = _zz_84;
+    _zz_85[14] = _zz_84;
+    _zz_85[13] = _zz_84;
+    _zz_85[12] = _zz_84;
+    _zz_85[11] = _zz_84;
+    _zz_85[10] = _zz_84;
+    _zz_85[9] = _zz_84;
+    _zz_85[8] = _zz_84;
+    _zz_85[7] = _zz_84;
+    _zz_85[6] = _zz_84;
+    _zz_85[5] = _zz_84;
+    _zz_85[4] = _zz_84;
+    _zz_85[3] = _zz_84;
+    _zz_85[2] = _zz_84;
+    _zz_85[1] = _zz_84;
+    _zz_85[0] = _zz_84;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77,{{{_zz_369,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79,{{{_zz_370,_zz_371},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_83,{{{_zz_382,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_85,{{{_zz_383,_zz_384},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3283,52 +3332,52 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_183 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_184 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_185 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_184;
+  assign _zz_194 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_195 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_196 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_195;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_187 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_188 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_189 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_198 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_199 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_200 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_222)begin
+    if(_zz_233)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_220)begin
+    if(_zz_231)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_190 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_220)begin
-      _zz_190 = 1'b1;
+    _zz_201 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_231)begin
+      _zz_201 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_221)begin
+    if(_zz_232)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_219)begin
+    if(_zz_230)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_221)begin
+    if(_zz_232)begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_219)begin
+    if(_zz_230)begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
@@ -3338,9 +3387,9 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_182 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_193 = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_209 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_220 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
@@ -3367,43 +3416,43 @@ module VexRiscv (
   assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_191 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_192 = execute_SRC_ADD;
+  assign _zz_202 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_203 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_82 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_88 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_82 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_88 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_82 = execute_RS2[31 : 0];
+        _zz_88 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_208 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_193 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_194 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_193;
+  assign _zz_219 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_204 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_205 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_204;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_194;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_205;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @ (*) begin
-    _zz_195 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_54 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_195 = 1'b1;
+    _zz_206 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_206 = 1'b1;
     end
   end
 
-  assign _zz_196 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_197 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_198 = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_207 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_208 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_209 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_231)begin
+    if(_zz_240)begin
       if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3413,7 +3462,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_231)begin
+    if(_zz_240)begin
       if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3432,15 +3481,15 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_231)begin
+    if(_zz_240)begin
       if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_295};
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_304};
       end
       if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
       if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_296};
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_305};
       end
     end
   end
@@ -3462,63 +3511,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_83 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_89 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_84[31] = _zz_83;
-    _zz_84[30] = _zz_83;
-    _zz_84[29] = _zz_83;
-    _zz_84[28] = _zz_83;
-    _zz_84[27] = _zz_83;
-    _zz_84[26] = _zz_83;
-    _zz_84[25] = _zz_83;
-    _zz_84[24] = _zz_83;
-    _zz_84[23] = _zz_83;
-    _zz_84[22] = _zz_83;
-    _zz_84[21] = _zz_83;
-    _zz_84[20] = _zz_83;
-    _zz_84[19] = _zz_83;
-    _zz_84[18] = _zz_83;
-    _zz_84[17] = _zz_83;
-    _zz_84[16] = _zz_83;
-    _zz_84[15] = _zz_83;
-    _zz_84[14] = _zz_83;
-    _zz_84[13] = _zz_83;
-    _zz_84[12] = _zz_83;
-    _zz_84[11] = _zz_83;
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_90[31] = _zz_89;
+    _zz_90[30] = _zz_89;
+    _zz_90[29] = _zz_89;
+    _zz_90[28] = _zz_89;
+    _zz_90[27] = _zz_89;
+    _zz_90[26] = _zz_89;
+    _zz_90[25] = _zz_89;
+    _zz_90[24] = _zz_89;
+    _zz_90[23] = _zz_89;
+    _zz_90[22] = _zz_89;
+    _zz_90[21] = _zz_89;
+    _zz_90[20] = _zz_89;
+    _zz_90[19] = _zz_89;
+    _zz_90[18] = _zz_89;
+    _zz_90[17] = _zz_89;
+    _zz_90[16] = _zz_89;
+    _zz_90[15] = _zz_89;
+    _zz_90[14] = _zz_89;
+    _zz_90[13] = _zz_89;
+    _zz_90[12] = _zz_89;
+    _zz_90[11] = _zz_89;
+    _zz_90[10] = _zz_89;
+    _zz_90[9] = _zz_89;
+    _zz_90[8] = _zz_89;
+    _zz_90[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_91 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_86[31] = _zz_85;
-    _zz_86[30] = _zz_85;
-    _zz_86[29] = _zz_85;
-    _zz_86[28] = _zz_85;
-    _zz_86[27] = _zz_85;
-    _zz_86[26] = _zz_85;
-    _zz_86[25] = _zz_85;
-    _zz_86[24] = _zz_85;
-    _zz_86[23] = _zz_85;
-    _zz_86[22] = _zz_85;
-    _zz_86[21] = _zz_85;
-    _zz_86[20] = _zz_85;
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_92[31] = _zz_91;
+    _zz_92[30] = _zz_91;
+    _zz_92[29] = _zz_91;
+    _zz_92[28] = _zz_91;
+    _zz_92[27] = _zz_91;
+    _zz_92[26] = _zz_91;
+    _zz_92[25] = _zz_91;
+    _zz_92[24] = _zz_91;
+    _zz_92[23] = _zz_91;
+    _zz_92[22] = _zz_91;
+    _zz_92[21] = _zz_91;
+    _zz_92[20] = _zz_91;
+    _zz_92[19] = _zz_91;
+    _zz_92[18] = _zz_91;
+    _zz_92[17] = _zz_91;
+    _zz_92[16] = _zz_91;
+    _zz_92[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_251)
+    case(_zz_260)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_84;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_90;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_92;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -3544,49 +3593,52 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_88 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_90 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_91 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_87 = {(((decode_INSTRUCTION & _zz_372) == 32'h00100050) != 1'b0),{(_zz_91 != 1'b0),{(_zz_91 != 1'b0),{(_zz_373 != _zz_374),{_zz_375,{_zz_376,_zz_377}}}}}};
-  assign _zz_92 = _zz_87[2 : 1];
-  assign _zz_49 = _zz_92;
-  assign _zz_93 = _zz_87[7 : 6];
-  assign _zz_48 = _zz_93;
-  assign _zz_94 = _zz_87[9 : 8];
-  assign _zz_47 = _zz_94;
-  assign _zz_95 = _zz_87[19 : 18];
-  assign _zz_46 = _zz_95;
-  assign _zz_96 = _zz_87[22 : 21];
-  assign _zz_45 = _zz_96;
-  assign _zz_97 = _zz_87[24 : 23];
-  assign _zz_44 = _zz_97;
-  assign _zz_98 = _zz_87[27 : 26];
-  assign _zz_43 = _zz_98;
+  assign _zz_94 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_95 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_96 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_97 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_98 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_93 = {1'b0,{(_zz_97 != 1'b0),{(_zz_98 != 1'b0),{(_zz_98 != 1'b0),{(_zz_385 != _zz_386),{_zz_387,{_zz_388,_zz_389}}}}}}};
+  assign _zz_99 = _zz_93[2 : 1];
+  assign _zz_56 = _zz_99;
+  assign _zz_100 = _zz_93[7 : 6];
+  assign _zz_55 = _zz_100;
+  assign _zz_101 = _zz_93[9 : 8];
+  assign _zz_54 = _zz_101;
+  assign _zz_102 = _zz_93[19 : 18];
+  assign _zz_53 = _zz_102;
+  assign _zz_103 = _zz_93[22 : 21];
+  assign _zz_52 = _zz_103;
+  assign _zz_104 = _zz_93[24 : 23];
+  assign _zz_51 = _zz_104;
+  assign _zz_105 = _zz_93[27 : 26];
+  assign _zz_50 = _zz_105;
+  assign _zz_106 = _zz_93[33 : 33];
+  assign _zz_49 = _zz_106;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_210;
-  assign decode_RegFilePlugin_rs2Data = _zz_211;
+  assign decode_RegFilePlugin_rs1Data = _zz_221;
+  assign decode_RegFilePlugin_rs2Data = _zz_222;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_99)begin
+    lastStageRegFileWrite_valid = (_zz_47 && writeBack_arbitration_isFiring);
+    if(_zz_107)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_99)begin
+    lastStageRegFileWrite_payload_address = _zz_46[11 : 7];
+    if(_zz_107)begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_99)begin
+    lastStageRegFileWrite_payload_data = _zz_57;
+    if(_zz_107)begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
@@ -3608,13 +3660,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_100 = execute_IntAluPlugin_bitwise;
+        _zz_108 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_100 = {31'd0, _zz_297};
+        _zz_108 = {31'd0, _zz_306};
       end
       default : begin
-        _zz_100 = execute_SRC_ADD_SUB;
+        _zz_108 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -3622,87 +3674,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_101 = execute_RS1;
+        _zz_109 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_101 = {29'd0, _zz_298};
+        _zz_109 = {29'd0, _zz_307};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_101 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_109 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_101 = {27'd0, _zz_299};
+        _zz_109 = {27'd0, _zz_308};
       end
     endcase
   end
 
-  assign _zz_102 = _zz_300[11];
+  assign _zz_110 = _zz_309[11];
   always @ (*) begin
-    _zz_103[19] = _zz_102;
-    _zz_103[18] = _zz_102;
-    _zz_103[17] = _zz_102;
-    _zz_103[16] = _zz_102;
-    _zz_103[15] = _zz_102;
-    _zz_103[14] = _zz_102;
-    _zz_103[13] = _zz_102;
-    _zz_103[12] = _zz_102;
-    _zz_103[11] = _zz_102;
-    _zz_103[10] = _zz_102;
-    _zz_103[9] = _zz_102;
-    _zz_103[8] = _zz_102;
-    _zz_103[7] = _zz_102;
-    _zz_103[6] = _zz_102;
-    _zz_103[5] = _zz_102;
-    _zz_103[4] = _zz_102;
-    _zz_103[3] = _zz_102;
-    _zz_103[2] = _zz_102;
-    _zz_103[1] = _zz_102;
-    _zz_103[0] = _zz_102;
+    _zz_111[19] = _zz_110;
+    _zz_111[18] = _zz_110;
+    _zz_111[17] = _zz_110;
+    _zz_111[16] = _zz_110;
+    _zz_111[15] = _zz_110;
+    _zz_111[14] = _zz_110;
+    _zz_111[13] = _zz_110;
+    _zz_111[12] = _zz_110;
+    _zz_111[11] = _zz_110;
+    _zz_111[10] = _zz_110;
+    _zz_111[9] = _zz_110;
+    _zz_111[8] = _zz_110;
+    _zz_111[7] = _zz_110;
+    _zz_111[6] = _zz_110;
+    _zz_111[5] = _zz_110;
+    _zz_111[4] = _zz_110;
+    _zz_111[3] = _zz_110;
+    _zz_111[2] = _zz_110;
+    _zz_111[1] = _zz_110;
+    _zz_111[0] = _zz_110;
   end
 
-  assign _zz_104 = _zz_301[11];
+  assign _zz_112 = _zz_310[11];
   always @ (*) begin
-    _zz_105[19] = _zz_104;
-    _zz_105[18] = _zz_104;
-    _zz_105[17] = _zz_104;
-    _zz_105[16] = _zz_104;
-    _zz_105[15] = _zz_104;
-    _zz_105[14] = _zz_104;
-    _zz_105[13] = _zz_104;
-    _zz_105[12] = _zz_104;
-    _zz_105[11] = _zz_104;
-    _zz_105[10] = _zz_104;
-    _zz_105[9] = _zz_104;
-    _zz_105[8] = _zz_104;
-    _zz_105[7] = _zz_104;
-    _zz_105[6] = _zz_104;
-    _zz_105[5] = _zz_104;
-    _zz_105[4] = _zz_104;
-    _zz_105[3] = _zz_104;
-    _zz_105[2] = _zz_104;
-    _zz_105[1] = _zz_104;
-    _zz_105[0] = _zz_104;
+    _zz_113[19] = _zz_112;
+    _zz_113[18] = _zz_112;
+    _zz_113[17] = _zz_112;
+    _zz_113[16] = _zz_112;
+    _zz_113[15] = _zz_112;
+    _zz_113[14] = _zz_112;
+    _zz_113[13] = _zz_112;
+    _zz_113[12] = _zz_112;
+    _zz_113[11] = _zz_112;
+    _zz_113[10] = _zz_112;
+    _zz_113[9] = _zz_112;
+    _zz_113[8] = _zz_112;
+    _zz_113[7] = _zz_112;
+    _zz_113[6] = _zz_112;
+    _zz_113[5] = _zz_112;
+    _zz_113[4] = _zz_112;
+    _zz_113[3] = _zz_112;
+    _zz_113[2] = _zz_112;
+    _zz_113[1] = _zz_112;
+    _zz_113[0] = _zz_112;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_106 = execute_RS2;
+        _zz_114 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_106 = {_zz_103,execute_INSTRUCTION[31 : 20]};
+        _zz_114 = {_zz_111,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_106 = {_zz_105,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_114 = {_zz_113,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_106 = _zz_35;
+        _zz_114 = _zz_41;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_302;
+    execute_SrcPlugin_addSub = _zz_311;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -3711,246 +3763,246 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_107[0] = execute_SRC1[31];
-    _zz_107[1] = execute_SRC1[30];
-    _zz_107[2] = execute_SRC1[29];
-    _zz_107[3] = execute_SRC1[28];
-    _zz_107[4] = execute_SRC1[27];
-    _zz_107[5] = execute_SRC1[26];
-    _zz_107[6] = execute_SRC1[25];
-    _zz_107[7] = execute_SRC1[24];
-    _zz_107[8] = execute_SRC1[23];
-    _zz_107[9] = execute_SRC1[22];
-    _zz_107[10] = execute_SRC1[21];
-    _zz_107[11] = execute_SRC1[20];
-    _zz_107[12] = execute_SRC1[19];
-    _zz_107[13] = execute_SRC1[18];
-    _zz_107[14] = execute_SRC1[17];
-    _zz_107[15] = execute_SRC1[16];
-    _zz_107[16] = execute_SRC1[15];
-    _zz_107[17] = execute_SRC1[14];
-    _zz_107[18] = execute_SRC1[13];
-    _zz_107[19] = execute_SRC1[12];
-    _zz_107[20] = execute_SRC1[11];
-    _zz_107[21] = execute_SRC1[10];
-    _zz_107[22] = execute_SRC1[9];
-    _zz_107[23] = execute_SRC1[8];
-    _zz_107[24] = execute_SRC1[7];
-    _zz_107[25] = execute_SRC1[6];
-    _zz_107[26] = execute_SRC1[5];
-    _zz_107[27] = execute_SRC1[4];
-    _zz_107[28] = execute_SRC1[3];
-    _zz_107[29] = execute_SRC1[2];
-    _zz_107[30] = execute_SRC1[1];
-    _zz_107[31] = execute_SRC1[0];
+    _zz_115[0] = execute_SRC1[31];
+    _zz_115[1] = execute_SRC1[30];
+    _zz_115[2] = execute_SRC1[29];
+    _zz_115[3] = execute_SRC1[28];
+    _zz_115[4] = execute_SRC1[27];
+    _zz_115[5] = execute_SRC1[26];
+    _zz_115[6] = execute_SRC1[25];
+    _zz_115[7] = execute_SRC1[24];
+    _zz_115[8] = execute_SRC1[23];
+    _zz_115[9] = execute_SRC1[22];
+    _zz_115[10] = execute_SRC1[21];
+    _zz_115[11] = execute_SRC1[20];
+    _zz_115[12] = execute_SRC1[19];
+    _zz_115[13] = execute_SRC1[18];
+    _zz_115[14] = execute_SRC1[17];
+    _zz_115[15] = execute_SRC1[16];
+    _zz_115[16] = execute_SRC1[15];
+    _zz_115[17] = execute_SRC1[14];
+    _zz_115[18] = execute_SRC1[13];
+    _zz_115[19] = execute_SRC1[12];
+    _zz_115[20] = execute_SRC1[11];
+    _zz_115[21] = execute_SRC1[10];
+    _zz_115[22] = execute_SRC1[9];
+    _zz_115[23] = execute_SRC1[8];
+    _zz_115[24] = execute_SRC1[7];
+    _zz_115[25] = execute_SRC1[6];
+    _zz_115[26] = execute_SRC1[5];
+    _zz_115[27] = execute_SRC1[4];
+    _zz_115[28] = execute_SRC1[3];
+    _zz_115[29] = execute_SRC1[2];
+    _zz_115[30] = execute_SRC1[1];
+    _zz_115[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_107 : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_115 : execute_SRC1);
   always @ (*) begin
-    _zz_108[0] = memory_SHIFT_RIGHT[31];
-    _zz_108[1] = memory_SHIFT_RIGHT[30];
-    _zz_108[2] = memory_SHIFT_RIGHT[29];
-    _zz_108[3] = memory_SHIFT_RIGHT[28];
-    _zz_108[4] = memory_SHIFT_RIGHT[27];
-    _zz_108[5] = memory_SHIFT_RIGHT[26];
-    _zz_108[6] = memory_SHIFT_RIGHT[25];
-    _zz_108[7] = memory_SHIFT_RIGHT[24];
-    _zz_108[8] = memory_SHIFT_RIGHT[23];
-    _zz_108[9] = memory_SHIFT_RIGHT[22];
-    _zz_108[10] = memory_SHIFT_RIGHT[21];
-    _zz_108[11] = memory_SHIFT_RIGHT[20];
-    _zz_108[12] = memory_SHIFT_RIGHT[19];
-    _zz_108[13] = memory_SHIFT_RIGHT[18];
-    _zz_108[14] = memory_SHIFT_RIGHT[17];
-    _zz_108[15] = memory_SHIFT_RIGHT[16];
-    _zz_108[16] = memory_SHIFT_RIGHT[15];
-    _zz_108[17] = memory_SHIFT_RIGHT[14];
-    _zz_108[18] = memory_SHIFT_RIGHT[13];
-    _zz_108[19] = memory_SHIFT_RIGHT[12];
-    _zz_108[20] = memory_SHIFT_RIGHT[11];
-    _zz_108[21] = memory_SHIFT_RIGHT[10];
-    _zz_108[22] = memory_SHIFT_RIGHT[9];
-    _zz_108[23] = memory_SHIFT_RIGHT[8];
-    _zz_108[24] = memory_SHIFT_RIGHT[7];
-    _zz_108[25] = memory_SHIFT_RIGHT[6];
-    _zz_108[26] = memory_SHIFT_RIGHT[5];
-    _zz_108[27] = memory_SHIFT_RIGHT[4];
-    _zz_108[28] = memory_SHIFT_RIGHT[3];
-    _zz_108[29] = memory_SHIFT_RIGHT[2];
-    _zz_108[30] = memory_SHIFT_RIGHT[1];
-    _zz_108[31] = memory_SHIFT_RIGHT[0];
+    _zz_116[0] = memory_SHIFT_RIGHT[31];
+    _zz_116[1] = memory_SHIFT_RIGHT[30];
+    _zz_116[2] = memory_SHIFT_RIGHT[29];
+    _zz_116[3] = memory_SHIFT_RIGHT[28];
+    _zz_116[4] = memory_SHIFT_RIGHT[27];
+    _zz_116[5] = memory_SHIFT_RIGHT[26];
+    _zz_116[6] = memory_SHIFT_RIGHT[25];
+    _zz_116[7] = memory_SHIFT_RIGHT[24];
+    _zz_116[8] = memory_SHIFT_RIGHT[23];
+    _zz_116[9] = memory_SHIFT_RIGHT[22];
+    _zz_116[10] = memory_SHIFT_RIGHT[21];
+    _zz_116[11] = memory_SHIFT_RIGHT[20];
+    _zz_116[12] = memory_SHIFT_RIGHT[19];
+    _zz_116[13] = memory_SHIFT_RIGHT[18];
+    _zz_116[14] = memory_SHIFT_RIGHT[17];
+    _zz_116[15] = memory_SHIFT_RIGHT[16];
+    _zz_116[16] = memory_SHIFT_RIGHT[15];
+    _zz_116[17] = memory_SHIFT_RIGHT[14];
+    _zz_116[18] = memory_SHIFT_RIGHT[13];
+    _zz_116[19] = memory_SHIFT_RIGHT[12];
+    _zz_116[20] = memory_SHIFT_RIGHT[11];
+    _zz_116[21] = memory_SHIFT_RIGHT[10];
+    _zz_116[22] = memory_SHIFT_RIGHT[9];
+    _zz_116[23] = memory_SHIFT_RIGHT[8];
+    _zz_116[24] = memory_SHIFT_RIGHT[7];
+    _zz_116[25] = memory_SHIFT_RIGHT[6];
+    _zz_116[26] = memory_SHIFT_RIGHT[5];
+    _zz_116[27] = memory_SHIFT_RIGHT[4];
+    _zz_116[28] = memory_SHIFT_RIGHT[3];
+    _zz_116[29] = memory_SHIFT_RIGHT[2];
+    _zz_116[30] = memory_SHIFT_RIGHT[1];
+    _zz_116[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_109 = 1'b0;
-    if(_zz_232)begin
-      if(_zz_233)begin
-        if(_zz_114)begin
-          _zz_109 = 1'b1;
+    _zz_117 = 1'b0;
+    if(_zz_241)begin
+      if(_zz_242)begin
+        if(_zz_122)begin
+          _zz_117 = 1'b1;
         end
       end
     end
-    if(_zz_234)begin
-      if(_zz_235)begin
-        if(_zz_116)begin
-          _zz_109 = 1'b1;
+    if(_zz_243)begin
+      if(_zz_244)begin
+        if(_zz_124)begin
+          _zz_117 = 1'b1;
         end
       end
     end
-    if(_zz_236)begin
-      if(_zz_237)begin
-        if(_zz_118)begin
-          _zz_109 = 1'b1;
+    if(_zz_245)begin
+      if(_zz_246)begin
+        if(_zz_126)begin
+          _zz_117 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_109 = 1'b0;
+      _zz_117 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_110 = 1'b0;
-    if(_zz_232)begin
-      if(_zz_233)begin
-        if(_zz_115)begin
-          _zz_110 = 1'b1;
+    _zz_118 = 1'b0;
+    if(_zz_241)begin
+      if(_zz_242)begin
+        if(_zz_123)begin
+          _zz_118 = 1'b1;
         end
       end
     end
-    if(_zz_234)begin
-      if(_zz_235)begin
-        if(_zz_117)begin
-          _zz_110 = 1'b1;
+    if(_zz_243)begin
+      if(_zz_244)begin
+        if(_zz_125)begin
+          _zz_118 = 1'b1;
         end
       end
     end
-    if(_zz_236)begin
-      if(_zz_237)begin
-        if(_zz_119)begin
-          _zz_110 = 1'b1;
+    if(_zz_245)begin
+      if(_zz_246)begin
+        if(_zz_127)begin
+          _zz_118 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_110 = 1'b0;
+      _zz_118 = 1'b0;
     end
   end
 
-  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_115 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_117 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_119 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_122 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_123 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_124 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_125 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_126 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_127 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_120 = execute_INSTRUCTION[14 : 12];
+  assign _zz_128 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_120 == 3'b000)) begin
-        _zz_121 = execute_BranchPlugin_eq;
-    end else if((_zz_120 == 3'b001)) begin
-        _zz_121 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_120 & 3'b101) == 3'b101))) begin
-        _zz_121 = (! execute_SRC_LESS);
+    if((_zz_128 == 3'b000)) begin
+        _zz_129 = execute_BranchPlugin_eq;
+    end else if((_zz_128 == 3'b001)) begin
+        _zz_129 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_128 & 3'b101) == 3'b101))) begin
+        _zz_129 = (! execute_SRC_LESS);
     end else begin
-        _zz_121 = execute_SRC_LESS;
+        _zz_129 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_122 = 1'b0;
+        _zz_130 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_122 = 1'b1;
+        _zz_130 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_122 = 1'b1;
+        _zz_130 = 1'b1;
       end
       default : begin
-        _zz_122 = _zz_121;
+        _zz_130 = _zz_129;
       end
     endcase
   end
 
-  assign _zz_123 = _zz_309[11];
+  assign _zz_131 = _zz_318[11];
   always @ (*) begin
-    _zz_124[19] = _zz_123;
-    _zz_124[18] = _zz_123;
-    _zz_124[17] = _zz_123;
-    _zz_124[16] = _zz_123;
-    _zz_124[15] = _zz_123;
-    _zz_124[14] = _zz_123;
-    _zz_124[13] = _zz_123;
-    _zz_124[12] = _zz_123;
-    _zz_124[11] = _zz_123;
-    _zz_124[10] = _zz_123;
-    _zz_124[9] = _zz_123;
-    _zz_124[8] = _zz_123;
-    _zz_124[7] = _zz_123;
-    _zz_124[6] = _zz_123;
-    _zz_124[5] = _zz_123;
-    _zz_124[4] = _zz_123;
-    _zz_124[3] = _zz_123;
-    _zz_124[2] = _zz_123;
-    _zz_124[1] = _zz_123;
-    _zz_124[0] = _zz_123;
+    _zz_132[19] = _zz_131;
+    _zz_132[18] = _zz_131;
+    _zz_132[17] = _zz_131;
+    _zz_132[16] = _zz_131;
+    _zz_132[15] = _zz_131;
+    _zz_132[14] = _zz_131;
+    _zz_132[13] = _zz_131;
+    _zz_132[12] = _zz_131;
+    _zz_132[11] = _zz_131;
+    _zz_132[10] = _zz_131;
+    _zz_132[9] = _zz_131;
+    _zz_132[8] = _zz_131;
+    _zz_132[7] = _zz_131;
+    _zz_132[6] = _zz_131;
+    _zz_132[5] = _zz_131;
+    _zz_132[4] = _zz_131;
+    _zz_132[3] = _zz_131;
+    _zz_132[2] = _zz_131;
+    _zz_132[1] = _zz_131;
+    _zz_132[0] = _zz_131;
   end
 
-  assign _zz_125 = _zz_310[19];
+  assign _zz_133 = _zz_319[19];
   always @ (*) begin
-    _zz_126[10] = _zz_125;
-    _zz_126[9] = _zz_125;
-    _zz_126[8] = _zz_125;
-    _zz_126[7] = _zz_125;
-    _zz_126[6] = _zz_125;
-    _zz_126[5] = _zz_125;
-    _zz_126[4] = _zz_125;
-    _zz_126[3] = _zz_125;
-    _zz_126[2] = _zz_125;
-    _zz_126[1] = _zz_125;
-    _zz_126[0] = _zz_125;
+    _zz_134[10] = _zz_133;
+    _zz_134[9] = _zz_133;
+    _zz_134[8] = _zz_133;
+    _zz_134[7] = _zz_133;
+    _zz_134[6] = _zz_133;
+    _zz_134[5] = _zz_133;
+    _zz_134[4] = _zz_133;
+    _zz_134[3] = _zz_133;
+    _zz_134[2] = _zz_133;
+    _zz_134[1] = _zz_133;
+    _zz_134[0] = _zz_133;
   end
 
-  assign _zz_127 = _zz_311[11];
+  assign _zz_135 = _zz_320[11];
   always @ (*) begin
-    _zz_128[18] = _zz_127;
-    _zz_128[17] = _zz_127;
-    _zz_128[16] = _zz_127;
-    _zz_128[15] = _zz_127;
-    _zz_128[14] = _zz_127;
-    _zz_128[13] = _zz_127;
-    _zz_128[12] = _zz_127;
-    _zz_128[11] = _zz_127;
-    _zz_128[10] = _zz_127;
-    _zz_128[9] = _zz_127;
-    _zz_128[8] = _zz_127;
-    _zz_128[7] = _zz_127;
-    _zz_128[6] = _zz_127;
-    _zz_128[5] = _zz_127;
-    _zz_128[4] = _zz_127;
-    _zz_128[3] = _zz_127;
-    _zz_128[2] = _zz_127;
-    _zz_128[1] = _zz_127;
-    _zz_128[0] = _zz_127;
+    _zz_136[18] = _zz_135;
+    _zz_136[17] = _zz_135;
+    _zz_136[16] = _zz_135;
+    _zz_136[15] = _zz_135;
+    _zz_136[14] = _zz_135;
+    _zz_136[13] = _zz_135;
+    _zz_136[12] = _zz_135;
+    _zz_136[11] = _zz_135;
+    _zz_136[10] = _zz_135;
+    _zz_136[9] = _zz_135;
+    _zz_136[8] = _zz_135;
+    _zz_136[7] = _zz_135;
+    _zz_136[6] = _zz_135;
+    _zz_136[5] = _zz_135;
+    _zz_136[4] = _zz_135;
+    _zz_136[3] = _zz_135;
+    _zz_136[2] = _zz_135;
+    _zz_136[1] = _zz_135;
+    _zz_136[0] = _zz_135;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_129 = (_zz_312[1] ^ execute_RS1[1]);
+        _zz_137 = (_zz_321[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_129 = _zz_313[1];
+        _zz_137 = _zz_322[1];
       end
       default : begin
-        _zz_129 = _zz_314[1];
+        _zz_137 = _zz_323[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_129);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_137);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -3962,88 +4014,94 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_130 = _zz_315[11];
+  assign _zz_138 = _zz_324[11];
   always @ (*) begin
-    _zz_131[19] = _zz_130;
-    _zz_131[18] = _zz_130;
-    _zz_131[17] = _zz_130;
-    _zz_131[16] = _zz_130;
-    _zz_131[15] = _zz_130;
-    _zz_131[14] = _zz_130;
-    _zz_131[13] = _zz_130;
-    _zz_131[12] = _zz_130;
-    _zz_131[11] = _zz_130;
-    _zz_131[10] = _zz_130;
-    _zz_131[9] = _zz_130;
-    _zz_131[8] = _zz_130;
-    _zz_131[7] = _zz_130;
-    _zz_131[6] = _zz_130;
-    _zz_131[5] = _zz_130;
-    _zz_131[4] = _zz_130;
-    _zz_131[3] = _zz_130;
-    _zz_131[2] = _zz_130;
-    _zz_131[1] = _zz_130;
-    _zz_131[0] = _zz_130;
+    _zz_139[19] = _zz_138;
+    _zz_139[18] = _zz_138;
+    _zz_139[17] = _zz_138;
+    _zz_139[16] = _zz_138;
+    _zz_139[15] = _zz_138;
+    _zz_139[14] = _zz_138;
+    _zz_139[13] = _zz_138;
+    _zz_139[12] = _zz_138;
+    _zz_139[11] = _zz_138;
+    _zz_139[10] = _zz_138;
+    _zz_139[9] = _zz_138;
+    _zz_139[8] = _zz_138;
+    _zz_139[7] = _zz_138;
+    _zz_139[6] = _zz_138;
+    _zz_139[5] = _zz_138;
+    _zz_139[4] = _zz_138;
+    _zz_139[3] = _zz_138;
+    _zz_139[2] = _zz_138;
+    _zz_139[1] = _zz_138;
+    _zz_139[0] = _zz_138;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_131,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_139,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_133,{{{_zz_536,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_135,{{{_zz_537,_zz_538},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_141,{{{_zz_552,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_143,{{{_zz_553,_zz_554},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_318};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_327};
         end
       end
     endcase
   end
 
-  assign _zz_132 = _zz_316[19];
+  assign _zz_140 = _zz_325[19];
   always @ (*) begin
-    _zz_133[10] = _zz_132;
-    _zz_133[9] = _zz_132;
-    _zz_133[8] = _zz_132;
-    _zz_133[7] = _zz_132;
-    _zz_133[6] = _zz_132;
-    _zz_133[5] = _zz_132;
-    _zz_133[4] = _zz_132;
-    _zz_133[3] = _zz_132;
-    _zz_133[2] = _zz_132;
-    _zz_133[1] = _zz_132;
-    _zz_133[0] = _zz_132;
+    _zz_141[10] = _zz_140;
+    _zz_141[9] = _zz_140;
+    _zz_141[8] = _zz_140;
+    _zz_141[7] = _zz_140;
+    _zz_141[6] = _zz_140;
+    _zz_141[5] = _zz_140;
+    _zz_141[4] = _zz_140;
+    _zz_141[3] = _zz_140;
+    _zz_141[2] = _zz_140;
+    _zz_141[1] = _zz_140;
+    _zz_141[0] = _zz_140;
   end
 
-  assign _zz_134 = _zz_317[11];
+  assign _zz_142 = _zz_326[11];
   always @ (*) begin
-    _zz_135[18] = _zz_134;
-    _zz_135[17] = _zz_134;
-    _zz_135[16] = _zz_134;
-    _zz_135[15] = _zz_134;
-    _zz_135[14] = _zz_134;
-    _zz_135[13] = _zz_134;
-    _zz_135[12] = _zz_134;
-    _zz_135[11] = _zz_134;
-    _zz_135[10] = _zz_134;
-    _zz_135[9] = _zz_134;
-    _zz_135[8] = _zz_134;
-    _zz_135[7] = _zz_134;
-    _zz_135[6] = _zz_134;
-    _zz_135[5] = _zz_134;
-    _zz_135[4] = _zz_134;
-    _zz_135[3] = _zz_134;
-    _zz_135[2] = _zz_134;
-    _zz_135[1] = _zz_134;
-    _zz_135[0] = _zz_134;
+    _zz_143[18] = _zz_142;
+    _zz_143[17] = _zz_142;
+    _zz_143[16] = _zz_142;
+    _zz_143[15] = _zz_142;
+    _zz_143[14] = _zz_142;
+    _zz_143[13] = _zz_142;
+    _zz_143[12] = _zz_142;
+    _zz_143[11] = _zz_142;
+    _zz_143[10] = _zz_142;
+    _zz_143[9] = _zz_142;
+    _zz_143[8] = _zz_142;
+    _zz_143[7] = _zz_142;
+    _zz_143[6] = _zz_142;
+    _zz_143[5] = _zz_142;
+    _zz_143[4] = _zz_142;
+    _zz_143[3] = _zz_142;
+    _zz_143[2] = _zz_142;
+    _zz_143[1] = _zz_142;
+    _zz_143[0] = _zz_142;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
-  assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
-  assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
-  assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
+  assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && (! 1'b0));
+  assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
+  always @ (*) begin
+    BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
+    if(1'b0)begin
+      BranchPlugin_branchExceptionPort_valid = 1'b0;
+    end
+  end
+
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
-  assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
+  assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4052,16 +4110,18 @@ module VexRiscv (
     end
   end
 
-  assign _zz_136 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_137 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_138 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_144 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_145 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_146 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_139 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_140 = _zz_319[0];
+  assign _zz_147 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_148 = _zz_328[0];
+  assign _zz_149 = {CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid};
+  assign _zz_150 = _zz_330[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_223)begin
+    if(_zz_234)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -4071,7 +4131,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(_zz_236)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
     if(execute_arbitration_isFlushed)begin
@@ -4081,7 +4141,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(CfuPlugin_joinException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -4248,7 +4308,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_238)begin
+    if(_zz_247)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -4267,20 +4327,20 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_239)begin
+    if(_zz_248)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_240)begin
+    if(_zz_249)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_239)begin
+    if(_zz_248)begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_240)begin
+    if(_zz_249)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4295,14 +4355,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_238)begin
+    if(_zz_247)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_238)begin
+    if(_zz_247)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4311,7 +4371,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_252)
+    case(_zz_261)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -4325,7 +4385,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_241)
+    case(_zz_250)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4339,7 +4399,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_241)
+    case(_zz_250)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4358,12 +4418,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_321) + $signed(_zz_322));
+  assign writeBack_MulPlugin_result = ($signed(_zz_332) + $signed(_zz_333));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_218)begin
-      if(_zz_242)begin
+    if(_zz_229)begin
+      if(_zz_251)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -4371,7 +4431,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_243)begin
+    if(_zz_252)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -4382,99 +4442,125 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_326);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_337);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_141 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_141[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_327);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_328 : _zz_329);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_330[31:0];
-  assign _zz_142 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_143 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_144 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_151 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_151[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_338);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_339 : _zz_340);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_341[31:0];
+  assign _zz_152 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_153 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_154 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_145[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_145[31 : 0] = execute_RS1;
+    _zz_155[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_155[31 : 0] = execute_RS1;
   end
 
-  assign _zz_147 = (_zz_146 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_147 != 32'h0);
+  assign _zz_157 = (_zz_156 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_157 != 32'h0);
+  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
+  assign execute_CfuPlugin_functionsIds_0 = _zz_351;
+  assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
+  assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
+  assign _zz_158 = _zz_352[7];
   always @ (*) begin
-    debug_bus_cmd_ready = 1'b1;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_244)
-        6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
-            debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
-          end
-        end
-        default : begin
-        end
-      endcase
+    _zz_159[23] = _zz_158;
+    _zz_159[22] = _zz_158;
+    _zz_159[21] = _zz_158;
+    _zz_159[20] = _zz_158;
+    _zz_159[19] = _zz_158;
+    _zz_159[18] = _zz_158;
+    _zz_159[17] = _zz_158;
+    _zz_159[16] = _zz_158;
+    _zz_159[15] = _zz_158;
+    _zz_159[14] = _zz_158;
+    _zz_159[13] = _zz_158;
+    _zz_159[12] = _zz_158;
+    _zz_159[11] = _zz_158;
+    _zz_159[10] = _zz_158;
+    _zz_159[9] = _zz_158;
+    _zz_159[8] = _zz_158;
+    _zz_159[7] = _zz_158;
+    _zz_159[6] = _zz_158;
+    _zz_159[5] = _zz_158;
+    _zz_159[4] = _zz_158;
+    _zz_159[3] = _zz_158;
+    _zz_159[2] = _zz_158;
+    _zz_159[1] = _zz_158;
+    _zz_159[0] = _zz_158;
+  end
+
+  always @ (*) begin
+    case(execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : begin
+        _zz_160 = execute_RS2;
+      end
+      default : begin
+        _zz_160 = {_zz_159,execute_INSTRUCTION[31 : 24]};
+      end
+    endcase
+  end
+
+  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_160;
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_s2mPipe_rValid);
+  assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_s2mPipe_rValid);
+  assign memory_CfuPlugin_rsp_payload_response_ok = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_response_ok : CfuPlugin_bus_rsp_payload_response_ok);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  always @ (*) begin
+    CfuPlugin_joinException_valid = 1'b0;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      if(memory_arbitration_isValid)begin
+        CfuPlugin_joinException_valid = (! memory_CfuPlugin_rsp_payload_response_ok);
+      end
     end
   end
 
+  assign CfuPlugin_joinException_payload_code = 4'b1111;
+  assign CfuPlugin_joinException_payload_badAddr = 32'h0;
   always @ (*) begin
-    debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_148))begin
-      debug_bus_rsp_data[0] = DebugPlugin_resetIt;
-      debug_bus_rsp_data[1] = DebugPlugin_haltIt;
-      debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
-      debug_bus_rsp_data[3] = DebugPlugin_haltedByBreak;
-      debug_bus_rsp_data[4] = DebugPlugin_stepIt;
+    memory_CfuPlugin_rsp_ready = 1'b0;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
     end
   end
 
-  always @ (*) begin
-    IBusCachedPlugin_injectionPort_valid = 1'b0;
-    if(debug_bus_cmd_valid)begin
-      case(_zz_244)
-        6'h01 : begin
-          if(debug_bus_cmd_payload_wr)begin
-            IBusCachedPlugin_injectionPort_valid = 1'b1;
-          end
-        end
-        default : begin
-        end
-      endcase
-    end
-  end
-
-  assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
-  assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_51 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_29 = decode_SRC1_CTRL;
+  assign _zz_27 = _zz_56;
+  assign _zz_43 = decode_to_execute_SRC1_CTRL;
+  assign _zz_26 = decode_ALU_CTRL;
+  assign _zz_24 = _zz_55;
+  assign _zz_44 = decode_to_execute_ALU_CTRL;
+  assign _zz_23 = decode_SRC2_CTRL;
+  assign _zz_21 = _zz_54;
+  assign _zz_42 = decode_to_execute_SRC2_CTRL;
+  assign _zz_20 = decode_ALU_BITWISE_CTRL;
+  assign _zz_18 = _zz_53;
+  assign _zz_45 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_17 = decode_SHIFT_CTRL;
+  assign _zz_14 = execute_SHIFT_CTRL;
+  assign _zz_15 = _zz_52;
+  assign _zz_40 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_39 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_12 = decode_BRANCH_CTRL;
+  assign _zz_58 = _zz_51;
+  assign _zz_36 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_10 = decode_ENV_CTRL;
+  assign _zz_7 = execute_ENV_CTRL;
+  assign _zz_5 = memory_ENV_CTRL;
+  assign _zz_8 = _zz_50;
+  assign _zz_34 = decode_to_execute_ENV_CTRL;
+  assign _zz_33 = execute_to_memory_ENV_CTRL;
+  assign _zz_35 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_3 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_1 = _zz_49;
+  assign _zz_32 = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4496,227 +4582,216 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_149)
-      3'b100 : begin
-        IBusCachedPlugin_injectionPort_ready = 1'b1;
-      end
-      default : begin
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    _zz_150 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_150[12 : 0] = 13'h1000;
-      _zz_150[25 : 20] = 6'h20;
-    end
-  end
-
-  always @ (*) begin
-    _zz_151 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_151[3 : 0] = 4'b1011;
-    end
-  end
-
-  always @ (*) begin
-    _zz_152 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_152[4 : 0] = 5'h16;
-    end
-  end
-
-  always @ (*) begin
-    _zz_153 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_153[5 : 0] = 6'h21;
-    end
-  end
-
-  always @ (*) begin
-    _zz_154 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_154[31 : 30] = CsrPlugin_misa_base;
-      _zz_154[25 : 0] = CsrPlugin_misa_extensions;
-    end
-  end
-
-  always @ (*) begin
-    _zz_155 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_155[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_155[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_155[3 : 3] = CsrPlugin_mstatus_MIE;
-    end
-  end
-
-  always @ (*) begin
-    _zz_156 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_156[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_156[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_156[3 : 3] = CsrPlugin_mip_MSIP;
-    end
-  end
-
-  always @ (*) begin
-    _zz_157 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_157[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_157[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_157[3 : 3] = CsrPlugin_mie_MSIE;
-    end
-  end
-
-  always @ (*) begin
-    _zz_158 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_158[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_158[1 : 0] = CsrPlugin_mtvec_mode;
-    end
-  end
-
-  always @ (*) begin
-    _zz_159 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_159[31 : 0] = CsrPlugin_mepc;
-    end
-  end
-
-  always @ (*) begin
-    _zz_160 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_160[31 : 0] = CsrPlugin_mscratch;
-    end
-  end
-
-  always @ (*) begin
     _zz_161 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_161[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_161[3 : 0] = CsrPlugin_mcause_exceptionCode;
+    if(execute_CsrPlugin_csr_3264)begin
+      _zz_161[12 : 0] = 13'h1000;
+      _zz_161[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
     _zz_162 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_162[31 : 0] = CsrPlugin_mtval;
+    if(execute_CsrPlugin_csr_3857)begin
+      _zz_162[3 : 0] = 4'b1011;
     end
   end
 
   always @ (*) begin
     _zz_163 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_163[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    if(execute_CsrPlugin_csr_3858)begin
+      _zz_163[4 : 0] = 5'h16;
     end
   end
 
   always @ (*) begin
     _zz_164 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_164[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    if(execute_CsrPlugin_csr_3859)begin
+      _zz_164[5 : 0] = 6'h21;
     end
   end
 
   always @ (*) begin
     _zz_165 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_165[31 : 0] = CsrPlugin_minstret[31 : 0];
+    if(execute_CsrPlugin_csr_769)begin
+      _zz_165[31 : 30] = CsrPlugin_misa_base;
+      _zz_165[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
   always @ (*) begin
     _zz_166 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_166[31 : 0] = CsrPlugin_minstret[63 : 32];
+    if(execute_CsrPlugin_csr_768)begin
+      _zz_166[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_166[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_166[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
     _zz_167 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_167[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    if(execute_CsrPlugin_csr_836)begin
+      _zz_167[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_167[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_167[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
     _zz_168 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_168[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    if(execute_CsrPlugin_csr_772)begin
+      _zz_168[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_168[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_168[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
     _zz_169 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_169[31 : 0] = CsrPlugin_minstret[31 : 0];
+    if(execute_CsrPlugin_csr_773)begin
+      _zz_169[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_169[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
   always @ (*) begin
     _zz_170 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_170[31 : 0] = CsrPlugin_minstret[63 : 32];
+    if(execute_CsrPlugin_csr_833)begin
+      _zz_170[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
     _zz_171 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_171[31 : 0] = _zz_146;
+    if(execute_CsrPlugin_csr_832)begin
+      _zz_171[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
     _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_172[31 : 0] = _zz_147;
+    if(execute_CsrPlugin_csr_834)begin
+      _zz_172[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_172[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_150 | _zz_151) | (_zz_152 | _zz_153)) | ((_zz_539 | _zz_154) | (_zz_155 | _zz_156))) | (((_zz_157 | _zz_158) | (_zz_159 | _zz_160)) | ((_zz_161 | _zz_162) | (_zz_163 | _zz_164)))) | (((_zz_165 | _zz_166) | (_zz_167 | _zz_168)) | ((_zz_169 | _zz_170) | (_zz_171 | _zz_172))));
-  assign iBusWishbone_ADR = {_zz_347,_zz_173};
-  assign iBusWishbone_CTI = ((_zz_173 == 3'b111) ? 3'b111 : 3'b010);
+  always @ (*) begin
+    _zz_173 = 32'h0;
+    if(execute_CsrPlugin_csr_835)begin
+      _zz_173[31 : 0] = CsrPlugin_mtval;
+    end
+  end
+
+  always @ (*) begin
+    _zz_174 = 32'h0;
+    if(execute_CsrPlugin_csr_2816)begin
+      _zz_174[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    end
+  end
+
+  always @ (*) begin
+    _zz_175 = 32'h0;
+    if(execute_CsrPlugin_csr_2944)begin
+      _zz_175[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    end
+  end
+
+  always @ (*) begin
+    _zz_176 = 32'h0;
+    if(execute_CsrPlugin_csr_2818)begin
+      _zz_176[31 : 0] = CsrPlugin_minstret[31 : 0];
+    end
+  end
+
+  always @ (*) begin
+    _zz_177 = 32'h0;
+    if(execute_CsrPlugin_csr_2946)begin
+      _zz_177[31 : 0] = CsrPlugin_minstret[63 : 32];
+    end
+  end
+
+  always @ (*) begin
+    _zz_178 = 32'h0;
+    if(execute_CsrPlugin_csr_3072)begin
+      _zz_178[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    end
+  end
+
+  always @ (*) begin
+    _zz_179 = 32'h0;
+    if(execute_CsrPlugin_csr_3200)begin
+      _zz_179[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    end
+  end
+
+  always @ (*) begin
+    _zz_180 = 32'h0;
+    if(execute_CsrPlugin_csr_3074)begin
+      _zz_180[31 : 0] = CsrPlugin_minstret[31 : 0];
+    end
+  end
+
+  always @ (*) begin
+    _zz_181 = 32'h0;
+    if(execute_CsrPlugin_csr_3202)begin
+      _zz_181[31 : 0] = CsrPlugin_minstret[63 : 32];
+    end
+  end
+
+  always @ (*) begin
+    _zz_182 = 32'h0;
+    if(execute_CsrPlugin_csr_3008)begin
+      _zz_182[31 : 0] = _zz_156;
+    end
+  end
+
+  always @ (*) begin
+    _zz_183 = 32'h0;
+    if(execute_CsrPlugin_csr_4032)begin
+      _zz_183[31 : 0] = _zz_157;
+    end
+  end
+
+  assign execute_CsrPlugin_readData = (((((_zz_161 | _zz_162) | (_zz_163 | _zz_164)) | ((_zz_555 | _zz_165) | (_zz_166 | _zz_167))) | (((_zz_168 | _zz_169) | (_zz_170 | _zz_171)) | ((_zz_172 | _zz_173) | (_zz_174 | _zz_175)))) | (((_zz_176 | _zz_177) | (_zz_178 | _zz_179)) | ((_zz_180 | _zz_181) | (_zz_182 | _zz_183))));
+  assign iBusWishbone_ADR = {_zz_360,_zz_184};
+  assign iBusWishbone_CTI = ((_zz_184 == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_245)begin
+    if(_zz_253)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_245)begin
+    if(_zz_253)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_174;
+  assign iBus_rsp_valid = _zz_185;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_180 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_176 = dBus_cmd_valid;
-  assign _zz_178 = dBus_cmd_payload_wr;
-  assign _zz_179 = (_zz_175 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_177 && (_zz_178 || _zz_179));
-  assign dBusWishbone_ADR = ((_zz_180 ? {{dBus_cmd_payload_address[31 : 5],_zz_175},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_180 ? (_zz_179 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_191 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_187 = dBus_cmd_valid;
+  assign _zz_189 = dBus_cmd_payload_wr;
+  assign _zz_190 = (_zz_186 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_188 && (_zz_189 || _zz_190));
+  assign dBusWishbone_ADR = ((_zz_191 ? {{dBus_cmd_payload_address[31 : 5],_zz_186},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_191 ? (_zz_190 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_178 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_178;
+  assign dBusWishbone_SEL = (_zz_189 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_189;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_177 = (_zz_176 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_176;
-  assign dBusWishbone_STB = _zz_176;
-  assign dBus_rsp_valid = _zz_181;
+  assign _zz_188 = (_zz_187 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_187;
+  assign dBusWishbone_STB = _zz_187;
+  assign dBus_rsp_valid = _zz_192;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -4725,21 +4800,21 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_65 <= 1'b0;
-      _zz_67 <= 1'b0;
+      _zz_71 <= 1'b0;
+      _zz_73 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_80;
+      IBusCachedPlugin_rspCounter <= _zz_86;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_81;
+      DBusCachedPlugin_rspCounter <= _zz_87;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_99 <= 1'b1;
-      _zz_111 <= 1'b0;
+      _zz_107 <= 1'b1;
+      _zz_119 <= 1'b0;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4760,15 +4835,18 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_146 <= 32'h0;
+      _zz_156 <= 32'h0;
+      execute_CfuPlugin_hold <= 1'b0;
+      execute_CfuPlugin_fired <= 1'b0;
+      CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_149 <= 3'b000;
-      _zz_173 <= 3'b000;
-      _zz_174 <= 1'b0;
-      _zz_175 <= 3'b000;
-      _zz_181 <= 1'b0;
+      execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
+      _zz_184 <= 3'b000;
+      _zz_185 <= 1'b0;
+      _zz_186 <= 3'b000;
+      _zz_192 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -4790,16 +4868,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65 <= 1'b0;
+        _zz_71 <= 1'b0;
       end
-      if(_zz_63)begin
-        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_69)begin
+        _zz_71 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67 <= 1'b0;
+        _zz_73 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_73 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -4849,7 +4927,7 @@ module VexRiscv (
       if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_246)begin
+      if(_zz_254)begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
       if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
@@ -4858,8 +4936,8 @@ module VexRiscv (
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_99 <= 1'b0;
-      _zz_111 <= (_zz_41 && writeBack_arbitration_isFiring);
+      _zz_107 <= 1'b0;
+      _zz_119 <= (_zz_47 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -4881,14 +4959,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_247)begin
-        if(_zz_248)begin
+      if(_zz_255)begin
+        if(_zz_256)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_249)begin
+        if(_zz_257)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_250)begin
+        if(_zz_258)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -4913,7 +4991,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_227)begin
+      if(_zz_237)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4924,8 +5002,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_228)begin
-        case(_zz_230)
+      if(_zz_238)begin
+        case(_zz_239)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4935,8 +5013,29 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_138,{_zz_137,_zz_136}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_146,{_zz_145,_zz_144}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
+      if(execute_CfuPlugin_schedule)begin
+        execute_CfuPlugin_hold <= 1'b1;
+      end
+      if(CfuPlugin_bus_cmd_ready)begin
+        execute_CfuPlugin_hold <= 1'b0;
+      end
+      if((CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready))begin
+        execute_CfuPlugin_fired <= 1'b1;
+      end
+      if((! execute_arbitration_isStuckByOthers))begin
+        execute_CfuPlugin_fired <= 1'b0;
+      end
+      if(memory_CfuPlugin_rsp_ready)begin
+        CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
+      end
+      if(_zz_259)begin
+        CfuPlugin_bus_rsp_s2mPipe_rValid <= CfuPlugin_bus_rsp_valid;
+      end
+      if((! memory_arbitration_isStuck))begin
+        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_31;
+      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -4955,29 +5054,6 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_149)
-        3'b000 : begin
-          if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_149 <= 3'b001;
-          end
-        end
-        3'b001 : begin
-          _zz_149 <= 3'b010;
-        end
-        3'b010 : begin
-          _zz_149 <= 3'b011;
-        end
-        3'b011 : begin
-          if((! decode_arbitration_isStuck))begin
-            _zz_149 <= 3'b100;
-          end
-        end
-        3'b100 : begin
-          _zz_149 <= 3'b000;
-        end
-        default : begin
-        end
-      endcase
       if(execute_CsrPlugin_csr_769)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
@@ -4987,41 +5063,41 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_340[0];
-          CsrPlugin_mstatus_MIE <= _zz_341[0];
+          CsrPlugin_mstatus_MPIE <= _zz_353[0];
+          CsrPlugin_mstatus_MIE <= _zz_354[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_343[0];
-          CsrPlugin_mie_MTIE <= _zz_344[0];
-          CsrPlugin_mie_MSIE <= _zz_345[0];
+          CsrPlugin_mie_MEIE <= _zz_356[0];
+          CsrPlugin_mie_MTIE <= _zz_357[0];
+          CsrPlugin_mie_MSIE <= _zz_358[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_146 <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_156 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_245)begin
+      if(_zz_253)begin
         if(iBusWishbone_ACK)begin
-          _zz_173 <= (_zz_173 + 3'b001);
+          _zz_184 <= (_zz_184 + 3'b001);
         end
       end
-      _zz_174 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_176 && _zz_177))begin
-        _zz_175 <= (_zz_175 + 3'b001);
-        if(_zz_179)begin
-          _zz_175 <= 3'b000;
+      _zz_185 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_187 && _zz_188))begin
+        _zz_186 <= (_zz_186 + 3'b001);
+        if(_zz_190)begin
+          _zz_186 <= 3'b000;
         end
       end
-      _zz_181 <= ((_zz_176 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_192 <= ((_zz_187 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_68 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_74 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -5029,7 +5105,7 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_246)begin
+    if(_zz_254)begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
@@ -5047,8 +5123,8 @@ module VexRiscv (
       dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
       dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_112 <= _zz_40[11 : 7];
-    _zz_113 <= _zz_50;
+    _zz_120 <= _zz_46[11 : 7];
+    _zz_121 <= _zz_57;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -5056,37 +5132,37 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_223)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_234)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_148 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_148 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
+    if(_zz_236)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_150 ? BranchPlugin_branchExceptionPort_payload_code : CsrPlugin_selfException_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_150 ? BranchPlugin_branchExceptionPort_payload_badAddr : CsrPlugin_selfException_payload_badAddr);
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
+    if(CfuPlugin_joinException_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CfuPlugin_joinException_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CfuPlugin_joinException_payload_badAddr;
     end
     if(DBusCachedPlugin_exceptionBus_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_247)begin
-      if(_zz_248)begin
+    if(_zz_255)begin
+      if(_zz_256)begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_249)begin
+      if(_zz_257)begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_250)begin
+      if(_zz_258)begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_227)begin
+    if(_zz_237)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5106,27 +5182,31 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_218)begin
-      if(_zz_242)begin
+    if(_zz_229)begin
+      if(_zz_251)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_331[31:0];
+          memory_DivPlugin_div_result <= _zz_342[31:0];
         end
       end
     end
-    if(_zz_243)begin
+    if(_zz_252)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_144 ? (~ _zz_145) : _zz_145) + _zz_337);
-      memory_DivPlugin_rs2 <= ((_zz_143 ? (~ execute_RS2) : execute_RS2) + _zz_339);
-      memory_DivPlugin_div_needRevert <= ((_zz_144 ^ (_zz_143 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_154 ? (~ _zz_155) : _zz_155) + _zz_348);
+      memory_DivPlugin_rs2 <= ((_zz_153 ? (~ execute_RS2) : execute_RS2) + _zz_350);
+      memory_DivPlugin_div_needRevert <= ((_zz_154 ^ (_zz_153 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
+    if(_zz_259)begin
+      CfuPlugin_bus_rsp_s2mPipe_rData_response_ok <= CfuPlugin_bus_rsp_payload_response_ok;
+      CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
+    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+      execute_to_memory_PC <= _zz_41;
     end
     if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5141,19 +5221,19 @@ module VexRiscv (
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_60;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_59;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
+      memory_to_writeBack_FORMAL_PC_NEXT <= memory_FORMAL_PC_NEXT;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+      decode_to_execute_SRC1_CTRL <= _zz_28;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
@@ -5168,10 +5248,10 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+      decode_to_execute_ALU_CTRL <= _zz_25;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+      decode_to_execute_SRC2_CTRL <= _zz_22;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
@@ -5207,28 +5287,28 @@ module VexRiscv (
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_19;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+      decode_to_execute_SHIFT_CTRL <= _zz_16;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+      execute_to_memory_SHIFT_CTRL <= _zz_13;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+      decode_to_execute_BRANCH_CTRL <= _zz_11;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+      decode_to_execute_ENV_CTRL <= _zz_9;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+      execute_to_memory_ENV_CTRL <= _zz_6;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+      memory_to_writeBack_ENV_CTRL <= _zz_4;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
@@ -5252,6 +5332,12 @@ module VexRiscv (
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_2;
+    end
+    if((! execute_arbitration_isStuck))begin
       decode_to_execute_RS1 <= decode_RS1;
     end
     if((! execute_arbitration_isStuck))begin
@@ -5269,9 +5355,6 @@ module VexRiscv (
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
-    end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
@@ -5279,19 +5362,13 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_37;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_38;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
@@ -5307,6 +5384,9 @@ module VexRiscv (
     end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_30;
     end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
@@ -5385,7 +5465,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_342[0];
+        CsrPlugin_mip_MSIP <= _zz_355[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -5406,7 +5486,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_834)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_346[0];
+        CsrPlugin_mcause_interrupt <= _zz_359[0];
         CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -5437,77 +5517,6 @@ module VexRiscv (
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
-  end
-
-  always @ (posedge clk) begin
-    DebugPlugin_firstCycle <= 1'b0;
-    if(debug_bus_cmd_ready)begin
-      DebugPlugin_firstCycle <= 1'b1;
-    end
-    DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
-    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
-    if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50;
-    end
-    _zz_148 <= debug_bus_cmd_payload_address[2];
-    if(_zz_225)begin
-      DebugPlugin_busReadDataReg <= execute_PC;
-    end
-    DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
-  end
-
-  always @ (posedge clk) begin
-    if(debugReset) begin
-      DebugPlugin_resetIt <= 1'b0;
-      DebugPlugin_haltIt <= 1'b0;
-      DebugPlugin_stepIt <= 1'b0;
-      DebugPlugin_godmode <= 1'b0;
-      DebugPlugin_haltedByBreak <= 1'b0;
-    end else begin
-      if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
-        DebugPlugin_godmode <= 1'b1;
-      end
-      if(debug_bus_cmd_valid)begin
-        case(_zz_244)
-          6'h0 : begin
-            if(debug_bus_cmd_payload_wr)begin
-              DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
-              if(debug_bus_cmd_payload_data[16])begin
-                DebugPlugin_resetIt <= 1'b1;
-              end
-              if(debug_bus_cmd_payload_data[24])begin
-                DebugPlugin_resetIt <= 1'b0;
-              end
-              if(debug_bus_cmd_payload_data[17])begin
-                DebugPlugin_haltIt <= 1'b1;
-              end
-              if(debug_bus_cmd_payload_data[25])begin
-                DebugPlugin_haltIt <= 1'b0;
-              end
-              if(debug_bus_cmd_payload_data[25])begin
-                DebugPlugin_haltedByBreak <= 1'b0;
-              end
-              if(debug_bus_cmd_payload_data[25])begin
-                DebugPlugin_godmode <= 1'b0;
-              end
-            end
-          end
-          default : begin
-          end
-        endcase
-      end
-      if(_zz_225)begin
-        if(_zz_226)begin
-          DebugPlugin_haltIt <= 1'b1;
-          DebugPlugin_haltedByBreak <= 1'b1;
-        end
-      end
-      if(_zz_229)begin
-        if(decode_arbitration_isValid)begin
-          DebugPlugin_haltIt <= 1'b1;
-        end
-      end
-    end
   end
 
 
@@ -6353,18 +6362,16 @@ module InstructionCache (
   input               io_mem_rsp_valid,
   input      [31:0]   io_mem_rsp_payload_data,
   input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_9,
-  input      [31:0]   _zz_10,
   input               clk,
   input               reset
 );
-  reg        [31:0]   _zz_11;
-  reg        [21:0]   _zz_12;
-  wire                _zz_13;
-  wire                _zz_14;
-  wire       [0:0]    _zz_15;
-  wire       [0:0]    _zz_16;
-  wire       [21:0]   _zz_17;
+  reg        [31:0]   _zz_9;
+  reg        [21:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [21:0]   _zz_15;
   reg                 _zz_1;
   reg                 _zz_2;
   reg                 lineLoader_fire;
@@ -6418,11 +6425,11 @@ module InstructionCache (
   (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
   (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
 
-  assign _zz_13 = (! lineLoader_flushCounter[7]);
-  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_15 = _zz_8[0 : 0];
-  assign _zz_16 = _zz_8[1 : 1];
-  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  assign _zz_11 = (! lineLoader_flushCounter[7]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
   always @ (posedge clk) begin
     if(_zz_1) begin
       banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
@@ -6431,19 +6438,19 @@ module InstructionCache (
 
   always @ (posedge clk) begin
     if(_zz_5) begin
-      _zz_11 <= banks_0[_zz_4];
+      _zz_9 <= banks_0[_zz_4];
     end
   end
 
   always @ (posedge clk) begin
     if(_zz_2) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
     end
   end
 
   always @ (posedge clk) begin
     if(_zz_7) begin
-      _zz_12 <= ways_0_tags[_zz_6];
+      _zz_10 <= ways_0_tags[_zz_6];
     end
   end
 
@@ -6472,7 +6479,7 @@ module InstructionCache (
 
   always @ (*) begin
     io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_13)begin
+    if(_zz_11)begin
       io_cpu_prefetch_haltIt = 1'b1;
     end
     if((! _zz_3))begin
@@ -6506,13 +6513,13 @@ module InstructionCache (
   assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
   assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
   assign _zz_5 = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
   assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
   assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
   assign _zz_7 = (! io_cpu_fetch_isStuck);
-  assign _zz_8 = _zz_12;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
   assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
   assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
   assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
@@ -6547,7 +6554,7 @@ module InstructionCache (
       if(io_flush)begin
         lineLoader_flushPending <= 1'b1;
       end
-      if(_zz_14)begin
+      if(_zz_12)begin
         lineLoader_flushPending <= 1'b0;
       end
       if((io_mem_cmd_valid && io_mem_cmd_ready))begin
@@ -6569,11 +6576,11 @@ module InstructionCache (
     if(io_cpu_fill_valid)begin
       lineLoader_address <= io_cpu_fill_payload;
     end
-    if(_zz_13)begin
+    if(_zz_11)begin
       lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
     end
     _zz_3 <= lineLoader_flushCounter[7];
-    if(_zz_14)begin
+    if(_zz_12)begin
       lineLoader_flushCounter <= 8'h0;
     end
     if((! io_cpu_decode_isStuck))begin
@@ -6595,9 +6602,6 @@ module InstructionCache (
     end
     if((! io_cpu_decode_isStuck))begin
       decodeStage_hit_error <= fetchStage_hit_error;
-    end
-    if((_zz_9 != 3'b000))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_10;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfu.yaml
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfu.yaml
@@ -1,0 +1,4 @@
+iBus: !!vexriscv.BusReport
+  flushInstructions: [4111, 19, 19, 19]
+  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 4096}
+  kind: cached

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfuDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfuDebug.v
@@ -3,6 +3,10 @@
 // Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
 
+`define Input2Kind_defaultEncoding_type [0:0]
+`define Input2Kind_defaultEncoding_RS 1'b0
+`define Input2Kind_defaultEncoding_IMM_I 1'b1
+
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
 `define EnvCtrlEnum_defaultEncoding_XRET 2'b01
@@ -56,6 +60,15 @@ module VexRiscv (
   input      [31:0]   debug_bus_cmd_payload_data,
   output reg [31:0]   debug_bus_rsp_data,
   output              debug_resetOut,
+  output              CfuPlugin_bus_cmd_valid,
+  input               CfuPlugin_bus_cmd_ready,
+  output     [9:0]    CfuPlugin_bus_cmd_payload_function_id,
+  output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_0,
+  output     [31:0]   CfuPlugin_bus_cmd_payload_inputs_1,
+  input               CfuPlugin_bus_rsp_valid,
+  output              CfuPlugin_bus_rsp_ready,
+  input               CfuPlugin_bus_rsp_payload_response_ok,
+  input      [31:0]   CfuPlugin_bus_rsp_payload_outputs_0,
   output reg          iBusWishbone_CYC,
   output reg          iBusWishbone_STB,
   input               iBusWishbone_ACK,
@@ -82,37 +95,37 @@ module VexRiscv (
   input               reset,
   input               debugReset
 );
-  wire                _zz_182;
-  wire                _zz_183;
-  wire                _zz_184;
-  wire                _zz_185;
-  wire                _zz_186;
-  wire                _zz_187;
-  wire                _zz_188;
-  wire                _zz_189;
-  reg                 _zz_190;
-  wire                _zz_191;
-  wire       [31:0]   _zz_192;
-  wire                _zz_193;
-  wire       [31:0]   _zz_194;
-  reg                 _zz_195;
   wire                _zz_196;
   wire                _zz_197;
-  wire       [31:0]   _zz_198;
+  wire                _zz_198;
   wire                _zz_199;
   wire                _zz_200;
   wire                _zz_201;
   wire                _zz_202;
   wire                _zz_203;
-  wire                _zz_204;
+  reg                 _zz_204;
   wire                _zz_205;
-  wire                _zz_206;
-  wire       [3:0]    _zz_207;
-  wire                _zz_208;
-  wire                _zz_209;
-  reg        [31:0]   _zz_210;
-  reg        [31:0]   _zz_211;
-  reg        [31:0]   _zz_212;
+  wire       [31:0]   _zz_206;
+  wire                _zz_207;
+  wire       [31:0]   _zz_208;
+  reg                 _zz_209;
+  wire                _zz_210;
+  wire                _zz_211;
+  wire       [31:0]   _zz_212;
+  wire                _zz_213;
+  wire                _zz_214;
+  wire                _zz_215;
+  wire                _zz_216;
+  wire                _zz_217;
+  wire                _zz_218;
+  wire                _zz_219;
+  wire                _zz_220;
+  wire       [3:0]    _zz_221;
+  wire                _zz_222;
+  wire                _zz_223;
+  reg        [31:0]   _zz_224;
+  reg        [31:0]   _zz_225;
+  reg        [31:0]   _zz_226;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
@@ -145,24 +158,10 @@ module VexRiscv (
   wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
   wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
   wire                dataCache_1_io_mem_cmd_payload_last;
-  wire                _zz_213;
-  wire                _zz_214;
-  wire                _zz_215;
-  wire                _zz_216;
-  wire                _zz_217;
-  wire                _zz_218;
-  wire                _zz_219;
-  wire                _zz_220;
-  wire                _zz_221;
-  wire                _zz_222;
-  wire                _zz_223;
-  wire                _zz_224;
-  wire                _zz_225;
-  wire                _zz_226;
   wire                _zz_227;
   wire                _zz_228;
   wire                _zz_229;
-  wire       [1:0]    _zz_230;
+  wire                _zz_230;
   wire                _zz_231;
   wire                _zz_232;
   wire                _zz_233;
@@ -173,313 +172,339 @@ module VexRiscv (
   wire                _zz_238;
   wire                _zz_239;
   wire                _zz_240;
-  wire       [1:0]    _zz_241;
+  wire                _zz_241;
   wire                _zz_242;
   wire                _zz_243;
-  wire       [5:0]    _zz_244;
-  wire                _zz_245;
+  wire                _zz_244;
+  wire       [1:0]    _zz_245;
   wire                _zz_246;
   wire                _zz_247;
   wire                _zz_248;
   wire                _zz_249;
   wire                _zz_250;
-  wire       [1:0]    _zz_251;
+  wire                _zz_251;
   wire                _zz_252;
-  wire       [1:0]    _zz_253;
-  wire       [51:0]   _zz_254;
-  wire       [51:0]   _zz_255;
-  wire       [51:0]   _zz_256;
-  wire       [32:0]   _zz_257;
-  wire       [51:0]   _zz_258;
-  wire       [49:0]   _zz_259;
-  wire       [51:0]   _zz_260;
-  wire       [49:0]   _zz_261;
-  wire       [51:0]   _zz_262;
-  wire       [32:0]   _zz_263;
-  wire       [31:0]   _zz_264;
-  wire       [32:0]   _zz_265;
-  wire       [0:0]    _zz_266;
-  wire       [0:0]    _zz_267;
-  wire       [0:0]    _zz_268;
-  wire       [0:0]    _zz_269;
-  wire       [0:0]    _zz_270;
-  wire       [0:0]    _zz_271;
-  wire       [0:0]    _zz_272;
-  wire       [0:0]    _zz_273;
-  wire       [0:0]    _zz_274;
-  wire       [0:0]    _zz_275;
-  wire       [0:0]    _zz_276;
-  wire       [0:0]    _zz_277;
-  wire       [0:0]    _zz_278;
-  wire       [0:0]    _zz_279;
-  wire       [0:0]    _zz_280;
-  wire       [0:0]    _zz_281;
+  wire                _zz_253;
+  wire                _zz_254;
+  wire                _zz_255;
+  wire       [1:0]    _zz_256;
+  wire                _zz_257;
+  wire                _zz_258;
+  wire       [5:0]    _zz_259;
+  wire                _zz_260;
+  wire                _zz_261;
+  wire                _zz_262;
+  wire                _zz_263;
+  wire                _zz_264;
+  wire                _zz_265;
+  wire                _zz_266;
+  wire       [1:0]    _zz_267;
+  wire                _zz_268;
+  wire       [1:0]    _zz_269;
+  wire       [51:0]   _zz_270;
+  wire       [51:0]   _zz_271;
+  wire       [51:0]   _zz_272;
+  wire       [32:0]   _zz_273;
+  wire       [51:0]   _zz_274;
+  wire       [49:0]   _zz_275;
+  wire       [51:0]   _zz_276;
+  wire       [49:0]   _zz_277;
+  wire       [51:0]   _zz_278;
+  wire       [32:0]   _zz_279;
+  wire       [31:0]   _zz_280;
+  wire       [32:0]   _zz_281;
   wire       [0:0]    _zz_282;
   wire       [0:0]    _zz_283;
-  wire       [3:0]    _zz_284;
-  wire       [2:0]    _zz_285;
-  wire       [31:0]   _zz_286;
-  wire       [11:0]   _zz_287;
-  wire       [31:0]   _zz_288;
-  wire       [19:0]   _zz_289;
-  wire       [11:0]   _zz_290;
-  wire       [31:0]   _zz_291;
-  wire       [31:0]   _zz_292;
-  wire       [19:0]   _zz_293;
-  wire       [11:0]   _zz_294;
-  wire       [2:0]    _zz_295;
-  wire       [2:0]    _zz_296;
+  wire       [0:0]    _zz_284;
+  wire       [0:0]    _zz_285;
+  wire       [0:0]    _zz_286;
+  wire       [0:0]    _zz_287;
+  wire       [0:0]    _zz_288;
+  wire       [0:0]    _zz_289;
+  wire       [0:0]    _zz_290;
+  wire       [0:0]    _zz_291;
+  wire       [0:0]    _zz_292;
+  wire       [0:0]    _zz_293;
+  wire       [0:0]    _zz_294;
+  wire       [0:0]    _zz_295;
+  wire       [0:0]    _zz_296;
   wire       [0:0]    _zz_297;
-  wire       [2:0]    _zz_298;
-  wire       [4:0]    _zz_299;
-  wire       [11:0]   _zz_300;
-  wire       [11:0]   _zz_301;
-  wire       [31:0]   _zz_302;
+  wire       [0:0]    _zz_298;
+  wire       [0:0]    _zz_299;
+  wire       [0:0]    _zz_300;
+  wire       [3:0]    _zz_301;
+  wire       [2:0]    _zz_302;
   wire       [31:0]   _zz_303;
-  wire       [31:0]   _zz_304;
+  wire       [11:0]   _zz_304;
   wire       [31:0]   _zz_305;
-  wire       [31:0]   _zz_306;
-  wire       [31:0]   _zz_307;
+  wire       [19:0]   _zz_306;
+  wire       [11:0]   _zz_307;
   wire       [31:0]   _zz_308;
-  wire       [11:0]   _zz_309;
+  wire       [31:0]   _zz_309;
   wire       [19:0]   _zz_310;
   wire       [11:0]   _zz_311;
-  wire       [31:0]   _zz_312;
-  wire       [31:0]   _zz_313;
-  wire       [31:0]   _zz_314;
-  wire       [11:0]   _zz_315;
-  wire       [19:0]   _zz_316;
+  wire       [2:0]    _zz_312;
+  wire       [2:0]    _zz_313;
+  wire       [0:0]    _zz_314;
+  wire       [2:0]    _zz_315;
+  wire       [4:0]    _zz_316;
   wire       [11:0]   _zz_317;
-  wire       [2:0]    _zz_318;
-  wire       [1:0]    _zz_319;
-  wire       [1:0]    _zz_320;
-  wire       [65:0]   _zz_321;
-  wire       [65:0]   _zz_322;
+  wire       [11:0]   _zz_318;
+  wire       [31:0]   _zz_319;
+  wire       [31:0]   _zz_320;
+  wire       [31:0]   _zz_321;
+  wire       [31:0]   _zz_322;
   wire       [31:0]   _zz_323;
   wire       [31:0]   _zz_324;
-  wire       [0:0]    _zz_325;
-  wire       [5:0]    _zz_326;
-  wire       [32:0]   _zz_327;
-  wire       [31:0]   _zz_328;
+  wire       [31:0]   _zz_325;
+  wire       [11:0]   _zz_326;
+  wire       [19:0]   _zz_327;
+  wire       [11:0]   _zz_328;
   wire       [31:0]   _zz_329;
-  wire       [32:0]   _zz_330;
-  wire       [32:0]   _zz_331;
-  wire       [32:0]   _zz_332;
-  wire       [32:0]   _zz_333;
-  wire       [0:0]    _zz_334;
-  wire       [32:0]   _zz_335;
-  wire       [0:0]    _zz_336;
-  wire       [32:0]   _zz_337;
-  wire       [0:0]    _zz_338;
-  wire       [31:0]   _zz_339;
-  wire       [0:0]    _zz_340;
-  wire       [0:0]    _zz_341;
-  wire       [0:0]    _zz_342;
-  wire       [0:0]    _zz_343;
+  wire       [31:0]   _zz_330;
+  wire       [31:0]   _zz_331;
+  wire       [11:0]   _zz_332;
+  wire       [19:0]   _zz_333;
+  wire       [11:0]   _zz_334;
+  wire       [2:0]    _zz_335;
+  wire       [1:0]    _zz_336;
+  wire       [1:0]    _zz_337;
+  wire       [1:0]    _zz_338;
+  wire       [1:0]    _zz_339;
+  wire       [65:0]   _zz_340;
+  wire       [65:0]   _zz_341;
+  wire       [31:0]   _zz_342;
+  wire       [31:0]   _zz_343;
   wire       [0:0]    _zz_344;
-  wire       [0:0]    _zz_345;
-  wire       [0:0]    _zz_346;
-  wire       [26:0]   _zz_347;
-  wire                _zz_348;
-  wire                _zz_349;
-  wire       [1:0]    _zz_350;
-  wire       [31:0]   _zz_351;
-  wire       [31:0]   _zz_352;
-  wire       [31:0]   _zz_353;
-  wire                _zz_354;
+  wire       [5:0]    _zz_345;
+  wire       [32:0]   _zz_346;
+  wire       [31:0]   _zz_347;
+  wire       [31:0]   _zz_348;
+  wire       [32:0]   _zz_349;
+  wire       [32:0]   _zz_350;
+  wire       [32:0]   _zz_351;
+  wire       [32:0]   _zz_352;
+  wire       [0:0]    _zz_353;
+  wire       [32:0]   _zz_354;
   wire       [0:0]    _zz_355;
-  wire       [13:0]   _zz_356;
-  wire       [31:0]   _zz_357;
+  wire       [32:0]   _zz_356;
+  wire       [0:0]    _zz_357;
   wire       [31:0]   _zz_358;
-  wire       [31:0]   _zz_359;
-  wire                _zz_360;
+  wire       [9:0]    _zz_359;
+  wire       [7:0]    _zz_360;
   wire       [0:0]    _zz_361;
-  wire       [7:0]    _zz_362;
-  wire       [31:0]   _zz_363;
-  wire       [31:0]   _zz_364;
-  wire       [31:0]   _zz_365;
-  wire                _zz_366;
+  wire       [0:0]    _zz_362;
+  wire       [0:0]    _zz_363;
+  wire       [0:0]    _zz_364;
+  wire       [0:0]    _zz_365;
+  wire       [0:0]    _zz_366;
   wire       [0:0]    _zz_367;
-  wire       [1:0]    _zz_368;
+  wire       [26:0]   _zz_368;
   wire                _zz_369;
   wire                _zz_370;
-  wire                _zz_371;
+  wire       [1:0]    _zz_371;
   wire       [31:0]   _zz_372;
-  wire       [0:0]    _zz_373;
-  wire       [0:0]    _zz_374;
+  wire       [31:0]   _zz_373;
+  wire       [31:0]   _zz_374;
   wire                _zz_375;
   wire       [0:0]    _zz_376;
-  wire       [26:0]   _zz_377;
+  wire       [14:0]   _zz_377;
   wire       [31:0]   _zz_378;
-  wire                _zz_379;
-  wire                _zz_380;
+  wire       [31:0]   _zz_379;
+  wire       [31:0]   _zz_380;
   wire                _zz_381;
-  wire       [1:0]    _zz_382;
-  wire       [1:0]    _zz_383;
-  wire                _zz_384;
-  wire       [0:0]    _zz_385;
-  wire       [22:0]   _zz_386;
-  wire       [31:0]   _zz_387;
-  wire       [31:0]   _zz_388;
-  wire       [31:0]   _zz_389;
-  wire       [31:0]   _zz_390;
+  wire       [0:0]    _zz_382;
+  wire       [8:0]    _zz_383;
+  wire       [31:0]   _zz_384;
+  wire       [31:0]   _zz_385;
+  wire       [31:0]   _zz_386;
+  wire                _zz_387;
+  wire       [0:0]    _zz_388;
+  wire       [2:0]    _zz_389;
+  wire                _zz_390;
   wire                _zz_391;
   wire                _zz_392;
-  wire       [1:0]    _zz_393;
-  wire       [1:0]    _zz_394;
-  wire                _zz_395;
+  wire       [31:0]   _zz_393;
+  wire       [31:0]   _zz_394;
+  wire       [0:0]    _zz_395;
   wire       [0:0]    _zz_396;
-  wire       [19:0]   _zz_397;
-  wire       [31:0]   _zz_398;
-  wire       [31:0]   _zz_399;
+  wire                _zz_397;
+  wire       [0:0]    _zz_398;
+  wire       [27:0]   _zz_399;
   wire       [31:0]   _zz_400;
-  wire       [31:0]   _zz_401;
+  wire                _zz_401;
   wire                _zz_402;
-  wire       [0:0]    _zz_403;
-  wire       [0:0]    _zz_404;
-  wire                _zz_405;
-  wire       [0:0]    _zz_406;
+  wire                _zz_403;
+  wire       [1:0]    _zz_404;
+  wire       [1:0]    _zz_405;
+  wire                _zz_406;
   wire       [0:0]    _zz_407;
-  wire                _zz_408;
-  wire       [0:0]    _zz_409;
-  wire       [16:0]   _zz_410;
+  wire       [22:0]   _zz_408;
+  wire       [31:0]   _zz_409;
+  wire       [31:0]   _zz_410;
   wire       [31:0]   _zz_411;
   wire       [31:0]   _zz_412;
-  wire       [31:0]   _zz_413;
-  wire       [31:0]   _zz_414;
-  wire       [31:0]   _zz_415;
-  wire       [0:0]    _zz_416;
-  wire       [0:0]    _zz_417;
+  wire                _zz_413;
+  wire                _zz_414;
+  wire       [1:0]    _zz_415;
+  wire       [1:0]    _zz_416;
+  wire                _zz_417;
   wire       [0:0]    _zz_418;
-  wire       [0:0]    _zz_419;
-  wire                _zz_420;
-  wire       [0:0]    _zz_421;
-  wire       [13:0]   _zz_422;
+  wire       [19:0]   _zz_419;
+  wire       [31:0]   _zz_420;
+  wire       [31:0]   _zz_421;
+  wire       [31:0]   _zz_422;
   wire       [31:0]   _zz_423;
-  wire       [31:0]   _zz_424;
-  wire       [31:0]   _zz_425;
-  wire                _zz_426;
+  wire                _zz_424;
+  wire       [0:0]    _zz_425;
+  wire       [0:0]    _zz_426;
   wire                _zz_427;
   wire       [0:0]    _zz_428;
-  wire       [3:0]    _zz_429;
-  wire       [0:0]    _zz_430;
+  wire       [0:0]    _zz_429;
+  wire                _zz_430;
   wire       [0:0]    _zz_431;
-  wire                _zz_432;
-  wire       [0:0]    _zz_433;
-  wire       [10:0]   _zz_434;
+  wire       [16:0]   _zz_432;
+  wire       [31:0]   _zz_433;
+  wire       [31:0]   _zz_434;
   wire       [31:0]   _zz_435;
   wire       [31:0]   _zz_436;
   wire       [31:0]   _zz_437;
-  wire                _zz_438;
+  wire       [0:0]    _zz_438;
   wire       [0:0]    _zz_439;
   wire       [0:0]    _zz_440;
-  wire       [31:0]   _zz_441;
+  wire       [0:0]    _zz_441;
   wire                _zz_442;
   wire       [0:0]    _zz_443;
-  wire       [2:0]    _zz_444;
-  wire       [0:0]    _zz_445;
-  wire       [3:0]    _zz_446;
-  wire       [5:0]    _zz_447;
-  wire       [5:0]    _zz_448;
-  wire                _zz_449;
+  wire       [13:0]   _zz_444;
+  wire       [31:0]   _zz_445;
+  wire       [31:0]   _zz_446;
+  wire       [31:0]   _zz_447;
+  wire       [0:0]    _zz_448;
+  wire       [0:0]    _zz_449;
   wire       [0:0]    _zz_450;
-  wire       [7:0]    _zz_451;
-  wire       [31:0]   _zz_452;
-  wire       [31:0]   _zz_453;
-  wire       [31:0]   _zz_454;
-  wire       [31:0]   _zz_455;
-  wire       [31:0]   _zz_456;
+  wire       [3:0]    _zz_451;
+  wire       [0:0]    _zz_452;
+  wire       [0:0]    _zz_453;
+  wire                _zz_454;
+  wire       [0:0]    _zz_455;
+  wire       [10:0]   _zz_456;
   wire       [31:0]   _zz_457;
-  wire                _zz_458;
-  wire       [0:0]    _zz_459;
-  wire       [0:0]    _zz_460;
-  wire                _zz_461;
-  wire       [0:0]    _zz_462;
-  wire       [1:0]    _zz_463;
+  wire       [31:0]   _zz_458;
+  wire       [31:0]   _zz_459;
+  wire       [31:0]   _zz_460;
+  wire       [31:0]   _zz_461;
+  wire                _zz_462;
+  wire       [0:0]    _zz_463;
   wire       [0:0]    _zz_464;
-  wire       [3:0]    _zz_465;
-  wire       [0:0]    _zz_466;
+  wire       [31:0]   _zz_465;
+  wire                _zz_466;
   wire       [0:0]    _zz_467;
-  wire       [1:0]    _zz_468;
-  wire       [1:0]    _zz_469;
-  wire                _zz_470;
-  wire       [0:0]    _zz_471;
+  wire       [3:0]    _zz_468;
+  wire       [0:0]    _zz_469;
+  wire       [3:0]    _zz_470;
+  wire       [5:0]    _zz_471;
   wire       [5:0]    _zz_472;
-  wire       [31:0]   _zz_473;
-  wire       [31:0]   _zz_474;
-  wire       [31:0]   _zz_475;
+  wire                _zz_473;
+  wire       [0:0]    _zz_474;
+  wire       [7:0]    _zz_475;
   wire       [31:0]   _zz_476;
   wire       [31:0]   _zz_477;
   wire       [31:0]   _zz_478;
   wire       [31:0]   _zz_479;
   wire       [31:0]   _zz_480;
-  wire                _zz_481;
-  wire                _zz_482;
+  wire       [31:0]   _zz_481;
+  wire       [31:0]   _zz_482;
   wire       [31:0]   _zz_483;
-  wire       [31:0]   _zz_484;
-  wire                _zz_485;
-  wire       [0:0]    _zz_486;
-  wire       [1:0]    _zz_487;
-  wire       [31:0]   _zz_488;
-  wire       [31:0]   _zz_489;
-  wire                _zz_490;
-  wire                _zz_491;
+  wire       [0:0]    _zz_484;
+  wire       [1:0]    _zz_485;
+  wire                _zz_486;
+  wire       [0:0]    _zz_487;
+  wire       [1:0]    _zz_488;
+  wire       [0:0]    _zz_489;
+  wire       [3:0]    _zz_490;
+  wire       [0:0]    _zz_491;
   wire       [0:0]    _zz_492;
-  wire       [0:0]    _zz_493;
-  wire                _zz_494;
-  wire       [0:0]    _zz_495;
-  wire       [3:0]    _zz_496;
-  wire       [31:0]   _zz_497;
+  wire       [1:0]    _zz_493;
+  wire       [1:0]    _zz_494;
+  wire                _zz_495;
+  wire       [0:0]    _zz_496;
+  wire       [5:0]    _zz_497;
   wire       [31:0]   _zz_498;
   wire       [31:0]   _zz_499;
-  wire       [31:0]   _zz_500;
-  wire       [31:0]   _zz_501;
-  wire                _zz_502;
-  wire                _zz_503;
+  wire                _zz_500;
+  wire                _zz_501;
+  wire       [31:0]   _zz_502;
+  wire       [31:0]   _zz_503;
   wire       [31:0]   _zz_504;
-  wire       [31:0]   _zz_505;
-  wire       [31:0]   _zz_506;
+  wire                _zz_505;
+  wire                _zz_506;
   wire       [31:0]   _zz_507;
-  wire       [0:0]    _zz_508;
-  wire       [2:0]    _zz_509;
+  wire       [31:0]   _zz_508;
+  wire                _zz_509;
   wire       [0:0]    _zz_510;
-  wire       [0:0]    _zz_511;
-  wire                _zz_512;
-  wire       [0:0]    _zz_513;
-  wire       [1:0]    _zz_514;
-  wire       [31:0]   _zz_515;
-  wire       [31:0]   _zz_516;
-  wire       [31:0]   _zz_517;
+  wire       [1:0]    _zz_511;
+  wire       [31:0]   _zz_512;
+  wire       [31:0]   _zz_513;
+  wire                _zz_514;
+  wire                _zz_515;
+  wire       [0:0]    _zz_516;
+  wire       [0:0]    _zz_517;
   wire                _zz_518;
-  wire                _zz_519;
-  wire       [31:0]   _zz_520;
-  wire                _zz_521;
-  wire       [0:0]    _zz_522;
-  wire       [0:0]    _zz_523;
-  wire       [0:0]    _zz_524;
-  wire       [0:0]    _zz_525;
-  wire       [1:0]    _zz_526;
-  wire       [1:0]    _zz_527;
-  wire       [0:0]    _zz_528;
-  wire       [0:0]    _zz_529;
+  wire       [0:0]    _zz_519;
+  wire       [3:0]    _zz_520;
+  wire       [31:0]   _zz_521;
+  wire       [31:0]   _zz_522;
+  wire       [31:0]   _zz_523;
+  wire       [31:0]   _zz_524;
+  wire       [31:0]   _zz_525;
+  wire       [31:0]   _zz_526;
+  wire       [31:0]   _zz_527;
+  wire                _zz_528;
+  wire                _zz_529;
   wire       [31:0]   _zz_530;
   wire       [31:0]   _zz_531;
   wire       [31:0]   _zz_532;
   wire       [31:0]   _zz_533;
-  wire       [31:0]   _zz_534;
-  wire       [31:0]   _zz_535;
-  wire                _zz_536;
-  wire                _zz_537;
+  wire       [0:0]    _zz_534;
+  wire       [2:0]    _zz_535;
+  wire       [0:0]    _zz_536;
+  wire       [0:0]    _zz_537;
   wire                _zz_538;
-  wire       [31:0]   _zz_539;
+  wire       [0:0]    _zz_539;
+  wire       [1:0]    _zz_540;
+  wire       [31:0]   _zz_541;
+  wire       [31:0]   _zz_542;
+  wire       [31:0]   _zz_543;
+  wire                _zz_544;
+  wire                _zz_545;
+  wire       [31:0]   _zz_546;
+  wire                _zz_547;
+  wire       [0:0]    _zz_548;
+  wire       [0:0]    _zz_549;
+  wire       [0:0]    _zz_550;
+  wire       [0:0]    _zz_551;
+  wire       [1:0]    _zz_552;
+  wire       [1:0]    _zz_553;
+  wire       [0:0]    _zz_554;
+  wire       [0:0]    _zz_555;
+  wire       [31:0]   _zz_556;
+  wire       [31:0]   _zz_557;
+  wire       [31:0]   _zz_558;
+  wire       [31:0]   _zz_559;
+  wire       [31:0]   _zz_560;
+  wire       [31:0]   _zz_561;
+  wire                _zz_562;
+  wire                _zz_563;
+  wire                _zz_564;
+  wire       [31:0]   _zz_565;
   wire       [51:0]   memory_MUL_LOW;
+  wire                writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  wire                execute_CfuPlugin_CFU_IN_FLIGHT;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
   wire       [33:0]   execute_MUL_HL;
   wire       [33:0]   execute_MUL_LH;
   wire       [31:0]   execute_MUL_LL;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
   wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
@@ -489,33 +514,38 @@ module VexRiscv (
   wire                decode_CSR_WRITE_OPCODE;
   wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
+  wire       `Input2Kind_defaultEncoding_type decode_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       `Input2Kind_defaultEncoding_type _zz_1;
+  wire       `Input2Kind_defaultEncoding_type _zz_2;
+  wire       `Input2Kind_defaultEncoding_type _zz_3;
+  wire                decode_CfuPlugin_CFU_ENABLE;
   wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
   wire                decode_IS_DIV;
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
   wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10;
   wire                decode_IS_CSR;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_12;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
   wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_19;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_20;
   wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
@@ -524,23 +554,29 @@ module VexRiscv (
   wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_24;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_25;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_26;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_28;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_29;
   wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
   wire       [31:0]   memory_PC;
+  reg                 _zz_30;
+  reg                 _zz_31;
+  wire                memory_CfuPlugin_CFU_IN_FLIGHT;
+  wire       `Input2Kind_defaultEncoding_type execute_CfuPlugin_CFU_INPUT_2_KIND;
+  wire       `Input2Kind_defaultEncoding_type _zz_32;
+  wire                execute_CfuPlugin_CFU_ENABLE;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -557,22 +593,22 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_33;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_34;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
-  wire       [31:0]   memory_BRANCH_CALC;
-  wire                memory_BRANCH_DO;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_35;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_36;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31;
+  reg        [31:0]   _zz_37;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -582,43 +618,44 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32;
+  reg        [31:0]   _zz_38;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_39;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_40;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35;
+  wire       [31:0]   _zz_41;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_42;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_43;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_44;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
-  wire       [31:0]   _zz_40;
-  wire                _zz_41;
-  reg                 _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_45;
+  wire       [31:0]   _zz_46;
+  wire                _zz_47;
+  reg                 _zz_48;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
-  reg        [31:0]   _zz_50;
+  wire       `Input2Kind_defaultEncoding_type _zz_49;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_50;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_52;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_53;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_54;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_55;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_56;
+  reg        [31:0]   _zz_57;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
@@ -639,10 +676,10 @@ module VexRiscv (
   reg                 IBusCachedPlugin_rsp_issueDetected_2;
   reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_58;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_52;
-  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_59;
+  reg        [31:0]   _zz_60;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -755,13 +792,13 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_54;
+  reg                 _zz_61;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
   wire                BranchPlugin_jumpInterface_valid;
   wire       [31:0]   BranchPlugin_jumpInterface_payload;
-  wire                BranchPlugin_branchExceptionPort_valid;
+  reg                 BranchPlugin_branchExceptionPort_valid;
   wire       [3:0]    BranchPlugin_branchExceptionPort_payload_code;
   wire       [31:0]   BranchPlugin_branchExceptionPort_payload_badAddr;
   reg                 CsrPlugin_inWfi /* verilator public */ ;
@@ -784,14 +821,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injectionPort_valid;
   reg                 IBusCachedPlugin_injectionPort_ready;
   wire       [31:0]   IBusCachedPlugin_injectionPort_payload;
+  reg                 CfuPlugin_joinException_valid;
+  wire       [3:0]    CfuPlugin_joinException_payload_code;
+  wire       [31:0]   CfuPlugin_joinException_payload_badAddr;
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55;
-  wire       [3:0]    _zz_56;
-  wire                _zz_57;
-  wire                _zz_58;
-  wire                _zz_59;
+  wire       [3:0]    _zz_62;
+  wire       [3:0]    _zz_63;
+  wire                _zz_64;
+  wire                _zz_65;
+  wire                _zz_66;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -828,16 +868,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_60;
-  wire                _zz_61;
-  wire                _zz_62;
+  wire                _zz_67;
+  wire                _zz_68;
+  wire                _zz_69;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63;
-  wire                _zz_64;
-  reg                 _zz_65;
-  wire                _zz_66;
-  reg                 _zz_67;
-  reg        [31:0]   _zz_68;
+  wire                _zz_70;
+  wire                _zz_71;
+  reg                 _zz_72;
+  wire                _zz_73;
+  reg                 _zz_74;
+  reg        [31:0]   _zz_75;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -850,17 +890,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_69;
-  reg        [18:0]   _zz_70;
-  wire                _zz_71;
-  reg        [10:0]   _zz_72;
-  wire                _zz_73;
-  reg        [18:0]   _zz_74;
-  reg                 _zz_75;
   wire                _zz_76;
-  reg        [10:0]   _zz_77;
+  reg        [18:0]   _zz_77;
   wire                _zz_78;
-  reg        [18:0]   _zz_79;
+  reg        [10:0]   _zz_79;
+  wire                _zz_80;
+  reg        [18:0]   _zz_81;
+  reg                 _zz_82;
+  wire                _zz_83;
+  reg        [10:0]   _zz_84;
+  wire                _zz_85;
+  reg        [18:0]   _zz_86;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -868,7 +908,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_80;
+  wire       [31:0]   _zz_87;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -910,28 +950,30 @@ module VexRiscv (
   reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
   reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
   reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_81;
+  wire       [31:0]   _zz_88;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_82;
+  reg        [31:0]   _zz_89;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_83;
-  reg        [31:0]   _zz_84;
-  wire                _zz_85;
-  reg        [31:0]   _zz_86;
-  reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [32:0]   _zz_87;
-  wire                _zz_88;
-  wire                _zz_89;
   wire                _zz_90;
-  wire                _zz_91;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_92;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_93;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_94;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_95;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_96;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_97;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_98;
+  reg        [31:0]   _zz_91;
+  wire                _zz_92;
+  reg        [31:0]   _zz_93;
+  reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
+  wire       [34:0]   _zz_94;
+  wire                _zz_95;
+  wire                _zz_96;
+  wire                _zz_97;
+  wire                _zz_98;
+  wire                _zz_99;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_100;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_101;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_102;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_103;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_104;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_105;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_106;
+  wire       `Input2Kind_defaultEncoding_type _zz_107;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
@@ -939,52 +981,52 @@ module VexRiscv (
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
   reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
   reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_99;
+  reg                 _zz_108;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_100;
-  reg        [31:0]   _zz_101;
-  wire                _zz_102;
-  reg        [19:0]   _zz_103;
-  wire                _zz_104;
-  reg        [19:0]   _zz_105;
-  reg        [31:0]   _zz_106;
+  reg        [31:0]   _zz_109;
+  reg        [31:0]   _zz_110;
+  wire                _zz_111;
+  reg        [19:0]   _zz_112;
+  wire                _zz_113;
+  reg        [19:0]   _zz_114;
+  reg        [31:0]   _zz_115;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_107;
+  reg        [31:0]   _zz_116;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_108;
-  reg                 _zz_109;
-  reg                 _zz_110;
-  reg                 _zz_111;
-  reg        [4:0]    _zz_112;
-  reg        [31:0]   _zz_113;
-  wire                _zz_114;
-  wire                _zz_115;
-  wire                _zz_116;
-  wire                _zz_117;
-  wire                _zz_118;
-  wire                _zz_119;
-  wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_120;
-  reg                 _zz_121;
-  reg                 _zz_122;
+  reg        [31:0]   _zz_117;
+  reg                 _zz_118;
+  reg                 _zz_119;
+  reg                 _zz_120;
+  reg        [4:0]    _zz_121;
+  reg        [31:0]   _zz_122;
   wire                _zz_123;
-  reg        [19:0]   _zz_124;
+  wire                _zz_124;
   wire                _zz_125;
-  reg        [10:0]   _zz_126;
+  wire                _zz_126;
   wire                _zz_127;
-  reg        [18:0]   _zz_128;
-  reg                 _zz_129;
+  wire                _zz_128;
+  wire                execute_BranchPlugin_eq;
+  wire       [2:0]    _zz_129;
+  reg                 _zz_130;
+  reg                 _zz_131;
+  wire                _zz_132;
+  reg        [19:0]   _zz_133;
+  wire                _zz_134;
+  reg        [10:0]   _zz_135;
+  wire                _zz_136;
+  reg        [18:0]   _zz_137;
+  reg                 _zz_138;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_130;
-  reg        [19:0]   _zz_131;
-  wire                _zz_132;
-  reg        [10:0]   _zz_133;
-  wire                _zz_134;
-  reg        [18:0]   _zz_135;
+  wire                _zz_139;
+  reg        [19:0]   _zz_140;
+  wire                _zz_141;
+  reg        [10:0]   _zz_142;
+  wire                _zz_143;
+  reg        [18:0]   _zz_144;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -1006,9 +1048,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_136;
-  wire                _zz_137;
-  wire                _zz_138;
+  wire                _zz_145;
+  wire                _zz_146;
+  wire                _zz_147;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1021,8 +1063,10 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_139;
-  wire                _zz_140;
+  wire       [1:0]    _zz_148;
+  wire                _zz_149;
+  wire       [1:0]    _zz_150;
+  wire                _zz_151;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -1075,18 +1119,18 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_141;
+  wire       [31:0]   _zz_152;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_142;
-  wire                _zz_143;
-  wire                _zz_144;
-  reg        [32:0]   _zz_145;
+  wire       [31:0]   _zz_153;
+  wire                _zz_154;
+  wire                _zz_155;
+  reg        [32:0]   _zz_156;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_146;
-  wire       [31:0]   _zz_147;
+  reg        [31:0]   _zz_157;
+  wire       [31:0]   _zz_158;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1096,9 +1140,23 @@ module VexRiscv (
   reg                 DebugPlugin_godmode;
   reg                 DebugPlugin_haltedByBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_148;
+  reg                 _zz_159;
   wire                DebugPlugin_allowEBreak;
   reg                 DebugPlugin_resetIt_regNext;
+  wire                execute_CfuPlugin_schedule;
+  reg                 execute_CfuPlugin_hold;
+  reg                 execute_CfuPlugin_fired;
+  wire       [9:0]    execute_CfuPlugin_functionsIds_0;
+  wire                _zz_160;
+  reg        [23:0]   _zz_161;
+  reg        [31:0]   _zz_162;
+  wire                memory_CfuPlugin_rsp_valid;
+  reg                 memory_CfuPlugin_rsp_ready;
+  wire                memory_CfuPlugin_rsp_payload_response_ok;
+  wire       [31:0]   memory_CfuPlugin_rsp_payload_outputs_0;
+  reg                 CfuPlugin_bus_rsp_s2mPipe_rValid;
+  reg                 CfuPlugin_bus_rsp_s2mPipe_rData_response_ok;
+  reg        [31:0]   CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
@@ -1142,6 +1200,8 @@ module VexRiscv (
   reg                 execute_to_memory_IS_DIV;
   reg                 decode_to_execute_IS_RS1_SIGNED;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_CfuPlugin_CFU_ENABLE;
+  reg        `Input2Kind_defaultEncoding_type decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   reg        [31:0]   decode_to_execute_RS1;
   reg        [31:0]   decode_to_execute_RS2;
   reg                 decode_to_execute_SRC2_FORCE_ZERO;
@@ -1154,15 +1214,15 @@ module VexRiscv (
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
   reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
   reg        [31:0]   execute_to_memory_MUL_LL;
   reg        [33:0]   execute_to_memory_MUL_LH;
   reg        [33:0]   execute_to_memory_MUL_HL;
   reg        [33:0]   execute_to_memory_MUL_HH;
   reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg                 execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  reg                 memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
   reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [2:0]    _zz_149;
+  reg        [2:0]    _zz_163;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_3857;
   reg                 execute_CsrPlugin_csr_3858;
@@ -1187,20 +1247,6 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_3202;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_150;
-  reg        [31:0]   _zz_151;
-  reg        [31:0]   _zz_152;
-  reg        [31:0]   _zz_153;
-  reg        [31:0]   _zz_154;
-  reg        [31:0]   _zz_155;
-  reg        [31:0]   _zz_156;
-  reg        [31:0]   _zz_157;
-  reg        [31:0]   _zz_158;
-  reg        [31:0]   _zz_159;
-  reg        [31:0]   _zz_160;
-  reg        [31:0]   _zz_161;
-  reg        [31:0]   _zz_162;
-  reg        [31:0]   _zz_163;
   reg        [31:0]   _zz_164;
   reg        [31:0]   _zz_165;
   reg        [31:0]   _zz_166;
@@ -1210,86 +1256,108 @@ module VexRiscv (
   reg        [31:0]   _zz_170;
   reg        [31:0]   _zz_171;
   reg        [31:0]   _zz_172;
-  reg        [2:0]    _zz_173;
-  reg                 _zz_174;
+  reg        [31:0]   _zz_173;
+  reg        [31:0]   _zz_174;
+  reg        [31:0]   _zz_175;
+  reg        [31:0]   _zz_176;
+  reg        [31:0]   _zz_177;
+  reg        [31:0]   _zz_178;
+  reg        [31:0]   _zz_179;
+  reg        [31:0]   _zz_180;
+  reg        [31:0]   _zz_181;
+  reg        [31:0]   _zz_182;
+  reg        [31:0]   _zz_183;
+  reg        [31:0]   _zz_184;
+  reg        [31:0]   _zz_185;
+  reg        [31:0]   _zz_186;
+  reg        [2:0]    _zz_187;
+  reg                 _zz_188;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_175;
-  wire                _zz_176;
-  wire                _zz_177;
-  wire                _zz_178;
-  wire                _zz_179;
-  wire                _zz_180;
-  reg                 _zz_181;
+  reg        [2:0]    _zz_189;
+  wire                _zz_190;
+  wire                _zz_191;
+  wire                _zz_192;
+  wire                _zz_193;
+  wire                _zz_194;
+  reg                 _zz_195;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
+  reg [39:0] decode_CfuPlugin_CFU_INPUT_2_KIND_string;
   reg [39:0] _zz_1_string;
   reg [39:0] _zz_2_string;
   reg [39:0] _zz_3_string;
   reg [39:0] _zz_4_string;
-  reg [39:0] decode_ENV_CTRL_string;
   reg [39:0] _zz_5_string;
   reg [39:0] _zz_6_string;
   reg [39:0] _zz_7_string;
-  reg [31:0] _zz_8_string;
-  reg [31:0] _zz_9_string;
-  reg [71:0] _zz_10_string;
-  reg [71:0] _zz_11_string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12_string;
+  reg [39:0] decode_ENV_CTRL_string;
+  reg [39:0] _zz_8_string;
+  reg [39:0] _zz_9_string;
+  reg [39:0] _zz_10_string;
+  reg [31:0] _zz_11_string;
+  reg [31:0] _zz_12_string;
   reg [71:0] _zz_13_string;
   reg [71:0] _zz_14_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_15_string;
+  reg [71:0] _zz_16_string;
+  reg [71:0] _zz_17_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_15_string;
-  reg [39:0] _zz_16_string;
-  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_18_string;
+  reg [39:0] _zz_19_string;
+  reg [39:0] _zz_20_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_18_string;
-  reg [23:0] _zz_19_string;
-  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_21_string;
+  reg [23:0] _zz_22_string;
+  reg [23:0] _zz_23_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_21_string;
-  reg [63:0] _zz_22_string;
-  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_24_string;
+  reg [63:0] _zz_25_string;
+  reg [63:0] _zz_26_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_24_string;
-  reg [95:0] _zz_25_string;
-  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_27_string;
+  reg [95:0] _zz_28_string;
+  reg [95:0] _zz_29_string;
+  reg [39:0] execute_CfuPlugin_CFU_INPUT_2_KIND_string;
+  reg [39:0] _zz_32_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27_string;
+  reg [39:0] _zz_33_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28_string;
+  reg [39:0] _zz_34_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29_string;
+  reg [39:0] _zz_35_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30_string;
+  reg [31:0] _zz_36_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33_string;
+  reg [71:0] _zz_39_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34_string;
+  reg [71:0] _zz_40_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36_string;
+  reg [23:0] _zz_42_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37_string;
+  reg [95:0] _zz_43_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38_string;
+  reg [63:0] _zz_44_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39_string;
-  reg [39:0] _zz_43_string;
-  reg [31:0] _zz_44_string;
-  reg [71:0] _zz_45_string;
-  reg [39:0] _zz_46_string;
-  reg [23:0] _zz_47_string;
-  reg [63:0] _zz_48_string;
-  reg [95:0] _zz_49_string;
-  reg [31:0] decode_BRANCH_CTRL_string;
+  reg [39:0] _zz_45_string;
+  reg [39:0] _zz_49_string;
+  reg [39:0] _zz_50_string;
   reg [31:0] _zz_51_string;
-  reg [95:0] _zz_92_string;
-  reg [63:0] _zz_93_string;
-  reg [23:0] _zz_94_string;
-  reg [39:0] _zz_95_string;
-  reg [71:0] _zz_96_string;
-  reg [31:0] _zz_97_string;
-  reg [39:0] _zz_98_string;
+  reg [71:0] _zz_52_string;
+  reg [39:0] _zz_53_string;
+  reg [23:0] _zz_54_string;
+  reg [63:0] _zz_55_string;
+  reg [95:0] _zz_56_string;
+  reg [31:0] decode_BRANCH_CTRL_string;
+  reg [31:0] _zz_58_string;
+  reg [95:0] _zz_100_string;
+  reg [63:0] _zz_101_string;
+  reg [23:0] _zz_102_string;
+  reg [39:0] _zz_103_string;
+  reg [71:0] _zz_104_string;
+  reg [31:0] _zz_105_string;
+  reg [39:0] _zz_106_string;
+  reg [39:0] _zz_107_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
@@ -1300,363 +1368,376 @@ module VexRiscv (
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
+  reg [39:0] decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_213 = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_214 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_215 = 1'b1;
-  assign _zz_216 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_217 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_218 = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_219 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
-  assign _zz_220 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
-  assign _zz_221 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
-  assign _zz_222 = ((_zz_187 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_223 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
-  assign _zz_224 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_225 = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_226 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
-  assign _zz_227 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_228 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_229 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_230 = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_231 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_232 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_233 = (1'b0 || (! 1'b1));
-  assign _zz_234 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_235 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_236 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_237 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_238 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_239 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_240 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_241 = execute_INSTRUCTION[13 : 12];
-  assign _zz_242 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_243 = (! memory_arbitration_isStuck);
-  assign _zz_244 = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_245 = (iBus_cmd_valid || (_zz_173 != 3'b000));
-  assign _zz_246 = (_zz_209 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
-  assign _zz_247 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
-  assign _zz_248 = ((_zz_136 && 1'b1) && (! 1'b0));
-  assign _zz_249 = ((_zz_137 && 1'b1) && (! 1'b0));
-  assign _zz_250 = ((_zz_138 && 1'b1) && (! 1'b0));
-  assign _zz_251 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_252 = execute_INSTRUCTION[13];
-  assign _zz_253 = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_254 = ($signed(_zz_255) + $signed(_zz_260));
-  assign _zz_255 = ($signed(_zz_256) + $signed(_zz_258));
-  assign _zz_256 = 52'h0;
-  assign _zz_257 = {1'b0,memory_MUL_LL};
-  assign _zz_258 = {{19{_zz_257[32]}}, _zz_257};
-  assign _zz_259 = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_260 = {{2{_zz_259[49]}}, _zz_259};
-  assign _zz_261 = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_262 = {{2{_zz_261[49]}}, _zz_261};
-  assign _zz_263 = ($signed(_zz_265) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_264 = _zz_263[31 : 0];
-  assign _zz_265 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_266 = _zz_87[31 : 31];
-  assign _zz_267 = _zz_87[30 : 30];
-  assign _zz_268 = _zz_87[29 : 29];
-  assign _zz_269 = _zz_87[28 : 28];
-  assign _zz_270 = _zz_87[25 : 25];
-  assign _zz_271 = _zz_87[17 : 17];
-  assign _zz_272 = _zz_87[16 : 16];
-  assign _zz_273 = _zz_87[13 : 13];
-  assign _zz_274 = _zz_87[12 : 12];
-  assign _zz_275 = _zz_87[11 : 11];
-  assign _zz_276 = _zz_87[32 : 32];
-  assign _zz_277 = _zz_87[15 : 15];
-  assign _zz_278 = _zz_87[5 : 5];
-  assign _zz_279 = _zz_87[3 : 3];
-  assign _zz_280 = _zz_87[20 : 20];
-  assign _zz_281 = _zz_87[10 : 10];
-  assign _zz_282 = _zz_87[4 : 4];
-  assign _zz_283 = _zz_87[0 : 0];
-  assign _zz_284 = (_zz_55 - 4'b0001);
-  assign _zz_285 = {IBusCachedPlugin_fetchPc_inc,2'b00};
-  assign _zz_286 = {29'd0, _zz_285};
-  assign _zz_287 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_288 = {{_zz_70,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_289 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_290 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_291 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_292 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_293 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_294 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_295 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
-  assign _zz_296 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
-  assign _zz_297 = execute_SRC_LESS;
-  assign _zz_298 = 3'b100;
-  assign _zz_299 = execute_INSTRUCTION[19 : 15];
-  assign _zz_300 = execute_INSTRUCTION[31 : 20];
-  assign _zz_301 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_302 = ($signed(_zz_303) + $signed(_zz_306));
-  assign _zz_303 = ($signed(_zz_304) + $signed(_zz_305));
-  assign _zz_304 = execute_SRC1;
-  assign _zz_305 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_306 = (execute_SRC_USE_SUB_LESS ? _zz_307 : _zz_308);
-  assign _zz_307 = 32'h00000001;
-  assign _zz_308 = 32'h0;
-  assign _zz_309 = execute_INSTRUCTION[31 : 20];
-  assign _zz_310 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_311 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_312 = {_zz_124,execute_INSTRUCTION[31 : 20]};
-  assign _zz_313 = {{_zz_126,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_314 = {{_zz_128,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_315 = execute_INSTRUCTION[31 : 20];
-  assign _zz_316 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_317 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_318 = 3'b100;
-  assign _zz_319 = (_zz_139 & (~ _zz_320));
-  assign _zz_320 = (_zz_139 - 2'b01);
-  assign _zz_321 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_322 = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_323 = writeBack_MUL_LOW[31 : 0];
-  assign _zz_324 = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_325 = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_326 = {5'd0, _zz_325};
-  assign _zz_327 = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_328 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_329 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_330 = {_zz_141,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_331 = _zz_332;
-  assign _zz_332 = _zz_333;
-  assign _zz_333 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_142) : _zz_142)} + _zz_335);
-  assign _zz_334 = memory_DivPlugin_div_needRevert;
-  assign _zz_335 = {32'd0, _zz_334};
-  assign _zz_336 = _zz_144;
-  assign _zz_337 = {32'd0, _zz_336};
-  assign _zz_338 = _zz_143;
-  assign _zz_339 = {31'd0, _zz_338};
-  assign _zz_340 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_341 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_342 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_343 = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_344 = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_345 = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_346 = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_347 = (iBus_cmd_payload_address >>> 5);
-  assign _zz_348 = 1'b1;
-  assign _zz_349 = 1'b1;
-  assign _zz_350 = {_zz_59,_zz_58};
-  assign _zz_351 = 32'h0000107f;
-  assign _zz_352 = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_353 = 32'h00002073;
-  assign _zz_354 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_355 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_356 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_357) == 32'h00000003),{(_zz_358 == _zz_359),{_zz_360,{_zz_361,_zz_362}}}}}};
-  assign _zz_357 = 32'h0000505f;
-  assign _zz_358 = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_359 = 32'h00000063;
-  assign _zz_360 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_361 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_362 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_363) == 32'h00001013),{(_zz_364 == _zz_365),{_zz_366,{_zz_367,_zz_368}}}}}};
-  assign _zz_363 = 32'hfc00307f;
-  assign _zz_364 = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_365 = 32'h00005033;
-  assign _zz_366 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_367 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_368 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
-  assign _zz_369 = decode_INSTRUCTION[31];
-  assign _zz_370 = decode_INSTRUCTION[31];
-  assign _zz_371 = decode_INSTRUCTION[7];
-  assign _zz_372 = 32'h10103050;
-  assign _zz_373 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
-  assign _zz_374 = 1'b0;
-  assign _zz_375 = (((decode_INSTRUCTION & _zz_378) == 32'h02000030) != 1'b0);
-  assign _zz_376 = ({_zz_379,_zz_380} != 2'b00);
-  assign _zz_377 = {(_zz_381 != 1'b0),{(_zz_382 != _zz_383),{_zz_384,{_zz_385,_zz_386}}}};
-  assign _zz_378 = 32'h02004074;
-  assign _zz_379 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
-  assign _zz_380 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_381 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
-  assign _zz_382 = {(_zz_387 == _zz_388),(_zz_389 == _zz_390)};
-  assign _zz_383 = 2'b00;
-  assign _zz_384 = ({_zz_90,_zz_391} != 2'b00);
-  assign _zz_385 = (_zz_392 != 1'b0);
-  assign _zz_386 = {(_zz_393 != _zz_394),{_zz_395,{_zz_396,_zz_397}}};
-  assign _zz_387 = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_388 = 32'h00001050;
-  assign _zz_389 = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_390 = 32'h00002050;
-  assign _zz_391 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_392 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_393 = {(_zz_398 == _zz_399),(_zz_400 == _zz_401)};
-  assign _zz_394 = 2'b00;
-  assign _zz_395 = ({_zz_402,{_zz_403,_zz_404}} != 3'b000);
-  assign _zz_396 = (_zz_405 != 1'b0);
-  assign _zz_397 = {(_zz_406 != _zz_407),{_zz_408,{_zz_409,_zz_410}}};
-  assign _zz_398 = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_399 = 32'h00005010;
-  assign _zz_400 = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_401 = 32'h00005020;
-  assign _zz_402 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_403 = ((decode_INSTRUCTION & _zz_411) == 32'h00001010);
-  assign _zz_404 = ((decode_INSTRUCTION & _zz_412) == 32'h00001010);
-  assign _zz_405 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_406 = ((decode_INSTRUCTION & _zz_413) == 32'h00001000);
-  assign _zz_407 = 1'b0;
-  assign _zz_408 = ((_zz_414 == _zz_415) != 1'b0);
-  assign _zz_409 = ({_zz_416,_zz_417} != 2'b00);
-  assign _zz_410 = {(_zz_418 != _zz_419),{_zz_420,{_zz_421,_zz_422}}};
-  assign _zz_411 = 32'h00007034;
-  assign _zz_412 = 32'h02007054;
-  assign _zz_413 = 32'h00001000;
-  assign _zz_414 = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_415 = 32'h00002000;
-  assign _zz_416 = ((decode_INSTRUCTION & _zz_423) == 32'h00002000);
-  assign _zz_417 = ((decode_INSTRUCTION & _zz_424) == 32'h00001000);
-  assign _zz_418 = ((decode_INSTRUCTION & _zz_425) == 32'h00004008);
-  assign _zz_419 = 1'b0;
-  assign _zz_420 = ({_zz_426,_zz_427} != 2'b00);
-  assign _zz_421 = ({_zz_428,_zz_429} != 5'h0);
-  assign _zz_422 = {(_zz_430 != _zz_431),{_zz_432,{_zz_433,_zz_434}}};
-  assign _zz_423 = 32'h00002010;
-  assign _zz_424 = 32'h00005000;
-  assign _zz_425 = 32'h00004048;
-  assign _zz_426 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_427 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_428 = ((decode_INSTRUCTION & _zz_435) == 32'h00002040);
-  assign _zz_429 = {(_zz_436 == _zz_437),{_zz_438,{_zz_439,_zz_440}}};
-  assign _zz_430 = ((decode_INSTRUCTION & _zz_441) == 32'h00000020);
-  assign _zz_431 = 1'b0;
-  assign _zz_432 = ({_zz_442,{_zz_443,_zz_444}} != 5'h0);
-  assign _zz_433 = ({_zz_445,_zz_446} != 5'h0);
-  assign _zz_434 = {(_zz_447 != _zz_448),{_zz_449,{_zz_450,_zz_451}}};
-  assign _zz_435 = 32'h00002040;
-  assign _zz_436 = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_437 = 32'h00001040;
-  assign _zz_438 = ((decode_INSTRUCTION & _zz_452) == 32'h00000040);
-  assign _zz_439 = (_zz_453 == _zz_454);
-  assign _zz_440 = (_zz_455 == _zz_456);
-  assign _zz_441 = 32'h00000020;
-  assign _zz_442 = ((decode_INSTRUCTION & _zz_457) == 32'h00000040);
-  assign _zz_443 = _zz_89;
-  assign _zz_444 = {_zz_458,{_zz_459,_zz_460}};
-  assign _zz_445 = _zz_89;
-  assign _zz_446 = {_zz_461,{_zz_462,_zz_463}};
-  assign _zz_447 = {_zz_90,{_zz_464,_zz_465}};
-  assign _zz_448 = 6'h0;
-  assign _zz_449 = ({_zz_466,_zz_467} != 2'b00);
-  assign _zz_450 = (_zz_468 != _zz_469);
-  assign _zz_451 = {_zz_470,{_zz_471,_zz_472}};
-  assign _zz_452 = 32'h00100040;
-  assign _zz_453 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_454 = 32'h00000040;
-  assign _zz_455 = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_456 = 32'h0;
-  assign _zz_457 = 32'h00000040;
-  assign _zz_458 = ((decode_INSTRUCTION & _zz_473) == 32'h00004020);
-  assign _zz_459 = (_zz_474 == _zz_475);
-  assign _zz_460 = (_zz_476 == _zz_477);
-  assign _zz_461 = ((decode_INSTRUCTION & _zz_478) == 32'h00002010);
-  assign _zz_462 = (_zz_479 == _zz_480);
-  assign _zz_463 = {_zz_481,_zz_482};
-  assign _zz_464 = (_zz_483 == _zz_484);
-  assign _zz_465 = {_zz_485,{_zz_486,_zz_487}};
-  assign _zz_466 = _zz_89;
-  assign _zz_467 = (_zz_488 == _zz_489);
-  assign _zz_468 = {_zz_89,_zz_490};
-  assign _zz_469 = 2'b00;
-  assign _zz_470 = (_zz_491 != 1'b0);
-  assign _zz_471 = (_zz_492 != _zz_493);
-  assign _zz_472 = {_zz_494,{_zz_495,_zz_496}};
-  assign _zz_473 = 32'h00004020;
-  assign _zz_474 = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_475 = 32'h00000010;
-  assign _zz_476 = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_477 = 32'h00000020;
-  assign _zz_478 = 32'h00002030;
-  assign _zz_479 = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_480 = 32'h00000010;
-  assign _zz_481 = ((decode_INSTRUCTION & _zz_497) == 32'h00002020);
-  assign _zz_482 = ((decode_INSTRUCTION & _zz_498) == 32'h00000020);
-  assign _zz_483 = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_484 = 32'h00001010;
-  assign _zz_485 = ((decode_INSTRUCTION & _zz_499) == 32'h00002010);
-  assign _zz_486 = (_zz_500 == _zz_501);
-  assign _zz_487 = {_zz_502,_zz_503};
-  assign _zz_488 = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_489 = 32'h00000020;
-  assign _zz_490 = ((decode_INSTRUCTION & _zz_504) == 32'h0);
-  assign _zz_491 = ((decode_INSTRUCTION & _zz_505) == 32'h00004010);
-  assign _zz_492 = (_zz_506 == _zz_507);
-  assign _zz_493 = 1'b0;
-  assign _zz_494 = ({_zz_508,_zz_509} != 4'b0000);
-  assign _zz_495 = (_zz_510 != _zz_511);
-  assign _zz_496 = {_zz_512,{_zz_513,_zz_514}};
-  assign _zz_497 = 32'h02002060;
-  assign _zz_498 = 32'h02003020;
-  assign _zz_499 = 32'h00002010;
-  assign _zz_500 = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_501 = 32'h00000010;
-  assign _zz_502 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_503 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz_504 = 32'h00000020;
-  assign _zz_505 = 32'h00004014;
-  assign _zz_506 = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_507 = 32'h00002010;
-  assign _zz_508 = ((decode_INSTRUCTION & _zz_515) == 32'h0);
-  assign _zz_509 = {(_zz_516 == _zz_517),{_zz_518,_zz_519}};
-  assign _zz_510 = ((decode_INSTRUCTION & _zz_520) == 32'h0);
-  assign _zz_511 = 1'b0;
-  assign _zz_512 = ({_zz_521,{_zz_522,_zz_523}} != 3'b000);
-  assign _zz_513 = ({_zz_524,_zz_525} != 2'b00);
-  assign _zz_514 = {(_zz_526 != _zz_527),(_zz_528 != _zz_529)};
-  assign _zz_515 = 32'h00000044;
-  assign _zz_516 = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_517 = 32'h0;
-  assign _zz_518 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_519 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_520 = 32'h00000058;
-  assign _zz_521 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_522 = ((decode_INSTRUCTION & _zz_530) == 32'h00002010);
-  assign _zz_523 = ((decode_INSTRUCTION & _zz_531) == 32'h40000030);
-  assign _zz_524 = ((decode_INSTRUCTION & _zz_532) == 32'h00000004);
-  assign _zz_525 = _zz_88;
-  assign _zz_526 = {(_zz_533 == _zz_534),_zz_88};
-  assign _zz_527 = 2'b00;
-  assign _zz_528 = ((decode_INSTRUCTION & _zz_535) == 32'h00001008);
-  assign _zz_529 = 1'b0;
-  assign _zz_530 = 32'h00002014;
-  assign _zz_531 = 32'h40000034;
-  assign _zz_532 = 32'h00000014;
-  assign _zz_533 = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_534 = 32'h00000004;
-  assign _zz_535 = 32'h00005048;
-  assign _zz_536 = execute_INSTRUCTION[31];
-  assign _zz_537 = execute_INSTRUCTION[31];
-  assign _zz_538 = execute_INSTRUCTION[7];
-  assign _zz_539 = 32'h0;
+  assign _zz_227 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_228 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_229 = 1'b1;
+  assign _zz_230 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_231 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_232 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_233 = ((_zz_201 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_234 = ((_zz_201 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_235 = ((_zz_201 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_236 = ((_zz_201 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_237 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_238 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_239 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign _zz_240 = ({CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid} != 2'b00);
+  assign _zz_241 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign _zz_242 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_243 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_244 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign _zz_245 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_246 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_247 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_248 = (1'b0 || (! 1'b1));
+  assign _zz_249 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_250 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_251 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_252 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_253 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_254 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_255 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_256 = execute_INSTRUCTION[13 : 12];
+  assign _zz_257 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_258 = (! memory_arbitration_isStuck);
+  assign _zz_259 = debug_bus_cmd_payload_address[7 : 2];
+  assign _zz_260 = (iBus_cmd_valid || (_zz_187 != 3'b000));
+  assign _zz_261 = (_zz_223 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_262 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_263 = ((_zz_145 && 1'b1) && (! 1'b0));
+  assign _zz_264 = ((_zz_146 && 1'b1) && (! 1'b0));
+  assign _zz_265 = ((_zz_147 && 1'b1) && (! 1'b0));
+  assign _zz_266 = (CfuPlugin_bus_rsp_ready && (! memory_CfuPlugin_rsp_ready));
+  assign _zz_267 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_268 = execute_INSTRUCTION[13];
+  assign _zz_269 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_270 = ($signed(_zz_271) + $signed(_zz_276));
+  assign _zz_271 = ($signed(_zz_272) + $signed(_zz_274));
+  assign _zz_272 = 52'h0;
+  assign _zz_273 = {1'b0,memory_MUL_LL};
+  assign _zz_274 = {{19{_zz_273[32]}}, _zz_273};
+  assign _zz_275 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_276 = {{2{_zz_275[49]}}, _zz_275};
+  assign _zz_277 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_278 = {{2{_zz_277[49]}}, _zz_277};
+  assign _zz_279 = ($signed(_zz_281) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_280 = _zz_279[31 : 0];
+  assign _zz_281 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_282 = _zz_94[33 : 33];
+  assign _zz_283 = _zz_94[31 : 31];
+  assign _zz_284 = _zz_94[30 : 30];
+  assign _zz_285 = _zz_94[29 : 29];
+  assign _zz_286 = _zz_94[28 : 28];
+  assign _zz_287 = _zz_94[25 : 25];
+  assign _zz_288 = _zz_94[17 : 17];
+  assign _zz_289 = _zz_94[16 : 16];
+  assign _zz_290 = _zz_94[13 : 13];
+  assign _zz_291 = _zz_94[12 : 12];
+  assign _zz_292 = _zz_94[11 : 11];
+  assign _zz_293 = _zz_94[32 : 32];
+  assign _zz_294 = _zz_94[15 : 15];
+  assign _zz_295 = _zz_94[5 : 5];
+  assign _zz_296 = _zz_94[3 : 3];
+  assign _zz_297 = _zz_94[20 : 20];
+  assign _zz_298 = _zz_94[10 : 10];
+  assign _zz_299 = _zz_94[4 : 4];
+  assign _zz_300 = _zz_94[0 : 0];
+  assign _zz_301 = (_zz_62 - 4'b0001);
+  assign _zz_302 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_303 = {29'd0, _zz_302};
+  assign _zz_304 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_305 = {{_zz_77,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_306 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_307 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_308 = {{_zz_79,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_309 = {{_zz_81,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_310 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_311 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_312 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_313 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_314 = execute_SRC_LESS;
+  assign _zz_315 = 3'b100;
+  assign _zz_316 = execute_INSTRUCTION[19 : 15];
+  assign _zz_317 = execute_INSTRUCTION[31 : 20];
+  assign _zz_318 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_319 = ($signed(_zz_320) + $signed(_zz_323));
+  assign _zz_320 = ($signed(_zz_321) + $signed(_zz_322));
+  assign _zz_321 = execute_SRC1;
+  assign _zz_322 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_323 = (execute_SRC_USE_SUB_LESS ? _zz_324 : _zz_325);
+  assign _zz_324 = 32'h00000001;
+  assign _zz_325 = 32'h0;
+  assign _zz_326 = execute_INSTRUCTION[31 : 20];
+  assign _zz_327 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_328 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_329 = {_zz_133,execute_INSTRUCTION[31 : 20]};
+  assign _zz_330 = {{_zz_135,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_331 = {{_zz_137,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_332 = execute_INSTRUCTION[31 : 20];
+  assign _zz_333 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_334 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_335 = 3'b100;
+  assign _zz_336 = (_zz_148 & (~ _zz_337));
+  assign _zz_337 = (_zz_148 - 2'b01);
+  assign _zz_338 = (_zz_150 & (~ _zz_339));
+  assign _zz_339 = (_zz_150 - 2'b01);
+  assign _zz_340 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_341 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_342 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_343 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_344 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_345 = {5'd0, _zz_344};
+  assign _zz_346 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_347 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_348 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_349 = {_zz_152,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_350 = _zz_351;
+  assign _zz_351 = _zz_352;
+  assign _zz_352 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_153) : _zz_153)} + _zz_354);
+  assign _zz_353 = memory_DivPlugin_div_needRevert;
+  assign _zz_354 = {32'd0, _zz_353};
+  assign _zz_355 = _zz_155;
+  assign _zz_356 = {32'd0, _zz_355};
+  assign _zz_357 = _zz_154;
+  assign _zz_358 = {31'd0, _zz_357};
+  assign _zz_359 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[14 : 12]};
+  assign _zz_360 = execute_INSTRUCTION[31 : 24];
+  assign _zz_361 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_362 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_363 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_364 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_365 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_366 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_367 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_368 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_369 = 1'b1;
+  assign _zz_370 = 1'b1;
+  assign _zz_371 = {_zz_66,_zz_65};
+  assign _zz_372 = 32'h0000106f;
+  assign _zz_373 = (decode_INSTRUCTION & 32'h0000107f);
+  assign _zz_374 = 32'h00001073;
+  assign _zz_375 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002073);
+  assign _zz_376 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_377 = {((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013),{((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & _zz_378) == 32'h00000003),{(_zz_379 == _zz_380),{_zz_381,{_zz_382,_zz_383}}}}}};
+  assign _zz_378 = 32'h0000207f;
+  assign _zz_379 = (decode_INSTRUCTION & 32'h0000505f);
+  assign _zz_380 = 32'h00000003;
+  assign _zz_381 = ((decode_INSTRUCTION & 32'h0000707b) == 32'h00000063);
+  assign _zz_382 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_383 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_384) == 32'h00005013),{(_zz_385 == _zz_386),{_zz_387,{_zz_388,_zz_389}}}}}};
+  assign _zz_384 = 32'hbc00707f;
+  assign _zz_385 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_386 = 32'h00001013;
+  assign _zz_387 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_388 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_389 = {((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)}};
+  assign _zz_390 = decode_INSTRUCTION[31];
+  assign _zz_391 = decode_INSTRUCTION[31];
+  assign _zz_392 = decode_INSTRUCTION[7];
+  assign _zz_393 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz_394 = 32'h00100050;
+  assign _zz_395 = _zz_99;
+  assign _zz_396 = 1'b0;
+  assign _zz_397 = (((decode_INSTRUCTION & 32'h02004064) == 32'h02004020) != 1'b0);
+  assign _zz_398 = (((decode_INSTRUCTION & _zz_400) == 32'h02000030) != 1'b0);
+  assign _zz_399 = {({_zz_401,_zz_402} != 2'b00),{(_zz_403 != 1'b0),{(_zz_404 != _zz_405),{_zz_406,{_zz_407,_zz_408}}}}};
+  assign _zz_400 = 32'h02004074;
+  assign _zz_401 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
+  assign _zz_402 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz_403 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
+  assign _zz_404 = {(_zz_409 == _zz_410),(_zz_411 == _zz_412)};
+  assign _zz_405 = 2'b00;
+  assign _zz_406 = ({_zz_97,_zz_413} != 2'b00);
+  assign _zz_407 = (_zz_414 != 1'b0);
+  assign _zz_408 = {(_zz_415 != _zz_416),{_zz_417,{_zz_418,_zz_419}}};
+  assign _zz_409 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_410 = 32'h00001050;
+  assign _zz_411 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_412 = 32'h00002050;
+  assign _zz_413 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_414 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_415 = {(_zz_420 == _zz_421),(_zz_422 == _zz_423)};
+  assign _zz_416 = 2'b00;
+  assign _zz_417 = ({_zz_424,{_zz_425,_zz_426}} != 3'b000);
+  assign _zz_418 = (_zz_427 != 1'b0);
+  assign _zz_419 = {(_zz_428 != _zz_429),{_zz_430,{_zz_431,_zz_432}}};
+  assign _zz_420 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_421 = 32'h00005010;
+  assign _zz_422 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz_423 = 32'h00005020;
+  assign _zz_424 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz_425 = ((decode_INSTRUCTION & _zz_433) == 32'h00001010);
+  assign _zz_426 = ((decode_INSTRUCTION & _zz_434) == 32'h00001010);
+  assign _zz_427 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz_428 = ((decode_INSTRUCTION & _zz_435) == 32'h00001000);
+  assign _zz_429 = 1'b0;
+  assign _zz_430 = ((_zz_436 == _zz_437) != 1'b0);
+  assign _zz_431 = ({_zz_438,_zz_439} != 2'b00);
+  assign _zz_432 = {(_zz_440 != _zz_441),{_zz_442,{_zz_443,_zz_444}}};
+  assign _zz_433 = 32'h00007034;
+  assign _zz_434 = 32'h02007054;
+  assign _zz_435 = 32'h00001000;
+  assign _zz_436 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz_437 = 32'h00002000;
+  assign _zz_438 = ((decode_INSTRUCTION & _zz_445) == 32'h00002000);
+  assign _zz_439 = ((decode_INSTRUCTION & _zz_446) == 32'h00001000);
+  assign _zz_440 = ((decode_INSTRUCTION & _zz_447) == 32'h00004004);
+  assign _zz_441 = 1'b0;
+  assign _zz_442 = ({_zz_98,{_zz_448,_zz_449}} != 3'b000);
+  assign _zz_443 = ({_zz_450,_zz_451} != 5'h0);
+  assign _zz_444 = {(_zz_452 != _zz_453),{_zz_454,{_zz_455,_zz_456}}};
+  assign _zz_445 = 32'h00002010;
+  assign _zz_446 = 32'h00005000;
+  assign _zz_447 = 32'h00004054;
+  assign _zz_448 = ((decode_INSTRUCTION & _zz_457) == 32'h00000020);
+  assign _zz_449 = ((decode_INSTRUCTION & _zz_458) == 32'h00000020);
+  assign _zz_450 = ((decode_INSTRUCTION & _zz_459) == 32'h00002040);
+  assign _zz_451 = {(_zz_460 == _zz_461),{_zz_462,{_zz_463,_zz_464}}};
+  assign _zz_452 = ((decode_INSTRUCTION & _zz_465) == 32'h00000020);
+  assign _zz_453 = 1'b0;
+  assign _zz_454 = ({_zz_466,{_zz_467,_zz_468}} != 6'h0);
+  assign _zz_455 = ({_zz_469,_zz_470} != 5'h0);
+  assign _zz_456 = {(_zz_471 != _zz_472),{_zz_473,{_zz_474,_zz_475}}};
+  assign _zz_457 = 32'h00000034;
+  assign _zz_458 = 32'h00000064;
+  assign _zz_459 = 32'h00002040;
+  assign _zz_460 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz_461 = 32'h00001040;
+  assign _zz_462 = ((decode_INSTRUCTION & _zz_476) == 32'h00000040);
+  assign _zz_463 = (_zz_477 == _zz_478);
+  assign _zz_464 = (_zz_479 == _zz_480);
+  assign _zz_465 = 32'h00000020;
+  assign _zz_466 = ((decode_INSTRUCTION & _zz_481) == 32'h00000008);
+  assign _zz_467 = (_zz_482 == _zz_483);
+  assign _zz_468 = {_zz_96,{_zz_484,_zz_485}};
+  assign _zz_469 = _zz_96;
+  assign _zz_470 = {_zz_486,{_zz_487,_zz_488}};
+  assign _zz_471 = {_zz_97,{_zz_489,_zz_490}};
+  assign _zz_472 = 6'h0;
+  assign _zz_473 = ({_zz_491,_zz_492} != 2'b00);
+  assign _zz_474 = (_zz_493 != _zz_494);
+  assign _zz_475 = {_zz_495,{_zz_496,_zz_497}};
+  assign _zz_476 = 32'h00100040;
+  assign _zz_477 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_478 = 32'h00000040;
+  assign _zz_479 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_480 = 32'h0;
+  assign _zz_481 = 32'h00000008;
+  assign _zz_482 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_483 = 32'h00000040;
+  assign _zz_484 = (_zz_498 == _zz_499);
+  assign _zz_485 = {_zz_500,_zz_501};
+  assign _zz_486 = ((decode_INSTRUCTION & _zz_502) == 32'h00002010);
+  assign _zz_487 = (_zz_503 == _zz_504);
+  assign _zz_488 = {_zz_505,_zz_506};
+  assign _zz_489 = (_zz_507 == _zz_508);
+  assign _zz_490 = {_zz_509,{_zz_510,_zz_511}};
+  assign _zz_491 = _zz_96;
+  assign _zz_492 = (_zz_512 == _zz_513);
+  assign _zz_493 = {_zz_96,_zz_514};
+  assign _zz_494 = 2'b00;
+  assign _zz_495 = (_zz_515 != 1'b0);
+  assign _zz_496 = (_zz_516 != _zz_517);
+  assign _zz_497 = {_zz_518,{_zz_519,_zz_520}};
+  assign _zz_498 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz_499 = 32'h00004020;
+  assign _zz_500 = ((decode_INSTRUCTION & _zz_521) == 32'h00000010);
+  assign _zz_501 = ((decode_INSTRUCTION & _zz_522) == 32'h00000020);
+  assign _zz_502 = 32'h00002030;
+  assign _zz_503 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz_504 = 32'h00000010;
+  assign _zz_505 = ((decode_INSTRUCTION & _zz_523) == 32'h00002020);
+  assign _zz_506 = ((decode_INSTRUCTION & _zz_524) == 32'h00000020);
+  assign _zz_507 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_508 = 32'h00001010;
+  assign _zz_509 = ((decode_INSTRUCTION & _zz_525) == 32'h00002010);
+  assign _zz_510 = (_zz_526 == _zz_527);
+  assign _zz_511 = {_zz_528,_zz_529};
+  assign _zz_512 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_513 = 32'h00000020;
+  assign _zz_514 = ((decode_INSTRUCTION & _zz_530) == 32'h0);
+  assign _zz_515 = ((decode_INSTRUCTION & _zz_531) == 32'h00004010);
+  assign _zz_516 = (_zz_532 == _zz_533);
+  assign _zz_517 = 1'b0;
+  assign _zz_518 = ({_zz_534,_zz_535} != 4'b0000);
+  assign _zz_519 = (_zz_536 != _zz_537);
+  assign _zz_520 = {_zz_538,{_zz_539,_zz_540}};
+  assign _zz_521 = 32'h00000030;
+  assign _zz_522 = 32'h02000020;
+  assign _zz_523 = 32'h02002060;
+  assign _zz_524 = 32'h02003020;
+  assign _zz_525 = 32'h00002010;
+  assign _zz_526 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_527 = 32'h00000010;
+  assign _zz_528 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_529 = ((decode_INSTRUCTION & 32'h00000024) == 32'h0);
+  assign _zz_530 = 32'h00000020;
+  assign _zz_531 = 32'h00004014;
+  assign _zz_532 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_533 = 32'h00002010;
+  assign _zz_534 = ((decode_INSTRUCTION & _zz_541) == 32'h0);
+  assign _zz_535 = {(_zz_542 == _zz_543),{_zz_544,_zz_545}};
+  assign _zz_536 = ((decode_INSTRUCTION & _zz_546) == 32'h0);
+  assign _zz_537 = 1'b0;
+  assign _zz_538 = ({_zz_547,{_zz_548,_zz_549}} != 3'b000);
+  assign _zz_539 = ({_zz_550,_zz_551} != 2'b00);
+  assign _zz_540 = {(_zz_552 != _zz_553),(_zz_554 != _zz_555)};
+  assign _zz_541 = 32'h00000044;
+  assign _zz_542 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_543 = 32'h0;
+  assign _zz_544 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_545 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz_546 = 32'h00000058;
+  assign _zz_547 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_548 = ((decode_INSTRUCTION & _zz_556) == 32'h00002010);
+  assign _zz_549 = ((decode_INSTRUCTION & _zz_557) == 32'h40000030);
+  assign _zz_550 = ((decode_INSTRUCTION & _zz_558) == 32'h00000004);
+  assign _zz_551 = _zz_95;
+  assign _zz_552 = {(_zz_559 == _zz_560),_zz_95};
+  assign _zz_553 = 2'b00;
+  assign _zz_554 = ((decode_INSTRUCTION & _zz_561) == 32'h00001004);
+  assign _zz_555 = 1'b0;
+  assign _zz_556 = 32'h00002014;
+  assign _zz_557 = 32'h40000034;
+  assign _zz_558 = 32'h00000014;
+  assign _zz_559 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_560 = 32'h00000004;
+  assign _zz_561 = 32'h00005054;
+  assign _zz_562 = execute_INSTRUCTION[31];
+  assign _zz_563 = execute_INSTRUCTION[31];
+  assign _zz_564 = execute_INSTRUCTION[7];
+  assign _zz_565 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_348) begin
-      _zz_210 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_369) begin
+      _zz_224 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_349) begin
-      _zz_211 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_370) begin
+      _zz_225 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42) begin
+    if(_zz_48) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
   InstructionCache IBusCachedPlugin_cache (
-    .io_flush                                 (_zz_182                                                     ), //i
-    .io_cpu_prefetch_isValid                  (_zz_183                                                     ), //i
+    .io_flush                                 (_zz_196                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_197                                                     ), //i
     .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
     .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
-    .io_cpu_fetch_isValid                     (_zz_184                                                     ), //i
-    .io_cpu_fetch_isStuck                     (_zz_185                                                     ), //i
-    .io_cpu_fetch_isRemoved                   (_zz_186                                                     ), //i
+    .io_cpu_fetch_isValid                     (_zz_198                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_199                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_200                                                     ), //i
     .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
     .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
     .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
@@ -1669,8 +1750,8 @@ module VexRiscv (
     .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
     .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
     .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
-    .io_cpu_decode_isValid                    (_zz_187                                                     ), //i
-    .io_cpu_decode_isStuck                    (_zz_188                                                     ), //i
+    .io_cpu_decode_isValid                    (_zz_201                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_202                                                     ), //i
     .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
     .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
     .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
@@ -1678,8 +1759,8 @@ module VexRiscv (
     .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
     .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
     .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
-    .io_cpu_decode_isUser                     (_zz_189                                                     ), //i
-    .io_cpu_fill_valid                        (_zz_190                                                     ), //i
+    .io_cpu_decode_isUser                     (_zz_203                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_204                                                     ), //i
     .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
     .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
     .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
@@ -1688,26 +1769,26 @@ module VexRiscv (
     .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
     .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
     .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
-    ._zz_9                                    (_zz_149[2:0]                                                ), //i
+    ._zz_9                                    (_zz_163[2:0]                                                ), //i
     ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
     .clk                                      (clk                                                         ), //i
     .reset                                    (reset                                                       )  //i
   );
   DataCache dataCache_1 (
-    .io_cpu_execute_isValid                    (_zz_191                                            ), //i
-    .io_cpu_execute_address                    (_zz_192[31:0]                                      ), //i
+    .io_cpu_execute_isValid                    (_zz_205                                            ), //i
+    .io_cpu_execute_address                    (_zz_206[31:0]                                      ), //i
     .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
     .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
-    .io_cpu_execute_args_data                  (_zz_82[31:0]                                       ), //i
+    .io_cpu_execute_args_data                  (_zz_89[31:0]                                       ), //i
     .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
     .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
     .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
-    .io_cpu_memory_isValid                     (_zz_193                                            ), //i
+    .io_cpu_memory_isValid                     (_zz_207                                            ), //i
     .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
     .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
-    .io_cpu_memory_address                     (_zz_194[31:0]                                      ), //i
+    .io_cpu_memory_address                     (_zz_208[31:0]                                      ), //i
     .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
-    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_195                                            ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_209                                            ), //i
     .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
     .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
     .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
@@ -1715,31 +1796,31 @@ module VexRiscv (
     .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
     .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
     .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
-    .io_cpu_writeBack_isValid                  (_zz_196                                            ), //i
+    .io_cpu_writeBack_isValid                  (_zz_210                                            ), //i
     .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
-    .io_cpu_writeBack_isUser                   (_zz_197                                            ), //i
+    .io_cpu_writeBack_isUser                   (_zz_211                                            ), //i
     .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
     .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
     .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
-    .io_cpu_writeBack_address                  (_zz_198[31:0]                                      ), //i
+    .io_cpu_writeBack_address                  (_zz_212[31:0]                                      ), //i
     .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
     .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
     .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
     .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
-    .io_cpu_writeBack_fence_SW                 (_zz_199                                            ), //i
-    .io_cpu_writeBack_fence_SR                 (_zz_200                                            ), //i
-    .io_cpu_writeBack_fence_SO                 (_zz_201                                            ), //i
-    .io_cpu_writeBack_fence_SI                 (_zz_202                                            ), //i
-    .io_cpu_writeBack_fence_PW                 (_zz_203                                            ), //i
-    .io_cpu_writeBack_fence_PR                 (_zz_204                                            ), //i
-    .io_cpu_writeBack_fence_PO                 (_zz_205                                            ), //i
-    .io_cpu_writeBack_fence_PI                 (_zz_206                                            ), //i
-    .io_cpu_writeBack_fence_FM                 (_zz_207[3:0]                                       ), //i
+    .io_cpu_writeBack_fence_SW                 (_zz_213                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_214                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_215                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_216                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_217                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_218                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_219                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_220                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_221[3:0]                                       ), //i
     .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
-    .io_cpu_flush_valid                        (_zz_208                                            ), //i
+    .io_cpu_flush_valid                        (_zz_222                                            ), //i
     .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
     .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
-    .io_mem_cmd_ready                          (_zz_209                                            ), //i
+    .io_mem_cmd_ready                          (_zz_223                                            ), //i
     .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
     .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
     .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
@@ -1755,47 +1836,48 @@ module VexRiscv (
     .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_350)
+    case(_zz_371)
       2'b00 : begin
-        _zz_212 = DBusCachedPlugin_redoBranch_payload;
+        _zz_226 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_212 = CsrPlugin_jumpInterface_payload;
+        _zz_226 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_212 = BranchPlugin_jumpInterface_payload;
+        _zz_226 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_212 = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_226 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
+    case(decode_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : decode_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_1)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      `Input2Kind_defaultEncoding_RS : _zz_1_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_1_string = "IMM_I";
       default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_2)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      `Input2Kind_defaultEncoding_RS : _zz_2_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_2_string = "IMM_I";
       default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_3)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      `Input2Kind_defaultEncoding_RS : _zz_3_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_3_string = "IMM_I";
       default : _zz_3_string = "?????";
     endcase
   end
@@ -1806,15 +1888,6 @@ module VexRiscv (
       `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
       `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
       default : _zz_4_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ENV_CTRL)
-      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : decode_ENV_CTRL_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
-      default : decode_ENV_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1845,57 +1918,57 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(decode_ENV_CTRL)
+      `EnvCtrlEnum_defaultEncoding_NONE : decode_ENV_CTRL_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : decode_ENV_CTRL_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : decode_ENV_CTRL_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : decode_ENV_CTRL_string = "ECALL";
+      default : decode_ENV_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
     case(_zz_8)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
-      default : _zz_8_string = "????";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_8_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8_string = "ECALL";
+      default : _zz_8_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_9)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
-      default : _zz_9_string = "????";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_9_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9_string = "ECALL";
+      default : _zz_9_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_10)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
-      default : _zz_10_string = "?????????";
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_10_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10_string = "ECALL";
+      default : _zz_10_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_11)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
-      default : _zz_11_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_11_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_11_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_11_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_11_string = "JALR";
+      default : _zz_11_string = "????";
     endcase
   end
   always @(*) begin
     case(_zz_12)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
-      default : _zz_12_string = "?????????";
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_12_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_12_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_12_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_12_string = "JALR";
+      default : _zz_12_string = "????";
     endcase
   end
   always @(*) begin
@@ -1917,6 +1990,42 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15_string = "SRA_1    ";
+      default : _zz_15_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_16_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_16_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_16_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_16_string = "SRA_1    ";
+      default : _zz_16_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17_string = "SRA_1    ";
+      default : _zz_17_string = "?????????";
+    endcase
+  end
+  always @(*) begin
     case(decode_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
       `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
@@ -1925,27 +2034,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_15)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
-      default : _zz_15_string = "?????";
+    case(_zz_18)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
+      default : _zz_18_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_16)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
-      default : _zz_16_string = "?????";
+    case(_zz_19)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_19_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_19_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_19_string = "AND_1";
+      default : _zz_19_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_17)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
-      default : _zz_17_string = "?????";
+    case(_zz_20)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_20_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_20_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_20_string = "AND_1";
+      default : _zz_20_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1958,30 +2067,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
-      default : _zz_18_string = "???";
+    case(_zz_21)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_21_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_21_string = "PC ";
+      default : _zz_21_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_19)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
-      default : _zz_19_string = "???";
+    case(_zz_22)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_22_string = "PC ";
+      default : _zz_22_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_20)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
-      default : _zz_20_string = "???";
+    case(_zz_23)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_23_string = "PC ";
+      default : _zz_23_string = "???";
     endcase
   end
   always @(*) begin
@@ -1993,27 +2102,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
-      default : _zz_21_string = "????????";
+    case(_zz_24)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24_string = "BITWISE ";
+      default : _zz_24_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
-      default : _zz_22_string = "????????";
+    case(_zz_25)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_25_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_25_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_25_string = "BITWISE ";
+      default : _zz_25_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
-      default : _zz_23_string = "????????";
+    case(_zz_26)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_26_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_26_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_26_string = "BITWISE ";
+      default : _zz_26_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2026,30 +2135,44 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
-      default : _zz_24_string = "????????????";
+    case(_zz_27)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27_string = "URS1        ";
+      default : _zz_27_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
-      default : _zz_25_string = "????????????";
+    case(_zz_28)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_28_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_28_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_28_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_28_string = "URS1        ";
+      default : _zz_28_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
-      default : _zz_26_string = "????????????";
+    case(_zz_29)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_29_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_29_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_29_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_29_string = "URS1        ";
+      default : _zz_29_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_32)
+      `Input2Kind_defaultEncoding_RS : _zz_32_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_32_string = "IMM_I";
+      default : _zz_32_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2062,12 +2185,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
-      default : _zz_27_string = "?????";
+    case(_zz_33)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_33_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_33_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_33_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_33_string = "ECALL";
+      default : _zz_33_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2080,12 +2203,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
-      default : _zz_28_string = "?????";
+    case(_zz_34)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_34_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_34_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_34_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_34_string = "ECALL";
+      default : _zz_34_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2098,12 +2221,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
-      default : _zz_29_string = "?????";
+    case(_zz_35)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_35_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_35_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_35_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_35_string = "ECALL";
+      default : _zz_35_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2116,12 +2239,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
-      default : _zz_30_string = "????";
+    case(_zz_36)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_36_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_36_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_36_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_36_string = "JALR";
+      default : _zz_36_string = "????";
     endcase
   end
   always @(*) begin
@@ -2134,12 +2257,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
-      default : _zz_33_string = "?????????";
+    case(_zz_39)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_39_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_39_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_39_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_39_string = "SRA_1    ";
+      default : _zz_39_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2152,12 +2275,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
-      default : _zz_34_string = "?????????";
+    case(_zz_40)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_40_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_40_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_40_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_40_string = "SRA_1    ";
+      default : _zz_40_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2170,12 +2293,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
-      default : _zz_36_string = "???";
+    case(_zz_42)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_42_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_42_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_42_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_42_string = "PC ";
+      default : _zz_42_string = "???";
     endcase
   end
   always @(*) begin
@@ -2188,12 +2311,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
-      default : _zz_37_string = "????????????";
+    case(_zz_43)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_43_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_43_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_43_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_43_string = "URS1        ";
+      default : _zz_43_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2205,11 +2328,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
-      default : _zz_38_string = "????????";
+    case(_zz_44)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_44_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_44_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_44_string = "BITWISE ";
+      default : _zz_44_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2221,81 +2344,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
-      default : _zz_39_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_43)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
-      default : _zz_43_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_44)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
-      default : _zz_44_string = "????";
-    endcase
-  end
-  always @(*) begin
     case(_zz_45)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
-      default : _zz_45_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_46)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
-      default : _zz_46_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_47)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
-      default : _zz_47_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_48)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
-      default : _zz_48_string = "????????";
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_45_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_45_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_45_string = "AND_1";
+      default : _zz_45_string = "?????";
     endcase
   end
   always @(*) begin
     case(_zz_49)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
-      default : _zz_49_string = "????????????";
+      `Input2Kind_defaultEncoding_RS : _zz_49_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_49_string = "IMM_I";
+      default : _zz_49_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_BRANCH_CTRL_string = "JALR";
-      default : decode_BRANCH_CTRL_string = "????";
+    case(_zz_50)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_50_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_50_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_50_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_50_string = "ECALL";
+      default : _zz_50_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2308,64 +2377,132 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_92)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_92_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_92_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_92_string = "URS1        ";
-      default : _zz_92_string = "????????????";
+    case(_zz_52)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_52_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_52_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_52_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_52_string = "SRA_1    ";
+      default : _zz_52_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_93_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_93_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_93_string = "BITWISE ";
-      default : _zz_93_string = "????????";
+    case(_zz_53)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_53_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_53_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_53_string = "AND_1";
+      default : _zz_53_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_94)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_94_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_94_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_94_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_94_string = "PC ";
-      default : _zz_94_string = "???";
+    case(_zz_54)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_54_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_54_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_54_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_54_string = "PC ";
+      default : _zz_54_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_95_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_95_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_95_string = "AND_1";
-      default : _zz_95_string = "?????";
+    case(_zz_55)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_55_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_55_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_55_string = "BITWISE ";
+      default : _zz_55_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_96)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_96_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_96_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_96_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_96_string = "SRA_1    ";
-      default : _zz_96_string = "?????????";
+    case(_zz_56)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_56_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_56_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_56_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_56_string = "URS1        ";
+      default : _zz_56_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_97)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_97_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_97_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_97_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_97_string = "JALR";
-      default : _zz_97_string = "????";
+    case(decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_BRANCH_CTRL_string = "JALR";
+      default : decode_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_98)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_98_string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_98_string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_98_string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_98_string = "ECALL";
-      default : _zz_98_string = "?????";
+    case(_zz_58)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_58_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_58_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_58_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_58_string = "JALR";
+      default : _zz_58_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_100)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_100_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_100_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_100_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_100_string = "URS1        ";
+      default : _zz_100_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_101)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_101_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_101_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_101_string = "BITWISE ";
+      default : _zz_101_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_102)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_102_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_102_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_102_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_102_string = "PC ";
+      default : _zz_102_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_103)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_103_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_103_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_103_string = "AND_1";
+      default : _zz_103_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_104)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_104_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_104_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_104_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_104_string = "SRA_1    ";
+      default : _zz_104_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_105)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_105_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_105_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_105_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_105_string = "JALR";
+      default : _zz_105_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_106)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_106_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_106_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_106_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_106_string = "ECALL";
+      default : _zz_106_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_107)
+      `Input2Kind_defaultEncoding_RS : _zz_107_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : _zz_107_string = "IMM_I";
+      default : _zz_107_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2456,63 +2593,90 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
+  always @(*) begin
+    case(decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "RS   ";
+      `Input2Kind_defaultEncoding_IMM_I : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "IMM_I";
+      default : decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND_string = "?????";
+    endcase
+  end
   `endif
 
-  assign memory_MUL_LOW = ($signed(_zz_254) + $signed(_zz_262));
+  assign memory_MUL_LOW = ($signed(_zz_270) + $signed(_zz_278));
+  assign writeBack_CfuPlugin_CFU_IN_FLIGHT = memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT;
+  assign execute_CfuPlugin_CFU_IN_FLIGHT = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) || execute_CfuPlugin_fired);
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
   assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign execute_SHIFT_RIGHT = _zz_264;
-  assign execute_REGFILE_WRITE_DATA = _zz_100;
+  assign execute_SHIFT_RIGHT = _zz_280;
+  assign execute_REGFILE_WRITE_DATA = _zz_109;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_192[1 : 0];
+  assign execute_MEMORY_ADDRESS_LOW = _zz_206[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
   assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_RS2_SIGNED = _zz_266[0];
-  assign decode_IS_RS1_SIGNED = _zz_267[0];
-  assign decode_IS_DIV = _zz_268[0];
+  assign decode_CfuPlugin_CFU_INPUT_2_KIND = _zz_1;
+  assign _zz_2 = _zz_3;
+  assign decode_CfuPlugin_CFU_ENABLE = _zz_282[0];
+  assign decode_IS_RS2_SIGNED = _zz_283[0];
+  assign decode_IS_RS1_SIGNED = _zz_284[0];
+  assign decode_IS_DIV = _zz_285[0];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_269[0];
-  assign _zz_1 = _zz_2;
-  assign _zz_3 = _zz_4;
-  assign decode_ENV_CTRL = _zz_5;
+  assign decode_IS_MUL = _zz_286[0];
+  assign _zz_4 = _zz_5;
   assign _zz_6 = _zz_7;
-  assign decode_IS_CSR = _zz_270[0];
-  assign _zz_8 = _zz_9;
-  assign _zz_10 = _zz_11;
-  assign decode_SHIFT_CTRL = _zz_12;
+  assign decode_ENV_CTRL = _zz_8;
+  assign _zz_9 = _zz_10;
+  assign decode_IS_CSR = _zz_287[0];
+  assign _zz_11 = _zz_12;
   assign _zz_13 = _zz_14;
-  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign decode_SHIFT_CTRL = _zz_15;
   assign _zz_16 = _zz_17;
-  assign decode_SRC_LESS_UNSIGNED = _zz_271[0];
-  assign decode_MEMORY_MANAGMENT = _zz_272[0];
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_273[0];
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_274[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_275[0];
-  assign decode_SRC2_CTRL = _zz_18;
+  assign decode_ALU_BITWISE_CTRL = _zz_18;
   assign _zz_19 = _zz_20;
-  assign decode_ALU_CTRL = _zz_21;
+  assign decode_SRC_LESS_UNSIGNED = _zz_288[0];
+  assign decode_MEMORY_MANAGMENT = _zz_289[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_290[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_291[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_292[0];
+  assign decode_SRC2_CTRL = _zz_21;
   assign _zz_22 = _zz_23;
-  assign decode_SRC1_CTRL = _zz_24;
+  assign decode_ALU_CTRL = _zz_24;
   assign _zz_25 = _zz_26;
+  assign decode_SRC1_CTRL = _zz_27;
+  assign _zz_28 = _zz_29;
   assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
   assign memory_PC = execute_to_memory_PC;
+  always @ (*) begin
+    _zz_30 = memory_CfuPlugin_CFU_IN_FLIGHT;
+    if(memory_arbitration_isStuck)begin
+      _zz_30 = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    _zz_31 = execute_CfuPlugin_CFU_IN_FLIGHT;
+    if(execute_arbitration_isStuck)begin
+      _zz_31 = 1'b0;
+    end
+  end
+
+  assign memory_CfuPlugin_CFU_IN_FLIGHT = execute_to_memory_CfuPlugin_CFU_IN_FLIGHT;
+  assign execute_CfuPlugin_CFU_INPUT_2_KIND = _zz_32;
+  assign execute_CfuPlugin_CFU_ENABLE = decode_to_execute_CfuPlugin_CFU_ENABLE;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_276[0];
+  assign decode_IS_EBREAK = _zz_293[0];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -2526,22 +2690,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27;
-  assign execute_ENV_CTRL = _zz_28;
-  assign writeBack_ENV_CTRL = _zz_29;
-  assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
-  assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
+  assign memory_ENV_CTRL = _zz_33;
+  assign execute_ENV_CTRL = _zz_34;
+  assign writeBack_ENV_CTRL = _zz_35;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_122;
-  assign execute_BRANCH_CTRL = _zz_30;
-  assign decode_RS2_USE = _zz_277[0];
-  assign decode_RS1_USE = _zz_278[0];
+  assign execute_BRANCH_COND_RESULT = _zz_131;
+  assign execute_BRANCH_CTRL = _zz_36;
+  assign decode_RS2_USE = _zz_294[0];
+  assign decode_RS1_USE = _zz_295[0];
   always @ (*) begin
-    _zz_31 = execute_REGFILE_WRITE_DATA;
-    if(_zz_213)begin
-      _zz_31 = execute_CsrPlugin_readData;
+    _zz_37 = execute_REGFILE_WRITE_DATA;
+    if(_zz_227)begin
+      _zz_37 = execute_CsrPlugin_readData;
     end
   end
 
@@ -2553,29 +2717,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_111)begin
-      if((_zz_112 == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_113;
+    if(_zz_120)begin
+      if((_zz_121 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_122;
       end
     end
-    if(_zz_214)begin
-      if(_zz_215)begin
-        if(_zz_115)begin
-          decode_RS2 = _zz_50;
+    if(_zz_228)begin
+      if(_zz_229)begin
+        if(_zz_124)begin
+          decode_RS2 = _zz_57;
         end
       end
     end
-    if(_zz_216)begin
+    if(_zz_230)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_117)begin
-          decode_RS2 = _zz_32;
+        if(_zz_126)begin
+          decode_RS2 = _zz_38;
         end
       end
     end
-    if(_zz_217)begin
+    if(_zz_231)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_119)begin
-          decode_RS2 = _zz_31;
+        if(_zz_128)begin
+          decode_RS2 = _zz_37;
         end
       end
     end
@@ -2583,29 +2747,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_111)begin
-      if((_zz_112 == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_113;
+    if(_zz_120)begin
+      if((_zz_121 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_122;
       end
     end
-    if(_zz_214)begin
-      if(_zz_215)begin
-        if(_zz_114)begin
-          decode_RS1 = _zz_50;
+    if(_zz_228)begin
+      if(_zz_229)begin
+        if(_zz_123)begin
+          decode_RS1 = _zz_57;
         end
       end
     end
-    if(_zz_216)begin
+    if(_zz_230)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116)begin
-          decode_RS1 = _zz_32;
+        if(_zz_125)begin
+          decode_RS1 = _zz_38;
         end
       end
     end
-    if(_zz_217)begin
+    if(_zz_231)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118)begin
-          decode_RS1 = _zz_31;
+        if(_zz_127)begin
+          decode_RS1 = _zz_37;
         end
       end
     end
@@ -2613,70 +2777,73 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32 = memory_REGFILE_WRITE_DATA;
+    _zz_38 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32 = _zz_108;
+          _zz_38 = _zz_117;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32 = memory_SHIFT_RIGHT;
+          _zz_38 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_218)begin
-      _zz_32 = memory_DivPlugin_div_result;
+    if(_zz_232)begin
+      _zz_38 = memory_DivPlugin_div_result;
+    end
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      _zz_38 = memory_CfuPlugin_rsp_payload_outputs_0;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33;
-  assign execute_SHIFT_CTRL = _zz_34;
+  assign memory_SHIFT_CTRL = _zz_39;
+  assign execute_SHIFT_CTRL = _zz_40;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35 = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36;
-  assign execute_SRC1_CTRL = _zz_37;
-  assign decode_SRC_USE_SUB_LESS = _zz_279[0];
-  assign decode_SRC_ADD_ZERO = _zz_280[0];
+  assign _zz_41 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_42;
+  assign execute_SRC1_CTRL = _zz_43;
+  assign decode_SRC_USE_SUB_LESS = _zz_296[0];
+  assign decode_SRC_ADD_ZERO = _zz_297[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38;
-  assign execute_SRC2 = _zz_106;
-  assign execute_SRC1 = _zz_101;
-  assign execute_ALU_BITWISE_CTRL = _zz_39;
-  assign _zz_40 = writeBack_INSTRUCTION;
-  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_44;
+  assign execute_SRC2 = _zz_115;
+  assign execute_SRC1 = _zz_110;
+  assign execute_ALU_BITWISE_CTRL = _zz_45;
+  assign _zz_46 = writeBack_INSTRUCTION;
+  assign _zz_47 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42 = 1'b0;
+    _zz_48 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42 = 1'b1;
+      _zz_48 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_281[0];
+    decode_REGFILE_WRITE_VALID = _zz_298[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_351) == 32'h00001073),{(_zz_352 == _zz_353),{_zz_354,{_zz_355,_zz_356}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000000b),{((decode_INSTRUCTION & _zz_372) == 32'h00000003),{(_zz_373 == _zz_374),{_zz_375,{_zz_376,_zz_377}}}}}}} != 22'h0);
   always @ (*) begin
-    _zz_50 = writeBack_REGFILE_WRITE_DATA;
+    _zz_57 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_57 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_253)
+      case(_zz_269)
         2'b00 : begin
-          _zz_50 = _zz_323;
+          _zz_57 = _zz_342;
         end
         default : begin
-          _zz_50 = _zz_324;
+          _zz_57 = _zz_343;
         end
       endcase
     end
@@ -2695,49 +2862,49 @@ module VexRiscv (
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_282[0];
-  assign decode_FLUSH_ALL = _zz_283[0];
+  assign decode_MEMORY_ENABLE = _zz_299[0];
+  assign decode_FLUSH_ALL = _zz_300[0];
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
-    if(_zz_219)begin
+    if(_zz_233)begin
       IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
-    if(_zz_220)begin
+    if(_zz_234)begin
       IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
-    if(_zz_221)begin
+    if(_zz_235)begin
       IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_222)begin
+    if(_zz_236)begin
       IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_51;
+  assign decode_BRANCH_CTRL = _zz_58;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_52 = memory_FORMAL_PC_NEXT;
+    _zz_59 = execute_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_52 = BranchPlugin_jumpInterface_payload;
+      _zz_59 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_53 = decode_FORMAL_PC_NEXT;
+    _zz_60 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_60 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -2749,7 +2916,7 @@ module VexRiscv (
     if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_149)
+    case(_zz_163)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
       end
@@ -2760,7 +2927,7 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_109 || _zz_110)))begin
+    if((decode_arbitration_isValid && (_zz_118 || _zz_119)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
@@ -2773,7 +2940,7 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_223)begin
+    if(_zz_237)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -2787,25 +2954,28 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_223)begin
+    if(_zz_237)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((_zz_208 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
+    if(((_zz_222 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_224)begin
+    if(_zz_238)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_213)begin
+    if(_zz_227)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
+    end
+    if((CfuPlugin_bus_cmd_valid && (! CfuPlugin_bus_cmd_ready)))begin
+      execute_arbitration_haltItself = 1'b1;
     end
   end
 
@@ -2814,14 +2984,14 @@ module VexRiscv (
     if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
       execute_arbitration_haltByOther = 1'b1;
     end
-    if(_zz_225)begin
+    if(_zz_239)begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(_zz_240)begin
       execute_arbitration_removeIt = 1'b1;
     end
     if(execute_arbitration_isFlushed)begin
@@ -2831,8 +3001,8 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_225)begin
-      if(_zz_226)begin
+    if(_zz_239)begin
+      if(_zz_241)begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2840,11 +3010,14 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_flushNext = 1'b0;
-    if(CsrPlugin_selfException_valid)begin
+    if(BranchPlugin_jumpInterface_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_225)begin
-      if(_zz_226)begin
+    if(_zz_240)begin
+      execute_arbitration_flushNext = 1'b1;
+    end
+    if(_zz_239)begin
+      if(_zz_241)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2852,8 +3025,13 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_218)begin
+    if(_zz_232)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
+        memory_arbitration_haltItself = 1'b1;
+      end
+    end
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      if((! memory_CfuPlugin_rsp_valid))begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
@@ -2862,7 +3040,7 @@ module VexRiscv (
   assign memory_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(CfuPlugin_joinException_valid)begin
       memory_arbitration_removeIt = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -2873,10 +3051,7 @@ module VexRiscv (
   assign memory_arbitration_flushIt = 1'b0;
   always @ (*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(BranchPlugin_jumpInterface_valid)begin
-      memory_arbitration_flushNext = 1'b1;
-    end
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(CfuPlugin_joinException_valid)begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
@@ -2914,10 +3089,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_227)begin
+    if(_zz_242)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_228)begin
+    if(_zz_243)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2931,21 +3106,21 @@ module VexRiscv (
     if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_227)begin
+    if(_zz_242)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_228)begin
+    if(_zz_243)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_225)begin
-      if(_zz_226)begin
+    if(_zz_239)begin
+      if(_zz_241)begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_229)begin
+    if(_zz_244)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2958,15 +3133,15 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_54 = 1'b0;
+    _zz_61 = 1'b0;
     if(DebugPlugin_godmode)begin
-      _zz_54 = 1'b1;
+      _zz_61 = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_224)begin
+    if(_zz_238)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -2980,21 +3155,21 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_227)begin
+    if(_zz_242)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_228)begin
+    if(_zz_243)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_227)begin
+    if(_zz_242)begin
       CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_228)begin
-      case(_zz_230)
+    if(_zz_243)begin
+      case(_zz_245)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3027,12 +3202,12 @@ module VexRiscv (
 
   assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
-  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56 = (_zz_55 & (~ _zz_284));
-  assign _zz_57 = _zz_56[3];
-  assign _zz_58 = (_zz_56[1] || _zz_57);
-  assign _zz_59 = (_zz_56[2] || _zz_57);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_212;
+  assign _zz_62 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_63 = (_zz_62 & (~ _zz_301));
+  assign _zz_64 = _zz_63[3];
+  assign _zz_65 = (_zz_63[1] || _zz_64);
+  assign _zz_66 = (_zz_63[2] || _zz_64);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_226;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -3052,7 +3227,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_286);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_303);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -3092,9 +3267,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
+  assign _zz_67 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_67);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_67);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
@@ -3103,9 +3278,9 @@ module VexRiscv (
     end
   end
 
-  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
+  assign _zz_68 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_68);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_68);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
@@ -3114,22 +3289,22 @@ module VexRiscv (
     end
   end
 
-  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
+  assign _zz_69 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_69);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_69);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
-  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64 = _zz_65;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_70;
+  assign _zz_70 = ((1'b0 && (! _zz_71)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_71 = _zz_72;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_71;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_66 = _zz_67;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_73)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_73 = _zz_74;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_73;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_75;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -3144,7 +3319,7 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @ (*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_149)
+    case(_zz_163)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
@@ -3156,88 +3331,16 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_69 = _zz_287[11];
+  assign _zz_76 = _zz_304[11];
   always @ (*) begin
-    _zz_70[18] = _zz_69;
-    _zz_70[17] = _zz_69;
-    _zz_70[16] = _zz_69;
-    _zz_70[15] = _zz_69;
-    _zz_70[14] = _zz_69;
-    _zz_70[13] = _zz_69;
-    _zz_70[12] = _zz_69;
-    _zz_70[11] = _zz_69;
-    _zz_70[10] = _zz_69;
-    _zz_70[9] = _zz_69;
-    _zz_70[8] = _zz_69;
-    _zz_70[7] = _zz_69;
-    _zz_70[6] = _zz_69;
-    _zz_70[5] = _zz_69;
-    _zz_70[4] = _zz_69;
-    _zz_70[3] = _zz_69;
-    _zz_70[2] = _zz_69;
-    _zz_70[1] = _zz_69;
-    _zz_70[0] = _zz_69;
-  end
-
-  always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_288[31]));
-    if(_zz_75)begin
-      IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
-    end
-  end
-
-  assign _zz_71 = _zz_289[19];
-  always @ (*) begin
-    _zz_72[10] = _zz_71;
-    _zz_72[9] = _zz_71;
-    _zz_72[8] = _zz_71;
-    _zz_72[7] = _zz_71;
-    _zz_72[6] = _zz_71;
-    _zz_72[5] = _zz_71;
-    _zz_72[4] = _zz_71;
-    _zz_72[3] = _zz_71;
-    _zz_72[2] = _zz_71;
-    _zz_72[1] = _zz_71;
-    _zz_72[0] = _zz_71;
-  end
-
-  assign _zz_73 = _zz_290[11];
-  always @ (*) begin
-    _zz_74[18] = _zz_73;
-    _zz_74[17] = _zz_73;
-    _zz_74[16] = _zz_73;
-    _zz_74[15] = _zz_73;
-    _zz_74[14] = _zz_73;
-    _zz_74[13] = _zz_73;
-    _zz_74[12] = _zz_73;
-    _zz_74[11] = _zz_73;
-    _zz_74[10] = _zz_73;
-    _zz_74[9] = _zz_73;
-    _zz_74[8] = _zz_73;
-    _zz_74[7] = _zz_73;
-    _zz_74[6] = _zz_73;
-    _zz_74[5] = _zz_73;
-    _zz_74[4] = _zz_73;
-    _zz_74[3] = _zz_73;
-    _zz_74[2] = _zz_73;
-    _zz_74[1] = _zz_73;
-    _zz_74[0] = _zz_73;
-  end
-
-  always @ (*) begin
-    case(decode_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_75 = _zz_291[1];
-      end
-      default : begin
-        _zz_75 = _zz_292[1];
-      end
-    endcase
-  end
-
-  assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_76 = _zz_293[19];
-  always @ (*) begin
+    _zz_77[18] = _zz_76;
+    _zz_77[17] = _zz_76;
+    _zz_77[16] = _zz_76;
+    _zz_77[15] = _zz_76;
+    _zz_77[14] = _zz_76;
+    _zz_77[13] = _zz_76;
+    _zz_77[12] = _zz_76;
+    _zz_77[11] = _zz_76;
     _zz_77[10] = _zz_76;
     _zz_77[9] = _zz_76;
     _zz_77[8] = _zz_76;
@@ -3251,16 +3354,15 @@ module VexRiscv (
     _zz_77[0] = _zz_76;
   end
 
-  assign _zz_78 = _zz_294[11];
   always @ (*) begin
-    _zz_79[18] = _zz_78;
-    _zz_79[17] = _zz_78;
-    _zz_79[16] = _zz_78;
-    _zz_79[15] = _zz_78;
-    _zz_79[14] = _zz_78;
-    _zz_79[13] = _zz_78;
-    _zz_79[12] = _zz_78;
-    _zz_79[11] = _zz_78;
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_305[31]));
+    if(_zz_82)begin
+      IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
+    end
+  end
+
+  assign _zz_78 = _zz_306[19];
+  always @ (*) begin
     _zz_79[10] = _zz_78;
     _zz_79[9] = _zz_78;
     _zz_79[8] = _zz_78;
@@ -3274,7 +3376,80 @@ module VexRiscv (
     _zz_79[0] = _zz_78;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77,{{{_zz_369,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79,{{{_zz_370,_zz_371},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign _zz_80 = _zz_307[11];
+  always @ (*) begin
+    _zz_81[18] = _zz_80;
+    _zz_81[17] = _zz_80;
+    _zz_81[16] = _zz_80;
+    _zz_81[15] = _zz_80;
+    _zz_81[14] = _zz_80;
+    _zz_81[13] = _zz_80;
+    _zz_81[12] = _zz_80;
+    _zz_81[11] = _zz_80;
+    _zz_81[10] = _zz_80;
+    _zz_81[9] = _zz_80;
+    _zz_81[8] = _zz_80;
+    _zz_81[7] = _zz_80;
+    _zz_81[6] = _zz_80;
+    _zz_81[5] = _zz_80;
+    _zz_81[4] = _zz_80;
+    _zz_81[3] = _zz_80;
+    _zz_81[2] = _zz_80;
+    _zz_81[1] = _zz_80;
+    _zz_81[0] = _zz_80;
+  end
+
+  always @ (*) begin
+    case(decode_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_82 = _zz_308[1];
+      end
+      default : begin
+        _zz_82 = _zz_309[1];
+      end
+    endcase
+  end
+
+  assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
+  assign _zz_83 = _zz_310[19];
+  always @ (*) begin
+    _zz_84[10] = _zz_83;
+    _zz_84[9] = _zz_83;
+    _zz_84[8] = _zz_83;
+    _zz_84[7] = _zz_83;
+    _zz_84[6] = _zz_83;
+    _zz_84[5] = _zz_83;
+    _zz_84[4] = _zz_83;
+    _zz_84[3] = _zz_83;
+    _zz_84[2] = _zz_83;
+    _zz_84[1] = _zz_83;
+    _zz_84[0] = _zz_83;
+  end
+
+  assign _zz_85 = _zz_311[11];
+  always @ (*) begin
+    _zz_86[18] = _zz_85;
+    _zz_86[17] = _zz_85;
+    _zz_86[16] = _zz_85;
+    _zz_86[15] = _zz_85;
+    _zz_86[14] = _zz_85;
+    _zz_86[13] = _zz_85;
+    _zz_86[12] = _zz_85;
+    _zz_86[11] = _zz_85;
+    _zz_86[10] = _zz_85;
+    _zz_86[9] = _zz_85;
+    _zz_86[8] = _zz_85;
+    _zz_86[7] = _zz_85;
+    _zz_86[6] = _zz_85;
+    _zz_86[5] = _zz_85;
+    _zz_86[4] = _zz_85;
+    _zz_86[3] = _zz_85;
+    _zz_86[2] = _zz_85;
+    _zz_86[1] = _zz_85;
+    _zz_86[0] = _zz_85;
+  end
+
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_84,{{{_zz_390,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_86,{{{_zz_391,_zz_392},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3283,52 +3458,52 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_183 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_184 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_185 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_184;
+  assign _zz_197 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_198 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_199 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_198;
   assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
   assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
-  assign _zz_187 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_188 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_189 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_201 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_202 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_203 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_222)begin
+    if(_zz_236)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_220)begin
+    if(_zz_234)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_190 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_220)begin
-      _zz_190 = 1'b1;
+    _zz_204 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_234)begin
+      _zz_204 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_221)begin
+    if(_zz_235)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_219)begin
+    if(_zz_233)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
-    if(_zz_221)begin
+    if(_zz_235)begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_219)begin
+    if(_zz_233)begin
       IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
@@ -3338,9 +3513,9 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign _zz_182 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_196 = (decode_arbitration_isValid && decode_FLUSH_ALL);
   assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
-  assign _zz_209 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_223 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
   assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
@@ -3367,43 +3542,43 @@ module VexRiscv (
   assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
   assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_191 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_192 = execute_SRC_ADD;
+  assign _zz_205 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_206 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_82 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_89 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_82 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_89 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_82 = execute_RS2[31 : 0];
+        _zz_89 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_208 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_193 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_194 = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_193;
+  assign _zz_222 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_207 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_208 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_207;
   assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
-  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_194;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_208;
   assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
   assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @ (*) begin
-    _zz_195 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_54 && (! dataCache_1_io_cpu_memory_isWrite)))begin
-      _zz_195 = 1'b1;
+    _zz_209 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((_zz_61 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_209 = 1'b1;
     end
   end
 
-  assign _zz_196 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_197 = (CsrPlugin_privilege == 2'b00);
-  assign _zz_198 = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_210 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_211 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_212 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_231)begin
+    if(_zz_246)begin
       if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
@@ -3413,7 +3588,7 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_231)begin
+    if(_zz_246)begin
       if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
@@ -3432,15 +3607,15 @@ module VexRiscv (
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
-    if(_zz_231)begin
+    if(_zz_246)begin
       if(dataCache_1_io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_295};
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_312};
       end
       if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
       if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_296};
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_313};
       end
     end
   end
@@ -3462,63 +3637,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_83 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_90 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_84[31] = _zz_83;
-    _zz_84[30] = _zz_83;
-    _zz_84[29] = _zz_83;
-    _zz_84[28] = _zz_83;
-    _zz_84[27] = _zz_83;
-    _zz_84[26] = _zz_83;
-    _zz_84[25] = _zz_83;
-    _zz_84[24] = _zz_83;
-    _zz_84[23] = _zz_83;
-    _zz_84[22] = _zz_83;
-    _zz_84[21] = _zz_83;
-    _zz_84[20] = _zz_83;
-    _zz_84[19] = _zz_83;
-    _zz_84[18] = _zz_83;
-    _zz_84[17] = _zz_83;
-    _zz_84[16] = _zz_83;
-    _zz_84[15] = _zz_83;
-    _zz_84[14] = _zz_83;
-    _zz_84[13] = _zz_83;
-    _zz_84[12] = _zz_83;
-    _zz_84[11] = _zz_83;
-    _zz_84[10] = _zz_83;
-    _zz_84[9] = _zz_83;
-    _zz_84[8] = _zz_83;
-    _zz_84[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_91[31] = _zz_90;
+    _zz_91[30] = _zz_90;
+    _zz_91[29] = _zz_90;
+    _zz_91[28] = _zz_90;
+    _zz_91[27] = _zz_90;
+    _zz_91[26] = _zz_90;
+    _zz_91[25] = _zz_90;
+    _zz_91[24] = _zz_90;
+    _zz_91[23] = _zz_90;
+    _zz_91[22] = _zz_90;
+    _zz_91[21] = _zz_90;
+    _zz_91[20] = _zz_90;
+    _zz_91[19] = _zz_90;
+    _zz_91[18] = _zz_90;
+    _zz_91[17] = _zz_90;
+    _zz_91[16] = _zz_90;
+    _zz_91[15] = _zz_90;
+    _zz_91[14] = _zz_90;
+    _zz_91[13] = _zz_90;
+    _zz_91[12] = _zz_90;
+    _zz_91[11] = _zz_90;
+    _zz_91[10] = _zz_90;
+    _zz_91[9] = _zz_90;
+    _zz_91[8] = _zz_90;
+    _zz_91[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_92 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_86[31] = _zz_85;
-    _zz_86[30] = _zz_85;
-    _zz_86[29] = _zz_85;
-    _zz_86[28] = _zz_85;
-    _zz_86[27] = _zz_85;
-    _zz_86[26] = _zz_85;
-    _zz_86[25] = _zz_85;
-    _zz_86[24] = _zz_85;
-    _zz_86[23] = _zz_85;
-    _zz_86[22] = _zz_85;
-    _zz_86[21] = _zz_85;
-    _zz_86[20] = _zz_85;
-    _zz_86[19] = _zz_85;
-    _zz_86[18] = _zz_85;
-    _zz_86[17] = _zz_85;
-    _zz_86[16] = _zz_85;
-    _zz_86[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_93[31] = _zz_92;
+    _zz_93[30] = _zz_92;
+    _zz_93[29] = _zz_92;
+    _zz_93[28] = _zz_92;
+    _zz_93[27] = _zz_92;
+    _zz_93[26] = _zz_92;
+    _zz_93[25] = _zz_92;
+    _zz_93[24] = _zz_92;
+    _zz_93[23] = _zz_92;
+    _zz_93[22] = _zz_92;
+    _zz_93[21] = _zz_92;
+    _zz_93[20] = _zz_92;
+    _zz_93[19] = _zz_92;
+    _zz_93[18] = _zz_92;
+    _zz_93[17] = _zz_92;
+    _zz_93[16] = _zz_92;
+    _zz_93[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_251)
+    case(_zz_267)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_84;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_91;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_93;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -3544,49 +3719,52 @@ module VexRiscv (
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_88 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_89 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_90 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_91 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_87 = {(((decode_INSTRUCTION & _zz_372) == 32'h00100050) != 1'b0),{(_zz_91 != 1'b0),{(_zz_91 != 1'b0),{(_zz_373 != _zz_374),{_zz_375,{_zz_376,_zz_377}}}}}};
-  assign _zz_92 = _zz_87[2 : 1];
-  assign _zz_49 = _zz_92;
-  assign _zz_93 = _zz_87[7 : 6];
-  assign _zz_48 = _zz_93;
-  assign _zz_94 = _zz_87[9 : 8];
-  assign _zz_47 = _zz_94;
-  assign _zz_95 = _zz_87[19 : 18];
-  assign _zz_46 = _zz_95;
-  assign _zz_96 = _zz_87[22 : 21];
-  assign _zz_45 = _zz_96;
-  assign _zz_97 = _zz_87[24 : 23];
-  assign _zz_44 = _zz_97;
-  assign _zz_98 = _zz_87[27 : 26];
-  assign _zz_43 = _zz_98;
+  assign _zz_95 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_96 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_97 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_98 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000008);
+  assign _zz_99 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_94 = {1'b0,{(_zz_98 != 1'b0),{((_zz_393 == _zz_394) != 1'b0),{(_zz_99 != 1'b0),{(_zz_395 != _zz_396),{_zz_397,{_zz_398,_zz_399}}}}}}};
+  assign _zz_100 = _zz_94[2 : 1];
+  assign _zz_56 = _zz_100;
+  assign _zz_101 = _zz_94[7 : 6];
+  assign _zz_55 = _zz_101;
+  assign _zz_102 = _zz_94[9 : 8];
+  assign _zz_54 = _zz_102;
+  assign _zz_103 = _zz_94[19 : 18];
+  assign _zz_53 = _zz_103;
+  assign _zz_104 = _zz_94[22 : 21];
+  assign _zz_52 = _zz_104;
+  assign _zz_105 = _zz_94[24 : 23];
+  assign _zz_51 = _zz_105;
+  assign _zz_106 = _zz_94[27 : 26];
+  assign _zz_50 = _zz_106;
+  assign _zz_107 = _zz_94[34 : 34];
+  assign _zz_49 = _zz_107;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
   assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_210;
-  assign decode_RegFilePlugin_rs2Data = _zz_211;
+  assign decode_RegFilePlugin_rs1Data = _zz_224;
+  assign decode_RegFilePlugin_rs2Data = _zz_225;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
-    if(_zz_99)begin
+    lastStageRegFileWrite_valid = (_zz_47 && writeBack_arbitration_isFiring);
+    if(_zz_108)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
-    if(_zz_99)begin
+    lastStageRegFileWrite_payload_address = _zz_46[11 : 7];
+    if(_zz_108)begin
       lastStageRegFileWrite_payload_address = 5'h0;
     end
   end
 
   always @ (*) begin
-    lastStageRegFileWrite_payload_data = _zz_50;
-    if(_zz_99)begin
+    lastStageRegFileWrite_payload_data = _zz_57;
+    if(_zz_108)begin
       lastStageRegFileWrite_payload_data = 32'h0;
     end
   end
@@ -3608,13 +3786,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_100 = execute_IntAluPlugin_bitwise;
+        _zz_109 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_100 = {31'd0, _zz_297};
+        _zz_109 = {31'd0, _zz_314};
       end
       default : begin
-        _zz_100 = execute_SRC_ADD_SUB;
+        _zz_109 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -3622,87 +3800,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_101 = execute_RS1;
+        _zz_110 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_101 = {29'd0, _zz_298};
+        _zz_110 = {29'd0, _zz_315};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_101 = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_110 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_101 = {27'd0, _zz_299};
+        _zz_110 = {27'd0, _zz_316};
       end
     endcase
   end
 
-  assign _zz_102 = _zz_300[11];
+  assign _zz_111 = _zz_317[11];
   always @ (*) begin
-    _zz_103[19] = _zz_102;
-    _zz_103[18] = _zz_102;
-    _zz_103[17] = _zz_102;
-    _zz_103[16] = _zz_102;
-    _zz_103[15] = _zz_102;
-    _zz_103[14] = _zz_102;
-    _zz_103[13] = _zz_102;
-    _zz_103[12] = _zz_102;
-    _zz_103[11] = _zz_102;
-    _zz_103[10] = _zz_102;
-    _zz_103[9] = _zz_102;
-    _zz_103[8] = _zz_102;
-    _zz_103[7] = _zz_102;
-    _zz_103[6] = _zz_102;
-    _zz_103[5] = _zz_102;
-    _zz_103[4] = _zz_102;
-    _zz_103[3] = _zz_102;
-    _zz_103[2] = _zz_102;
-    _zz_103[1] = _zz_102;
-    _zz_103[0] = _zz_102;
+    _zz_112[19] = _zz_111;
+    _zz_112[18] = _zz_111;
+    _zz_112[17] = _zz_111;
+    _zz_112[16] = _zz_111;
+    _zz_112[15] = _zz_111;
+    _zz_112[14] = _zz_111;
+    _zz_112[13] = _zz_111;
+    _zz_112[12] = _zz_111;
+    _zz_112[11] = _zz_111;
+    _zz_112[10] = _zz_111;
+    _zz_112[9] = _zz_111;
+    _zz_112[8] = _zz_111;
+    _zz_112[7] = _zz_111;
+    _zz_112[6] = _zz_111;
+    _zz_112[5] = _zz_111;
+    _zz_112[4] = _zz_111;
+    _zz_112[3] = _zz_111;
+    _zz_112[2] = _zz_111;
+    _zz_112[1] = _zz_111;
+    _zz_112[0] = _zz_111;
   end
 
-  assign _zz_104 = _zz_301[11];
+  assign _zz_113 = _zz_318[11];
   always @ (*) begin
-    _zz_105[19] = _zz_104;
-    _zz_105[18] = _zz_104;
-    _zz_105[17] = _zz_104;
-    _zz_105[16] = _zz_104;
-    _zz_105[15] = _zz_104;
-    _zz_105[14] = _zz_104;
-    _zz_105[13] = _zz_104;
-    _zz_105[12] = _zz_104;
-    _zz_105[11] = _zz_104;
-    _zz_105[10] = _zz_104;
-    _zz_105[9] = _zz_104;
-    _zz_105[8] = _zz_104;
-    _zz_105[7] = _zz_104;
-    _zz_105[6] = _zz_104;
-    _zz_105[5] = _zz_104;
-    _zz_105[4] = _zz_104;
-    _zz_105[3] = _zz_104;
-    _zz_105[2] = _zz_104;
-    _zz_105[1] = _zz_104;
-    _zz_105[0] = _zz_104;
+    _zz_114[19] = _zz_113;
+    _zz_114[18] = _zz_113;
+    _zz_114[17] = _zz_113;
+    _zz_114[16] = _zz_113;
+    _zz_114[15] = _zz_113;
+    _zz_114[14] = _zz_113;
+    _zz_114[13] = _zz_113;
+    _zz_114[12] = _zz_113;
+    _zz_114[11] = _zz_113;
+    _zz_114[10] = _zz_113;
+    _zz_114[9] = _zz_113;
+    _zz_114[8] = _zz_113;
+    _zz_114[7] = _zz_113;
+    _zz_114[6] = _zz_113;
+    _zz_114[5] = _zz_113;
+    _zz_114[4] = _zz_113;
+    _zz_114[3] = _zz_113;
+    _zz_114[2] = _zz_113;
+    _zz_114[1] = _zz_113;
+    _zz_114[0] = _zz_113;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_106 = execute_RS2;
+        _zz_115 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_106 = {_zz_103,execute_INSTRUCTION[31 : 20]};
+        _zz_115 = {_zz_112,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_106 = {_zz_105,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_115 = {_zz_114,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_106 = _zz_35;
+        _zz_115 = _zz_41;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_302;
+    execute_SrcPlugin_addSub = _zz_319;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -3711,297 +3889,180 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_107[0] = execute_SRC1[31];
-    _zz_107[1] = execute_SRC1[30];
-    _zz_107[2] = execute_SRC1[29];
-    _zz_107[3] = execute_SRC1[28];
-    _zz_107[4] = execute_SRC1[27];
-    _zz_107[5] = execute_SRC1[26];
-    _zz_107[6] = execute_SRC1[25];
-    _zz_107[7] = execute_SRC1[24];
-    _zz_107[8] = execute_SRC1[23];
-    _zz_107[9] = execute_SRC1[22];
-    _zz_107[10] = execute_SRC1[21];
-    _zz_107[11] = execute_SRC1[20];
-    _zz_107[12] = execute_SRC1[19];
-    _zz_107[13] = execute_SRC1[18];
-    _zz_107[14] = execute_SRC1[17];
-    _zz_107[15] = execute_SRC1[16];
-    _zz_107[16] = execute_SRC1[15];
-    _zz_107[17] = execute_SRC1[14];
-    _zz_107[18] = execute_SRC1[13];
-    _zz_107[19] = execute_SRC1[12];
-    _zz_107[20] = execute_SRC1[11];
-    _zz_107[21] = execute_SRC1[10];
-    _zz_107[22] = execute_SRC1[9];
-    _zz_107[23] = execute_SRC1[8];
-    _zz_107[24] = execute_SRC1[7];
-    _zz_107[25] = execute_SRC1[6];
-    _zz_107[26] = execute_SRC1[5];
-    _zz_107[27] = execute_SRC1[4];
-    _zz_107[28] = execute_SRC1[3];
-    _zz_107[29] = execute_SRC1[2];
-    _zz_107[30] = execute_SRC1[1];
-    _zz_107[31] = execute_SRC1[0];
+    _zz_116[0] = execute_SRC1[31];
+    _zz_116[1] = execute_SRC1[30];
+    _zz_116[2] = execute_SRC1[29];
+    _zz_116[3] = execute_SRC1[28];
+    _zz_116[4] = execute_SRC1[27];
+    _zz_116[5] = execute_SRC1[26];
+    _zz_116[6] = execute_SRC1[25];
+    _zz_116[7] = execute_SRC1[24];
+    _zz_116[8] = execute_SRC1[23];
+    _zz_116[9] = execute_SRC1[22];
+    _zz_116[10] = execute_SRC1[21];
+    _zz_116[11] = execute_SRC1[20];
+    _zz_116[12] = execute_SRC1[19];
+    _zz_116[13] = execute_SRC1[18];
+    _zz_116[14] = execute_SRC1[17];
+    _zz_116[15] = execute_SRC1[16];
+    _zz_116[16] = execute_SRC1[15];
+    _zz_116[17] = execute_SRC1[14];
+    _zz_116[18] = execute_SRC1[13];
+    _zz_116[19] = execute_SRC1[12];
+    _zz_116[20] = execute_SRC1[11];
+    _zz_116[21] = execute_SRC1[10];
+    _zz_116[22] = execute_SRC1[9];
+    _zz_116[23] = execute_SRC1[8];
+    _zz_116[24] = execute_SRC1[7];
+    _zz_116[25] = execute_SRC1[6];
+    _zz_116[26] = execute_SRC1[5];
+    _zz_116[27] = execute_SRC1[4];
+    _zz_116[28] = execute_SRC1[3];
+    _zz_116[29] = execute_SRC1[2];
+    _zz_116[30] = execute_SRC1[1];
+    _zz_116[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_107 : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_116 : execute_SRC1);
   always @ (*) begin
-    _zz_108[0] = memory_SHIFT_RIGHT[31];
-    _zz_108[1] = memory_SHIFT_RIGHT[30];
-    _zz_108[2] = memory_SHIFT_RIGHT[29];
-    _zz_108[3] = memory_SHIFT_RIGHT[28];
-    _zz_108[4] = memory_SHIFT_RIGHT[27];
-    _zz_108[5] = memory_SHIFT_RIGHT[26];
-    _zz_108[6] = memory_SHIFT_RIGHT[25];
-    _zz_108[7] = memory_SHIFT_RIGHT[24];
-    _zz_108[8] = memory_SHIFT_RIGHT[23];
-    _zz_108[9] = memory_SHIFT_RIGHT[22];
-    _zz_108[10] = memory_SHIFT_RIGHT[21];
-    _zz_108[11] = memory_SHIFT_RIGHT[20];
-    _zz_108[12] = memory_SHIFT_RIGHT[19];
-    _zz_108[13] = memory_SHIFT_RIGHT[18];
-    _zz_108[14] = memory_SHIFT_RIGHT[17];
-    _zz_108[15] = memory_SHIFT_RIGHT[16];
-    _zz_108[16] = memory_SHIFT_RIGHT[15];
-    _zz_108[17] = memory_SHIFT_RIGHT[14];
-    _zz_108[18] = memory_SHIFT_RIGHT[13];
-    _zz_108[19] = memory_SHIFT_RIGHT[12];
-    _zz_108[20] = memory_SHIFT_RIGHT[11];
-    _zz_108[21] = memory_SHIFT_RIGHT[10];
-    _zz_108[22] = memory_SHIFT_RIGHT[9];
-    _zz_108[23] = memory_SHIFT_RIGHT[8];
-    _zz_108[24] = memory_SHIFT_RIGHT[7];
-    _zz_108[25] = memory_SHIFT_RIGHT[6];
-    _zz_108[26] = memory_SHIFT_RIGHT[5];
-    _zz_108[27] = memory_SHIFT_RIGHT[4];
-    _zz_108[28] = memory_SHIFT_RIGHT[3];
-    _zz_108[29] = memory_SHIFT_RIGHT[2];
-    _zz_108[30] = memory_SHIFT_RIGHT[1];
-    _zz_108[31] = memory_SHIFT_RIGHT[0];
+    _zz_117[0] = memory_SHIFT_RIGHT[31];
+    _zz_117[1] = memory_SHIFT_RIGHT[30];
+    _zz_117[2] = memory_SHIFT_RIGHT[29];
+    _zz_117[3] = memory_SHIFT_RIGHT[28];
+    _zz_117[4] = memory_SHIFT_RIGHT[27];
+    _zz_117[5] = memory_SHIFT_RIGHT[26];
+    _zz_117[6] = memory_SHIFT_RIGHT[25];
+    _zz_117[7] = memory_SHIFT_RIGHT[24];
+    _zz_117[8] = memory_SHIFT_RIGHT[23];
+    _zz_117[9] = memory_SHIFT_RIGHT[22];
+    _zz_117[10] = memory_SHIFT_RIGHT[21];
+    _zz_117[11] = memory_SHIFT_RIGHT[20];
+    _zz_117[12] = memory_SHIFT_RIGHT[19];
+    _zz_117[13] = memory_SHIFT_RIGHT[18];
+    _zz_117[14] = memory_SHIFT_RIGHT[17];
+    _zz_117[15] = memory_SHIFT_RIGHT[16];
+    _zz_117[16] = memory_SHIFT_RIGHT[15];
+    _zz_117[17] = memory_SHIFT_RIGHT[14];
+    _zz_117[18] = memory_SHIFT_RIGHT[13];
+    _zz_117[19] = memory_SHIFT_RIGHT[12];
+    _zz_117[20] = memory_SHIFT_RIGHT[11];
+    _zz_117[21] = memory_SHIFT_RIGHT[10];
+    _zz_117[22] = memory_SHIFT_RIGHT[9];
+    _zz_117[23] = memory_SHIFT_RIGHT[8];
+    _zz_117[24] = memory_SHIFT_RIGHT[7];
+    _zz_117[25] = memory_SHIFT_RIGHT[6];
+    _zz_117[26] = memory_SHIFT_RIGHT[5];
+    _zz_117[27] = memory_SHIFT_RIGHT[4];
+    _zz_117[28] = memory_SHIFT_RIGHT[3];
+    _zz_117[29] = memory_SHIFT_RIGHT[2];
+    _zz_117[30] = memory_SHIFT_RIGHT[1];
+    _zz_117[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_109 = 1'b0;
-    if(_zz_232)begin
-      if(_zz_233)begin
-        if(_zz_114)begin
-          _zz_109 = 1'b1;
+    _zz_118 = 1'b0;
+    if(_zz_247)begin
+      if(_zz_248)begin
+        if(_zz_123)begin
+          _zz_118 = 1'b1;
         end
       end
     end
-    if(_zz_234)begin
-      if(_zz_235)begin
-        if(_zz_116)begin
-          _zz_109 = 1'b1;
+    if(_zz_249)begin
+      if(_zz_250)begin
+        if(_zz_125)begin
+          _zz_118 = 1'b1;
         end
       end
     end
-    if(_zz_236)begin
-      if(_zz_237)begin
-        if(_zz_118)begin
-          _zz_109 = 1'b1;
+    if(_zz_251)begin
+      if(_zz_252)begin
+        if(_zz_127)begin
+          _zz_118 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_109 = 1'b0;
+      _zz_118 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_110 = 1'b0;
-    if(_zz_232)begin
-      if(_zz_233)begin
-        if(_zz_115)begin
-          _zz_110 = 1'b1;
+    _zz_119 = 1'b0;
+    if(_zz_247)begin
+      if(_zz_248)begin
+        if(_zz_124)begin
+          _zz_119 = 1'b1;
         end
       end
     end
-    if(_zz_234)begin
-      if(_zz_235)begin
-        if(_zz_117)begin
-          _zz_110 = 1'b1;
+    if(_zz_249)begin
+      if(_zz_250)begin
+        if(_zz_126)begin
+          _zz_119 = 1'b1;
         end
       end
     end
-    if(_zz_236)begin
-      if(_zz_237)begin
-        if(_zz_119)begin
-          _zz_110 = 1'b1;
+    if(_zz_251)begin
+      if(_zz_252)begin
+        if(_zz_128)begin
+          _zz_119 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_110 = 1'b0;
+      _zz_119 = 1'b0;
     end
   end
 
-  assign _zz_114 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_115 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_116 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_117 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_118 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_119 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_123 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_124 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_125 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_126 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_127 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_128 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_120 = execute_INSTRUCTION[14 : 12];
+  assign _zz_129 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_120 == 3'b000)) begin
-        _zz_121 = execute_BranchPlugin_eq;
-    end else if((_zz_120 == 3'b001)) begin
-        _zz_121 = (! execute_BranchPlugin_eq);
-    end else if((((_zz_120 & 3'b101) == 3'b101))) begin
-        _zz_121 = (! execute_SRC_LESS);
+    if((_zz_129 == 3'b000)) begin
+        _zz_130 = execute_BranchPlugin_eq;
+    end else if((_zz_129 == 3'b001)) begin
+        _zz_130 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_129 & 3'b101) == 3'b101))) begin
+        _zz_130 = (! execute_SRC_LESS);
     end else begin
-        _zz_121 = execute_SRC_LESS;
+        _zz_130 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_122 = 1'b0;
+        _zz_131 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_122 = 1'b1;
+        _zz_131 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_122 = 1'b1;
+        _zz_131 = 1'b1;
       end
       default : begin
-        _zz_122 = _zz_121;
+        _zz_131 = _zz_130;
       end
     endcase
   end
 
-  assign _zz_123 = _zz_309[11];
+  assign _zz_132 = _zz_326[11];
   always @ (*) begin
-    _zz_124[19] = _zz_123;
-    _zz_124[18] = _zz_123;
-    _zz_124[17] = _zz_123;
-    _zz_124[16] = _zz_123;
-    _zz_124[15] = _zz_123;
-    _zz_124[14] = _zz_123;
-    _zz_124[13] = _zz_123;
-    _zz_124[12] = _zz_123;
-    _zz_124[11] = _zz_123;
-    _zz_124[10] = _zz_123;
-    _zz_124[9] = _zz_123;
-    _zz_124[8] = _zz_123;
-    _zz_124[7] = _zz_123;
-    _zz_124[6] = _zz_123;
-    _zz_124[5] = _zz_123;
-    _zz_124[4] = _zz_123;
-    _zz_124[3] = _zz_123;
-    _zz_124[2] = _zz_123;
-    _zz_124[1] = _zz_123;
-    _zz_124[0] = _zz_123;
-  end
-
-  assign _zz_125 = _zz_310[19];
-  always @ (*) begin
-    _zz_126[10] = _zz_125;
-    _zz_126[9] = _zz_125;
-    _zz_126[8] = _zz_125;
-    _zz_126[7] = _zz_125;
-    _zz_126[6] = _zz_125;
-    _zz_126[5] = _zz_125;
-    _zz_126[4] = _zz_125;
-    _zz_126[3] = _zz_125;
-    _zz_126[2] = _zz_125;
-    _zz_126[1] = _zz_125;
-    _zz_126[0] = _zz_125;
-  end
-
-  assign _zz_127 = _zz_311[11];
-  always @ (*) begin
-    _zz_128[18] = _zz_127;
-    _zz_128[17] = _zz_127;
-    _zz_128[16] = _zz_127;
-    _zz_128[15] = _zz_127;
-    _zz_128[14] = _zz_127;
-    _zz_128[13] = _zz_127;
-    _zz_128[12] = _zz_127;
-    _zz_128[11] = _zz_127;
-    _zz_128[10] = _zz_127;
-    _zz_128[9] = _zz_127;
-    _zz_128[8] = _zz_127;
-    _zz_128[7] = _zz_127;
-    _zz_128[6] = _zz_127;
-    _zz_128[5] = _zz_127;
-    _zz_128[4] = _zz_127;
-    _zz_128[3] = _zz_127;
-    _zz_128[2] = _zz_127;
-    _zz_128[1] = _zz_127;
-    _zz_128[0] = _zz_127;
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_129 = (_zz_312[1] ^ execute_RS1[1]);
-      end
-      `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_129 = _zz_313[1];
-      end
-      default : begin
-        _zz_129 = _zz_314[1];
-      end
-    endcase
-  end
-
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_129);
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src1 = execute_RS1;
-      end
-      default : begin
-        execute_BranchPlugin_branch_src1 = execute_PC;
-      end
-    endcase
-  end
-
-  assign _zz_130 = _zz_315[11];
-  always @ (*) begin
-    _zz_131[19] = _zz_130;
-    _zz_131[18] = _zz_130;
-    _zz_131[17] = _zz_130;
-    _zz_131[16] = _zz_130;
-    _zz_131[15] = _zz_130;
-    _zz_131[14] = _zz_130;
-    _zz_131[13] = _zz_130;
-    _zz_131[12] = _zz_130;
-    _zz_131[11] = _zz_130;
-    _zz_131[10] = _zz_130;
-    _zz_131[9] = _zz_130;
-    _zz_131[8] = _zz_130;
-    _zz_131[7] = _zz_130;
-    _zz_131[6] = _zz_130;
-    _zz_131[5] = _zz_130;
-    _zz_131[4] = _zz_130;
-    _zz_131[3] = _zz_130;
-    _zz_131[2] = _zz_130;
-    _zz_131[1] = _zz_130;
-    _zz_131[0] = _zz_130;
-  end
-
-  always @ (*) begin
-    case(execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_131,execute_INSTRUCTION[31 : 20]};
-      end
-      default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_133,{{{_zz_536,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_135,{{{_zz_537,_zz_538},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
-        if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_318};
-        end
-      end
-    endcase
-  end
-
-  assign _zz_132 = _zz_316[19];
-  always @ (*) begin
+    _zz_133[19] = _zz_132;
+    _zz_133[18] = _zz_132;
+    _zz_133[17] = _zz_132;
+    _zz_133[16] = _zz_132;
+    _zz_133[15] = _zz_132;
+    _zz_133[14] = _zz_132;
+    _zz_133[13] = _zz_132;
+    _zz_133[12] = _zz_132;
+    _zz_133[11] = _zz_132;
     _zz_133[10] = _zz_132;
     _zz_133[9] = _zz_132;
     _zz_133[8] = _zz_132;
@@ -4015,16 +4076,8 @@ module VexRiscv (
     _zz_133[0] = _zz_132;
   end
 
-  assign _zz_134 = _zz_317[11];
+  assign _zz_134 = _zz_327[19];
   always @ (*) begin
-    _zz_135[18] = _zz_134;
-    _zz_135[17] = _zz_134;
-    _zz_135[16] = _zz_134;
-    _zz_135[15] = _zz_134;
-    _zz_135[14] = _zz_134;
-    _zz_135[13] = _zz_134;
-    _zz_135[12] = _zz_134;
-    _zz_135[11] = _zz_134;
     _zz_135[10] = _zz_134;
     _zz_135[9] = _zz_134;
     _zz_135[8] = _zz_134;
@@ -4038,12 +4091,143 @@ module VexRiscv (
     _zz_135[0] = _zz_134;
   end
 
+  assign _zz_136 = _zz_328[11];
+  always @ (*) begin
+    _zz_137[18] = _zz_136;
+    _zz_137[17] = _zz_136;
+    _zz_137[16] = _zz_136;
+    _zz_137[15] = _zz_136;
+    _zz_137[14] = _zz_136;
+    _zz_137[13] = _zz_136;
+    _zz_137[12] = _zz_136;
+    _zz_137[11] = _zz_136;
+    _zz_137[10] = _zz_136;
+    _zz_137[9] = _zz_136;
+    _zz_137[8] = _zz_136;
+    _zz_137[7] = _zz_136;
+    _zz_137[6] = _zz_136;
+    _zz_137[5] = _zz_136;
+    _zz_137[4] = _zz_136;
+    _zz_137[3] = _zz_136;
+    _zz_137[2] = _zz_136;
+    _zz_137[1] = _zz_136;
+    _zz_137[0] = _zz_136;
+  end
+
+  always @ (*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        _zz_138 = (_zz_329[1] ^ execute_RS1[1]);
+      end
+      `BranchCtrlEnum_defaultEncoding_JAL : begin
+        _zz_138 = _zz_330[1];
+      end
+      default : begin
+        _zz_138 = _zz_331[1];
+      end
+    endcase
+  end
+
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_138);
+  always @ (*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        execute_BranchPlugin_branch_src1 = execute_RS1;
+      end
+      default : begin
+        execute_BranchPlugin_branch_src1 = execute_PC;
+      end
+    endcase
+  end
+
+  assign _zz_139 = _zz_332[11];
+  always @ (*) begin
+    _zz_140[19] = _zz_139;
+    _zz_140[18] = _zz_139;
+    _zz_140[17] = _zz_139;
+    _zz_140[16] = _zz_139;
+    _zz_140[15] = _zz_139;
+    _zz_140[14] = _zz_139;
+    _zz_140[13] = _zz_139;
+    _zz_140[12] = _zz_139;
+    _zz_140[11] = _zz_139;
+    _zz_140[10] = _zz_139;
+    _zz_140[9] = _zz_139;
+    _zz_140[8] = _zz_139;
+    _zz_140[7] = _zz_139;
+    _zz_140[6] = _zz_139;
+    _zz_140[5] = _zz_139;
+    _zz_140[4] = _zz_139;
+    _zz_140[3] = _zz_139;
+    _zz_140[2] = _zz_139;
+    _zz_140[1] = _zz_139;
+    _zz_140[0] = _zz_139;
+  end
+
+  always @ (*) begin
+    case(execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_JALR : begin
+        execute_BranchPlugin_branch_src2 = {_zz_140,execute_INSTRUCTION[31 : 20]};
+      end
+      default : begin
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_142,{{{_zz_562,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_144,{{{_zz_563,_zz_564},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        if(execute_PREDICTION_HAD_BRANCHED2)begin
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_335};
+        end
+      end
+    endcase
+  end
+
+  assign _zz_141 = _zz_333[19];
+  always @ (*) begin
+    _zz_142[10] = _zz_141;
+    _zz_142[9] = _zz_141;
+    _zz_142[8] = _zz_141;
+    _zz_142[7] = _zz_141;
+    _zz_142[6] = _zz_141;
+    _zz_142[5] = _zz_141;
+    _zz_142[4] = _zz_141;
+    _zz_142[3] = _zz_141;
+    _zz_142[2] = _zz_141;
+    _zz_142[1] = _zz_141;
+    _zz_142[0] = _zz_141;
+  end
+
+  assign _zz_143 = _zz_334[11];
+  always @ (*) begin
+    _zz_144[18] = _zz_143;
+    _zz_144[17] = _zz_143;
+    _zz_144[16] = _zz_143;
+    _zz_144[15] = _zz_143;
+    _zz_144[14] = _zz_143;
+    _zz_144[13] = _zz_143;
+    _zz_144[12] = _zz_143;
+    _zz_144[11] = _zz_143;
+    _zz_144[10] = _zz_143;
+    _zz_144[9] = _zz_143;
+    _zz_144[8] = _zz_143;
+    _zz_144[7] = _zz_143;
+    _zz_144[6] = _zz_143;
+    _zz_144[5] = _zz_143;
+    _zz_144[4] = _zz_143;
+    _zz_144[3] = _zz_143;
+    _zz_144[2] = _zz_143;
+    _zz_144[1] = _zz_143;
+    _zz_144[0] = _zz_143;
+  end
+
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
-  assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
-  assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
-  assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
+  assign BranchPlugin_jumpInterface_valid = ((execute_arbitration_isValid && execute_BRANCH_DO) && (! 1'b0));
+  assign BranchPlugin_jumpInterface_payload = execute_BRANCH_CALC;
+  always @ (*) begin
+    BranchPlugin_branchExceptionPort_valid = (execute_arbitration_isValid && (execute_BRANCH_DO && execute_BRANCH_CALC[1]));
+    if(1'b0)begin
+      BranchPlugin_branchExceptionPort_valid = 1'b0;
+    end
+  end
+
   assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
-  assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
+  assign BranchPlugin_branchExceptionPort_payload_badAddr = execute_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
     CsrPlugin_privilege = 2'b11;
@@ -4052,16 +4236,18 @@ module VexRiscv (
     end
   end
 
-  assign _zz_136 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_137 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_138 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_145 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_146 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_147 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_139 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_140 = _zz_319[0];
+  assign _zz_148 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_149 = _zz_336[0];
+  assign _zz_150 = {CsrPlugin_selfException_valid,BranchPlugin_branchExceptionPort_valid};
+  assign _zz_151 = _zz_338[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_223)begin
+    if(_zz_237)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -4071,7 +4257,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_execute = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute;
-    if(CsrPlugin_selfException_valid)begin
+    if(_zz_240)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_execute = 1'b1;
     end
     if(execute_arbitration_isFlushed)begin
@@ -4081,7 +4267,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(BranchPlugin_branchExceptionPort_valid)begin
+    if(CfuPlugin_joinException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -4248,7 +4434,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_238)begin
+    if(_zz_253)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -4267,20 +4453,20 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_239)begin
+    if(_zz_254)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_240)begin
+    if(_zz_255)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_selfException_payload_code = 4'bxxxx;
-    if(_zz_239)begin
+    if(_zz_254)begin
       CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_240)begin
+    if(_zz_255)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
           CsrPlugin_selfException_payload_code = 4'b1000;
@@ -4295,14 +4481,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_238)begin
+    if(_zz_253)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_238)begin
+    if(_zz_253)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4311,7 +4497,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_252)
+    case(_zz_268)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -4325,7 +4511,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_241)
+    case(_zz_256)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -4339,7 +4525,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_241)
+    case(_zz_256)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -4358,12 +4544,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_321) + $signed(_zz_322));
+  assign writeBack_MulPlugin_result = ($signed(_zz_340) + $signed(_zz_341));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_218)begin
-      if(_zz_242)begin
+    if(_zz_232)begin
+      if(_zz_257)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -4371,7 +4557,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_243)begin
+    if(_zz_258)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -4382,32 +4568,32 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_326);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_345);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_141 = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_141[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_327);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_328 : _zz_329);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_330[31:0];
-  assign _zz_142 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_143 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_144 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_152 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_152[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_346);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_347 : _zz_348);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_349[31:0];
+  assign _zz_153 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_154 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_155 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_145[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_145[31 : 0] = execute_RS1;
+    _zz_156[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_156[31 : 0] = execute_RS1;
   end
 
-  assign _zz_147 = (_zz_146 & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_147 != 32'h0);
+  assign _zz_158 = (_zz_157 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_158 != 32'h0);
   always @ (*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid)begin
-      case(_zz_244)
+      case(_zz_259)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
@@ -4421,7 +4607,7 @@ module VexRiscv (
 
   always @ (*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_148))begin
+    if((! _zz_159))begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4433,7 +4619,7 @@ module VexRiscv (
   always @ (*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid)begin
-      case(_zz_244)
+      case(_zz_259)
         6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
@@ -4448,33 +4634,103 @@ module VexRiscv (
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
   assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26 = decode_SRC1_CTRL;
-  assign _zz_24 = _zz_49;
-  assign _zz_37 = decode_to_execute_SRC1_CTRL;
-  assign _zz_23 = decode_ALU_CTRL;
-  assign _zz_21 = _zz_48;
-  assign _zz_38 = decode_to_execute_ALU_CTRL;
-  assign _zz_20 = decode_SRC2_CTRL;
-  assign _zz_18 = _zz_47;
-  assign _zz_36 = decode_to_execute_SRC2_CTRL;
-  assign _zz_17 = decode_ALU_BITWISE_CTRL;
-  assign _zz_15 = _zz_46;
-  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_14 = decode_SHIFT_CTRL;
-  assign _zz_11 = execute_SHIFT_CTRL;
-  assign _zz_12 = _zz_45;
-  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9 = decode_BRANCH_CTRL;
-  assign _zz_51 = _zz_44;
-  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7 = decode_ENV_CTRL;
-  assign _zz_4 = execute_ENV_CTRL;
-  assign _zz_2 = memory_ENV_CTRL;
-  assign _zz_5 = _zz_43;
-  assign _zz_28 = decode_to_execute_ENV_CTRL;
-  assign _zz_27 = execute_to_memory_ENV_CTRL;
-  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign execute_CfuPlugin_schedule = (execute_arbitration_isValid && execute_CfuPlugin_CFU_ENABLE);
+  assign CfuPlugin_bus_cmd_valid = ((execute_CfuPlugin_schedule || execute_CfuPlugin_hold) && (! execute_CfuPlugin_fired));
+  assign execute_CfuPlugin_functionsIds_0 = _zz_359;
+  assign CfuPlugin_bus_cmd_payload_function_id = execute_CfuPlugin_functionsIds_0;
+  assign CfuPlugin_bus_cmd_payload_inputs_0 = execute_RS1;
+  assign _zz_160 = _zz_360[7];
+  always @ (*) begin
+    _zz_161[23] = _zz_160;
+    _zz_161[22] = _zz_160;
+    _zz_161[21] = _zz_160;
+    _zz_161[20] = _zz_160;
+    _zz_161[19] = _zz_160;
+    _zz_161[18] = _zz_160;
+    _zz_161[17] = _zz_160;
+    _zz_161[16] = _zz_160;
+    _zz_161[15] = _zz_160;
+    _zz_161[14] = _zz_160;
+    _zz_161[13] = _zz_160;
+    _zz_161[12] = _zz_160;
+    _zz_161[11] = _zz_160;
+    _zz_161[10] = _zz_160;
+    _zz_161[9] = _zz_160;
+    _zz_161[8] = _zz_160;
+    _zz_161[7] = _zz_160;
+    _zz_161[6] = _zz_160;
+    _zz_161[5] = _zz_160;
+    _zz_161[4] = _zz_160;
+    _zz_161[3] = _zz_160;
+    _zz_161[2] = _zz_160;
+    _zz_161[1] = _zz_160;
+    _zz_161[0] = _zz_160;
+  end
+
+  always @ (*) begin
+    case(execute_CfuPlugin_CFU_INPUT_2_KIND)
+      `Input2Kind_defaultEncoding_RS : begin
+        _zz_162 = execute_RS2;
+      end
+      default : begin
+        _zz_162 = {_zz_161,execute_INSTRUCTION[31 : 24]};
+      end
+    endcase
+  end
+
+  assign CfuPlugin_bus_cmd_payload_inputs_1 = _zz_162;
+  assign memory_CfuPlugin_rsp_valid = (CfuPlugin_bus_rsp_valid || CfuPlugin_bus_rsp_s2mPipe_rValid);
+  assign CfuPlugin_bus_rsp_ready = (! CfuPlugin_bus_rsp_s2mPipe_rValid);
+  assign memory_CfuPlugin_rsp_payload_response_ok = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_response_ok : CfuPlugin_bus_rsp_payload_response_ok);
+  assign memory_CfuPlugin_rsp_payload_outputs_0 = (CfuPlugin_bus_rsp_s2mPipe_rValid ? CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 : CfuPlugin_bus_rsp_payload_outputs_0);
+  always @ (*) begin
+    CfuPlugin_joinException_valid = 1'b0;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      if(memory_arbitration_isValid)begin
+        CfuPlugin_joinException_valid = (! memory_CfuPlugin_rsp_payload_response_ok);
+      end
+    end
+  end
+
+  assign CfuPlugin_joinException_payload_code = 4'b1111;
+  assign CfuPlugin_joinException_payload_badAddr = 32'h0;
+  always @ (*) begin
+    memory_CfuPlugin_rsp_ready = 1'b0;
+    if(memory_CfuPlugin_CFU_IN_FLIGHT)begin
+      memory_CfuPlugin_rsp_ready = (! memory_arbitration_isStuckByOthers);
+    end
+  end
+
+  assign _zz_29 = decode_SRC1_CTRL;
+  assign _zz_27 = _zz_56;
+  assign _zz_43 = decode_to_execute_SRC1_CTRL;
+  assign _zz_26 = decode_ALU_CTRL;
+  assign _zz_24 = _zz_55;
+  assign _zz_44 = decode_to_execute_ALU_CTRL;
+  assign _zz_23 = decode_SRC2_CTRL;
+  assign _zz_21 = _zz_54;
+  assign _zz_42 = decode_to_execute_SRC2_CTRL;
+  assign _zz_20 = decode_ALU_BITWISE_CTRL;
+  assign _zz_18 = _zz_53;
+  assign _zz_45 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_17 = decode_SHIFT_CTRL;
+  assign _zz_14 = execute_SHIFT_CTRL;
+  assign _zz_15 = _zz_52;
+  assign _zz_40 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_39 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_12 = decode_BRANCH_CTRL;
+  assign _zz_58 = _zz_51;
+  assign _zz_36 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_10 = decode_ENV_CTRL;
+  assign _zz_7 = execute_ENV_CTRL;
+  assign _zz_5 = memory_ENV_CTRL;
+  assign _zz_8 = _zz_50;
+  assign _zz_34 = decode_to_execute_ENV_CTRL;
+  assign _zz_33 = execute_to_memory_ENV_CTRL;
+  assign _zz_35 = memory_to_writeBack_ENV_CTRL;
+  assign _zz_3 = decode_CfuPlugin_CFU_INPUT_2_KIND;
+  assign _zz_1 = _zz_49;
+  assign _zz_32 = decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND;
   assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
   assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
   assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
@@ -4497,7 +4753,7 @@ module VexRiscv (
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_149)
+    case(_zz_163)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -4507,216 +4763,216 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_150 = 32'h0;
-    if(execute_CsrPlugin_csr_3264)begin
-      _zz_150[12 : 0] = 13'h1000;
-      _zz_150[25 : 20] = 6'h20;
-    end
-  end
-
-  always @ (*) begin
-    _zz_151 = 32'h0;
-    if(execute_CsrPlugin_csr_3857)begin
-      _zz_151[3 : 0] = 4'b1011;
-    end
-  end
-
-  always @ (*) begin
-    _zz_152 = 32'h0;
-    if(execute_CsrPlugin_csr_3858)begin
-      _zz_152[4 : 0] = 5'h16;
-    end
-  end
-
-  always @ (*) begin
-    _zz_153 = 32'h0;
-    if(execute_CsrPlugin_csr_3859)begin
-      _zz_153[5 : 0] = 6'h21;
-    end
-  end
-
-  always @ (*) begin
-    _zz_154 = 32'h0;
-    if(execute_CsrPlugin_csr_769)begin
-      _zz_154[31 : 30] = CsrPlugin_misa_base;
-      _zz_154[25 : 0] = CsrPlugin_misa_extensions;
-    end
-  end
-
-  always @ (*) begin
-    _zz_155 = 32'h0;
-    if(execute_CsrPlugin_csr_768)begin
-      _zz_155[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_155[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_155[3 : 3] = CsrPlugin_mstatus_MIE;
-    end
-  end
-
-  always @ (*) begin
-    _zz_156 = 32'h0;
-    if(execute_CsrPlugin_csr_836)begin
-      _zz_156[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_156[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_156[3 : 3] = CsrPlugin_mip_MSIP;
-    end
-  end
-
-  always @ (*) begin
-    _zz_157 = 32'h0;
-    if(execute_CsrPlugin_csr_772)begin
-      _zz_157[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_157[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_157[3 : 3] = CsrPlugin_mie_MSIE;
-    end
-  end
-
-  always @ (*) begin
-    _zz_158 = 32'h0;
-    if(execute_CsrPlugin_csr_773)begin
-      _zz_158[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_158[1 : 0] = CsrPlugin_mtvec_mode;
-    end
-  end
-
-  always @ (*) begin
-    _zz_159 = 32'h0;
-    if(execute_CsrPlugin_csr_833)begin
-      _zz_159[31 : 0] = CsrPlugin_mepc;
-    end
-  end
-
-  always @ (*) begin
-    _zz_160 = 32'h0;
-    if(execute_CsrPlugin_csr_832)begin
-      _zz_160[31 : 0] = CsrPlugin_mscratch;
-    end
-  end
-
-  always @ (*) begin
-    _zz_161 = 32'h0;
-    if(execute_CsrPlugin_csr_834)begin
-      _zz_161[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_161[3 : 0] = CsrPlugin_mcause_exceptionCode;
-    end
-  end
-
-  always @ (*) begin
-    _zz_162 = 32'h0;
-    if(execute_CsrPlugin_csr_835)begin
-      _zz_162[31 : 0] = CsrPlugin_mtval;
-    end
-  end
-
-  always @ (*) begin
-    _zz_163 = 32'h0;
-    if(execute_CsrPlugin_csr_2816)begin
-      _zz_163[31 : 0] = CsrPlugin_mcycle[31 : 0];
-    end
-  end
-
-  always @ (*) begin
     _zz_164 = 32'h0;
-    if(execute_CsrPlugin_csr_2944)begin
-      _zz_164[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    if(execute_CsrPlugin_csr_3264)begin
+      _zz_164[12 : 0] = 13'h1000;
+      _zz_164[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
     _zz_165 = 32'h0;
-    if(execute_CsrPlugin_csr_2818)begin
-      _zz_165[31 : 0] = CsrPlugin_minstret[31 : 0];
+    if(execute_CsrPlugin_csr_3857)begin
+      _zz_165[3 : 0] = 4'b1011;
     end
   end
 
   always @ (*) begin
     _zz_166 = 32'h0;
-    if(execute_CsrPlugin_csr_2946)begin
-      _zz_166[31 : 0] = CsrPlugin_minstret[63 : 32];
+    if(execute_CsrPlugin_csr_3858)begin
+      _zz_166[4 : 0] = 5'h16;
     end
   end
 
   always @ (*) begin
     _zz_167 = 32'h0;
-    if(execute_CsrPlugin_csr_3072)begin
-      _zz_167[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    if(execute_CsrPlugin_csr_3859)begin
+      _zz_167[5 : 0] = 6'h21;
     end
   end
 
   always @ (*) begin
     _zz_168 = 32'h0;
-    if(execute_CsrPlugin_csr_3200)begin
-      _zz_168[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    if(execute_CsrPlugin_csr_769)begin
+      _zz_168[31 : 30] = CsrPlugin_misa_base;
+      _zz_168[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
   always @ (*) begin
     _zz_169 = 32'h0;
-    if(execute_CsrPlugin_csr_3074)begin
-      _zz_169[31 : 0] = CsrPlugin_minstret[31 : 0];
+    if(execute_CsrPlugin_csr_768)begin
+      _zz_169[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_169[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_169[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
     _zz_170 = 32'h0;
-    if(execute_CsrPlugin_csr_3202)begin
-      _zz_170[31 : 0] = CsrPlugin_minstret[63 : 32];
+    if(execute_CsrPlugin_csr_836)begin
+      _zz_170[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_170[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_170[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
     _zz_171 = 32'h0;
-    if(execute_CsrPlugin_csr_3008)begin
-      _zz_171[31 : 0] = _zz_146;
+    if(execute_CsrPlugin_csr_772)begin
+      _zz_171[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_171[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_171[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
     _zz_172 = 32'h0;
-    if(execute_CsrPlugin_csr_4032)begin
-      _zz_172[31 : 0] = _zz_147;
+    if(execute_CsrPlugin_csr_773)begin
+      _zz_172[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_172[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_150 | _zz_151) | (_zz_152 | _zz_153)) | ((_zz_539 | _zz_154) | (_zz_155 | _zz_156))) | (((_zz_157 | _zz_158) | (_zz_159 | _zz_160)) | ((_zz_161 | _zz_162) | (_zz_163 | _zz_164)))) | (((_zz_165 | _zz_166) | (_zz_167 | _zz_168)) | ((_zz_169 | _zz_170) | (_zz_171 | _zz_172))));
-  assign iBusWishbone_ADR = {_zz_347,_zz_173};
-  assign iBusWishbone_CTI = ((_zz_173 == 3'b111) ? 3'b111 : 3'b010);
+  always @ (*) begin
+    _zz_173 = 32'h0;
+    if(execute_CsrPlugin_csr_833)begin
+      _zz_173[31 : 0] = CsrPlugin_mepc;
+    end
+  end
+
+  always @ (*) begin
+    _zz_174 = 32'h0;
+    if(execute_CsrPlugin_csr_832)begin
+      _zz_174[31 : 0] = CsrPlugin_mscratch;
+    end
+  end
+
+  always @ (*) begin
+    _zz_175 = 32'h0;
+    if(execute_CsrPlugin_csr_834)begin
+      _zz_175[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_175[3 : 0] = CsrPlugin_mcause_exceptionCode;
+    end
+  end
+
+  always @ (*) begin
+    _zz_176 = 32'h0;
+    if(execute_CsrPlugin_csr_835)begin
+      _zz_176[31 : 0] = CsrPlugin_mtval;
+    end
+  end
+
+  always @ (*) begin
+    _zz_177 = 32'h0;
+    if(execute_CsrPlugin_csr_2816)begin
+      _zz_177[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    end
+  end
+
+  always @ (*) begin
+    _zz_178 = 32'h0;
+    if(execute_CsrPlugin_csr_2944)begin
+      _zz_178[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    end
+  end
+
+  always @ (*) begin
+    _zz_179 = 32'h0;
+    if(execute_CsrPlugin_csr_2818)begin
+      _zz_179[31 : 0] = CsrPlugin_minstret[31 : 0];
+    end
+  end
+
+  always @ (*) begin
+    _zz_180 = 32'h0;
+    if(execute_CsrPlugin_csr_2946)begin
+      _zz_180[31 : 0] = CsrPlugin_minstret[63 : 32];
+    end
+  end
+
+  always @ (*) begin
+    _zz_181 = 32'h0;
+    if(execute_CsrPlugin_csr_3072)begin
+      _zz_181[31 : 0] = CsrPlugin_mcycle[31 : 0];
+    end
+  end
+
+  always @ (*) begin
+    _zz_182 = 32'h0;
+    if(execute_CsrPlugin_csr_3200)begin
+      _zz_182[31 : 0] = CsrPlugin_mcycle[63 : 32];
+    end
+  end
+
+  always @ (*) begin
+    _zz_183 = 32'h0;
+    if(execute_CsrPlugin_csr_3074)begin
+      _zz_183[31 : 0] = CsrPlugin_minstret[31 : 0];
+    end
+  end
+
+  always @ (*) begin
+    _zz_184 = 32'h0;
+    if(execute_CsrPlugin_csr_3202)begin
+      _zz_184[31 : 0] = CsrPlugin_minstret[63 : 32];
+    end
+  end
+
+  always @ (*) begin
+    _zz_185 = 32'h0;
+    if(execute_CsrPlugin_csr_3008)begin
+      _zz_185[31 : 0] = _zz_157;
+    end
+  end
+
+  always @ (*) begin
+    _zz_186 = 32'h0;
+    if(execute_CsrPlugin_csr_4032)begin
+      _zz_186[31 : 0] = _zz_158;
+    end
+  end
+
+  assign execute_CsrPlugin_readData = (((((_zz_164 | _zz_165) | (_zz_166 | _zz_167)) | ((_zz_565 | _zz_168) | (_zz_169 | _zz_170))) | (((_zz_171 | _zz_172) | (_zz_173 | _zz_174)) | ((_zz_175 | _zz_176) | (_zz_177 | _zz_178)))) | (((_zz_179 | _zz_180) | (_zz_181 | _zz_182)) | ((_zz_183 | _zz_184) | (_zz_185 | _zz_186))));
+  assign iBusWishbone_ADR = {_zz_368,_zz_187};
+  assign iBusWishbone_CTI = ((_zz_187 == 3'b111) ? 3'b111 : 3'b010);
   assign iBusWishbone_BTE = 2'b00;
   assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_245)begin
+    if(_zz_260)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_245)begin
+    if(_zz_260)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_174;
+  assign iBus_rsp_valid = _zz_188;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_180 = (dBus_cmd_payload_length != 3'b000);
-  assign _zz_176 = dBus_cmd_valid;
-  assign _zz_178 = dBus_cmd_payload_wr;
-  assign _zz_179 = (_zz_175 == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_177 && (_zz_178 || _zz_179));
-  assign dBusWishbone_ADR = ((_zz_180 ? {{dBus_cmd_payload_address[31 : 5],_zz_175},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_180 ? (_zz_179 ? 3'b111 : 3'b010) : 3'b000);
+  assign _zz_194 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_190 = dBus_cmd_valid;
+  assign _zz_192 = dBus_cmd_payload_wr;
+  assign _zz_193 = (_zz_189 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_191 && (_zz_192 || _zz_193));
+  assign dBusWishbone_ADR = ((_zz_194 ? {{dBus_cmd_payload_address[31 : 5],_zz_189},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_194 ? (_zz_193 ? 3'b111 : 3'b010) : 3'b000);
   assign dBusWishbone_BTE = 2'b00;
-  assign dBusWishbone_SEL = (_zz_178 ? dBus_cmd_payload_mask : 4'b1111);
-  assign dBusWishbone_WE = _zz_178;
+  assign dBusWishbone_SEL = (_zz_192 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_192;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_177 = (_zz_176 && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_176;
-  assign dBusWishbone_STB = _zz_176;
-  assign dBus_rsp_valid = _zz_181;
+  assign _zz_191 = (_zz_190 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_190;
+  assign dBusWishbone_STB = _zz_190;
+  assign dBus_rsp_valid = _zz_195;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -4725,21 +4981,21 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_65 <= 1'b0;
-      _zz_67 <= 1'b0;
+      _zz_72 <= 1'b0;
+      _zz_74 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_80;
+      IBusCachedPlugin_rspCounter <= _zz_87;
       IBusCachedPlugin_rspCounter <= 32'h0;
       dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_81;
+      DBusCachedPlugin_rspCounter <= _zz_88;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_99 <= 1'b1;
-      _zz_111 <= 1'b0;
+      _zz_108 <= 1'b1;
+      _zz_120 <= 1'b0;
       CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4760,15 +5016,19 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_146 <= 32'h0;
+      _zz_157 <= 32'h0;
+      execute_CfuPlugin_hold <= 1'b0;
+      execute_CfuPlugin_fired <= 1'b0;
+      CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_149 <= 3'b000;
-      _zz_173 <= 3'b000;
-      _zz_174 <= 1'b0;
-      _zz_175 <= 3'b000;
-      _zz_181 <= 1'b0;
+      _zz_163 <= 3'b000;
+      execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= 1'b0;
+      _zz_187 <= 3'b000;
+      _zz_188 <= 1'b0;
+      _zz_189 <= 3'b000;
+      _zz_195 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -4790,16 +5050,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65 <= 1'b0;
+        _zz_72 <= 1'b0;
       end
-      if(_zz_63)begin
-        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_70)begin
+        _zz_72 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67 <= 1'b0;
+        _zz_74 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_74 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -4849,7 +5109,7 @@ module VexRiscv (
       if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_246)begin
+      if(_zz_261)begin
         dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
       if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
@@ -4858,8 +5118,8 @@ module VexRiscv (
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_99 <= 1'b0;
-      _zz_111 <= (_zz_41 && writeBack_arbitration_isFiring);
+      _zz_108 <= 1'b0;
+      _zz_120 <= (_zz_47 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -4881,14 +5141,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_247)begin
-        if(_zz_248)begin
+      if(_zz_262)begin
+        if(_zz_263)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_249)begin
+        if(_zz_264)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_250)begin
+        if(_zz_265)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -4913,7 +5173,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_227)begin
+      if(_zz_242)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4924,8 +5184,8 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_228)begin
-        case(_zz_230)
+      if(_zz_243)begin
+        case(_zz_245)
           2'b11 : begin
             CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
@@ -4935,8 +5195,29 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_138,{_zz_137,_zz_136}} != 3'b000) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_147,{_zz_146,_zz_145}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
+      if(execute_CfuPlugin_schedule)begin
+        execute_CfuPlugin_hold <= 1'b1;
+      end
+      if(CfuPlugin_bus_cmd_ready)begin
+        execute_CfuPlugin_hold <= 1'b0;
+      end
+      if((CfuPlugin_bus_cmd_valid && CfuPlugin_bus_cmd_ready))begin
+        execute_CfuPlugin_fired <= 1'b1;
+      end
+      if((! execute_arbitration_isStuckByOthers))begin
+        execute_CfuPlugin_fired <= 1'b0;
+      end
+      if(memory_CfuPlugin_rsp_ready)begin
+        CfuPlugin_bus_rsp_s2mPipe_rValid <= 1'b0;
+      end
+      if(_zz_266)begin
+        CfuPlugin_bus_rsp_s2mPipe_rValid <= CfuPlugin_bus_rsp_valid;
+      end
+      if((! memory_arbitration_isStuck))begin
+        execute_to_memory_CfuPlugin_CFU_IN_FLIGHT <= _zz_31;
+      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -4955,25 +5236,25 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_149)
+      case(_zz_163)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_149 <= 3'b001;
+            _zz_163 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_149 <= 3'b010;
+          _zz_163 <= 3'b010;
         end
         3'b010 : begin
-          _zz_149 <= 3'b011;
+          _zz_163 <= 3'b011;
         end
         3'b011 : begin
           if((! decode_arbitration_isStuck))begin
-            _zz_149 <= 3'b100;
+            _zz_163 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_149 <= 3'b000;
+          _zz_163 <= 3'b000;
         end
         default : begin
         end
@@ -4987,41 +5268,41 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_340[0];
-          CsrPlugin_mstatus_MIE <= _zz_341[0];
+          CsrPlugin_mstatus_MPIE <= _zz_361[0];
+          CsrPlugin_mstatus_MIE <= _zz_362[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_343[0];
-          CsrPlugin_mie_MTIE <= _zz_344[0];
-          CsrPlugin_mie_MSIE <= _zz_345[0];
+          CsrPlugin_mie_MEIE <= _zz_364[0];
+          CsrPlugin_mie_MTIE <= _zz_365[0];
+          CsrPlugin_mie_MSIE <= _zz_366[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_146 <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_157 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_245)begin
+      if(_zz_260)begin
         if(iBusWishbone_ACK)begin
-          _zz_173 <= (_zz_173 + 3'b001);
+          _zz_187 <= (_zz_187 + 3'b001);
         end
       end
-      _zz_174 <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_176 && _zz_177))begin
-        _zz_175 <= (_zz_175 + 3'b001);
-        if(_zz_179)begin
-          _zz_175 <= 3'b000;
+      _zz_188 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_190 && _zz_191))begin
+        _zz_189 <= (_zz_189 + 3'b001);
+        if(_zz_193)begin
+          _zz_189 <= 3'b000;
         end
       end
-      _zz_181 <= ((_zz_176 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_195 <= ((_zz_190 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_68 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_75 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -5029,7 +5310,7 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_246)begin
+    if(_zz_261)begin
       dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
       dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
       dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
@@ -5047,8 +5328,8 @@ module VexRiscv (
       dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
       dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_112 <= _zz_40[11 : 7];
-    _zz_113 <= _zz_50;
+    _zz_121 <= _zz_46[11 : 7];
+    _zz_122 <= _zz_57;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -5056,37 +5337,37 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_223)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_140 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_237)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_149 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_149 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
-    if(CsrPlugin_selfException_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
+    if(_zz_240)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_151 ? BranchPlugin_branchExceptionPort_payload_code : CsrPlugin_selfException_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_151 ? BranchPlugin_branchExceptionPort_payload_badAddr : CsrPlugin_selfException_payload_badAddr);
     end
-    if(BranchPlugin_branchExceptionPort_valid)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= BranchPlugin_branchExceptionPort_payload_code;
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= BranchPlugin_branchExceptionPort_payload_badAddr;
+    if(CfuPlugin_joinException_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CfuPlugin_joinException_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CfuPlugin_joinException_payload_badAddr;
     end
     if(DBusCachedPlugin_exceptionBus_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_247)begin
-      if(_zz_248)begin
+    if(_zz_262)begin
+      if(_zz_263)begin
         CsrPlugin_interrupt_code <= 4'b0111;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_249)begin
+      if(_zz_264)begin
         CsrPlugin_interrupt_code <= 4'b0011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_250)begin
+      if(_zz_265)begin
         CsrPlugin_interrupt_code <= 4'b1011;
         CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_227)begin
+    if(_zz_242)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5106,27 +5387,31 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_218)begin
-      if(_zz_242)begin
+    if(_zz_232)begin
+      if(_zz_257)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_331[31:0];
+          memory_DivPlugin_div_result <= _zz_350[31:0];
         end
       end
     end
-    if(_zz_243)begin
+    if(_zz_258)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_144 ? (~ _zz_145) : _zz_145) + _zz_337);
-      memory_DivPlugin_rs2 <= ((_zz_143 ? (~ execute_RS2) : execute_RS2) + _zz_339);
-      memory_DivPlugin_div_needRevert <= ((_zz_144 ^ (_zz_143 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_155 ? (~ _zz_156) : _zz_156) + _zz_356);
+      memory_DivPlugin_rs2 <= ((_zz_154 ? (~ execute_RS2) : execute_RS2) + _zz_358);
+      memory_DivPlugin_div_needRevert <= ((_zz_155 ^ (_zz_154 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
+    if(_zz_266)begin
+      CfuPlugin_bus_rsp_s2mPipe_rData_response_ok <= CfuPlugin_bus_rsp_payload_response_ok;
+      CfuPlugin_bus_rsp_s2mPipe_rData_outputs_0 <= CfuPlugin_bus_rsp_payload_outputs_0;
+    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35;
+      execute_to_memory_PC <= _zz_41;
     end
     if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
       memory_to_writeBack_PC <= memory_PC;
@@ -5141,19 +5426,19 @@ module VexRiscv (
       memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_60;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_59;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
+      memory_to_writeBack_FORMAL_PC_NEXT <= memory_FORMAL_PC_NEXT;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_25;
+      decode_to_execute_SRC1_CTRL <= _zz_28;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
@@ -5168,10 +5453,10 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_22;
+      decode_to_execute_ALU_CTRL <= _zz_25;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_19;
+      decode_to_execute_SRC2_CTRL <= _zz_22;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
@@ -5207,28 +5492,28 @@ module VexRiscv (
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_19;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13;
+      decode_to_execute_SHIFT_CTRL <= _zz_16;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10;
+      execute_to_memory_SHIFT_CTRL <= _zz_13;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_8;
+      decode_to_execute_BRANCH_CTRL <= _zz_11;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6;
+      decode_to_execute_ENV_CTRL <= _zz_9;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3;
+      execute_to_memory_ENV_CTRL <= _zz_6;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1;
+      memory_to_writeBack_ENV_CTRL <= _zz_4;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
@@ -5250,6 +5535,12 @@ module VexRiscv (
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CfuPlugin_CFU_ENABLE <= decode_CfuPlugin_CFU_ENABLE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CfuPlugin_CFU_INPUT_2_KIND <= _zz_2;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_RS1 <= decode_RS1;
@@ -5279,19 +5570,13 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_37;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_38;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MUL_LL <= execute_MUL_LL;
@@ -5307,6 +5592,9 @@ module VexRiscv (
     end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_CfuPlugin_CFU_IN_FLIGHT <= _zz_30;
     end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
@@ -5385,7 +5673,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_342[0];
+        CsrPlugin_mip_MSIP <= _zz_363[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -5406,7 +5694,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_834)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_346[0];
+        CsrPlugin_mcause_interrupt <= _zz_367[0];
         CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -5447,10 +5735,10 @@ module VexRiscv (
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
     DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
     if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50;
+      DebugPlugin_busReadDataReg <= _zz_57;
     end
-    _zz_148 <= debug_bus_cmd_payload_address[2];
-    if(_zz_225)begin
+    _zz_159 <= debug_bus_cmd_payload_address[2];
+    if(_zz_239)begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -5468,7 +5756,7 @@ module VexRiscv (
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid)begin
-        case(_zz_244)
+        case(_zz_259)
           6'h0 : begin
             if(debug_bus_cmd_payload_wr)begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
@@ -5496,13 +5784,13 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_225)begin
-        if(_zz_226)begin
+      if(_zz_239)begin
+        if(_zz_241)begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_229)begin
+      if(_zz_244)begin
         if(decode_arbitration_isValid)begin
           DebugPlugin_haltIt <= 1'b1;
         end

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfuDebug.yaml
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_FullCfuDebug.yaml
@@ -1,0 +1,5 @@
+debug: !!vexriscv.DebugReport {hardwareBreakpointCount: 0}
+iBus: !!vexriscv.BusReport
+  flushInstructions: [4111, 19, 19, 19]
+  info: !!vexriscv.CacheReport {bytePerLine: 32, size: 4096}
+  kind: cached

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_IMAC.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_IMAC.v
@@ -1,13 +1,7 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:38:12
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
-
-`define BranchCtrlEnum_defaultEncoding_type [1:0]
-`define BranchCtrlEnum_defaultEncoding_INC 2'b00
-`define BranchCtrlEnum_defaultEncoding_B 2'b01
-`define BranchCtrlEnum_defaultEncoding_JAL 2'b10
-`define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
@@ -15,22 +9,11 @@
 `define EnvCtrlEnum_defaultEncoding_WFI 2'b10
 `define EnvCtrlEnum_defaultEncoding_ECALL 2'b11
 
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
-
-`define Src2CtrlEnum_defaultEncoding_type [1:0]
-`define Src2CtrlEnum_defaultEncoding_RS 2'b00
-`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
-`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
-`define Src2CtrlEnum_defaultEncoding_PC 2'b11
-
-`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+`define BranchCtrlEnum_defaultEncoding_type [1:0]
+`define BranchCtrlEnum_defaultEncoding_INC 2'b00
+`define BranchCtrlEnum_defaultEncoding_B 2'b01
+`define BranchCtrlEnum_defaultEncoding_JAL 2'b10
+`define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
 `define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
@@ -38,988 +21,28 @@
 `define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
 `define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
+`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+
+`define Src2CtrlEnum_defaultEncoding_type [1:0]
+`define Src2CtrlEnum_defaultEncoding_RS 2'b00
+`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
+`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
+`define Src2CtrlEnum_defaultEncoding_PC 2'b11
+
 `define AluCtrlEnum_defaultEncoding_type [1:0]
 `define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
 `define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
 `define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_cacheMiss,
-  output              io_cpu_fetch_error,
-  output              io_cpu_fetch_mmuRefilling,
-  output              io_cpu_fetch_mmuException,
-  input               io_cpu_fetch_isUser,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire       [0:0]    _zz_14_;
-  wire       [0:0]    _zz_15_;
-  wire       [21:0]   _zz_16_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-
-  assign _zz_12_ = (! lineLoader_flushCounter[7]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_fetch_cacheMiss = (! fetchStage_hit_valid);
-  assign io_cpu_fetch_error = fetchStage_hit_error;
-  assign io_cpu_fetch_mmuRefilling = io_cpu_fetch_mmuBus_rsp_refilling;
-  assign io_cpu_fetch_mmuException = ((! io_cpu_fetch_mmuBus_rsp_refilling) && (io_cpu_fetch_mmuBus_rsp_exception || (! io_cpu_fetch_mmuBus_rsp_allowExecute)));
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [0:0]    _zz_18_;
-  wire       [0:0]    _zz_19_;
-  wire       [2:0]    _zz_20_;
-  wire       [1:0]    _zz_21_;
-  wire       [21:0]   _zz_22_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  wire       [31:0]   stageB_requestDataBypass;
-  wire                stageB_isAmo;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_23_;
-  reg [7:0] _zz_24_;
-  reg [7:0] _zz_25_;
-  reg [7:0] _zz_26_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmo)));
-  assign _zz_15_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_16_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_17_ = _zz_4_[0 : 0];
-  assign _zz_18_ = _zz_4_[1 : 1];
-  assign _zz_19_ = loader_counter_willIncrement;
-  assign _zz_20_ = {2'd0, _zz_19_};
-  assign _zz_21_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_22_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_22_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_26_, _zz_25_, _zz_24_, _zz_23_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_23_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_24_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_25_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_26_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_17_[0];
-  assign ways_0_tagsReadRsp_error = _zz_18_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  assign stageB_requestDataBypass = stageB_request_data;
-  assign stageB_isAmo = 1'b0;
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((((! stageB_request_wr) || stageB_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0))))begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_15_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_20_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_16_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_16_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_15_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_21_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1035,8 +58,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1046,33 +69,44 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset 
+  input               reset
 );
-  wire                _zz_196_;
-  wire                _zz_197_;
-  wire                _zz_198_;
-  wire                _zz_199_;
-  wire                _zz_200_;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire       [31:0]   _zz_203_;
-  reg                 _zz_204_;
-  wire                _zz_205_;
-  wire       [31:0]   _zz_206_;
-  wire                _zz_207_;
-  wire       [31:0]   _zz_208_;
-  reg                 _zz_209_;
-  wire                _zz_210_;
-  wire                _zz_211_;
-  wire       [31:0]   _zz_212_;
-  wire                _zz_213_;
-  wire                _zz_214_;
-  reg        [31:0]   _zz_215_;
-  reg        [31:0]   _zz_216_;
-  reg        [31:0]   _zz_217_;
+  wire                _zz_198;
+  wire                _zz_199;
+  wire                _zz_200;
+  wire                _zz_201;
+  wire                _zz_202;
+  wire                _zz_203;
+  wire                _zz_204;
+  wire                _zz_205;
+  wire       [31:0]   _zz_206;
+  reg                 _zz_207;
+  wire                _zz_208;
+  wire       [31:0]   _zz_209;
+  reg                 _zz_210;
+  wire                _zz_211;
+  wire       [31:0]   _zz_212;
+  reg                 _zz_213;
+  wire                _zz_214;
+  wire                _zz_215;
+  wire       [31:0]   _zz_216;
+  wire                _zz_217;
+  wire                _zz_218;
+  wire                _zz_219;
+  wire                _zz_220;
+  wire                _zz_221;
+  wire                _zz_222;
+  wire                _zz_223;
+  wire                _zz_224;
+  wire       [3:0]    _zz_225;
+  wire                _zz_226;
+  wire                _zz_227;
+  reg        [31:0]   _zz_228;
+  reg        [31:0]   _zz_229;
+  reg        [31:0]   _zz_230;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_error;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling;
@@ -1080,420 +114,455 @@ module VexRiscv (
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_physicalAddress;
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_218_;
-  wire                _zz_219_;
-  wire                _zz_220_;
-  wire                _zz_221_;
-  wire                _zz_222_;
-  wire                _zz_223_;
-  wire                _zz_224_;
-  wire                _zz_225_;
-  wire                _zz_226_;
-  wire                _zz_227_;
-  wire                _zz_228_;
-  wire                _zz_229_;
-  wire                _zz_230_;
-  wire                _zz_231_;
-  wire       [1:0]    _zz_232_;
-  wire                _zz_233_;
-  wire                _zz_234_;
-  wire                _zz_235_;
-  wire                _zz_236_;
-  wire                _zz_237_;
-  wire                _zz_238_;
-  wire                _zz_239_;
-  wire                _zz_240_;
-  wire                _zz_241_;
-  wire                _zz_242_;
-  wire                _zz_243_;
-  wire       [1:0]    _zz_244_;
-  wire                _zz_245_;
-  wire                _zz_246_;
-  wire                _zz_247_;
-  wire                _zz_248_;
-  wire                _zz_249_;
-  wire                _zz_250_;
-  wire                _zz_251_;
-  wire                _zz_252_;
-  wire                _zz_253_;
-  wire       [4:0]    _zz_254_;
-  wire       [1:0]    _zz_255_;
-  wire       [1:0]    _zz_256_;
-  wire       [1:0]    _zz_257_;
-  wire                _zz_258_;
-  wire       [1:0]    _zz_259_;
-  wire       [0:0]    _zz_260_;
-  wire       [0:0]    _zz_261_;
-  wire       [51:0]   _zz_262_;
-  wire       [51:0]   _zz_263_;
-  wire       [51:0]   _zz_264_;
-  wire       [32:0]   _zz_265_;
-  wire       [51:0]   _zz_266_;
-  wire       [49:0]   _zz_267_;
-  wire       [51:0]   _zz_268_;
-  wire       [49:0]   _zz_269_;
-  wire       [51:0]   _zz_270_;
-  wire       [0:0]    _zz_271_;
-  wire       [0:0]    _zz_272_;
-  wire       [0:0]    _zz_273_;
-  wire       [0:0]    _zz_274_;
-  wire       [2:0]    _zz_275_;
-  wire       [31:0]   _zz_276_;
-  wire       [0:0]    _zz_277_;
-  wire       [0:0]    _zz_278_;
-  wire       [0:0]    _zz_279_;
-  wire       [0:0]    _zz_280_;
-  wire       [32:0]   _zz_281_;
-  wire       [31:0]   _zz_282_;
-  wire       [32:0]   _zz_283_;
-  wire       [0:0]    _zz_284_;
-  wire       [0:0]    _zz_285_;
-  wire       [0:0]    _zz_286_;
-  wire       [0:0]    _zz_287_;
-  wire       [0:0]    _zz_288_;
-  wire       [0:0]    _zz_289_;
-  wire       [0:0]    _zz_290_;
-  wire       [3:0]    _zz_291_;
-  wire       [2:0]    _zz_292_;
-  wire       [31:0]   _zz_293_;
-  wire       [2:0]    _zz_294_;
-  wire       [31:0]   _zz_295_;
-  wire       [31:0]   _zz_296_;
-  wire       [11:0]   _zz_297_;
-  wire       [11:0]   _zz_298_;
-  wire       [11:0]   _zz_299_;
-  wire       [31:0]   _zz_300_;
-  wire       [19:0]   _zz_301_;
-  wire       [11:0]   _zz_302_;
-  wire       [2:0]    _zz_303_;
-  wire       [2:0]    _zz_304_;
-  wire       [0:0]    _zz_305_;
-  wire       [2:0]    _zz_306_;
-  wire       [4:0]    _zz_307_;
-  wire       [11:0]   _zz_308_;
-  wire       [11:0]   _zz_309_;
-  wire       [31:0]   _zz_310_;
-  wire       [31:0]   _zz_311_;
-  wire       [31:0]   _zz_312_;
-  wire       [31:0]   _zz_313_;
-  wire       [31:0]   _zz_314_;
-  wire       [31:0]   _zz_315_;
-  wire       [31:0]   _zz_316_;
-  wire       [11:0]   _zz_317_;
-  wire       [19:0]   _zz_318_;
-  wire       [11:0]   _zz_319_;
-  wire       [2:0]    _zz_320_;
-  wire       [1:0]    _zz_321_;
-  wire       [1:0]    _zz_322_;
-  wire       [65:0]   _zz_323_;
-  wire       [65:0]   _zz_324_;
-  wire       [31:0]   _zz_325_;
-  wire       [31:0]   _zz_326_;
-  wire       [0:0]    _zz_327_;
-  wire       [5:0]    _zz_328_;
-  wire       [32:0]   _zz_329_;
-  wire       [31:0]   _zz_330_;
-  wire       [31:0]   _zz_331_;
-  wire       [32:0]   _zz_332_;
-  wire       [32:0]   _zz_333_;
-  wire       [32:0]   _zz_334_;
-  wire       [32:0]   _zz_335_;
-  wire       [0:0]    _zz_336_;
-  wire       [32:0]   _zz_337_;
-  wire       [0:0]    _zz_338_;
-  wire       [32:0]   _zz_339_;
-  wire       [0:0]    _zz_340_;
-  wire       [31:0]   _zz_341_;
-  wire       [0:0]    _zz_342_;
-  wire       [0:0]    _zz_343_;
-  wire       [0:0]    _zz_344_;
-  wire       [0:0]    _zz_345_;
-  wire       [0:0]    _zz_346_;
-  wire       [0:0]    _zz_347_;
-  wire       [0:0]    _zz_348_;
-  wire       [26:0]   _zz_349_;
-  wire                _zz_350_;
-  wire                _zz_351_;
-  wire       [1:0]    _zz_352_;
-  wire       [31:0]   _zz_353_;
-  wire       [31:0]   _zz_354_;
-  wire       [31:0]   _zz_355_;
-  wire                _zz_356_;
-  wire       [0:0]    _zz_357_;
-  wire       [13:0]   _zz_358_;
-  wire       [31:0]   _zz_359_;
-  wire       [31:0]   _zz_360_;
-  wire       [31:0]   _zz_361_;
-  wire                _zz_362_;
-  wire       [0:0]    _zz_363_;
-  wire       [7:0]    _zz_364_;
-  wire       [31:0]   _zz_365_;
-  wire       [31:0]   _zz_366_;
-  wire       [31:0]   _zz_367_;
-  wire                _zz_368_;
-  wire       [0:0]    _zz_369_;
-  wire       [1:0]    _zz_370_;
-  wire                _zz_371_;
-  wire                _zz_372_;
-  wire       [6:0]    _zz_373_;
-  wire       [4:0]    _zz_374_;
-  wire                _zz_375_;
-  wire       [4:0]    _zz_376_;
-  wire       [0:0]    _zz_377_;
-  wire       [7:0]    _zz_378_;
-  wire                _zz_379_;
-  wire       [0:0]    _zz_380_;
-  wire       [0:0]    _zz_381_;
-  wire       [31:0]   _zz_382_;
-  wire       [31:0]   _zz_383_;
-  wire       [31:0]   _zz_384_;
-  wire       [0:0]    _zz_385_;
-  wire       [0:0]    _zz_386_;
-  wire       [0:0]    _zz_387_;
-  wire       [0:0]    _zz_388_;
-  wire                _zz_389_;
-  wire       [0:0]    _zz_390_;
-  wire       [25:0]   _zz_391_;
-  wire       [31:0]   _zz_392_;
-  wire       [31:0]   _zz_393_;
-  wire       [31:0]   _zz_394_;
-  wire       [31:0]   _zz_395_;
-  wire       [31:0]   _zz_396_;
-  wire                _zz_397_;
-  wire       [4:0]    _zz_398_;
-  wire       [4:0]    _zz_399_;
-  wire                _zz_400_;
-  wire       [0:0]    _zz_401_;
-  wire       [22:0]   _zz_402_;
-  wire       [31:0]   _zz_403_;
-  wire       [31:0]   _zz_404_;
-  wire       [0:0]    _zz_405_;
-  wire       [1:0]    _zz_406_;
-  wire       [31:0]   _zz_407_;
-  wire       [31:0]   _zz_408_;
-  wire                _zz_409_;
-  wire       [1:0]    _zz_410_;
-  wire       [1:0]    _zz_411_;
-  wire                _zz_412_;
-  wire       [0:0]    _zz_413_;
-  wire       [19:0]   _zz_414_;
-  wire       [31:0]   _zz_415_;
-  wire       [31:0]   _zz_416_;
-  wire       [31:0]   _zz_417_;
-  wire       [31:0]   _zz_418_;
-  wire       [31:0]   _zz_419_;
-  wire       [31:0]   _zz_420_;
-  wire       [31:0]   _zz_421_;
-  wire       [31:0]   _zz_422_;
-  wire       [31:0]   _zz_423_;
-  wire       [0:0]    _zz_424_;
-  wire       [0:0]    _zz_425_;
-  wire       [1:0]    _zz_426_;
-  wire       [1:0]    _zz_427_;
-  wire                _zz_428_;
-  wire       [0:0]    _zz_429_;
-  wire       [16:0]   _zz_430_;
-  wire       [31:0]   _zz_431_;
-  wire       [31:0]   _zz_432_;
-  wire       [31:0]   _zz_433_;
-  wire       [31:0]   _zz_434_;
-  wire       [31:0]   _zz_435_;
-  wire       [31:0]   _zz_436_;
-  wire                _zz_437_;
-  wire       [0:0]    _zz_438_;
-  wire       [0:0]    _zz_439_;
-  wire                _zz_440_;
-  wire       [2:0]    _zz_441_;
-  wire       [2:0]    _zz_442_;
-  wire                _zz_443_;
-  wire       [0:0]    _zz_444_;
-  wire       [13:0]   _zz_445_;
-  wire       [31:0]   _zz_446_;
-  wire       [31:0]   _zz_447_;
-  wire       [31:0]   _zz_448_;
-  wire       [31:0]   _zz_449_;
-  wire                _zz_450_;
-  wire                _zz_451_;
-  wire       [31:0]   _zz_452_;
-  wire       [31:0]   _zz_453_;
-  wire       [0:0]    _zz_454_;
-  wire       [3:0]    _zz_455_;
-  wire       [4:0]    _zz_456_;
-  wire       [4:0]    _zz_457_;
-  wire                _zz_458_;
-  wire       [0:0]    _zz_459_;
-  wire       [10:0]   _zz_460_;
-  wire       [31:0]   _zz_461_;
-  wire       [31:0]   _zz_462_;
-  wire                _zz_463_;
-  wire       [0:0]    _zz_464_;
-  wire       [0:0]    _zz_465_;
-  wire       [31:0]   _zz_466_;
-  wire       [31:0]   _zz_467_;
-  wire                _zz_468_;
-  wire       [0:0]    _zz_469_;
-  wire       [1:0]    _zz_470_;
-  wire       [0:0]    _zz_471_;
-  wire       [0:0]    _zz_472_;
-  wire       [1:0]    _zz_473_;
-  wire       [1:0]    _zz_474_;
-  wire                _zz_475_;
-  wire       [0:0]    _zz_476_;
-  wire       [7:0]    _zz_477_;
-  wire       [31:0]   _zz_478_;
-  wire       [31:0]   _zz_479_;
-  wire       [31:0]   _zz_480_;
-  wire       [31:0]   _zz_481_;
-  wire       [31:0]   _zz_482_;
-  wire       [31:0]   _zz_483_;
-  wire       [31:0]   _zz_484_;
-  wire       [31:0]   _zz_485_;
-  wire                _zz_486_;
-  wire                _zz_487_;
-  wire       [31:0]   _zz_488_;
-  wire       [31:0]   _zz_489_;
-  wire                _zz_490_;
-  wire       [0:0]    _zz_491_;
-  wire       [2:0]    _zz_492_;
-  wire       [1:0]    _zz_493_;
-  wire       [1:0]    _zz_494_;
-  wire                _zz_495_;
-  wire       [0:0]    _zz_496_;
-  wire       [5:0]    _zz_497_;
-  wire       [31:0]   _zz_498_;
-  wire       [31:0]   _zz_499_;
-  wire       [31:0]   _zz_500_;
-  wire       [31:0]   _zz_501_;
-  wire       [31:0]   _zz_502_;
-  wire                _zz_503_;
-  wire       [0:0]    _zz_504_;
-  wire       [0:0]    _zz_505_;
-  wire                _zz_506_;
-  wire       [0:0]    _zz_507_;
-  wire       [0:0]    _zz_508_;
-  wire       [0:0]    _zz_509_;
-  wire       [0:0]    _zz_510_;
-  wire                _zz_511_;
-  wire       [0:0]    _zz_512_;
-  wire       [3:0]    _zz_513_;
-  wire       [31:0]   _zz_514_;
-  wire       [31:0]   _zz_515_;
-  wire       [31:0]   _zz_516_;
-  wire       [31:0]   _zz_517_;
-  wire                _zz_518_;
-  wire       [0:0]    _zz_519_;
-  wire       [0:0]    _zz_520_;
-  wire                _zz_521_;
-  wire       [0:0]    _zz_522_;
-  wire       [0:0]    _zz_523_;
-  wire                _zz_524_;
-  wire       [0:0]    _zz_525_;
-  wire       [2:0]    _zz_526_;
-  wire       [31:0]   _zz_527_;
-  wire       [31:0]   _zz_528_;
-  wire       [31:0]   _zz_529_;
-  wire       [31:0]   _zz_530_;
-  wire                _zz_531_;
-  wire                _zz_532_;
-  wire                _zz_533_;
-  wire       [31:0]   _zz_534_;
-  wire                decode_IS_CSR;
-  wire       [31:0]   execute_MUL_LL;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire       [31:0]   memory_PC;
-  wire                decode_IS_RS2_SIGNED;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_2_;
-  wire                execute_BRANCH_DO;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_231;
+  wire                _zz_232;
+  wire                _zz_233;
+  wire                _zz_234;
+  wire                _zz_235;
+  wire                _zz_236;
+  wire                _zz_237;
+  wire                _zz_238;
+  wire                _zz_239;
+  wire                _zz_240;
+  wire                _zz_241;
+  wire                _zz_242;
+  wire                _zz_243;
+  wire                _zz_244;
+  wire       [1:0]    _zz_245;
+  wire                _zz_246;
+  wire                _zz_247;
+  wire                _zz_248;
+  wire                _zz_249;
+  wire                _zz_250;
+  wire                _zz_251;
+  wire                _zz_252;
+  wire                _zz_253;
+  wire                _zz_254;
+  wire                _zz_255;
+  wire                _zz_256;
+  wire       [1:0]    _zz_257;
+  wire                _zz_258;
+  wire                _zz_259;
+  wire                _zz_260;
+  wire                _zz_261;
+  wire                _zz_262;
+  wire                _zz_263;
+  wire                _zz_264;
+  wire                _zz_265;
+  wire                _zz_266;
+  wire       [4:0]    _zz_267;
+  wire       [1:0]    _zz_268;
+  wire       [1:0]    _zz_269;
+  wire       [1:0]    _zz_270;
+  wire                _zz_271;
+  wire       [1:0]    _zz_272;
+  wire       [51:0]   _zz_273;
+  wire       [51:0]   _zz_274;
+  wire       [51:0]   _zz_275;
+  wire       [32:0]   _zz_276;
+  wire       [51:0]   _zz_277;
+  wire       [49:0]   _zz_278;
+  wire       [51:0]   _zz_279;
+  wire       [49:0]   _zz_280;
+  wire       [51:0]   _zz_281;
+  wire       [32:0]   _zz_282;
+  wire       [31:0]   _zz_283;
+  wire       [32:0]   _zz_284;
+  wire       [0:0]    _zz_285;
+  wire       [0:0]    _zz_286;
+  wire       [0:0]    _zz_287;
+  wire       [0:0]    _zz_288;
+  wire       [0:0]    _zz_289;
+  wire       [0:0]    _zz_290;
+  wire       [0:0]    _zz_291;
+  wire       [0:0]    _zz_292;
+  wire       [0:0]    _zz_293;
+  wire       [0:0]    _zz_294;
+  wire       [2:0]    _zz_295;
+  wire       [31:0]   _zz_296;
+  wire       [0:0]    _zz_297;
+  wire       [0:0]    _zz_298;
+  wire       [0:0]    _zz_299;
+  wire       [0:0]    _zz_300;
+  wire       [0:0]    _zz_301;
+  wire       [0:0]    _zz_302;
+  wire       [0:0]    _zz_303;
+  wire       [0:0]    _zz_304;
+  wire       [3:0]    _zz_305;
+  wire       [2:0]    _zz_306;
+  wire       [31:0]   _zz_307;
+  wire       [2:0]    _zz_308;
+  wire       [31:0]   _zz_309;
+  wire       [31:0]   _zz_310;
+  wire       [11:0]   _zz_311;
+  wire       [11:0]   _zz_312;
+  wire       [11:0]   _zz_313;
+  wire       [31:0]   _zz_314;
+  wire       [19:0]   _zz_315;
+  wire       [11:0]   _zz_316;
+  wire       [2:0]    _zz_317;
+  wire       [2:0]    _zz_318;
+  wire       [0:0]    _zz_319;
+  wire       [2:0]    _zz_320;
+  wire       [4:0]    _zz_321;
+  wire       [11:0]   _zz_322;
+  wire       [11:0]   _zz_323;
+  wire       [31:0]   _zz_324;
+  wire       [31:0]   _zz_325;
+  wire       [31:0]   _zz_326;
+  wire       [31:0]   _zz_327;
+  wire       [31:0]   _zz_328;
+  wire       [31:0]   _zz_329;
+  wire       [31:0]   _zz_330;
+  wire       [11:0]   _zz_331;
+  wire       [19:0]   _zz_332;
+  wire       [11:0]   _zz_333;
+  wire       [2:0]    _zz_334;
+  wire       [1:0]    _zz_335;
+  wire       [1:0]    _zz_336;
+  wire       [65:0]   _zz_337;
+  wire       [65:0]   _zz_338;
+  wire       [31:0]   _zz_339;
+  wire       [31:0]   _zz_340;
+  wire       [0:0]    _zz_341;
+  wire       [5:0]    _zz_342;
+  wire       [32:0]   _zz_343;
+  wire       [31:0]   _zz_344;
+  wire       [31:0]   _zz_345;
+  wire       [32:0]   _zz_346;
+  wire       [32:0]   _zz_347;
+  wire       [32:0]   _zz_348;
+  wire       [32:0]   _zz_349;
+  wire       [0:0]    _zz_350;
+  wire       [32:0]   _zz_351;
+  wire       [0:0]    _zz_352;
+  wire       [32:0]   _zz_353;
+  wire       [0:0]    _zz_354;
+  wire       [31:0]   _zz_355;
+  wire       [0:0]    _zz_356;
+  wire       [0:0]    _zz_357;
+  wire       [0:0]    _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [0:0]    _zz_360;
+  wire       [0:0]    _zz_361;
+  wire       [0:0]    _zz_362;
+  wire       [26:0]   _zz_363;
+  wire                _zz_364;
+  wire                _zz_365;
+  wire       [1:0]    _zz_366;
+  wire       [31:0]   _zz_367;
+  wire       [31:0]   _zz_368;
+  wire       [31:0]   _zz_369;
+  wire                _zz_370;
+  wire       [0:0]    _zz_371;
+  wire       [15:0]   _zz_372;
+  wire       [31:0]   _zz_373;
+  wire       [31:0]   _zz_374;
+  wire       [31:0]   _zz_375;
+  wire                _zz_376;
+  wire       [0:0]    _zz_377;
+  wire       [9:0]    _zz_378;
+  wire       [31:0]   _zz_379;
+  wire       [31:0]   _zz_380;
+  wire       [31:0]   _zz_381;
+  wire                _zz_382;
+  wire       [0:0]    _zz_383;
+  wire       [3:0]    _zz_384;
+  wire                _zz_385;
+  wire                _zz_386;
+  wire       [6:0]    _zz_387;
+  wire       [4:0]    _zz_388;
+  wire                _zz_389;
+  wire       [4:0]    _zz_390;
+  wire       [0:0]    _zz_391;
+  wire       [7:0]    _zz_392;
+  wire                _zz_393;
+  wire       [0:0]    _zz_394;
+  wire       [0:0]    _zz_395;
+  wire       [31:0]   _zz_396;
+  wire       [31:0]   _zz_397;
+  wire                _zz_398;
+  wire       [0:0]    _zz_399;
+  wire       [0:0]    _zz_400;
+  wire                _zz_401;
+  wire       [0:0]    _zz_402;
+  wire       [25:0]   _zz_403;
+  wire       [31:0]   _zz_404;
+  wire                _zz_405;
+  wire                _zz_406;
+  wire       [0:0]    _zz_407;
+  wire       [0:0]    _zz_408;
+  wire       [0:0]    _zz_409;
+  wire       [0:0]    _zz_410;
+  wire                _zz_411;
+  wire       [0:0]    _zz_412;
+  wire       [21:0]   _zz_413;
+  wire       [31:0]   _zz_414;
+  wire       [31:0]   _zz_415;
+  wire                _zz_416;
+  wire                _zz_417;
+  wire       [0:0]    _zz_418;
+  wire       [1:0]    _zz_419;
+  wire       [0:0]    _zz_420;
+  wire       [0:0]    _zz_421;
+  wire                _zz_422;
+  wire       [0:0]    _zz_423;
+  wire       [18:0]   _zz_424;
+  wire       [31:0]   _zz_425;
+  wire       [31:0]   _zz_426;
+  wire       [31:0]   _zz_427;
+  wire       [31:0]   _zz_428;
+  wire       [31:0]   _zz_429;
+  wire       [31:0]   _zz_430;
+  wire       [31:0]   _zz_431;
+  wire       [31:0]   _zz_432;
+  wire       [0:0]    _zz_433;
+  wire       [0:0]    _zz_434;
+  wire       [0:0]    _zz_435;
+  wire       [0:0]    _zz_436;
+  wire                _zz_437;
+  wire       [0:0]    _zz_438;
+  wire       [15:0]   _zz_439;
+  wire       [31:0]   _zz_440;
+  wire       [31:0]   _zz_441;
+  wire       [31:0]   _zz_442;
+  wire       [31:0]   _zz_443;
+  wire       [31:0]   _zz_444;
+  wire       [0:0]    _zz_445;
+  wire       [1:0]    _zz_446;
+  wire       [0:0]    _zz_447;
+  wire       [0:0]    _zz_448;
+  wire                _zz_449;
+  wire       [0:0]    _zz_450;
+  wire       [12:0]   _zz_451;
+  wire       [31:0]   _zz_452;
+  wire       [31:0]   _zz_453;
+  wire       [31:0]   _zz_454;
+  wire       [31:0]   _zz_455;
+  wire       [31:0]   _zz_456;
+  wire       [31:0]   _zz_457;
+  wire                _zz_458;
+  wire       [0:0]    _zz_459;
+  wire       [3:0]    _zz_460;
+  wire       [0:0]    _zz_461;
+  wire       [0:0]    _zz_462;
+  wire       [4:0]    _zz_463;
+  wire       [4:0]    _zz_464;
+  wire                _zz_465;
+  wire       [0:0]    _zz_466;
+  wire       [9:0]    _zz_467;
+  wire       [31:0]   _zz_468;
+  wire       [31:0]   _zz_469;
+  wire       [31:0]   _zz_470;
+  wire                _zz_471;
+  wire       [0:0]    _zz_472;
+  wire       [1:0]    _zz_473;
+  wire       [31:0]   _zz_474;
+  wire       [31:0]   _zz_475;
+  wire       [31:0]   _zz_476;
+  wire       [31:0]   _zz_477;
+  wire                _zz_478;
+  wire       [0:0]    _zz_479;
+  wire       [2:0]    _zz_480;
+  wire       [0:0]    _zz_481;
+  wire       [3:0]    _zz_482;
+  wire       [6:0]    _zz_483;
+  wire       [6:0]    _zz_484;
+  wire                _zz_485;
+  wire       [0:0]    _zz_486;
+  wire       [7:0]    _zz_487;
+  wire       [31:0]   _zz_488;
+  wire       [31:0]   _zz_489;
+  wire       [31:0]   _zz_490;
+  wire                _zz_491;
+  wire                _zz_492;
+  wire       [31:0]   _zz_493;
+  wire       [31:0]   _zz_494;
+  wire       [31:0]   _zz_495;
+  wire                _zz_496;
+  wire       [0:0]    _zz_497;
+  wire       [0:0]    _zz_498;
+  wire                _zz_499;
+  wire       [0:0]    _zz_500;
+  wire       [1:0]    _zz_501;
+  wire       [0:0]    _zz_502;
+  wire       [4:0]    _zz_503;
+  wire       [0:0]    _zz_504;
+  wire       [0:0]    _zz_505;
+  wire       [1:0]    _zz_506;
+  wire       [1:0]    _zz_507;
+  wire                _zz_508;
+  wire       [0:0]    _zz_509;
+  wire       [5:0]    _zz_510;
+  wire       [31:0]   _zz_511;
+  wire       [31:0]   _zz_512;
+  wire       [31:0]   _zz_513;
+  wire       [31:0]   _zz_514;
+  wire       [31:0]   _zz_515;
+  wire       [31:0]   _zz_516;
+  wire       [31:0]   _zz_517;
+  wire       [31:0]   _zz_518;
+  wire                _zz_519;
+  wire                _zz_520;
+  wire       [31:0]   _zz_521;
+  wire       [31:0]   _zz_522;
+  wire                _zz_523;
+  wire       [0:0]    _zz_524;
+  wire       [2:0]    _zz_525;
+  wire       [31:0]   _zz_526;
+  wire       [31:0]   _zz_527;
+  wire                _zz_528;
+  wire                _zz_529;
+  wire       [0:0]    _zz_530;
+  wire       [0:0]    _zz_531;
+  wire                _zz_532;
+  wire       [0:0]    _zz_533;
+  wire       [3:0]    _zz_534;
+  wire       [31:0]   _zz_535;
+  wire       [31:0]   _zz_536;
+  wire       [31:0]   _zz_537;
+  wire       [31:0]   _zz_538;
+  wire       [31:0]   _zz_539;
+  wire                _zz_540;
+  wire       [0:0]    _zz_541;
+  wire       [0:0]    _zz_542;
+  wire       [31:0]   _zz_543;
+  wire       [31:0]   _zz_544;
+  wire       [31:0]   _zz_545;
+  wire       [31:0]   _zz_546;
+  wire       [0:0]    _zz_547;
+  wire       [3:0]    _zz_548;
+  wire       [1:0]    _zz_549;
+  wire       [1:0]    _zz_550;
+  wire                _zz_551;
+  wire       [0:0]    _zz_552;
+  wire       [1:0]    _zz_553;
+  wire       [31:0]   _zz_554;
+  wire       [31:0]   _zz_555;
+  wire       [31:0]   _zz_556;
+  wire       [31:0]   _zz_557;
+  wire       [31:0]   _zz_558;
+  wire                _zz_559;
+  wire       [0:0]    _zz_560;
+  wire       [1:0]    _zz_561;
+  wire                _zz_562;
+  wire       [0:0]    _zz_563;
+  wire       [1:0]    _zz_564;
+  wire       [2:0]    _zz_565;
+  wire       [2:0]    _zz_566;
+  wire                _zz_567;
+  wire                _zz_568;
+  wire       [31:0]   _zz_569;
+  wire       [31:0]   _zz_570;
+  wire       [31:0]   _zz_571;
+  wire                _zz_572;
+  wire       [31:0]   _zz_573;
+  wire       [31:0]   _zz_574;
+  wire       [31:0]   _zz_575;
+  wire                _zz_576;
+  wire                _zz_577;
+  wire       [0:0]    _zz_578;
+  wire       [0:0]    _zz_579;
+  wire       [0:0]    _zz_580;
+  wire       [0:0]    _zz_581;
+  wire                _zz_582;
+  wire                _zz_583;
+  wire                _zz_584;
+  wire                _zz_585;
+  wire       [31:0]   _zz_586;
   wire       [51:0]   memory_MUL_LOW;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       [33:0]   execute_MUL_HL;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_12_;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
-  wire                memory_MEMORY_WR;
-  wire                decode_MEMORY_WR;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_15_;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_20_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_23_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire                decode_SRC_LESS_UNSIGNED;
   wire                decode_MEMORY_MANAGMENT;
-  wire                decode_CSR_READ_OPCODE;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire                decode_IS_RS1_SIGNED;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [33:0]   execute_MUL_LH;
-  wire                decode_IS_DIV;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_26_;
-  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   memory_PC;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -1508,11 +577,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -1520,10 +589,10 @@ module VexRiscv (
   wire                execute_BRANCH_COND_RESULT;
   wire                execute_PREDICTION_HAD_BRANCHED2;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1533,66 +602,70 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire                execute_IS_RVC;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_49_;
-  reg        [31:0]   _zz_50_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
+  wire                execute_MEMORY_LRSC;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
+  wire                decode_MEMORY_LRSC;
+  reg                 _zz_51;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_51_;
-  reg                 _zz_51__2;
-  reg                 _zz_51__1;
-  reg                 _zz_51__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52_;
-  reg        [31:0]   _zz_53_;
-  reg        [31:0]   _zz_54_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
+  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_54;
   wire       [31:0]   decode_PC;
   wire       [31:0]   decode_INSTRUCTION;
   wire                decode_IS_RVC;
@@ -1610,7 +683,7 @@ module VexRiscv (
   wire                decode_arbitration_isMoving;
   wire                decode_arbitration_isFiring;
   reg                 execute_arbitration_haltItself;
-  wire                execute_arbitration_haltByOther;
+  reg                 execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
   wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
@@ -1659,28 +732,47 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                DBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -1713,11 +805,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55_;
-  wire       [3:0]    _zz_56_;
-  wire                _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
+  wire       [3:0]    _zz_55;
+  wire       [3:0]    _zz_56;
+  wire                _zz_57;
+  wire                _zz_58;
+  wire                _zz_59;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -1751,12 +843,12 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_1_halt;
-  wire                _zz_60_;
-  wire                _zz_61_;
+  wire                _zz_60;
+  wire                _zz_61;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_62_;
-  wire                _zz_63_;
-  reg                 _zz_64_;
+  wire                _zz_62;
+  wire                _zz_63;
+  reg                 _zz_64;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1787,34 +879,34 @@ module VexRiscv (
   wire                IBusCachedPlugin_decompressor_unaligned;
   wire       [31:0]   IBusCachedPlugin_decompressor_raw;
   wire                IBusCachedPlugin_decompressor_isRvc;
-  wire       [15:0]   _zz_65_;
+  wire       [15:0]   _zz_65;
   reg        [31:0]   IBusCachedPlugin_decompressor_decompressed;
-  wire       [4:0]    _zz_66_;
-  wire       [4:0]    _zz_67_;
-  wire       [11:0]   _zz_68_;
-  wire                _zz_69_;
-  reg        [11:0]   _zz_70_;
-  wire                _zz_71_;
-  reg        [9:0]    _zz_72_;
-  wire       [20:0]   _zz_73_;
-  wire                _zz_74_;
-  reg        [14:0]   _zz_75_;
-  wire                _zz_76_;
-  reg        [2:0]    _zz_77_;
-  wire                _zz_78_;
-  reg        [9:0]    _zz_79_;
-  wire       [20:0]   _zz_80_;
-  wire                _zz_81_;
-  reg        [4:0]    _zz_82_;
-  wire       [12:0]   _zz_83_;
-  wire       [4:0]    _zz_84_;
-  wire       [4:0]    _zz_85_;
-  wire       [4:0]    _zz_86_;
-  wire                _zz_87_;
-  reg        [2:0]    _zz_88_;
-  reg        [2:0]    _zz_89_;
-  wire                _zz_90_;
-  reg        [6:0]    _zz_91_;
+  wire       [4:0]    _zz_66;
+  wire       [4:0]    _zz_67;
+  wire       [11:0]   _zz_68;
+  wire                _zz_69;
+  reg        [11:0]   _zz_70;
+  wire                _zz_71;
+  reg        [9:0]    _zz_72;
+  wire       [20:0]   _zz_73;
+  wire                _zz_74;
+  reg        [14:0]   _zz_75;
+  wire                _zz_76;
+  reg        [2:0]    _zz_77;
+  wire                _zz_78;
+  reg        [9:0]    _zz_79;
+  wire       [20:0]   _zz_80;
+  wire                _zz_81;
+  reg        [4:0]    _zz_82;
+  wire       [12:0]   _zz_83;
+  wire       [4:0]    _zz_84;
+  wire       [4:0]    _zz_85;
+  wire       [4:0]    _zz_86;
+  wire                _zz_87;
+  reg        [2:0]    _zz_88;
+  reg        [2:0]    _zz_89;
+  wire                _zz_90;
+  reg        [6:0]    _zz_91;
   wire                IBusCachedPlugin_decompressor_bufferFill;
   wire                IBusCachedPlugin_injector_decodeInput_valid;
   wire                IBusCachedPlugin_injector_decodeInput_ready;
@@ -1822,22 +914,22 @@ module VexRiscv (
   wire                IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
   wire                IBusCachedPlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_92_;
-  reg        [31:0]   _zz_93_;
-  reg                 _zz_94_;
-  reg        [31:0]   _zz_95_;
-  reg                 _zz_96_;
+  reg                 _zz_92;
+  reg        [31:0]   _zz_93;
+  reg                 _zz_94;
+  reg        [31:0]   _zz_95;
+  reg                 _zz_96;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg        [31:0]   IBusCachedPlugin_injector_formal_rawInDecode;
-  wire                _zz_97_;
-  reg        [18:0]   _zz_98_;
-  wire                _zz_99_;
-  reg        [10:0]   _zz_100_;
-  wire                _zz_101_;
-  reg        [18:0]   _zz_102_;
+  wire                _zz_97;
+  reg        [18:0]   _zz_98;
+  wire                _zz_99;
+  reg        [10:0]   _zz_100;
+  wire                _zz_101;
+  reg        [18:0]   _zz_102;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1845,122 +937,117 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_103_;
+  wire       [31:0]   _zz_103;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_104_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_104;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_105_;
+  reg        [31:0]   _zz_105;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_106_;
-  reg        [31:0]   _zz_107_;
-  wire                _zz_108_;
-  reg        [31:0]   _zz_109_;
+  wire                _zz_106;
+  reg        [31:0]   _zz_107;
+  wire                _zz_108;
+  reg        [31:0]   _zz_109;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [31:0]   _zz_110_;
-  wire                _zz_111_;
-  wire                _zz_112_;
-  wire                _zz_113_;
-  wire                _zz_114_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_115_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_116_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_117_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_118_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_119_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_120_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_121_;
+  wire       [32:0]   _zz_110;
+  wire                _zz_111;
+  wire                _zz_112;
+  wire                _zz_113;
+  wire                _zz_114;
+  wire                _zz_115;
+  wire                _zz_116;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_117;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_118;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_119;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_120;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_121;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_122;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_123;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_122_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_124;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_123_;
-  reg        [31:0]   _zz_124_;
-  wire                _zz_125_;
-  reg        [19:0]   _zz_126_;
-  wire                _zz_127_;
-  reg        [19:0]   _zz_128_;
-  reg        [31:0]   _zz_129_;
+  reg        [31:0]   _zz_125;
+  reg        [31:0]   _zz_126;
+  wire                _zz_127;
+  reg        [19:0]   _zz_128;
+  wire                _zz_129;
+  reg        [19:0]   _zz_130;
+  reg        [31:0]   _zz_131;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_130_;
+  reg        [31:0]   _zz_132;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_131_;
-  reg                 _zz_132_;
-  reg                 _zz_133_;
-  reg                 _zz_134_;
-  reg        [4:0]    _zz_135_;
-  reg        [31:0]   _zz_136_;
-  wire                _zz_137_;
-  wire                _zz_138_;
-  wire                _zz_139_;
-  wire                _zz_140_;
-  wire                _zz_141_;
-  wire                _zz_142_;
+  reg        [31:0]   _zz_133;
+  reg                 _zz_134;
+  reg                 _zz_135;
+  reg                 _zz_136;
+  reg        [4:0]    _zz_137;
+  reg        [31:0]   _zz_138;
+  wire                _zz_139;
+  wire                _zz_140;
+  wire                _zz_141;
+  wire                _zz_142;
+  wire                _zz_143;
+  wire                _zz_144;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_143_;
-  reg                 _zz_144_;
-  reg                 _zz_145_;
+  wire       [2:0]    _zz_145;
+  reg                 _zz_146;
+  reg                 _zz_147;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_146_;
-  reg        [19:0]   _zz_147_;
-  wire                _zz_148_;
-  reg        [10:0]   _zz_149_;
-  wire                _zz_150_;
-  reg        [18:0]   _zz_151_;
+  wire                _zz_148;
+  reg        [19:0]   _zz_149;
+  wire                _zz_150;
+  reg        [10:0]   _zz_151;
+  wire                _zz_152;
+  reg        [18:0]   _zz_153;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -1982,9 +1069,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_152_;
-  wire                _zz_153_;
-  wire                _zz_154_;
+  wire                _zz_154;
+  wire                _zz_155;
+  wire                _zz_156;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1997,8 +1084,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_155_;
-  wire                _zz_156_;
+  wire       [1:0]    _zz_157;
+  wire                _zz_158;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -2010,7 +1097,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2051,80 +1138,82 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_157_;
+  wire       [31:0]   _zz_159;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_158_;
-  wire                _zz_159_;
-  wire                _zz_160_;
-  reg        [32:0]   _zz_161_;
+  wire       [31:0]   _zz_160;
+  wire                _zz_161;
+  wire                _zz_162;
+  reg        [32:0]   _zz_163;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_162_;
-  wire       [31:0]   _zz_163_;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg        [31:0]   decode_to_execute_INSTRUCTION;
-  reg        [31:0]   execute_to_memory_INSTRUCTION;
-  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
-  reg        [33:0]   execute_to_memory_MUL_LH;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 decode_to_execute_IS_RVC;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 memory_to_writeBack_IS_MUL;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg                 decode_to_execute_MEMORY_WR;
-  reg                 execute_to_memory_MEMORY_WR;
-  reg                 memory_to_writeBack_MEMORY_WR;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        [33:0]   execute_to_memory_MUL_HL;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   _zz_164;
+  wire       [31:0]   _zz_165;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  reg                 decode_to_execute_IS_RVC;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
+  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_LRSC;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
   reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 memory_to_writeBack_IS_MUL;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_3857;
   reg                 execute_CsrPlugin_csr_3858;
@@ -2149,624 +1238,653 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_3202;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_164_;
-  reg        [31:0]   _zz_165_;
-  reg        [31:0]   _zz_166_;
-  reg        [31:0]   _zz_167_;
-  reg        [31:0]   _zz_168_;
-  reg        [31:0]   _zz_169_;
-  reg        [31:0]   _zz_170_;
-  reg        [31:0]   _zz_171_;
-  reg        [31:0]   _zz_172_;
-  reg        [31:0]   _zz_173_;
-  reg        [31:0]   _zz_174_;
-  reg        [31:0]   _zz_175_;
-  reg        [31:0]   _zz_176_;
-  reg        [31:0]   _zz_177_;
-  reg        [31:0]   _zz_178_;
-  reg        [31:0]   _zz_179_;
-  reg        [31:0]   _zz_180_;
-  reg        [31:0]   _zz_181_;
-  reg        [31:0]   _zz_182_;
-  reg        [31:0]   _zz_183_;
-  reg        [31:0]   _zz_184_;
-  reg        [31:0]   _zz_185_;
-  reg        [31:0]   _zz_186_;
-  reg        [2:0]    _zz_187_;
-  reg                 _zz_188_;
+  reg        [31:0]   _zz_166;
+  reg        [31:0]   _zz_167;
+  reg        [31:0]   _zz_168;
+  reg        [31:0]   _zz_169;
+  reg        [31:0]   _zz_170;
+  reg        [31:0]   _zz_171;
+  reg        [31:0]   _zz_172;
+  reg        [31:0]   _zz_173;
+  reg        [31:0]   _zz_174;
+  reg        [31:0]   _zz_175;
+  reg        [31:0]   _zz_176;
+  reg        [31:0]   _zz_177;
+  reg        [31:0]   _zz_178;
+  reg        [31:0]   _zz_179;
+  reg        [31:0]   _zz_180;
+  reg        [31:0]   _zz_181;
+  reg        [31:0]   _zz_182;
+  reg        [31:0]   _zz_183;
+  reg        [31:0]   _zz_184;
+  reg        [31:0]   _zz_185;
+  reg        [31:0]   _zz_186;
+  reg        [31:0]   _zz_187;
+  reg        [31:0]   _zz_188;
+  reg        [2:0]    _zz_189;
+  reg                 _zz_190;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_189_;
-  wire                _zz_190_;
-  wire                _zz_191_;
-  wire                _zz_192_;
-  wire                _zz_193_;
-  wire                _zz_194_;
-  reg                 _zz_195_;
+  reg        [2:0]    _zz_191;
+  wire                _zz_192;
+  wire                _zz_193;
+  wire                _zz_194;
+  wire                _zz_195;
+  wire                _zz_196;
+  reg                 _zz_197;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [31:0] _zz_1__string;
-  reg [31:0] _zz_2__string;
-  reg [39:0] _zz_3__string;
-  reg [39:0] _zz_4__string;
-  reg [39:0] _zz_5__string;
-  reg [39:0] _zz_6__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_7__string;
-  reg [39:0] _zz_8__string;
-  reg [39:0] _zz_9__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_10__string;
-  reg [95:0] _zz_11__string;
-  reg [95:0] _zz_12__string;
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_13__string;
-  reg [23:0] _zz_14__string;
-  reg [23:0] _zz_15__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_16__string;
-  reg [39:0] _zz_17__string;
-  reg [39:0] _zz_18__string;
-  reg [71:0] _zz_19__string;
-  reg [71:0] _zz_20__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
   reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_21__string;
-  reg [71:0] _zz_22__string;
-  reg [71:0] _zz_23__string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_24__string;
-  reg [63:0] _zz_25__string;
-  reg [63:0] _zz_26__string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [63:0] _zz_43__string;
-  reg [39:0] _zz_44__string;
-  reg [31:0] _zz_45__string;
-  reg [71:0] _zz_46__string;
-  reg [95:0] _zz_47__string;
-  reg [23:0] _zz_48__string;
-  reg [39:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52__string;
-  reg [39:0] _zz_115__string;
-  reg [23:0] _zz_116__string;
-  reg [95:0] _zz_117__string;
-  reg [71:0] _zz_118__string;
-  reg [31:0] _zz_119__string;
-  reg [39:0] _zz_120__string;
-  reg [63:0] _zz_121__string;
+  reg [31:0] _zz_52_string;
+  reg [95:0] _zz_117_string;
+  reg [63:0] _zz_118_string;
+  reg [23:0] _zz_119_string;
+  reg [39:0] _zz_120_string;
+  reg [71:0] _zz_121_string;
+  reg [31:0] _zz_122_string;
+  reg [39:0] _zz_123_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
   reg [71:0] execute_to_memory_SHIFT_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_218_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_219_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_220_ = 1'b1;
-  assign _zz_221_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_222_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_223_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_224_ = ((_zz_198_ && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! _zz_51__2));
-  assign _zz_225_ = ((_zz_198_ && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! _zz_51__1));
-  assign _zz_226_ = ((_zz_198_ && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! _zz_51__0));
-  assign _zz_227_ = ((_zz_198_ && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_228_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_229_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_230_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_231_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_232_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_233_ = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
-  assign _zz_234_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_235_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_236_ = (1'b0 || (! 1'b1));
-  assign _zz_237_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_238_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_239_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_240_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_241_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_242_ = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_243_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_244_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_245_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_246_ = (! memory_arbitration_isStuck);
-  assign _zz_247_ = (iBus_cmd_valid || (_zz_187_ != (3'b000)));
-  assign _zz_248_ = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign _zz_249_ = (_zz_214_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_250_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_251_ = ((_zz_152_ && 1'b1) && (! 1'b0));
-  assign _zz_252_ = ((_zz_153_ && 1'b1) && (! 1'b0));
-  assign _zz_253_ = ((_zz_154_ && 1'b1) && (! 1'b0));
-  assign _zz_254_ = {_zz_65_[1 : 0],_zz_65_[15 : 13]};
-  assign _zz_255_ = _zz_65_[6 : 5];
-  assign _zz_256_ = _zz_65_[11 : 10];
-  assign _zz_257_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_258_ = execute_INSTRUCTION[13];
-  assign _zz_259_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_260_ = _zz_110_[29 : 29];
-  assign _zz_261_ = _zz_110_[5 : 5];
-  assign _zz_262_ = ($signed(_zz_263_) + $signed(_zz_268_));
-  assign _zz_263_ = ($signed(_zz_264_) + $signed(_zz_266_));
-  assign _zz_264_ = 52'h0;
-  assign _zz_265_ = {1'b0,memory_MUL_LL};
-  assign _zz_266_ = {{19{_zz_265_[32]}}, _zz_265_};
-  assign _zz_267_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_268_ = {{2{_zz_267_[49]}}, _zz_267_};
-  assign _zz_269_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_270_ = {{2{_zz_269_[49]}}, _zz_269_};
-  assign _zz_271_ = _zz_110_[17 : 17];
-  assign _zz_272_ = _zz_110_[25 : 25];
-  assign _zz_273_ = _zz_110_[28 : 28];
-  assign _zz_274_ = _zz_110_[15 : 15];
-  assign _zz_275_ = (decode_IS_RVC ? (3'b010) : (3'b100));
-  assign _zz_276_ = {29'd0, _zz_275_};
-  assign _zz_277_ = _zz_110_[0 : 0];
-  assign _zz_278_ = _zz_110_[12 : 12];
-  assign _zz_279_ = _zz_110_[2 : 2];
-  assign _zz_280_ = _zz_110_[14 : 14];
-  assign _zz_281_ = ($signed(_zz_283_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_282_ = _zz_281_[31 : 0];
-  assign _zz_283_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_284_ = _zz_110_[20 : 20];
-  assign _zz_285_ = _zz_110_[9 : 9];
-  assign _zz_286_ = _zz_110_[16 : 16];
-  assign _zz_287_ = _zz_110_[26 : 26];
-  assign _zz_288_ = _zz_110_[1 : 1];
-  assign _zz_289_ = _zz_110_[27 : 27];
-  assign _zz_290_ = _zz_110_[6 : 6];
-  assign _zz_291_ = (_zz_55_ - (4'b0001));
-  assign _zz_292_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_293_ = {29'd0, _zz_292_};
-  assign _zz_294_ = (decode_IS_RVC ? (3'b010) : (3'b100));
-  assign _zz_295_ = {29'd0, _zz_294_};
-  assign _zz_296_ = {{_zz_75_,_zz_65_[6 : 2]},12'h0};
-  assign _zz_297_ = {{{(4'b0000),_zz_65_[8 : 7]},_zz_65_[12 : 9]},(2'b00)};
-  assign _zz_298_ = {{{(4'b0000),_zz_65_[8 : 7]},_zz_65_[12 : 9]},(2'b00)};
-  assign _zz_299_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_300_ = {{_zz_98_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_301_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_302_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_303_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_304_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_305_ = execute_SRC_LESS;
-  assign _zz_306_ = (execute_IS_RVC ? (3'b010) : (3'b100));
-  assign _zz_307_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_308_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_309_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_310_ = ($signed(_zz_311_) + $signed(_zz_314_));
-  assign _zz_311_ = ($signed(_zz_312_) + $signed(_zz_313_));
-  assign _zz_312_ = execute_SRC1;
-  assign _zz_313_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_314_ = (execute_SRC_USE_SUB_LESS ? _zz_315_ : _zz_316_);
-  assign _zz_315_ = 32'h00000001;
-  assign _zz_316_ = 32'h0;
-  assign _zz_317_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_318_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_319_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_320_ = (execute_IS_RVC ? (3'b010) : (3'b100));
-  assign _zz_321_ = (_zz_155_ & (~ _zz_322_));
-  assign _zz_322_ = (_zz_155_ - (2'b01));
-  assign _zz_323_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_324_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_325_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_326_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_327_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_328_ = {5'd0, _zz_327_};
-  assign _zz_329_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_330_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_331_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_332_ = {_zz_157_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_333_ = _zz_334_;
-  assign _zz_334_ = _zz_335_;
-  assign _zz_335_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_158_) : _zz_158_)} + _zz_337_);
-  assign _zz_336_ = memory_DivPlugin_div_needRevert;
-  assign _zz_337_ = {32'd0, _zz_336_};
-  assign _zz_338_ = _zz_160_;
-  assign _zz_339_ = {32'd0, _zz_338_};
-  assign _zz_340_ = _zz_159_;
-  assign _zz_341_ = {31'd0, _zz_340_};
-  assign _zz_342_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_343_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_344_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_345_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_346_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_347_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_348_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_349_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_350_ = 1'b1;
-  assign _zz_351_ = 1'b1;
-  assign _zz_352_ = {_zz_59_,_zz_58_};
-  assign _zz_353_ = 32'h0000107f;
-  assign _zz_354_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_355_ = 32'h00002073;
-  assign _zz_356_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_357_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_358_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_359_) == 32'h00000003),{(_zz_360_ == _zz_361_),{_zz_362_,{_zz_363_,_zz_364_}}}}}};
-  assign _zz_359_ = 32'h0000505f;
-  assign _zz_360_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_361_ = 32'h00000063;
-  assign _zz_362_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_363_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_364_ = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_365_) == 32'h00001013),{(_zz_366_ == _zz_367_),{_zz_368_,{_zz_369_,_zz_370_}}}}}};
-  assign _zz_365_ = 32'hfc00307f;
-  assign _zz_366_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_367_ = 32'h00005033;
-  assign _zz_368_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_369_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_370_ = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_371_ = (_zz_65_[11 : 10] == (2'b01));
-  assign _zz_372_ = ((_zz_65_[11 : 10] == (2'b11)) && (_zz_65_[6 : 5] == (2'b00)));
-  assign _zz_373_ = 7'h0;
-  assign _zz_374_ = _zz_65_[6 : 2];
-  assign _zz_375_ = _zz_65_[12];
-  assign _zz_376_ = _zz_65_[11 : 7];
-  assign _zz_377_ = decode_INSTRUCTION[31];
-  assign _zz_378_ = decode_INSTRUCTION[19 : 12];
-  assign _zz_379_ = decode_INSTRUCTION[20];
-  assign _zz_380_ = decode_INSTRUCTION[31];
-  assign _zz_381_ = decode_INSTRUCTION[7];
-  assign _zz_382_ = 32'h00004014;
-  assign _zz_383_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_384_ = 32'h00002010;
-  assign _zz_385_ = ((decode_INSTRUCTION & _zz_392_) == 32'h00001050);
-  assign _zz_386_ = ((decode_INSTRUCTION & _zz_393_) == 32'h00002050);
-  assign _zz_387_ = ((decode_INSTRUCTION & _zz_394_) == 32'h02000030);
-  assign _zz_388_ = (1'b0);
-  assign _zz_389_ = ((_zz_395_ == _zz_396_) != (1'b0));
-  assign _zz_390_ = (_zz_397_ != (1'b0));
-  assign _zz_391_ = {(_zz_398_ != _zz_399_),{_zz_400_,{_zz_401_,_zz_402_}}};
-  assign _zz_392_ = 32'h00001050;
-  assign _zz_393_ = 32'h00002050;
-  assign _zz_394_ = 32'h02004074;
-  assign _zz_395_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_396_ = 32'h0;
-  assign _zz_397_ = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_398_ = {(_zz_403_ == _zz_404_),{_zz_113_,{_zz_405_,_zz_406_}}};
-  assign _zz_399_ = 5'h0;
-  assign _zz_400_ = ((_zz_407_ == _zz_408_) != (1'b0));
-  assign _zz_401_ = (_zz_409_ != (1'b0));
-  assign _zz_402_ = {(_zz_410_ != _zz_411_),{_zz_412_,{_zz_413_,_zz_414_}}};
-  assign _zz_403_ = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_404_ = 32'h00000040;
-  assign _zz_405_ = ((decode_INSTRUCTION & _zz_415_) == 32'h00004020);
-  assign _zz_406_ = {(_zz_416_ == _zz_417_),(_zz_418_ == _zz_419_)};
-  assign _zz_407_ = (decode_INSTRUCTION & 32'h00203050);
-  assign _zz_408_ = 32'h00000050;
-  assign _zz_409_ = ((decode_INSTRUCTION & 32'h00403050) == 32'h00000050);
-  assign _zz_410_ = {_zz_111_,(_zz_420_ == _zz_421_)};
-  assign _zz_411_ = (2'b00);
-  assign _zz_412_ = ((_zz_422_ == _zz_423_) != (1'b0));
-  assign _zz_413_ = ({_zz_424_,_zz_425_} != (2'b00));
-  assign _zz_414_ = {(_zz_426_ != _zz_427_),{_zz_428_,{_zz_429_,_zz_430_}}};
-  assign _zz_415_ = 32'h00004020;
-  assign _zz_416_ = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_417_ = 32'h00000010;
-  assign _zz_418_ = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_419_ = 32'h00000020;
-  assign _zz_420_ = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_421_ = 32'h00000004;
-  assign _zz_422_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_423_ = 32'h00000040;
-  assign _zz_424_ = ((decode_INSTRUCTION & _zz_431_) == 32'h00000020);
-  assign _zz_425_ = ((decode_INSTRUCTION & _zz_432_) == 32'h00000020);
-  assign _zz_426_ = {(_zz_433_ == _zz_434_),(_zz_435_ == _zz_436_)};
-  assign _zz_427_ = (2'b00);
-  assign _zz_428_ = ({_zz_437_,{_zz_438_,_zz_439_}} != (3'b000));
-  assign _zz_429_ = (_zz_440_ != (1'b0));
-  assign _zz_430_ = {(_zz_441_ != _zz_442_),{_zz_443_,{_zz_444_,_zz_445_}}};
-  assign _zz_431_ = 32'h00000034;
-  assign _zz_432_ = 32'h00000064;
-  assign _zz_433_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_434_ = 32'h00005010;
-  assign _zz_435_ = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_436_ = 32'h00005020;
-  assign _zz_437_ = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_438_ = ((decode_INSTRUCTION & _zz_446_) == 32'h00001010);
-  assign _zz_439_ = ((decode_INSTRUCTION & _zz_447_) == 32'h00001010);
-  assign _zz_440_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_441_ = {(_zz_448_ == _zz_449_),{_zz_450_,_zz_451_}};
-  assign _zz_442_ = (3'b000);
-  assign _zz_443_ = ((_zz_452_ == _zz_453_) != (1'b0));
-  assign _zz_444_ = ({_zz_454_,_zz_455_} != 5'h0);
-  assign _zz_445_ = {(_zz_456_ != _zz_457_),{_zz_458_,{_zz_459_,_zz_460_}}};
-  assign _zz_446_ = 32'h00007034;
-  assign _zz_447_ = 32'h02007054;
-  assign _zz_448_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_449_ = 32'h00000040;
-  assign _zz_450_ = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_451_ = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz_452_ = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz_453_ = 32'h00004008;
-  assign _zz_454_ = _zz_113_;
-  assign _zz_455_ = {(_zz_461_ == _zz_462_),{_zz_463_,{_zz_464_,_zz_465_}}};
-  assign _zz_456_ = {(_zz_466_ == _zz_467_),{_zz_468_,{_zz_469_,_zz_470_}}};
-  assign _zz_457_ = 5'h0;
-  assign _zz_458_ = (_zz_112_ != (1'b0));
-  assign _zz_459_ = ({_zz_471_,_zz_472_} != (2'b00));
-  assign _zz_460_ = {(_zz_473_ != _zz_474_),{_zz_475_,{_zz_476_,_zz_477_}}};
-  assign _zz_461_ = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_462_ = 32'h00002010;
-  assign _zz_463_ = ((decode_INSTRUCTION & _zz_478_) == 32'h00000010);
-  assign _zz_464_ = (_zz_479_ == _zz_480_);
-  assign _zz_465_ = (_zz_481_ == _zz_482_);
-  assign _zz_466_ = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_467_ = 32'h00002040;
-  assign _zz_468_ = ((decode_INSTRUCTION & _zz_483_) == 32'h00001040);
-  assign _zz_469_ = (_zz_484_ == _zz_485_);
-  assign _zz_470_ = {_zz_486_,_zz_487_};
-  assign _zz_471_ = (_zz_488_ == _zz_489_);
-  assign _zz_472_ = _zz_114_;
-  assign _zz_473_ = {_zz_490_,_zz_114_};
-  assign _zz_474_ = (2'b00);
-  assign _zz_475_ = ({_zz_491_,_zz_492_} != (4'b0000));
-  assign _zz_476_ = (_zz_493_ != _zz_494_);
-  assign _zz_477_ = {_zz_495_,{_zz_496_,_zz_497_}};
-  assign _zz_478_ = 32'h00001030;
-  assign _zz_479_ = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz_480_ = 32'h00002020;
-  assign _zz_481_ = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_482_ = 32'h00000020;
-  assign _zz_483_ = 32'h00001040;
-  assign _zz_484_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_485_ = 32'h00000040;
-  assign _zz_486_ = ((decode_INSTRUCTION & _zz_498_) == 32'h00000040);
-  assign _zz_487_ = ((decode_INSTRUCTION & _zz_499_) == 32'h0);
-  assign _zz_488_ = (decode_INSTRUCTION & 32'h00000014);
-  assign _zz_489_ = 32'h00000004;
-  assign _zz_490_ = ((decode_INSTRUCTION & _zz_500_) == 32'h00000004);
-  assign _zz_491_ = (_zz_501_ == _zz_502_);
-  assign _zz_492_ = {_zz_503_,{_zz_504_,_zz_505_}};
-  assign _zz_493_ = {_zz_113_,_zz_506_};
-  assign _zz_494_ = (2'b00);
-  assign _zz_495_ = ({_zz_507_,_zz_508_} != (2'b00));
-  assign _zz_496_ = (_zz_509_ != _zz_510_);
-  assign _zz_497_ = {_zz_511_,{_zz_512_,_zz_513_}};
-  assign _zz_498_ = 32'h00400040;
-  assign _zz_499_ = 32'h00000038;
-  assign _zz_500_ = 32'h00000044;
-  assign _zz_501_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_502_ = 32'h0;
-  assign _zz_503_ = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_504_ = ((decode_INSTRUCTION & _zz_514_) == 32'h00002000);
-  assign _zz_505_ = ((decode_INSTRUCTION & _zz_515_) == 32'h00001000);
-  assign _zz_506_ = ((decode_INSTRUCTION & 32'h00000070) == 32'h00000020);
-  assign _zz_507_ = _zz_113_;
-  assign _zz_508_ = ((decode_INSTRUCTION & _zz_516_) == 32'h0);
-  assign _zz_509_ = ((decode_INSTRUCTION & _zz_517_) == 32'h00001008);
-  assign _zz_510_ = (1'b0);
-  assign _zz_511_ = (_zz_112_ != (1'b0));
-  assign _zz_512_ = (_zz_518_ != (1'b0));
-  assign _zz_513_ = {(_zz_519_ != _zz_520_),{_zz_521_,{_zz_522_,_zz_523_}}};
-  assign _zz_514_ = 32'h00006004;
-  assign _zz_515_ = 32'h00005004;
-  assign _zz_516_ = 32'h00000020;
-  assign _zz_517_ = 32'h00005048;
-  assign _zz_518_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz_519_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_520_ = (1'b0);
-  assign _zz_521_ = (((decode_INSTRUCTION & 32'h02004064) == 32'h02004020) != (1'b0));
-  assign _zz_522_ = ({_zz_111_,{_zz_524_,{_zz_525_,_zz_526_}}} != 6'h0);
-  assign _zz_523_ = ({(_zz_527_ == _zz_528_),(_zz_529_ == _zz_530_)} != (2'b00));
-  assign _zz_524_ = ((decode_INSTRUCTION & 32'h00001010) == 32'h00001010);
-  assign _zz_525_ = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
-  assign _zz_526_ = {((decode_INSTRUCTION & 32'h00000050) == 32'h00000010),{((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004),((decode_INSTRUCTION & 32'h00000028) == 32'h0)}};
-  assign _zz_527_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_528_ = 32'h00002000;
-  assign _zz_529_ = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_530_ = 32'h00001000;
-  assign _zz_531_ = execute_INSTRUCTION[31];
-  assign _zz_532_ = execute_INSTRUCTION[31];
-  assign _zz_533_ = execute_INSTRUCTION[7];
-  assign _zz_534_ = 32'h0;
+  assign _zz_231 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_232 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_233 = 1'b1;
+  assign _zz_234 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_235 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_236 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_237 = ((_zz_200 && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_238 = ((_zz_200 && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_239 = ((_zz_200 && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_240 = ((_zz_200 && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_241 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_242 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_243 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_244 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_245 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_246 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  assign _zz_247 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_248 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_249 = (1'b0 || (! 1'b1));
+  assign _zz_250 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_251 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_252 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_253 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_254 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_255 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_256 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_257 = execute_INSTRUCTION[13 : 12];
+  assign _zz_258 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_259 = (! memory_arbitration_isStuck);
+  assign _zz_260 = (iBus_cmd_valid || (_zz_189 != 3'b000));
+  assign _zz_261 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign _zz_262 = (_zz_227 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_263 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_264 = ((_zz_154 && 1'b1) && (! 1'b0));
+  assign _zz_265 = ((_zz_155 && 1'b1) && (! 1'b0));
+  assign _zz_266 = ((_zz_156 && 1'b1) && (! 1'b0));
+  assign _zz_267 = {_zz_65[1 : 0],_zz_65[15 : 13]};
+  assign _zz_268 = _zz_65[6 : 5];
+  assign _zz_269 = _zz_65[11 : 10];
+  assign _zz_270 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_271 = execute_INSTRUCTION[13];
+  assign _zz_272 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_273 = ($signed(_zz_274) + $signed(_zz_279));
+  assign _zz_274 = ($signed(_zz_275) + $signed(_zz_277));
+  assign _zz_275 = 52'h0;
+  assign _zz_276 = {1'b0,memory_MUL_LL};
+  assign _zz_277 = {{19{_zz_276[32]}}, _zz_276};
+  assign _zz_278 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_279 = {{2{_zz_278[49]}}, _zz_278};
+  assign _zz_280 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_281 = {{2{_zz_280[49]}}, _zz_280};
+  assign _zz_282 = ($signed(_zz_284) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_283 = _zz_282[31 : 0];
+  assign _zz_284 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_285 = _zz_110[32 : 32];
+  assign _zz_286 = _zz_110[31 : 31];
+  assign _zz_287 = _zz_110[30 : 30];
+  assign _zz_288 = _zz_110[29 : 29];
+  assign _zz_289 = _zz_110[26 : 26];
+  assign _zz_290 = _zz_110[19 : 19];
+  assign _zz_291 = _zz_110[18 : 18];
+  assign _zz_292 = _zz_110[13 : 13];
+  assign _zz_293 = _zz_110[12 : 12];
+  assign _zz_294 = _zz_110[11 : 11];
+  assign _zz_295 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_296 = {29'd0, _zz_295};
+  assign _zz_297 = _zz_110[16 : 16];
+  assign _zz_298 = _zz_110[5 : 5];
+  assign _zz_299 = _zz_110[3 : 3];
+  assign _zz_300 = _zz_110[17 : 17];
+  assign _zz_301 = _zz_110[10 : 10];
+  assign _zz_302 = _zz_110[15 : 15];
+  assign _zz_303 = _zz_110[4 : 4];
+  assign _zz_304 = _zz_110[0 : 0];
+  assign _zz_305 = (_zz_55 - 4'b0001);
+  assign _zz_306 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_307 = {29'd0, _zz_306};
+  assign _zz_308 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_309 = {29'd0, _zz_308};
+  assign _zz_310 = {{_zz_75,_zz_65[6 : 2]},12'h0};
+  assign _zz_311 = {{{4'b0000,_zz_65[8 : 7]},_zz_65[12 : 9]},2'b00};
+  assign _zz_312 = {{{4'b0000,_zz_65[8 : 7]},_zz_65[12 : 9]},2'b00};
+  assign _zz_313 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_314 = {{_zz_98,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_315 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_316 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_317 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_318 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_319 = execute_SRC_LESS;
+  assign _zz_320 = (execute_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_321 = execute_INSTRUCTION[19 : 15];
+  assign _zz_322 = execute_INSTRUCTION[31 : 20];
+  assign _zz_323 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_324 = ($signed(_zz_325) + $signed(_zz_328));
+  assign _zz_325 = ($signed(_zz_326) + $signed(_zz_327));
+  assign _zz_326 = execute_SRC1;
+  assign _zz_327 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_328 = (execute_SRC_USE_SUB_LESS ? _zz_329 : _zz_330);
+  assign _zz_329 = 32'h00000001;
+  assign _zz_330 = 32'h0;
+  assign _zz_331 = execute_INSTRUCTION[31 : 20];
+  assign _zz_332 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_333 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_334 = (execute_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_335 = (_zz_157 & (~ _zz_336));
+  assign _zz_336 = (_zz_157 - 2'b01);
+  assign _zz_337 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_338 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_339 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_340 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_341 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_342 = {5'd0, _zz_341};
+  assign _zz_343 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_344 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_345 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_346 = {_zz_159,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_347 = _zz_348;
+  assign _zz_348 = _zz_349;
+  assign _zz_349 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_160) : _zz_160)} + _zz_351);
+  assign _zz_350 = memory_DivPlugin_div_needRevert;
+  assign _zz_351 = {32'd0, _zz_350};
+  assign _zz_352 = _zz_162;
+  assign _zz_353 = {32'd0, _zz_352};
+  assign _zz_354 = _zz_161;
+  assign _zz_355 = {31'd0, _zz_354};
+  assign _zz_356 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_357 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_358 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_359 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_360 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_361 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_362 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_363 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_364 = 1'b1;
+  assign _zz_365 = 1'b1;
+  assign _zz_366 = {_zz_59,_zz_58};
+  assign _zz_367 = 32'h0000107f;
+  assign _zz_368 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_369 = 32'h00002073;
+  assign _zz_370 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_371 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_372 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_373) == 32'h00000003),{(_zz_374 == _zz_375),{_zz_376,{_zz_377,_zz_378}}}}}};
+  assign _zz_373 = 32'h0000505f;
+  assign _zz_374 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_375 = 32'h00000063;
+  assign _zz_376 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_377 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_378 = {((decode_INSTRUCTION & 32'hf800707f) == 32'h1800202f),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_379) == 32'h00005013),{(_zz_380 == _zz_381),{_zz_382,{_zz_383,_zz_384}}}}}};
+  assign _zz_379 = 32'hbc00707f;
+  assign _zz_380 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_381 = 32'h00001013;
+  assign _zz_382 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_383 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_384 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)}}};
+  assign _zz_385 = (_zz_65[11 : 10] == 2'b01);
+  assign _zz_386 = ((_zz_65[11 : 10] == 2'b11) && (_zz_65[6 : 5] == 2'b00));
+  assign _zz_387 = 7'h0;
+  assign _zz_388 = _zz_65[6 : 2];
+  assign _zz_389 = _zz_65[12];
+  assign _zz_390 = _zz_65[11 : 7];
+  assign _zz_391 = decode_INSTRUCTION[31];
+  assign _zz_392 = decode_INSTRUCTION[19 : 12];
+  assign _zz_393 = decode_INSTRUCTION[20];
+  assign _zz_394 = decode_INSTRUCTION[31];
+  assign _zz_395 = decode_INSTRUCTION[7];
+  assign _zz_396 = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz_397 = 32'h02004020;
+  assign _zz_398 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz_399 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
+  assign _zz_400 = 1'b0;
+  assign _zz_401 = (((decode_INSTRUCTION & _zz_404) == 32'h00000050) != 1'b0);
+  assign _zz_402 = ({_zz_405,_zz_406} != 2'b00);
+  assign _zz_403 = {({_zz_407,_zz_408} != 2'b00),{(_zz_409 != _zz_410),{_zz_411,{_zz_412,_zz_413}}}};
+  assign _zz_404 = 32'h00403050;
+  assign _zz_405 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz_406 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz_407 = _zz_112;
+  assign _zz_408 = ((decode_INSTRUCTION & _zz_414) == 32'h00000004);
+  assign _zz_409 = ((decode_INSTRUCTION & _zz_415) == 32'h00000040);
+  assign _zz_410 = 1'b0;
+  assign _zz_411 = ({_zz_416,_zz_417} != 2'b00);
+  assign _zz_412 = ({_zz_418,_zz_419} != 3'b000);
+  assign _zz_413 = {(_zz_420 != _zz_421),{_zz_422,{_zz_423,_zz_424}}};
+  assign _zz_414 = 32'h0000001c;
+  assign _zz_415 = 32'h00000058;
+  assign _zz_416 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz_417 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz_418 = ((decode_INSTRUCTION & _zz_425) == 32'h40001010);
+  assign _zz_419 = {(_zz_426 == _zz_427),(_zz_428 == _zz_429)};
+  assign _zz_420 = ((decode_INSTRUCTION & _zz_430) == 32'h00001000);
+  assign _zz_421 = 1'b0;
+  assign _zz_422 = ((_zz_431 == _zz_432) != 1'b0);
+  assign _zz_423 = ({_zz_433,_zz_434} != 2'b00);
+  assign _zz_424 = {(_zz_435 != _zz_436),{_zz_437,{_zz_438,_zz_439}}};
+  assign _zz_425 = 32'h40003054;
+  assign _zz_426 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_427 = 32'h00001010;
+  assign _zz_428 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz_429 = 32'h00001010;
+  assign _zz_430 = 32'h00001000;
+  assign _zz_431 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz_432 = 32'h00002000;
+  assign _zz_433 = ((decode_INSTRUCTION & _zz_440) == 32'h00002000);
+  assign _zz_434 = ((decode_INSTRUCTION & _zz_441) == 32'h00001000);
+  assign _zz_435 = ((decode_INSTRUCTION & _zz_442) == 32'h00004008);
+  assign _zz_436 = 1'b0;
+  assign _zz_437 = ((_zz_443 == _zz_444) != 1'b0);
+  assign _zz_438 = ({_zz_445,_zz_446} != 3'b000);
+  assign _zz_439 = {(_zz_447 != _zz_448),{_zz_449,{_zz_450,_zz_451}}};
+  assign _zz_440 = 32'h00002010;
+  assign _zz_441 = 32'h00005000;
+  assign _zz_442 = 32'h00004048;
+  assign _zz_443 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_444 = 32'h00000024;
+  assign _zz_445 = ((decode_INSTRUCTION & _zz_452) == 32'h00000020);
+  assign _zz_446 = {(_zz_453 == _zz_454),(_zz_455 == _zz_456)};
+  assign _zz_447 = ((decode_INSTRUCTION & _zz_457) == 32'h00000008);
+  assign _zz_448 = 1'b0;
+  assign _zz_449 = ({_zz_458,{_zz_459,_zz_460}} != 6'h0);
+  assign _zz_450 = ({_zz_461,_zz_462} != 2'b00);
+  assign _zz_451 = {(_zz_463 != _zz_464),{_zz_465,{_zz_466,_zz_467}}};
+  assign _zz_452 = 32'h00000034;
+  assign _zz_453 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_454 = 32'h00000020;
+  assign _zz_455 = (decode_INSTRUCTION & 32'h08000070);
+  assign _zz_456 = 32'h08000020;
+  assign _zz_457 = 32'h00000008;
+  assign _zz_458 = ((decode_INSTRUCTION & _zz_468) == 32'h00002040);
+  assign _zz_459 = (_zz_469 == _zz_470);
+  assign _zz_460 = {_zz_471,{_zz_472,_zz_473}};
+  assign _zz_461 = (_zz_474 == _zz_475);
+  assign _zz_462 = (_zz_476 == _zz_477);
+  assign _zz_463 = {_zz_478,{_zz_479,_zz_480}};
+  assign _zz_464 = 5'h0;
+  assign _zz_465 = ({_zz_481,_zz_482} != 5'h0);
+  assign _zz_466 = (_zz_483 != _zz_484);
+  assign _zz_467 = {_zz_485,{_zz_486,_zz_487}};
+  assign _zz_468 = 32'h00002040;
+  assign _zz_469 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz_470 = 32'h00001040;
+  assign _zz_471 = ((decode_INSTRUCTION & _zz_488) == 32'h00000040);
+  assign _zz_472 = (_zz_489 == _zz_490);
+  assign _zz_473 = {_zz_491,_zz_492};
+  assign _zz_474 = (decode_INSTRUCTION & 32'h08000020);
+  assign _zz_475 = 32'h08000020;
+  assign _zz_476 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_477 = 32'h00000020;
+  assign _zz_478 = ((decode_INSTRUCTION & _zz_493) == 32'h00000040);
+  assign _zz_479 = (_zz_494 == _zz_495);
+  assign _zz_480 = {_zz_496,{_zz_497,_zz_498}};
+  assign _zz_481 = _zz_115;
+  assign _zz_482 = {_zz_499,{_zz_500,_zz_501}};
+  assign _zz_483 = {_zz_112,{_zz_502,_zz_503}};
+  assign _zz_484 = 7'h0;
+  assign _zz_485 = ({_zz_504,_zz_505} != 2'b00);
+  assign _zz_486 = (_zz_506 != _zz_507);
+  assign _zz_487 = {_zz_508,{_zz_509,_zz_510}};
+  assign _zz_488 = 32'h00000050;
+  assign _zz_489 = (decode_INSTRUCTION & 32'h00400040);
+  assign _zz_490 = 32'h00000040;
+  assign _zz_491 = ((decode_INSTRUCTION & _zz_511) == 32'h00002008);
+  assign _zz_492 = ((decode_INSTRUCTION & _zz_512) == 32'h0);
+  assign _zz_493 = 32'h00000040;
+  assign _zz_494 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz_495 = 32'h00004020;
+  assign _zz_496 = ((decode_INSTRUCTION & _zz_513) == 32'h00000010);
+  assign _zz_497 = _zz_115;
+  assign _zz_498 = (_zz_514 == _zz_515);
+  assign _zz_499 = ((decode_INSTRUCTION & _zz_516) == 32'h00002010);
+  assign _zz_500 = (_zz_517 == _zz_518);
+  assign _zz_501 = {_zz_519,_zz_520};
+  assign _zz_502 = (_zz_521 == _zz_522);
+  assign _zz_503 = {_zz_523,{_zz_524,_zz_525}};
+  assign _zz_504 = _zz_114;
+  assign _zz_505 = (_zz_526 == _zz_527);
+  assign _zz_506 = {_zz_114,_zz_528};
+  assign _zz_507 = 2'b00;
+  assign _zz_508 = (_zz_529 != 1'b0);
+  assign _zz_509 = (_zz_530 != _zz_531);
+  assign _zz_510 = {_zz_532,{_zz_533,_zz_534}};
+  assign _zz_511 = 32'h08002008;
+  assign _zz_512 = 32'h00000038;
+  assign _zz_513 = 32'h00000030;
+  assign _zz_514 = (decode_INSTRUCTION & 32'h12000020);
+  assign _zz_515 = 32'h00000020;
+  assign _zz_516 = 32'h00002030;
+  assign _zz_517 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz_518 = 32'h00000010;
+  assign _zz_519 = ((decode_INSTRUCTION & _zz_535) == 32'h00000020);
+  assign _zz_520 = ((decode_INSTRUCTION & _zz_536) == 32'h00002020);
+  assign _zz_521 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_522 = 32'h00001010;
+  assign _zz_523 = ((decode_INSTRUCTION & _zz_537) == 32'h00002010);
+  assign _zz_524 = (_zz_538 == _zz_539);
+  assign _zz_525 = {_zz_540,{_zz_541,_zz_542}};
+  assign _zz_526 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_527 = 32'h00000020;
+  assign _zz_528 = ((decode_INSTRUCTION & _zz_543) == 32'h0);
+  assign _zz_529 = ((decode_INSTRUCTION & _zz_544) == 32'h00004010);
+  assign _zz_530 = (_zz_545 == _zz_546);
+  assign _zz_531 = 1'b0;
+  assign _zz_532 = ({_zz_547,_zz_548} != 5'h0);
+  assign _zz_533 = (_zz_549 != _zz_550);
+  assign _zz_534 = {_zz_551,{_zz_552,_zz_553}};
+  assign _zz_535 = 32'h02003020;
+  assign _zz_536 = 32'h12002060;
+  assign _zz_537 = 32'h00002010;
+  assign _zz_538 = (decode_INSTRUCTION & 32'h00002008);
+  assign _zz_539 = 32'h00002008;
+  assign _zz_540 = ((decode_INSTRUCTION & _zz_554) == 32'h00000010);
+  assign _zz_541 = _zz_115;
+  assign _zz_542 = (_zz_555 == _zz_556);
+  assign _zz_543 = 32'h00000020;
+  assign _zz_544 = 32'h00004014;
+  assign _zz_545 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_546 = 32'h00002010;
+  assign _zz_547 = (_zz_557 == _zz_558);
+  assign _zz_548 = {_zz_559,{_zz_560,_zz_561}};
+  assign _zz_549 = {_zz_113,_zz_562};
+  assign _zz_550 = 2'b00;
+  assign _zz_551 = ({_zz_563,_zz_564} != 3'b000);
+  assign _zz_552 = (_zz_565 != _zz_566);
+  assign _zz_553 = {_zz_567,_zz_568};
+  assign _zz_554 = 32'h00000050;
+  assign _zz_555 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_556 = 32'h0;
+  assign _zz_557 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_558 = 32'h0;
+  assign _zz_559 = ((decode_INSTRUCTION & _zz_569) == 32'h0);
+  assign _zz_560 = (_zz_570 == _zz_571);
+  assign _zz_561 = {_zz_572,_zz_113};
+  assign _zz_562 = ((decode_INSTRUCTION & _zz_573) == 32'h0);
+  assign _zz_563 = (_zz_574 == _zz_575);
+  assign _zz_564 = {_zz_576,_zz_577};
+  assign _zz_565 = {_zz_112,{_zz_578,_zz_579}};
+  assign _zz_566 = 3'b000;
+  assign _zz_567 = ({_zz_580,_zz_581} != 2'b00);
+  assign _zz_568 = (_zz_582 != 1'b0);
+  assign _zz_569 = 32'h00000018;
+  assign _zz_570 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz_571 = 32'h00002000;
+  assign _zz_572 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz_573 = 32'h00000058;
+  assign _zz_574 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_575 = 32'h00000040;
+  assign _zz_576 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_577 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz_578 = _zz_111;
+  assign _zz_579 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
+  assign _zz_580 = _zz_111;
+  assign _zz_581 = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
+  assign _zz_582 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_583 = execute_INSTRUCTION[31];
+  assign _zz_584 = execute_INSTRUCTION[31];
+  assign _zz_585 = execute_INSTRUCTION[7];
+  assign _zz_586 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_350_) begin
-      _zz_215_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_364) begin
+      _zz_228 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_351_) begin
-      _zz_216_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_365) begin
+      _zz_229 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_196_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_197_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_198_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_199_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_cacheMiss                       (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss                        ), //o
-    .io_cpu_fetch_error                           (IBusCachedPlugin_cache_io_cpu_fetch_error                            ), //o
-    .io_cpu_fetch_mmuRefilling                    (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling                     ), //o
-    .io_cpu_fetch_mmuException                    (IBusCachedPlugin_cache_io_cpu_fetch_mmuException                     ), //o
-    .io_cpu_fetch_isUser                          (_zz_200_                                                             ), //i
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_201_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_202_                                                             ), //i
-    .io_cpu_decode_pc                             (_zz_203_[31:0]                                                       ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_fill_valid                            (_zz_204_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_198                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_199                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_200                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_201                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_202                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_fetch_cacheMiss                   (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss               ), //o
+    .io_cpu_fetch_error                       (IBusCachedPlugin_cache_io_cpu_fetch_error                   ), //o
+    .io_cpu_fetch_mmuRefilling                (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling            ), //o
+    .io_cpu_fetch_mmuException                (IBusCachedPlugin_cache_io_cpu_fetch_mmuException            ), //o
+    .io_cpu_fetch_isUser                      (_zz_203                                                     ), //i
+    .io_cpu_decode_isValid                    (_zz_204                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_205                                                     ), //i
+    .io_cpu_decode_pc                         (_zz_206[31:0]                                               ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_fill_valid                        (_zz_207                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_205_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_206_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (execute_MEMORY_WR                                           ), //i
-    .io_cpu_execute_args_data                      (_zz_105_[31:0]                                              ), //i
-    .io_cpu_execute_args_size                      (execute_DBusCachedPlugin_size[1:0]                          ), //i
-    .io_cpu_memory_isValid                         (_zz_207_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_208_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_209_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_210_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_211_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_212_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_213_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_214_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_208                                            ), //i
+    .io_cpu_execute_address                    (_zz_209[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
+    .io_cpu_execute_args_data                  (_zz_105[31:0]                                      ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
+    .io_cpu_execute_args_isLrsc                (_zz_210                                            ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_211                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_212[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_213                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_writeBack_isValid                  (_zz_214                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_215                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_216[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_217                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_218                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_219                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_220                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_221                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_222                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_223                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_224                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_225[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_226                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_227                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_352_)
+    case(_zz_366)
       2'b00 : begin
-        _zz_217_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_230 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_217_ = CsrPlugin_jumpInterface_payload;
+        _zz_230 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_217_ = BranchPlugin_jumpInterface_payload;
+        _zz_230 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_217_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_230 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_1__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_1__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_1__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_1__string = "JALR";
-      default : _zz_1__string = "????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_2__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_2__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_2__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_2__string = "JALR";
-      default : _zz_2__string = "????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3__string = "ECALL";
-      default : _zz_3__string = "?????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4__string = "ECALL";
-      default : _zz_4__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5__string = "ECALL";
-      default : _zz_5__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6__string = "ECALL";
-      default : _zz_6__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2779,152 +1897,66 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_7_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7__string = "ECALL";
-      default : _zz_7__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_8__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8__string = "ECALL";
-      default : _zz_8__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_9_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_9__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9__string = "ECALL";
-      default : _zz_9__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_10__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_10__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_10__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_10__string = "URS1        ";
-      default : _zz_10__string = "????????????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_11_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_11__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_11__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_11__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_11__string = "URS1        ";
-      default : _zz_11__string = "????????????";
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_12_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_12__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_12__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_12__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_12__string = "URS1        ";
-      default : _zz_12__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_13__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_13__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_13__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_13__string = "PC ";
-      default : _zz_13__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_14__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_14__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_14__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_14__string = "PC ";
-      default : _zz_14__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_15__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_15__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_15__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_15__string = "PC ";
-      default : _zz_15__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16__string = "AND_1";
-      default : _zz_16__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17__string = "AND_1";
-      default : _zz_17__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18__string = "AND_1";
-      default : _zz_18__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_19__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_19__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_19__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_19__string = "SRA_1    ";
-      default : _zz_19__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_20__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_20__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_20__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_20__string = "SRA_1    ";
-      default : _zz_20__string = "?????????";
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2937,30 +1969,98 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_21__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_21__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_21__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_21__string = "SRA_1    ";
-      default : _zz_21__string = "?????????";
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_22__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_22__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_22__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_22__string = "SRA_1    ";
-      default : _zz_22__string = "?????????";
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_23__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_23__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_23__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_23__string = "SRA_1    ";
-      default : _zz_23__string = "?????????";
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
     endcase
   end
   always @(*) begin
@@ -2972,27 +2072,63 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24__string = "BITWISE ";
-      default : _zz_24__string = "????????";
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_25__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_25__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_25__string = "BITWISE ";
-      default : _zz_25__string = "????????";
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_26__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_26__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_26__string = "BITWISE ";
-      default : _zz_26__string = "????????";
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3005,12 +2141,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3023,12 +2159,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3041,12 +2177,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3059,12 +2195,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -3077,12 +2213,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3095,12 +2231,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3113,12 +2249,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -3131,12 +2267,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3148,11 +2284,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3164,72 +2300,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_43__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_43__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_43__string = "BITWISE ";
-      default : _zz_43__string = "????????";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_44__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_44__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_44__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_44__string = "ECALL";
-      default : _zz_44__string = "?????";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_45__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_45__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_45__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_45__string = "JALR";
-      default : _zz_45__string = "????";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46__string = "SRA_1    ";
-      default : _zz_46__string = "?????????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_47__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_47__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_47__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_47__string = "URS1        ";
-      default : _zz_47__string = "????????????";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_48__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_48__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_48__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_48__string = "PC ";
-      default : _zz_48__string = "???";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_49__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_49__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_49__string = "AND_1";
-      default : _zz_49__string = "?????";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3242,73 +2378,82 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52__string = "JALR";
-      default : _zz_52__string = "????";
+    case(_zz_52)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
+      default : _zz_52_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_115_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_115__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_115__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_115__string = "AND_1";
-      default : _zz_115__string = "?????";
+    case(_zz_117)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_117_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_117_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_117_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_117_string = "URS1        ";
+      default : _zz_117_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_116_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_116__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_116__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_116__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_116__string = "PC ";
-      default : _zz_116__string = "???";
+    case(_zz_118)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_118_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_118_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_118_string = "BITWISE ";
+      default : _zz_118_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_117_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_117__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_117__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_117__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_117__string = "URS1        ";
-      default : _zz_117__string = "????????????";
+    case(_zz_119)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_119_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_119_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_119_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_119_string = "PC ";
+      default : _zz_119_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_118_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_118__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_118__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_118__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_118__string = "SRA_1    ";
-      default : _zz_118__string = "?????????";
+    case(_zz_120)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_120_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_120_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_120_string = "AND_1";
+      default : _zz_120_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_119_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_119__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_119__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_119__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_119__string = "JALR";
-      default : _zz_119__string = "????";
+    case(_zz_121)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_121_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_121_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_121_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_121_string = "SRA_1    ";
+      default : _zz_121_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_120_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_120__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_120__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_120__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_120__string = "ECALL";
-      default : _zz_120__string = "?????";
+    case(_zz_122)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_122_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_122_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_122_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_122_string = "JALR";
+      default : _zz_122_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_121_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_121__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_121__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_121__string = "BITWISE ";
-      default : _zz_121__string = "????????";
+    case(_zz_123)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_123_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_123_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_123_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_123_string = "ECALL";
+      default : _zz_123_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3317,6 +2462,23 @@ module VexRiscv (
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
       `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3338,29 +2500,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
+    case(decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -3390,68 +2535,60 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
-      default : decode_to_execute_BRANCH_CTRL_string = "????";
-    endcase
-  end
   `endif
 
-  assign decode_IS_CSR = _zz_260_[0];
-  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign memory_PC = execute_to_memory_PC;
-  assign decode_IS_RS2_SIGNED = _zz_261_[0];
-  assign _zz_1_ = _zz_2_;
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign memory_MUL_LOW = ($signed(_zz_262_) + $signed(_zz_270_));
-  assign _zz_3_ = _zz_4_;
-  assign _zz_5_ = _zz_6_;
-  assign decode_ENV_CTRL = _zz_7_;
-  assign _zz_8_ = _zz_9_;
-  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign decode_SRC1_CTRL = _zz_10_;
-  assign _zz_11_ = _zz_12_;
+  assign memory_MUL_LOW = ($signed(_zz_273) + $signed(_zz_281));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_271_[0];
-  assign decode_SRC2_CTRL = _zz_13_;
-  assign _zz_14_ = _zz_15_;
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_272_[0];
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_SHIFT_RIGHT = _zz_283;
+  assign execute_REGFILE_WRITE_DATA = _zz_125;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_209[1 : 0];
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_285[0];
+  assign decode_IS_RS1_SIGNED = _zz_286[0];
+  assign decode_IS_DIV = _zz_287[0];
   assign memory_IS_MUL = execute_to_memory_IS_MUL;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_273_[0];
-  assign decode_ALU_BITWISE_CTRL = _zz_16_;
-  assign _zz_17_ = _zz_18_;
-  assign _zz_19_ = _zz_20_;
-  assign decode_SHIFT_CTRL = _zz_21_;
-  assign _zz_22_ = _zz_23_;
-  assign decode_MEMORY_MANAGMENT = _zz_274_[0];
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_IS_MUL = _zz_288[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_289[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_290[0];
+  assign decode_MEMORY_MANAGMENT = _zz_291[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_292[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_293[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_294[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_51;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
-  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_276_);
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_206_[1 : 0];
-  assign decode_SRC_LESS_UNSIGNED = _zz_277_[0];
-  assign decode_IS_RS1_SIGNED = _zz_278_[0];
-  assign execute_REGFILE_WRITE_DATA = _zz_123_;
-  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign decode_IS_DIV = _zz_279_[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_280_[0];
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_ALU_CTRL = _zz_24_;
-  assign _zz_25_ = _zz_26_;
-  assign execute_SHIFT_RIGHT = _zz_282_;
+  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_296);
+  assign memory_PC = execute_to_memory_PC;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3465,22 +2602,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_145_;
+  assign execute_BRANCH_COND_RESULT = _zz_147;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_284_[0];
-  assign decode_RS1_USE = _zz_285_[0];
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_297[0];
+  assign decode_RS1_USE = _zz_298[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_218_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_231)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
   end
 
@@ -3492,29 +2629,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_134_)begin
-      if((_zz_135_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_136_;
+    if(_zz_136)begin
+      if((_zz_137 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_138;
       end
     end
-    if(_zz_219_)begin
-      if(_zz_220_)begin
-        if(_zz_138_)begin
-          decode_RS2 = _zz_50_;
+    if(_zz_232)begin
+      if(_zz_233)begin
+        if(_zz_140)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_221_)begin
+    if(_zz_234)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_140_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_142)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_222_)begin
+    if(_zz_235)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_142_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_144)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -3522,29 +2659,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_134_)begin
-      if((_zz_135_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_136_;
+    if(_zz_136)begin
+      if((_zz_137 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_138;
       end
     end
-    if(_zz_219_)begin
-      if(_zz_220_)begin
-        if(_zz_137_)begin
-          decode_RS1 = _zz_50_;
+    if(_zz_232)begin
+      if(_zz_233)begin
+        if(_zz_139)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_221_)begin
+    if(_zz_234)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_139_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_141)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_222_)begin
+    if(_zz_235)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_141_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_143)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -3552,71 +2689,71 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_131_;
+          _zz_32 = _zz_133;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_223_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_236)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
   assign execute_IS_RVC = decode_to_execute_IS_RVC;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_286_[0];
-  assign decode_SRC_ADD_ZERO = _zz_287_[0];
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_299[0];
+  assign decode_SRC_ADD_ZERO = _zz_300[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_129_;
-  assign execute_SRC1 = _zz_124_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_131;
+  assign execute_SRC1 = _zz_126;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_decompressor_output_payload_rsp_inst);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_288_[0];
+    decode_REGFILE_WRITE_VALID = _zz_301[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_353_) == 32'h00001073),{(_zz_354_ == _zz_355_),{_zz_356_,{_zz_357_,_zz_358_}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_367) == 32'h00001073),{(_zz_368 == _zz_369),{_zz_370,{_zz_371,_zz_372}}}}}}} != 23'h0);
   always @ (*) begin
-    _zz_50_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_259_)
+      case(_zz_272)
         2'b00 : begin
-          _zz_50_ = _zz_325_;
+          _zz_50 = _zz_339;
         end
         default : begin
-          _zz_50_ = _zz_326_;
+          _zz_50 = _zz_340;
         end
       endcase
     end
@@ -3628,54 +2765,57 @@ module VexRiscv (
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
+  assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_289_[0];
-  assign decode_FLUSH_ALL = _zz_290_[0];
+  assign decode_MEMORY_LRSC = _zz_302[0];
+  assign decode_MEMORY_ENABLE = _zz_303[0];
+  assign decode_FLUSH_ALL = _zz_304[0];
   always @ (*) begin
-    _zz_51_ = _zz_51__2;
-    if(_zz_224_)begin
-      _zz_51_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_237)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(_zz_225_)begin
-      _zz_51__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_238)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(_zz_226_)begin
-      _zz_51__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_239)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_227_)begin
-      _zz_51__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_240)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52_;
+  assign decode_BRANCH_CTRL = _zz_52;
   always @ (*) begin
-    _zz_53_ = memory_FORMAL_PC_NEXT;
+    _zz_53 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_53_ = BranchPlugin_jumpInterface_payload;
+      _zz_53 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_54_ = decode_FORMAL_PC_NEXT;
+    _zz_54 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_54_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_54 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -3693,20 +2833,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_132_ || _zz_133_)))begin
+    if((decode_arbitration_isValid && (_zz_134 || _zz_135)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_228_)begin
+    if(_zz_241)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3720,32 +2860,35 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_228_)begin
+    if(_zz_241)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_213_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_226 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_229_)begin
+    if(_zz_242)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_218_)begin
+    if(_zz_231)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  assign execute_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    execute_arbitration_haltByOther = 1'b0;
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+  end
+
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
     if(CsrPlugin_selfException_valid)begin
@@ -3766,7 +2909,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_223_)begin
+    if(_zz_236)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -3791,7 +2934,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3822,10 +2965,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_230_)begin
+    if(_zz_243)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_231_)begin
+    if(_zz_244)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3836,13 +2979,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_230_)begin
+    if(_zz_243)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_231_)begin
+    if(_zz_244)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -3859,7 +3002,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_229_)begin
+    if(_zz_242)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -3867,21 +3010,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_230_)begin
+    if(_zz_243)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_231_)begin
+    if(_zz_244)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_230_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_243)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_231_)begin
-      case(_zz_232_)
+    if(_zz_244)begin
+      case(_zz_245)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3894,14 +3037,14 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_55_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56_ = (_zz_55_ & (~ _zz_291_));
-  assign _zz_57_ = _zz_56_[3];
-  assign _zz_58_ = (_zz_56_[1] || _zz_57_);
-  assign _zz_59_ = (_zz_56_[2] || _zz_57_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_217_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
+  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_56 = (_zz_55 & (~ _zz_305));
+  assign _zz_57 = _zz_56[3];
+  assign _zz_58 = (_zz_56[1] || _zz_57);
+  assign _zz_59 = (_zz_56[2] || _zz_57);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_230;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -3921,7 +3064,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_293_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_307);
     if(IBusCachedPlugin_fetchPc_inc)begin
       IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
     end
@@ -3948,12 +3091,12 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @ (*) begin
     IBusCachedPlugin_decodePc_flushed = 1'b0;
-    if(_zz_233_)begin
+    if(_zz_246)begin
       IBusCachedPlugin_decodePc_flushed = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_295_);
+  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_309);
   assign IBusCachedPlugin_decodePc_injectedDecode = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_redoFetch = 1'b0;
@@ -3972,23 +3115,23 @@ module VexRiscv (
     end
   end
 
-  assign _zz_60_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60_);
+  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
-    if((_zz_51_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_61_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61_);
+  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   always @ (*) begin
@@ -3999,10 +3142,10 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_iBusRsp_flush = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62_;
-  assign _zz_62_ = ((1'b0 && (! _zz_63_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_63_ = _zz_64_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62;
+  assign _zz_62 = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_63 = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
@@ -4019,194 +3162,194 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = IBusCachedPlugin_decompressor_input_ready;
   assign IBusCachedPlugin_decompressor_flushNext = 1'b0;
   assign IBusCachedPlugin_decompressor_consumeCurrent = 1'b0;
-  assign IBusCachedPlugin_decompressor_isInputLowRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[1 : 0] != (2'b11));
-  assign IBusCachedPlugin_decompressor_isInputHighRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[17 : 16] != (2'b11));
+  assign IBusCachedPlugin_decompressor_isInputLowRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[1 : 0] != 2'b11);
+  assign IBusCachedPlugin_decompressor_isInputHighRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[17 : 16] != 2'b11);
   assign IBusCachedPlugin_decompressor_throw2Bytes = (IBusCachedPlugin_decompressor_throw2BytesReg || IBusCachedPlugin_decompressor_input_payload_pc[1]);
   assign IBusCachedPlugin_decompressor_unaligned = (IBusCachedPlugin_decompressor_throw2Bytes || IBusCachedPlugin_decompressor_bufferValid);
   assign IBusCachedPlugin_decompressor_raw = (IBusCachedPlugin_decompressor_bufferValid ? {IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusCachedPlugin_decompressor_bufferData} : {IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusCachedPlugin_decompressor_throw2Bytes ? IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0])});
-  assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != (2'b11));
-  assign _zz_65_ = IBusCachedPlugin_decompressor_raw[15 : 0];
+  assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != 2'b11);
+  assign _zz_65 = IBusCachedPlugin_decompressor_raw[15 : 0];
   always @ (*) begin
     IBusCachedPlugin_decompressor_decompressed = 32'h0;
-    case(_zz_254_)
-      5'b00000 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{(2'b00),_zz_65_[10 : 7]},_zz_65_[12 : 11]},_zz_65_[5]},_zz_65_[6]},(2'b00)},5'h02},(3'b000)},_zz_67_},7'h13};
+    case(_zz_267)
+      5'h0 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_65[10 : 7]},_zz_65[12 : 11]},_zz_65[5]},_zz_65[6]},2'b00},5'h02},3'b000},_zz_67},7'h13};
       end
-      5'b00010 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_68_,_zz_66_},(3'b010)},_zz_67_},7'h03};
+      5'h02 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_68,_zz_66},3'b010},_zz_67},7'h03};
       end
-      5'b00110 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_68_[11 : 5],_zz_67_},_zz_66_},(3'b010)},_zz_68_[4 : 0]},7'h23};
+      5'h06 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_68[11 : 5],_zz_67},_zz_66},3'b010},_zz_68[4 : 0]},7'h23};
       end
-      5'b01000 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_70_,_zz_65_[11 : 7]},(3'b000)},_zz_65_[11 : 7]},7'h13};
+      5'h08 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_70,_zz_65[11 : 7]},3'b000},_zz_65[11 : 7]},7'h13};
       end
-      5'b01001 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_73_[20],_zz_73_[10 : 1]},_zz_73_[11]},_zz_73_[19 : 12]},_zz_85_},7'h6f};
+      5'h09 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_73[20],_zz_73[10 : 1]},_zz_73[11]},_zz_73[19 : 12]},_zz_85},7'h6f};
       end
-      5'b01010 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_70_,5'h0},(3'b000)},_zz_65_[11 : 7]},7'h13};
+      5'h0a : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_70,5'h0},3'b000},_zz_65[11 : 7]},7'h13};
       end
-      5'b01011 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_65_[11 : 7] == 5'h02) ? {{{{{{{{{_zz_77_,_zz_65_[4 : 3]},_zz_65_[5]},_zz_65_[2]},_zz_65_[6]},(4'b0000)},_zz_65_[11 : 7]},(3'b000)},_zz_65_[11 : 7]},7'h13} : {{_zz_296_[31 : 12],_zz_65_[11 : 7]},7'h37});
+      5'h0b : begin
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_65[11 : 7] == 5'h02) ? {{{{{{{{{_zz_77,_zz_65[4 : 3]},_zz_65[5]},_zz_65[2]},_zz_65[6]},4'b0000},_zz_65[11 : 7]},3'b000},_zz_65[11 : 7]},7'h13} : {{_zz_310[31 : 12],_zz_65[11 : 7]},7'h37});
       end
-      5'b01100 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_65_[11 : 10] == (2'b10)) ? _zz_91_ : {{(1'b0),(_zz_371_ || _zz_372_)},5'h0}),(((! _zz_65_[11]) || _zz_87_) ? _zz_65_[6 : 2] : _zz_67_)},_zz_66_},_zz_89_},_zz_66_},(_zz_87_ ? 7'h13 : 7'h33)};
+      5'h0c : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_65[11 : 10] == 2'b10) ? _zz_91 : {{1'b0,(_zz_385 || _zz_386)},5'h0}),(((! _zz_65[11]) || _zz_87) ? _zz_65[6 : 2] : _zz_67)},_zz_66},_zz_89},_zz_66},(_zz_87 ? 7'h13 : 7'h33)};
       end
-      5'b01101 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_80_[20],_zz_80_[10 : 1]},_zz_80_[11]},_zz_80_[19 : 12]},_zz_84_},7'h6f};
+      5'h0d : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_80[20],_zz_80[10 : 1]},_zz_80[11]},_zz_80[19 : 12]},_zz_84},7'h6f};
       end
-      5'b01110 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_83_[12],_zz_83_[10 : 5]},_zz_84_},_zz_66_},(3'b000)},_zz_83_[4 : 1]},_zz_83_[11]},7'h63};
+      5'h0e : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_83[12],_zz_83[10 : 5]},_zz_84},_zz_66},3'b000},_zz_83[4 : 1]},_zz_83[11]},7'h63};
       end
-      5'b01111 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_83_[12],_zz_83_[10 : 5]},_zz_84_},_zz_66_},(3'b001)},_zz_83_[4 : 1]},_zz_83_[11]},7'h63};
+      5'h0f : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_83[12],_zz_83[10 : 5]},_zz_84},_zz_66},3'b001},_zz_83[4 : 1]},_zz_83[11]},7'h63};
       end
-      5'b10000 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_65_[6 : 2]},_zz_65_[11 : 7]},(3'b001)},_zz_65_[11 : 7]},7'h13};
+      5'h10 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_65[6 : 2]},_zz_65[11 : 7]},3'b001},_zz_65[11 : 7]},7'h13};
       end
-      5'b10010 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{(4'b0000),_zz_65_[3 : 2]},_zz_65_[12]},_zz_65_[6 : 4]},(2'b00)},_zz_86_},(3'b010)},_zz_65_[11 : 7]},7'h03};
+      5'h12 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_65[3 : 2]},_zz_65[12]},_zz_65[6 : 4]},2'b00},_zz_86},3'b010},_zz_65[11 : 7]},7'h03};
       end
-      5'b10100 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_65_[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_65_[6 : 2] == 5'h0) ? {{{{12'h0,_zz_65_[11 : 7]},(3'b000)},(_zz_65_[12] ? _zz_85_ : _zz_84_)},7'h67} : {{{{{_zz_373_,_zz_374_},(_zz_375_ ? _zz_376_ : _zz_84_)},(3'b000)},_zz_65_[11 : 7]},7'h33}));
+      5'h14 : begin
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_65[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_65[6 : 2] == 5'h0) ? {{{{12'h0,_zz_65[11 : 7]},3'b000},(_zz_65[12] ? _zz_85 : _zz_84)},7'h67} : {{{{{_zz_387,_zz_388},(_zz_389 ? _zz_390 : _zz_84)},3'b000},_zz_65[11 : 7]},7'h33}));
       end
-      5'b10110 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_297_[11 : 5],_zz_65_[6 : 2]},_zz_86_},(3'b010)},_zz_298_[4 : 0]},7'h23};
+      5'h16 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_311[11 : 5],_zz_65[6 : 2]},_zz_86},3'b010},_zz_312[4 : 0]},7'h23};
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_66_ = {(2'b01),_zz_65_[9 : 7]};
-  assign _zz_67_ = {(2'b01),_zz_65_[4 : 2]};
-  assign _zz_68_ = {{{{5'h0,_zz_65_[5]},_zz_65_[12 : 10]},_zz_65_[6]},(2'b00)};
-  assign _zz_69_ = _zz_65_[12];
+  assign _zz_66 = {2'b01,_zz_65[9 : 7]};
+  assign _zz_67 = {2'b01,_zz_65[4 : 2]};
+  assign _zz_68 = {{{{5'h0,_zz_65[5]},_zz_65[12 : 10]},_zz_65[6]},2'b00};
+  assign _zz_69 = _zz_65[12];
   always @ (*) begin
-    _zz_70_[11] = _zz_69_;
-    _zz_70_[10] = _zz_69_;
-    _zz_70_[9] = _zz_69_;
-    _zz_70_[8] = _zz_69_;
-    _zz_70_[7] = _zz_69_;
-    _zz_70_[6] = _zz_69_;
-    _zz_70_[5] = _zz_69_;
-    _zz_70_[4 : 0] = _zz_65_[6 : 2];
+    _zz_70[11] = _zz_69;
+    _zz_70[10] = _zz_69;
+    _zz_70[9] = _zz_69;
+    _zz_70[8] = _zz_69;
+    _zz_70[7] = _zz_69;
+    _zz_70[6] = _zz_69;
+    _zz_70[5] = _zz_69;
+    _zz_70[4 : 0] = _zz_65[6 : 2];
   end
 
-  assign _zz_71_ = _zz_65_[12];
+  assign _zz_71 = _zz_65[12];
   always @ (*) begin
-    _zz_72_[9] = _zz_71_;
-    _zz_72_[8] = _zz_71_;
-    _zz_72_[7] = _zz_71_;
-    _zz_72_[6] = _zz_71_;
-    _zz_72_[5] = _zz_71_;
-    _zz_72_[4] = _zz_71_;
-    _zz_72_[3] = _zz_71_;
-    _zz_72_[2] = _zz_71_;
-    _zz_72_[1] = _zz_71_;
-    _zz_72_[0] = _zz_71_;
+    _zz_72[9] = _zz_71;
+    _zz_72[8] = _zz_71;
+    _zz_72[7] = _zz_71;
+    _zz_72[6] = _zz_71;
+    _zz_72[5] = _zz_71;
+    _zz_72[4] = _zz_71;
+    _zz_72[3] = _zz_71;
+    _zz_72[2] = _zz_71;
+    _zz_72[1] = _zz_71;
+    _zz_72[0] = _zz_71;
   end
 
-  assign _zz_73_ = {{{{{{{{_zz_72_,_zz_65_[8]},_zz_65_[10 : 9]},_zz_65_[6]},_zz_65_[7]},_zz_65_[2]},_zz_65_[11]},_zz_65_[5 : 3]},(1'b0)};
-  assign _zz_74_ = _zz_65_[12];
+  assign _zz_73 = {{{{{{{{_zz_72,_zz_65[8]},_zz_65[10 : 9]},_zz_65[6]},_zz_65[7]},_zz_65[2]},_zz_65[11]},_zz_65[5 : 3]},1'b0};
+  assign _zz_74 = _zz_65[12];
   always @ (*) begin
-    _zz_75_[14] = _zz_74_;
-    _zz_75_[13] = _zz_74_;
-    _zz_75_[12] = _zz_74_;
-    _zz_75_[11] = _zz_74_;
-    _zz_75_[10] = _zz_74_;
-    _zz_75_[9] = _zz_74_;
-    _zz_75_[8] = _zz_74_;
-    _zz_75_[7] = _zz_74_;
-    _zz_75_[6] = _zz_74_;
-    _zz_75_[5] = _zz_74_;
-    _zz_75_[4] = _zz_74_;
-    _zz_75_[3] = _zz_74_;
-    _zz_75_[2] = _zz_74_;
-    _zz_75_[1] = _zz_74_;
-    _zz_75_[0] = _zz_74_;
+    _zz_75[14] = _zz_74;
+    _zz_75[13] = _zz_74;
+    _zz_75[12] = _zz_74;
+    _zz_75[11] = _zz_74;
+    _zz_75[10] = _zz_74;
+    _zz_75[9] = _zz_74;
+    _zz_75[8] = _zz_74;
+    _zz_75[7] = _zz_74;
+    _zz_75[6] = _zz_74;
+    _zz_75[5] = _zz_74;
+    _zz_75[4] = _zz_74;
+    _zz_75[3] = _zz_74;
+    _zz_75[2] = _zz_74;
+    _zz_75[1] = _zz_74;
+    _zz_75[0] = _zz_74;
   end
 
-  assign _zz_76_ = _zz_65_[12];
+  assign _zz_76 = _zz_65[12];
   always @ (*) begin
-    _zz_77_[2] = _zz_76_;
-    _zz_77_[1] = _zz_76_;
-    _zz_77_[0] = _zz_76_;
+    _zz_77[2] = _zz_76;
+    _zz_77[1] = _zz_76;
+    _zz_77[0] = _zz_76;
   end
 
-  assign _zz_78_ = _zz_65_[12];
+  assign _zz_78 = _zz_65[12];
   always @ (*) begin
-    _zz_79_[9] = _zz_78_;
-    _zz_79_[8] = _zz_78_;
-    _zz_79_[7] = _zz_78_;
-    _zz_79_[6] = _zz_78_;
-    _zz_79_[5] = _zz_78_;
-    _zz_79_[4] = _zz_78_;
-    _zz_79_[3] = _zz_78_;
-    _zz_79_[2] = _zz_78_;
-    _zz_79_[1] = _zz_78_;
-    _zz_79_[0] = _zz_78_;
+    _zz_79[9] = _zz_78;
+    _zz_79[8] = _zz_78;
+    _zz_79[7] = _zz_78;
+    _zz_79[6] = _zz_78;
+    _zz_79[5] = _zz_78;
+    _zz_79[4] = _zz_78;
+    _zz_79[3] = _zz_78;
+    _zz_79[2] = _zz_78;
+    _zz_79[1] = _zz_78;
+    _zz_79[0] = _zz_78;
   end
 
-  assign _zz_80_ = {{{{{{{{_zz_79_,_zz_65_[8]},_zz_65_[10 : 9]},_zz_65_[6]},_zz_65_[7]},_zz_65_[2]},_zz_65_[11]},_zz_65_[5 : 3]},(1'b0)};
-  assign _zz_81_ = _zz_65_[12];
+  assign _zz_80 = {{{{{{{{_zz_79,_zz_65[8]},_zz_65[10 : 9]},_zz_65[6]},_zz_65[7]},_zz_65[2]},_zz_65[11]},_zz_65[5 : 3]},1'b0};
+  assign _zz_81 = _zz_65[12];
   always @ (*) begin
-    _zz_82_[4] = _zz_81_;
-    _zz_82_[3] = _zz_81_;
-    _zz_82_[2] = _zz_81_;
-    _zz_82_[1] = _zz_81_;
-    _zz_82_[0] = _zz_81_;
+    _zz_82[4] = _zz_81;
+    _zz_82[3] = _zz_81;
+    _zz_82[2] = _zz_81;
+    _zz_82[1] = _zz_81;
+    _zz_82[0] = _zz_81;
   end
 
-  assign _zz_83_ = {{{{{_zz_82_,_zz_65_[6 : 5]},_zz_65_[2]},_zz_65_[11 : 10]},_zz_65_[4 : 3]},(1'b0)};
-  assign _zz_84_ = 5'h0;
-  assign _zz_85_ = 5'h01;
-  assign _zz_86_ = 5'h02;
-  assign _zz_87_ = (_zz_65_[11 : 10] != (2'b11));
+  assign _zz_83 = {{{{{_zz_82,_zz_65[6 : 5]},_zz_65[2]},_zz_65[11 : 10]},_zz_65[4 : 3]},1'b0};
+  assign _zz_84 = 5'h0;
+  assign _zz_85 = 5'h01;
+  assign _zz_86 = 5'h02;
+  assign _zz_87 = (_zz_65[11 : 10] != 2'b11);
   always @ (*) begin
-    case(_zz_255_)
+    case(_zz_268)
       2'b00 : begin
-        _zz_88_ = (3'b000);
+        _zz_88 = 3'b000;
       end
       2'b01 : begin
-        _zz_88_ = (3'b100);
+        _zz_88 = 3'b100;
       end
       2'b10 : begin
-        _zz_88_ = (3'b110);
+        _zz_88 = 3'b110;
       end
       default : begin
-        _zz_88_ = (3'b111);
+        _zz_88 = 3'b111;
       end
     endcase
   end
 
   always @ (*) begin
-    case(_zz_256_)
+    case(_zz_269)
       2'b00 : begin
-        _zz_89_ = (3'b101);
+        _zz_89 = 3'b101;
       end
       2'b01 : begin
-        _zz_89_ = (3'b101);
+        _zz_89 = 3'b101;
       end
       2'b10 : begin
-        _zz_89_ = (3'b111);
+        _zz_89 = 3'b111;
       end
       default : begin
-        _zz_89_ = _zz_88_;
+        _zz_89 = _zz_88;
       end
     endcase
   end
 
-  assign _zz_90_ = _zz_65_[12];
+  assign _zz_90 = _zz_65[12];
   always @ (*) begin
-    _zz_91_[6] = _zz_90_;
-    _zz_91_[5] = _zz_90_;
-    _zz_91_[4] = _zz_90_;
-    _zz_91_[3] = _zz_90_;
-    _zz_91_[2] = _zz_90_;
-    _zz_91_[1] = _zz_90_;
-    _zz_91_[0] = _zz_90_;
+    _zz_91[6] = _zz_90;
+    _zz_91[5] = _zz_90;
+    _zz_91[4] = _zz_90;
+    _zz_91[3] = _zz_90;
+    _zz_91[2] = _zz_90;
+    _zz_91[1] = _zz_90;
+    _zz_91[0] = _zz_90;
   end
 
   assign IBusCachedPlugin_decompressor_output_valid = (IBusCachedPlugin_decompressor_input_valid && (! ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_bufferValid)) && (! IBusCachedPlugin_decompressor_isInputHighRvc))));
@@ -4216,81 +3359,81 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_input_ready = (IBusCachedPlugin_decompressor_output_ready && (((! IBusCachedPlugin_iBusRsp_stages_1_input_valid) || IBusCachedPlugin_decompressor_flushNext) || ((! (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc)) && (! (((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc)))));
   assign IBusCachedPlugin_decompressor_bufferFill = (((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && (! IBusCachedPlugin_decompressor_isInputHighRvc)) || (IBusCachedPlugin_decompressor_bufferValid && (! IBusCachedPlugin_decompressor_isInputHighRvc))) || ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_isRvc)) && (! IBusCachedPlugin_decompressor_isInputHighRvc)));
   assign IBusCachedPlugin_decompressor_output_ready = ((1'b0 && (! IBusCachedPlugin_injector_decodeInput_valid)) || IBusCachedPlugin_injector_decodeInput_ready);
-  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_92_;
-  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_93_;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_94_;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_95_;
-  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_96_;
+  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_92;
+  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_93;
+  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_94;
+  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_95;
+  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_96;
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_0;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_3;
   assign IBusCachedPlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_injector_decodeInput_valid;
-  assign _zz_97_ = _zz_299_[11];
+  assign _zz_97 = _zz_313[11];
   always @ (*) begin
-    _zz_98_[18] = _zz_97_;
-    _zz_98_[17] = _zz_97_;
-    _zz_98_[16] = _zz_97_;
-    _zz_98_[15] = _zz_97_;
-    _zz_98_[14] = _zz_97_;
-    _zz_98_[13] = _zz_97_;
-    _zz_98_[12] = _zz_97_;
-    _zz_98_[11] = _zz_97_;
-    _zz_98_[10] = _zz_97_;
-    _zz_98_[9] = _zz_97_;
-    _zz_98_[8] = _zz_97_;
-    _zz_98_[7] = _zz_97_;
-    _zz_98_[6] = _zz_97_;
-    _zz_98_[5] = _zz_97_;
-    _zz_98_[4] = _zz_97_;
-    _zz_98_[3] = _zz_97_;
-    _zz_98_[2] = _zz_97_;
-    _zz_98_[1] = _zz_97_;
-    _zz_98_[0] = _zz_97_;
+    _zz_98[18] = _zz_97;
+    _zz_98[17] = _zz_97;
+    _zz_98[16] = _zz_97;
+    _zz_98[15] = _zz_97;
+    _zz_98[14] = _zz_97;
+    _zz_98[13] = _zz_97;
+    _zz_98[12] = _zz_97;
+    _zz_98[11] = _zz_97;
+    _zz_98[10] = _zz_97;
+    _zz_98[9] = _zz_97;
+    _zz_98[8] = _zz_97;
+    _zz_98[7] = _zz_97;
+    _zz_98[6] = _zz_97;
+    _zz_98[5] = _zz_97;
+    _zz_98[4] = _zz_97;
+    _zz_98[3] = _zz_97;
+    _zz_98[2] = _zz_97;
+    _zz_98[1] = _zz_97;
+    _zz_98[0] = _zz_97;
   end
 
-  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_300_[31]));
+  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_314[31]));
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_99_ = _zz_301_[19];
+  assign _zz_99 = _zz_315[19];
   always @ (*) begin
-    _zz_100_[10] = _zz_99_;
-    _zz_100_[9] = _zz_99_;
-    _zz_100_[8] = _zz_99_;
-    _zz_100_[7] = _zz_99_;
-    _zz_100_[6] = _zz_99_;
-    _zz_100_[5] = _zz_99_;
-    _zz_100_[4] = _zz_99_;
-    _zz_100_[3] = _zz_99_;
-    _zz_100_[2] = _zz_99_;
-    _zz_100_[1] = _zz_99_;
-    _zz_100_[0] = _zz_99_;
+    _zz_100[10] = _zz_99;
+    _zz_100[9] = _zz_99;
+    _zz_100[8] = _zz_99;
+    _zz_100[7] = _zz_99;
+    _zz_100[6] = _zz_99;
+    _zz_100[5] = _zz_99;
+    _zz_100[4] = _zz_99;
+    _zz_100[3] = _zz_99;
+    _zz_100[2] = _zz_99;
+    _zz_100[1] = _zz_99;
+    _zz_100[0] = _zz_99;
   end
 
-  assign _zz_101_ = _zz_302_[11];
+  assign _zz_101 = _zz_316[11];
   always @ (*) begin
-    _zz_102_[18] = _zz_101_;
-    _zz_102_[17] = _zz_101_;
-    _zz_102_[16] = _zz_101_;
-    _zz_102_[15] = _zz_101_;
-    _zz_102_[14] = _zz_101_;
-    _zz_102_[13] = _zz_101_;
-    _zz_102_[12] = _zz_101_;
-    _zz_102_[11] = _zz_101_;
-    _zz_102_[10] = _zz_101_;
-    _zz_102_[9] = _zz_101_;
-    _zz_102_[8] = _zz_101_;
-    _zz_102_[7] = _zz_101_;
-    _zz_102_[6] = _zz_101_;
-    _zz_102_[5] = _zz_101_;
-    _zz_102_[4] = _zz_101_;
-    _zz_102_[3] = _zz_101_;
-    _zz_102_[2] = _zz_101_;
-    _zz_102_[1] = _zz_101_;
-    _zz_102_[0] = _zz_101_;
+    _zz_102[18] = _zz_101;
+    _zz_102[17] = _zz_101;
+    _zz_102[16] = _zz_101;
+    _zz_102[15] = _zz_101;
+    _zz_102[14] = _zz_101;
+    _zz_102[13] = _zz_101;
+    _zz_102[12] = _zz_101;
+    _zz_102[11] = _zz_101;
+    _zz_102[10] = _zz_101;
+    _zz_102[9] = _zz_101;
+    _zz_102[8] = _zz_101;
+    _zz_102[7] = _zz_101;
+    _zz_102[6] = _zz_101;
+    _zz_102[5] = _zz_101;
+    _zz_102[4] = _zz_101;
+    _zz_102[3] = _zz_101;
+    _zz_102[2] = _zz_101;
+    _zz_102[1] = _zz_101;
+    _zz_102[0] = _zz_101;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_100_,{{{_zz_377_,_zz_378_},_zz_379_},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_102_,{{{_zz_380_,_zz_381_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_100,{{{_zz_391,_zz_392},_zz_393},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_102,{{{_zz_394,_zz_395},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4299,121 +3442,142 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_197_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_198_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_199_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_200_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_199 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_200 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_201 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_200;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_203 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_227_)begin
+    if(_zz_240)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_225_)begin
+    if(_zz_238)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_204_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
-    if(_zz_225_)begin
-      _zz_204_ = 1'b1;
+    _zz_207 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
+    if(_zz_238)begin
+      _zz_207 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_226_)begin
+    if(_zz_239)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_224_)begin
+    if(_zz_237)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_226_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_239)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_224_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_237)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_1_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_fetch_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_1_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_196_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_214_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_198 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_227 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  always @ (*) begin
+    _zz_51 = 1'b0;
+    if(decode_INSTRUCTION[25])begin
+      if(decode_MEMORY_LRSC)begin
+        _zz_51 = 1'b1;
+      end
+    end
+  end
+
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_205_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_206_ = execute_SRC_ADD;
+  assign _zz_208 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_209 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_105_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_105 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_105_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_105 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_105_ = execute_RS2[31 : 0];
+        _zz_105 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_213_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_207_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_208_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+  assign _zz_226 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
   always @ (*) begin
-    _zz_209_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_209_ = 1'b1;
+    _zz_210 = 1'b0;
+    if(execute_MEMORY_LRSC)begin
+      _zz_210 = 1'b1;
     end
   end
 
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_210_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_211_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_212_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_211 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_212 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_211;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_212;
+  assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  always @ (*) begin
+    _zz_213 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_213 = 1'b1;
+    end
+  end
+
+  assign _zz_214 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_215 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_216 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_234_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_247)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -4422,17 +3586,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_234_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_247)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -4440,94 +3604,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_234_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_303_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_247)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_317};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_304_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_318};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_106_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_106 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_107_[31] = _zz_106_;
-    _zz_107_[30] = _zz_106_;
-    _zz_107_[29] = _zz_106_;
-    _zz_107_[28] = _zz_106_;
-    _zz_107_[27] = _zz_106_;
-    _zz_107_[26] = _zz_106_;
-    _zz_107_[25] = _zz_106_;
-    _zz_107_[24] = _zz_106_;
-    _zz_107_[23] = _zz_106_;
-    _zz_107_[22] = _zz_106_;
-    _zz_107_[21] = _zz_106_;
-    _zz_107_[20] = _zz_106_;
-    _zz_107_[19] = _zz_106_;
-    _zz_107_[18] = _zz_106_;
-    _zz_107_[17] = _zz_106_;
-    _zz_107_[16] = _zz_106_;
-    _zz_107_[15] = _zz_106_;
-    _zz_107_[14] = _zz_106_;
-    _zz_107_[13] = _zz_106_;
-    _zz_107_[12] = _zz_106_;
-    _zz_107_[11] = _zz_106_;
-    _zz_107_[10] = _zz_106_;
-    _zz_107_[9] = _zz_106_;
-    _zz_107_[8] = _zz_106_;
-    _zz_107_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_107[31] = _zz_106;
+    _zz_107[30] = _zz_106;
+    _zz_107[29] = _zz_106;
+    _zz_107[28] = _zz_106;
+    _zz_107[27] = _zz_106;
+    _zz_107[26] = _zz_106;
+    _zz_107[25] = _zz_106;
+    _zz_107[24] = _zz_106;
+    _zz_107[23] = _zz_106;
+    _zz_107[22] = _zz_106;
+    _zz_107[21] = _zz_106;
+    _zz_107[20] = _zz_106;
+    _zz_107[19] = _zz_106;
+    _zz_107[18] = _zz_106;
+    _zz_107[17] = _zz_106;
+    _zz_107[16] = _zz_106;
+    _zz_107[15] = _zz_106;
+    _zz_107[14] = _zz_106;
+    _zz_107[13] = _zz_106;
+    _zz_107[12] = _zz_106;
+    _zz_107[11] = _zz_106;
+    _zz_107[10] = _zz_106;
+    _zz_107[9] = _zz_106;
+    _zz_107[8] = _zz_106;
+    _zz_107[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_108_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_108 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_109_[31] = _zz_108_;
-    _zz_109_[30] = _zz_108_;
-    _zz_109_[29] = _zz_108_;
-    _zz_109_[28] = _zz_108_;
-    _zz_109_[27] = _zz_108_;
-    _zz_109_[26] = _zz_108_;
-    _zz_109_[25] = _zz_108_;
-    _zz_109_[24] = _zz_108_;
-    _zz_109_[23] = _zz_108_;
-    _zz_109_[22] = _zz_108_;
-    _zz_109_[21] = _zz_108_;
-    _zz_109_[20] = _zz_108_;
-    _zz_109_[19] = _zz_108_;
-    _zz_109_[18] = _zz_108_;
-    _zz_109_[17] = _zz_108_;
-    _zz_109_[16] = _zz_108_;
-    _zz_109_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_109[31] = _zz_108;
+    _zz_109[30] = _zz_108;
+    _zz_109[29] = _zz_108;
+    _zz_109[28] = _zz_108;
+    _zz_109[27] = _zz_108;
+    _zz_109[26] = _zz_108;
+    _zz_109[25] = _zz_108;
+    _zz_109[24] = _zz_108;
+    _zz_109[23] = _zz_108;
+    _zz_109[22] = _zz_108;
+    _zz_109[21] = _zz_108;
+    _zz_109[20] = _zz_108;
+    _zz_109[19] = _zz_108;
+    _zz_109[18] = _zz_108;
+    _zz_109[17] = _zz_108;
+    _zz_109[16] = _zz_108;
+    _zz_109[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_257_)
+    case(_zz_270)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_107_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_107;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_109_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_109;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -4535,57 +3699,73 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_111_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_112_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_113_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_114_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_110_ = {(((decode_INSTRUCTION & _zz_382_) == 32'h00004010) != (1'b0)),{((_zz_383_ == _zz_384_) != (1'b0)),{({_zz_385_,_zz_386_} != (2'b00)),{(_zz_387_ != _zz_388_),{_zz_389_,{_zz_390_,_zz_391_}}}}}};
-  assign _zz_115_ = _zz_110_[4 : 3];
-  assign _zz_49_ = _zz_115_;
-  assign _zz_116_ = _zz_110_[8 : 7];
-  assign _zz_48_ = _zz_116_;
-  assign _zz_117_ = _zz_110_[11 : 10];
-  assign _zz_47_ = _zz_117_;
-  assign _zz_118_ = _zz_110_[19 : 18];
-  assign _zz_46_ = _zz_118_;
-  assign _zz_119_ = _zz_110_[22 : 21];
-  assign _zz_45_ = _zz_119_;
-  assign _zz_120_ = _zz_110_[24 : 23];
-  assign _zz_44_ = _zz_120_;
-  assign _zz_121_ = _zz_110_[31 : 30];
-  assign _zz_43_ = _zz_121_;
+  assign _zz_111 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_112 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_113 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_114 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_115 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_116 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_110 = {(_zz_116 != 1'b0),{(_zz_116 != 1'b0),{((_zz_396 == _zz_397) != 1'b0),{(_zz_398 != 1'b0),{(_zz_399 != _zz_400),{_zz_401,{_zz_402,_zz_403}}}}}}};
+  assign _zz_117 = _zz_110[2 : 1];
+  assign _zz_49 = _zz_117;
+  assign _zz_118 = _zz_110[7 : 6];
+  assign _zz_48 = _zz_118;
+  assign _zz_119 = _zz_110[9 : 8];
+  assign _zz_47 = _zz_119;
+  assign _zz_120 = _zz_110[21 : 20];
+  assign _zz_46 = _zz_120;
+  assign _zz_121 = _zz_110[23 : 22];
+  assign _zz_45 = _zz_121;
+  assign _zz_122 = _zz_110[25 : 24];
+  assign _zz_44 = _zz_122;
+  assign _zz_123 = _zz_110[28 : 27];
+  assign _zz_43 = _zz_123;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_215_;
-  assign decode_RegFilePlugin_rs2Data = _zz_216_;
+  assign decode_RegFilePlugin_rs1Data = _zz_228;
+  assign decode_RegFilePlugin_rs2Data = _zz_229;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_122_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_124)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_50_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_124)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_124)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -4603,13 +3783,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_123_ = execute_IntAluPlugin_bitwise;
+        _zz_125 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_123_ = {31'd0, _zz_305_};
+        _zz_125 = {31'd0, _zz_319};
       end
       default : begin
-        _zz_123_ = execute_SRC_ADD_SUB;
+        _zz_125 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -4617,87 +3797,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_124_ = execute_RS1;
+        _zz_126 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_124_ = {29'd0, _zz_306_};
+        _zz_126 = {29'd0, _zz_320};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_124_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_126 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_124_ = {27'd0, _zz_307_};
+        _zz_126 = {27'd0, _zz_321};
       end
     endcase
   end
 
-  assign _zz_125_ = _zz_308_[11];
+  assign _zz_127 = _zz_322[11];
   always @ (*) begin
-    _zz_126_[19] = _zz_125_;
-    _zz_126_[18] = _zz_125_;
-    _zz_126_[17] = _zz_125_;
-    _zz_126_[16] = _zz_125_;
-    _zz_126_[15] = _zz_125_;
-    _zz_126_[14] = _zz_125_;
-    _zz_126_[13] = _zz_125_;
-    _zz_126_[12] = _zz_125_;
-    _zz_126_[11] = _zz_125_;
-    _zz_126_[10] = _zz_125_;
-    _zz_126_[9] = _zz_125_;
-    _zz_126_[8] = _zz_125_;
-    _zz_126_[7] = _zz_125_;
-    _zz_126_[6] = _zz_125_;
-    _zz_126_[5] = _zz_125_;
-    _zz_126_[4] = _zz_125_;
-    _zz_126_[3] = _zz_125_;
-    _zz_126_[2] = _zz_125_;
-    _zz_126_[1] = _zz_125_;
-    _zz_126_[0] = _zz_125_;
+    _zz_128[19] = _zz_127;
+    _zz_128[18] = _zz_127;
+    _zz_128[17] = _zz_127;
+    _zz_128[16] = _zz_127;
+    _zz_128[15] = _zz_127;
+    _zz_128[14] = _zz_127;
+    _zz_128[13] = _zz_127;
+    _zz_128[12] = _zz_127;
+    _zz_128[11] = _zz_127;
+    _zz_128[10] = _zz_127;
+    _zz_128[9] = _zz_127;
+    _zz_128[8] = _zz_127;
+    _zz_128[7] = _zz_127;
+    _zz_128[6] = _zz_127;
+    _zz_128[5] = _zz_127;
+    _zz_128[4] = _zz_127;
+    _zz_128[3] = _zz_127;
+    _zz_128[2] = _zz_127;
+    _zz_128[1] = _zz_127;
+    _zz_128[0] = _zz_127;
   end
 
-  assign _zz_127_ = _zz_309_[11];
+  assign _zz_129 = _zz_323[11];
   always @ (*) begin
-    _zz_128_[19] = _zz_127_;
-    _zz_128_[18] = _zz_127_;
-    _zz_128_[17] = _zz_127_;
-    _zz_128_[16] = _zz_127_;
-    _zz_128_[15] = _zz_127_;
-    _zz_128_[14] = _zz_127_;
-    _zz_128_[13] = _zz_127_;
-    _zz_128_[12] = _zz_127_;
-    _zz_128_[11] = _zz_127_;
-    _zz_128_[10] = _zz_127_;
-    _zz_128_[9] = _zz_127_;
-    _zz_128_[8] = _zz_127_;
-    _zz_128_[7] = _zz_127_;
-    _zz_128_[6] = _zz_127_;
-    _zz_128_[5] = _zz_127_;
-    _zz_128_[4] = _zz_127_;
-    _zz_128_[3] = _zz_127_;
-    _zz_128_[2] = _zz_127_;
-    _zz_128_[1] = _zz_127_;
-    _zz_128_[0] = _zz_127_;
+    _zz_130[19] = _zz_129;
+    _zz_130[18] = _zz_129;
+    _zz_130[17] = _zz_129;
+    _zz_130[16] = _zz_129;
+    _zz_130[15] = _zz_129;
+    _zz_130[14] = _zz_129;
+    _zz_130[13] = _zz_129;
+    _zz_130[12] = _zz_129;
+    _zz_130[11] = _zz_129;
+    _zz_130[10] = _zz_129;
+    _zz_130[9] = _zz_129;
+    _zz_130[8] = _zz_129;
+    _zz_130[7] = _zz_129;
+    _zz_130[6] = _zz_129;
+    _zz_130[5] = _zz_129;
+    _zz_130[4] = _zz_129;
+    _zz_130[3] = _zz_129;
+    _zz_130[2] = _zz_129;
+    _zz_130[1] = _zz_129;
+    _zz_130[0] = _zz_129;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_129_ = execute_RS2;
+        _zz_131 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_129_ = {_zz_126_,execute_INSTRUCTION[31 : 20]};
+        _zz_131 = {_zz_128,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_129_ = {_zz_128_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_131 = {_zz_130,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_129_ = _zz_35_;
+        _zz_131 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_310_;
+    execute_SrcPlugin_addSub = _zz_324;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -4706,165 +3886,165 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_130_[0] = execute_SRC1[31];
-    _zz_130_[1] = execute_SRC1[30];
-    _zz_130_[2] = execute_SRC1[29];
-    _zz_130_[3] = execute_SRC1[28];
-    _zz_130_[4] = execute_SRC1[27];
-    _zz_130_[5] = execute_SRC1[26];
-    _zz_130_[6] = execute_SRC1[25];
-    _zz_130_[7] = execute_SRC1[24];
-    _zz_130_[8] = execute_SRC1[23];
-    _zz_130_[9] = execute_SRC1[22];
-    _zz_130_[10] = execute_SRC1[21];
-    _zz_130_[11] = execute_SRC1[20];
-    _zz_130_[12] = execute_SRC1[19];
-    _zz_130_[13] = execute_SRC1[18];
-    _zz_130_[14] = execute_SRC1[17];
-    _zz_130_[15] = execute_SRC1[16];
-    _zz_130_[16] = execute_SRC1[15];
-    _zz_130_[17] = execute_SRC1[14];
-    _zz_130_[18] = execute_SRC1[13];
-    _zz_130_[19] = execute_SRC1[12];
-    _zz_130_[20] = execute_SRC1[11];
-    _zz_130_[21] = execute_SRC1[10];
-    _zz_130_[22] = execute_SRC1[9];
-    _zz_130_[23] = execute_SRC1[8];
-    _zz_130_[24] = execute_SRC1[7];
-    _zz_130_[25] = execute_SRC1[6];
-    _zz_130_[26] = execute_SRC1[5];
-    _zz_130_[27] = execute_SRC1[4];
-    _zz_130_[28] = execute_SRC1[3];
-    _zz_130_[29] = execute_SRC1[2];
-    _zz_130_[30] = execute_SRC1[1];
-    _zz_130_[31] = execute_SRC1[0];
+    _zz_132[0] = execute_SRC1[31];
+    _zz_132[1] = execute_SRC1[30];
+    _zz_132[2] = execute_SRC1[29];
+    _zz_132[3] = execute_SRC1[28];
+    _zz_132[4] = execute_SRC1[27];
+    _zz_132[5] = execute_SRC1[26];
+    _zz_132[6] = execute_SRC1[25];
+    _zz_132[7] = execute_SRC1[24];
+    _zz_132[8] = execute_SRC1[23];
+    _zz_132[9] = execute_SRC1[22];
+    _zz_132[10] = execute_SRC1[21];
+    _zz_132[11] = execute_SRC1[20];
+    _zz_132[12] = execute_SRC1[19];
+    _zz_132[13] = execute_SRC1[18];
+    _zz_132[14] = execute_SRC1[17];
+    _zz_132[15] = execute_SRC1[16];
+    _zz_132[16] = execute_SRC1[15];
+    _zz_132[17] = execute_SRC1[14];
+    _zz_132[18] = execute_SRC1[13];
+    _zz_132[19] = execute_SRC1[12];
+    _zz_132[20] = execute_SRC1[11];
+    _zz_132[21] = execute_SRC1[10];
+    _zz_132[22] = execute_SRC1[9];
+    _zz_132[23] = execute_SRC1[8];
+    _zz_132[24] = execute_SRC1[7];
+    _zz_132[25] = execute_SRC1[6];
+    _zz_132[26] = execute_SRC1[5];
+    _zz_132[27] = execute_SRC1[4];
+    _zz_132[28] = execute_SRC1[3];
+    _zz_132[29] = execute_SRC1[2];
+    _zz_132[30] = execute_SRC1[1];
+    _zz_132[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_130_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_132 : execute_SRC1);
   always @ (*) begin
-    _zz_131_[0] = memory_SHIFT_RIGHT[31];
-    _zz_131_[1] = memory_SHIFT_RIGHT[30];
-    _zz_131_[2] = memory_SHIFT_RIGHT[29];
-    _zz_131_[3] = memory_SHIFT_RIGHT[28];
-    _zz_131_[4] = memory_SHIFT_RIGHT[27];
-    _zz_131_[5] = memory_SHIFT_RIGHT[26];
-    _zz_131_[6] = memory_SHIFT_RIGHT[25];
-    _zz_131_[7] = memory_SHIFT_RIGHT[24];
-    _zz_131_[8] = memory_SHIFT_RIGHT[23];
-    _zz_131_[9] = memory_SHIFT_RIGHT[22];
-    _zz_131_[10] = memory_SHIFT_RIGHT[21];
-    _zz_131_[11] = memory_SHIFT_RIGHT[20];
-    _zz_131_[12] = memory_SHIFT_RIGHT[19];
-    _zz_131_[13] = memory_SHIFT_RIGHT[18];
-    _zz_131_[14] = memory_SHIFT_RIGHT[17];
-    _zz_131_[15] = memory_SHIFT_RIGHT[16];
-    _zz_131_[16] = memory_SHIFT_RIGHT[15];
-    _zz_131_[17] = memory_SHIFT_RIGHT[14];
-    _zz_131_[18] = memory_SHIFT_RIGHT[13];
-    _zz_131_[19] = memory_SHIFT_RIGHT[12];
-    _zz_131_[20] = memory_SHIFT_RIGHT[11];
-    _zz_131_[21] = memory_SHIFT_RIGHT[10];
-    _zz_131_[22] = memory_SHIFT_RIGHT[9];
-    _zz_131_[23] = memory_SHIFT_RIGHT[8];
-    _zz_131_[24] = memory_SHIFT_RIGHT[7];
-    _zz_131_[25] = memory_SHIFT_RIGHT[6];
-    _zz_131_[26] = memory_SHIFT_RIGHT[5];
-    _zz_131_[27] = memory_SHIFT_RIGHT[4];
-    _zz_131_[28] = memory_SHIFT_RIGHT[3];
-    _zz_131_[29] = memory_SHIFT_RIGHT[2];
-    _zz_131_[30] = memory_SHIFT_RIGHT[1];
-    _zz_131_[31] = memory_SHIFT_RIGHT[0];
+    _zz_133[0] = memory_SHIFT_RIGHT[31];
+    _zz_133[1] = memory_SHIFT_RIGHT[30];
+    _zz_133[2] = memory_SHIFT_RIGHT[29];
+    _zz_133[3] = memory_SHIFT_RIGHT[28];
+    _zz_133[4] = memory_SHIFT_RIGHT[27];
+    _zz_133[5] = memory_SHIFT_RIGHT[26];
+    _zz_133[6] = memory_SHIFT_RIGHT[25];
+    _zz_133[7] = memory_SHIFT_RIGHT[24];
+    _zz_133[8] = memory_SHIFT_RIGHT[23];
+    _zz_133[9] = memory_SHIFT_RIGHT[22];
+    _zz_133[10] = memory_SHIFT_RIGHT[21];
+    _zz_133[11] = memory_SHIFT_RIGHT[20];
+    _zz_133[12] = memory_SHIFT_RIGHT[19];
+    _zz_133[13] = memory_SHIFT_RIGHT[18];
+    _zz_133[14] = memory_SHIFT_RIGHT[17];
+    _zz_133[15] = memory_SHIFT_RIGHT[16];
+    _zz_133[16] = memory_SHIFT_RIGHT[15];
+    _zz_133[17] = memory_SHIFT_RIGHT[14];
+    _zz_133[18] = memory_SHIFT_RIGHT[13];
+    _zz_133[19] = memory_SHIFT_RIGHT[12];
+    _zz_133[20] = memory_SHIFT_RIGHT[11];
+    _zz_133[21] = memory_SHIFT_RIGHT[10];
+    _zz_133[22] = memory_SHIFT_RIGHT[9];
+    _zz_133[23] = memory_SHIFT_RIGHT[8];
+    _zz_133[24] = memory_SHIFT_RIGHT[7];
+    _zz_133[25] = memory_SHIFT_RIGHT[6];
+    _zz_133[26] = memory_SHIFT_RIGHT[5];
+    _zz_133[27] = memory_SHIFT_RIGHT[4];
+    _zz_133[28] = memory_SHIFT_RIGHT[3];
+    _zz_133[29] = memory_SHIFT_RIGHT[2];
+    _zz_133[30] = memory_SHIFT_RIGHT[1];
+    _zz_133[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_132_ = 1'b0;
-    if(_zz_235_)begin
-      if(_zz_236_)begin
-        if(_zz_137_)begin
-          _zz_132_ = 1'b1;
+    _zz_134 = 1'b0;
+    if(_zz_248)begin
+      if(_zz_249)begin
+        if(_zz_139)begin
+          _zz_134 = 1'b1;
         end
       end
     end
-    if(_zz_237_)begin
-      if(_zz_238_)begin
-        if(_zz_139_)begin
-          _zz_132_ = 1'b1;
+    if(_zz_250)begin
+      if(_zz_251)begin
+        if(_zz_141)begin
+          _zz_134 = 1'b1;
         end
       end
     end
-    if(_zz_239_)begin
-      if(_zz_240_)begin
-        if(_zz_141_)begin
-          _zz_132_ = 1'b1;
+    if(_zz_252)begin
+      if(_zz_253)begin
+        if(_zz_143)begin
+          _zz_134 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_132_ = 1'b0;
+      _zz_134 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_133_ = 1'b0;
-    if(_zz_235_)begin
-      if(_zz_236_)begin
-        if(_zz_138_)begin
-          _zz_133_ = 1'b1;
+    _zz_135 = 1'b0;
+    if(_zz_248)begin
+      if(_zz_249)begin
+        if(_zz_140)begin
+          _zz_135 = 1'b1;
         end
       end
     end
-    if(_zz_237_)begin
-      if(_zz_238_)begin
-        if(_zz_140_)begin
-          _zz_133_ = 1'b1;
+    if(_zz_250)begin
+      if(_zz_251)begin
+        if(_zz_142)begin
+          _zz_135 = 1'b1;
         end
       end
     end
-    if(_zz_239_)begin
-      if(_zz_240_)begin
-        if(_zz_142_)begin
-          _zz_133_ = 1'b1;
+    if(_zz_252)begin
+      if(_zz_253)begin
+        if(_zz_144)begin
+          _zz_135 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_133_ = 1'b0;
+      _zz_135 = 1'b0;
     end
   end
 
-  assign _zz_137_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_138_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_139_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_140_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_141_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_142_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_139 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_140 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_141 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_142 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_143 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_144 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_143_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_145 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_143_ == (3'b000))) begin
-        _zz_144_ = execute_BranchPlugin_eq;
-    end else if((_zz_143_ == (3'b001))) begin
-        _zz_144_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_143_ & (3'b101)) == (3'b101)))) begin
-        _zz_144_ = (! execute_SRC_LESS);
+    if((_zz_145 == 3'b000)) begin
+        _zz_146 = execute_BranchPlugin_eq;
+    end else if((_zz_145 == 3'b001)) begin
+        _zz_146 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_145 & 3'b101) == 3'b101))) begin
+        _zz_146 = (! execute_SRC_LESS);
     end else begin
-        _zz_144_ = execute_SRC_LESS;
+        _zz_146 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_145_ = 1'b0;
+        _zz_147 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_145_ = 1'b1;
+        _zz_147 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_145_ = 1'b1;
+        _zz_147 = 1'b1;
       end
       default : begin
-        _zz_145_ = _zz_144_;
+        _zz_147 = _zz_146;
       end
     endcase
   end
@@ -4881,80 +4061,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_146_ = _zz_317_[11];
+  assign _zz_148 = _zz_331[11];
   always @ (*) begin
-    _zz_147_[19] = _zz_146_;
-    _zz_147_[18] = _zz_146_;
-    _zz_147_[17] = _zz_146_;
-    _zz_147_[16] = _zz_146_;
-    _zz_147_[15] = _zz_146_;
-    _zz_147_[14] = _zz_146_;
-    _zz_147_[13] = _zz_146_;
-    _zz_147_[12] = _zz_146_;
-    _zz_147_[11] = _zz_146_;
-    _zz_147_[10] = _zz_146_;
-    _zz_147_[9] = _zz_146_;
-    _zz_147_[8] = _zz_146_;
-    _zz_147_[7] = _zz_146_;
-    _zz_147_[6] = _zz_146_;
-    _zz_147_[5] = _zz_146_;
-    _zz_147_[4] = _zz_146_;
-    _zz_147_[3] = _zz_146_;
-    _zz_147_[2] = _zz_146_;
-    _zz_147_[1] = _zz_146_;
-    _zz_147_[0] = _zz_146_;
+    _zz_149[19] = _zz_148;
+    _zz_149[18] = _zz_148;
+    _zz_149[17] = _zz_148;
+    _zz_149[16] = _zz_148;
+    _zz_149[15] = _zz_148;
+    _zz_149[14] = _zz_148;
+    _zz_149[13] = _zz_148;
+    _zz_149[12] = _zz_148;
+    _zz_149[11] = _zz_148;
+    _zz_149[10] = _zz_148;
+    _zz_149[9] = _zz_148;
+    _zz_149[8] = _zz_148;
+    _zz_149[7] = _zz_148;
+    _zz_149[6] = _zz_148;
+    _zz_149[5] = _zz_148;
+    _zz_149[4] = _zz_148;
+    _zz_149[3] = _zz_148;
+    _zz_149[2] = _zz_148;
+    _zz_149[1] = _zz_148;
+    _zz_149[0] = _zz_148;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_147_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_149,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_149_,{{{_zz_531_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_151_,{{{_zz_532_,_zz_533_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_151,{{{_zz_583,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_153,{{{_zz_584,_zz_585},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_320_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_334};
         end
       end
     endcase
   end
 
-  assign _zz_148_ = _zz_318_[19];
+  assign _zz_150 = _zz_332[19];
   always @ (*) begin
-    _zz_149_[10] = _zz_148_;
-    _zz_149_[9] = _zz_148_;
-    _zz_149_[8] = _zz_148_;
-    _zz_149_[7] = _zz_148_;
-    _zz_149_[6] = _zz_148_;
-    _zz_149_[5] = _zz_148_;
-    _zz_149_[4] = _zz_148_;
-    _zz_149_[3] = _zz_148_;
-    _zz_149_[2] = _zz_148_;
-    _zz_149_[1] = _zz_148_;
-    _zz_149_[0] = _zz_148_;
+    _zz_151[10] = _zz_150;
+    _zz_151[9] = _zz_150;
+    _zz_151[8] = _zz_150;
+    _zz_151[7] = _zz_150;
+    _zz_151[6] = _zz_150;
+    _zz_151[5] = _zz_150;
+    _zz_151[4] = _zz_150;
+    _zz_151[3] = _zz_150;
+    _zz_151[2] = _zz_150;
+    _zz_151[1] = _zz_150;
+    _zz_151[0] = _zz_150;
   end
 
-  assign _zz_150_ = _zz_319_[11];
+  assign _zz_152 = _zz_333[11];
   always @ (*) begin
-    _zz_151_[18] = _zz_150_;
-    _zz_151_[17] = _zz_150_;
-    _zz_151_[16] = _zz_150_;
-    _zz_151_[15] = _zz_150_;
-    _zz_151_[14] = _zz_150_;
-    _zz_151_[13] = _zz_150_;
-    _zz_151_[12] = _zz_150_;
-    _zz_151_[11] = _zz_150_;
-    _zz_151_[10] = _zz_150_;
-    _zz_151_[9] = _zz_150_;
-    _zz_151_[8] = _zz_150_;
-    _zz_151_[7] = _zz_150_;
-    _zz_151_[6] = _zz_150_;
-    _zz_151_[5] = _zz_150_;
-    _zz_151_[4] = _zz_150_;
-    _zz_151_[3] = _zz_150_;
-    _zz_151_[2] = _zz_150_;
-    _zz_151_[1] = _zz_150_;
-    _zz_151_[0] = _zz_150_;
+    _zz_153[18] = _zz_152;
+    _zz_153[17] = _zz_152;
+    _zz_153[16] = _zz_152;
+    _zz_153[15] = _zz_152;
+    _zz_153[14] = _zz_152;
+    _zz_153[13] = _zz_152;
+    _zz_153[12] = _zz_152;
+    _zz_153[11] = _zz_152;
+    _zz_153[10] = _zz_152;
+    _zz_153[9] = _zz_152;
+    _zz_153[8] = _zz_152;
+    _zz_153[7] = _zz_152;
+    _zz_153[6] = _zz_152;
+    _zz_153[5] = _zz_152;
+    _zz_153[4] = _zz_152;
+    _zz_153[3] = _zz_152;
+    _zz_153[2] = _zz_152;
+    _zz_153[1] = _zz_152;
+    _zz_153[0] = _zz_152;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -4962,22 +4142,22 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_152_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_153_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_154_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_154 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_155 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_156 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_155_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_156_ = _zz_321_[0];
+  assign _zz_157 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_158 = _zz_335[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_228_)begin
+    if(_zz_241)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -5020,7 +4200,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -5044,7 +4224,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -5066,7 +4246,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -5161,7 +4341,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_241_)begin
+    if(_zz_254)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -5180,26 +4360,26 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_242_)begin
+    if(_zz_255)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_243_)begin
+    if(_zz_256)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_242_)begin
-      CsrPlugin_selfException_payload_code = (4'b0010);
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_255)begin
+      CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_243_)begin
+    if(_zz_256)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -5208,14 +4388,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_241_)begin
+    if(_zz_254)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_241_)begin
+    if(_zz_254)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5224,7 +4404,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_258_)
+    case(_zz_271)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -5238,7 +4418,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_244_)
+    case(_zz_257)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5252,7 +4432,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_244_)
+    case(_zz_257)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5271,12 +4451,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_323_) + $signed(_zz_324_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_337) + $signed(_zz_338));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_223_)begin
-      if(_zz_245_)begin
+    if(_zz_236)begin
+      if(_zz_258)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -5284,7 +4464,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_246_)begin
+    if(_zz_259)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -5295,59 +4475,59 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_328_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_342);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_157_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_157_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_329_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_330_ : _zz_331_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_332_[31:0];
-  assign _zz_158_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_159_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_160_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_159 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_159[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_343);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_344 : _zz_345);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_346[31:0];
+  assign _zz_160 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_161 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_162 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_161_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_161_[31 : 0] = execute_RS1;
+    _zz_163[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_163[31 : 0] = execute_RS1;
   end
 
-  assign _zz_163_ = (_zz_162_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_163_ != 32'h0);
-  assign _zz_26_ = decode_ALU_CTRL;
-  assign _zz_24_ = _zz_43_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign _zz_23_ = decode_SHIFT_CTRL;
-  assign _zz_20_ = execute_SHIFT_CTRL;
-  assign _zz_21_ = _zz_46_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_18_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_16_ = _zz_49_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_15_ = decode_SRC2_CTRL;
-  assign _zz_13_ = _zz_48_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_12_ = decode_SRC1_CTRL;
-  assign _zz_10_ = _zz_47_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_9_ = decode_ENV_CTRL;
-  assign _zz_6_ = execute_ENV_CTRL;
-  assign _zz_4_ = memory_ENV_CTRL;
-  assign _zz_7_ = _zz_44_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_2_ = decode_BRANCH_CTRL;
-  assign _zz_52_ = _zz_45_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_165 = (_zz_164 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_165 != 32'h0);
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_52 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -5365,216 +4545,216 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_164_ = 32'h0;
+    _zz_166 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_164_[12 : 0] = 13'h1000;
-      _zz_164_[25 : 20] = 6'h20;
+      _zz_166[12 : 0] = 13'h1000;
+      _zz_166[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_165_ = 32'h0;
+    _zz_167 = 32'h0;
     if(execute_CsrPlugin_csr_3857)begin
-      _zz_165_[3 : 0] = (4'b1011);
+      _zz_167[3 : 0] = 4'b1011;
     end
   end
 
   always @ (*) begin
-    _zz_166_ = 32'h0;
+    _zz_168 = 32'h0;
     if(execute_CsrPlugin_csr_3858)begin
-      _zz_166_[4 : 0] = 5'h16;
+      _zz_168[4 : 0] = 5'h16;
     end
   end
 
   always @ (*) begin
-    _zz_167_ = 32'h0;
+    _zz_169 = 32'h0;
     if(execute_CsrPlugin_csr_3859)begin
-      _zz_167_[5 : 0] = 6'h21;
+      _zz_169[5 : 0] = 6'h21;
     end
   end
 
   always @ (*) begin
-    _zz_168_ = 32'h0;
+    _zz_170 = 32'h0;
     if(execute_CsrPlugin_csr_769)begin
-      _zz_168_[31 : 30] = CsrPlugin_misa_base;
-      _zz_168_[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_170[31 : 30] = CsrPlugin_misa_base;
+      _zz_170[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
   always @ (*) begin
-    _zz_169_ = 32'h0;
+    _zz_171 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_169_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_169_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_169_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_171[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_171[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_171[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_170_ = 32'h0;
+    _zz_172 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_170_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_170_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_170_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_172[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_172[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_172[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_171_ = 32'h0;
+    _zz_173 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_171_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_171_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_171_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_173[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_173[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_173[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_172_ = 32'h0;
+    _zz_174 = 32'h0;
     if(execute_CsrPlugin_csr_773)begin
-      _zz_172_[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_172_[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_174[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_174[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
   always @ (*) begin
-    _zz_173_ = 32'h0;
+    _zz_175 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_173_[31 : 0] = CsrPlugin_mepc;
+      _zz_175[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_174_ = 32'h0;
+    _zz_176 = 32'h0;
     if(execute_CsrPlugin_csr_832)begin
-      _zz_174_[31 : 0] = CsrPlugin_mscratch;
+      _zz_176[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
-    _zz_175_ = 32'h0;
+    _zz_177 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_175_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_175_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_177[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_177[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_176_ = 32'h0;
+    _zz_178 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_176_[31 : 0] = CsrPlugin_mtval;
+      _zz_178[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_177_ = 32'h0;
+    _zz_179 = 32'h0;
     if(execute_CsrPlugin_csr_2816)begin
-      _zz_177_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_179[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_178_ = 32'h0;
+    _zz_180 = 32'h0;
     if(execute_CsrPlugin_csr_2944)begin
-      _zz_178_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_180[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_179_ = 32'h0;
+    _zz_181 = 32'h0;
     if(execute_CsrPlugin_csr_2818)begin
-      _zz_179_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_181[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_180_ = 32'h0;
+    _zz_182 = 32'h0;
     if(execute_CsrPlugin_csr_2946)begin
-      _zz_180_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_182[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_181_ = 32'h0;
+    _zz_183 = 32'h0;
     if(execute_CsrPlugin_csr_3072)begin
-      _zz_181_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_183[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_182_ = 32'h0;
+    _zz_184 = 32'h0;
     if(execute_CsrPlugin_csr_3200)begin
-      _zz_182_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_184[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_183_ = 32'h0;
+    _zz_185 = 32'h0;
     if(execute_CsrPlugin_csr_3074)begin
-      _zz_183_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_185[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_184_ = 32'h0;
+    _zz_186 = 32'h0;
     if(execute_CsrPlugin_csr_3202)begin
-      _zz_184_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_186[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_185_ = 32'h0;
+    _zz_187 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_185_[31 : 0] = _zz_162_;
+      _zz_187[31 : 0] = _zz_164;
     end
   end
 
   always @ (*) begin
-    _zz_186_ = 32'h0;
+    _zz_188 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_186_[31 : 0] = _zz_163_;
+      _zz_188[31 : 0] = _zz_165;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_164_ | _zz_165_) | (_zz_166_ | _zz_167_)) | ((_zz_534_ | _zz_168_) | (_zz_169_ | _zz_170_))) | (((_zz_171_ | _zz_172_) | (_zz_173_ | _zz_174_)) | ((_zz_175_ | _zz_176_) | (_zz_177_ | _zz_178_)))) | (((_zz_179_ | _zz_180_) | (_zz_181_ | _zz_182_)) | ((_zz_183_ | _zz_184_) | (_zz_185_ | _zz_186_))));
-  assign iBusWishbone_ADR = {_zz_349_,_zz_187_};
-  assign iBusWishbone_CTI = ((_zz_187_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((((_zz_166 | _zz_167) | (_zz_168 | _zz_169)) | ((_zz_586 | _zz_170) | (_zz_171 | _zz_172))) | (((_zz_173 | _zz_174) | (_zz_175 | _zz_176)) | ((_zz_177 | _zz_178) | (_zz_179 | _zz_180)))) | (((_zz_181 | _zz_182) | (_zz_183 | _zz_184)) | ((_zz_185 | _zz_186) | (_zz_187 | _zz_188))));
+  assign iBusWishbone_ADR = {_zz_363,_zz_189};
+  assign iBusWishbone_CTI = ((_zz_189 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_247_)begin
+    if(_zz_260)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_247_)begin
+    if(_zz_260)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_188_;
+  assign iBus_rsp_valid = _zz_190;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_194_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_190_ = dBus_cmd_valid;
-  assign _zz_192_ = dBus_cmd_payload_wr;
-  assign _zz_193_ = (_zz_189_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_191_ && (_zz_192_ || _zz_193_));
-  assign dBusWishbone_ADR = ((_zz_194_ ? {{dBus_cmd_payload_address[31 : 5],_zz_189_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_194_ ? (_zz_193_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_192_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_192_;
+  assign _zz_196 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_192 = dBus_cmd_valid;
+  assign _zz_194 = dBus_cmd_payload_wr;
+  assign _zz_195 = (_zz_191 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_193 && (_zz_194 || _zz_195));
+  assign dBusWishbone_ADR = ((_zz_196 ? {{dBus_cmd_payload_address[31 : 5],_zz_191},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_196 ? (_zz_195 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_194 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_194;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_191_ = (_zz_190_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_190_;
-  assign dBusWishbone_STB = _zz_190_;
-  assign dBus_rsp_valid = _zz_195_;
+  assign _zz_193 = (_zz_192 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_192;
+  assign dBusWishbone_STB = _zz_192;
+  assign dBus_rsp_valid = _zz_197;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -5584,27 +4764,27 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
       IBusCachedPlugin_decodePc_pcReg <= externalResetVector;
-      _zz_64_ <= 1'b0;
+      _zz_64 <= 1'b0;
       IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
-      _zz_92_ <= 1'b0;
+      _zz_92 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_103_;
+      IBusCachedPlugin_rspCounter <= _zz_103;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_104_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_104;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_122_ <= 1'b1;
-      _zz_134_ <= 1'b0;
-      CsrPlugin_misa_base <= (2'b01);
+      _zz_124 <= 1'b1;
+      _zz_136 <= 1'b0;
+      CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -5620,16 +4800,14 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_162_ <= 32'h0;
+      _zz_164 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_187_ <= (3'b000);
-      _zz_188_ <= 1'b0;
-      _zz_189_ <= (3'b000);
-      _zz_195_ <= 1'b0;
+      _zz_189 <= 3'b000;
+      _zz_190 <= 1'b0;
+      _zz_191 <= 3'b000;
+      _zz_197 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -5653,14 +4831,14 @@ module VexRiscv (
       if((decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode)))begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_decodePc_pcPlus;
       end
-      if(_zz_233_)begin
+      if(_zz_246)begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_jump_pcLoad_payload;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_64_ <= 1'b0;
+        _zz_64 <= 1'b0;
       end
-      if(_zz_62_)begin
-        _zz_64_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_62)begin
+        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if((IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready))begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= ((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc) || (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc));
@@ -5668,7 +4846,7 @@ module VexRiscv (
       if((IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid))begin
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
-      if(_zz_248_)begin
+      if(_zz_261)begin
         if(IBusCachedPlugin_decompressor_bufferFill)begin
           IBusCachedPlugin_decompressor_bufferValid <= 1'b1;
         end
@@ -5678,10 +4856,10 @@ module VexRiscv (
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
       if(decode_arbitration_removeIt)begin
-        _zz_92_ <= 1'b0;
+        _zz_92 <= 1'b0;
       end
       if(IBusCachedPlugin_decompressor_output_ready)begin
-        _zz_92_ <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
+        _zz_92 <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
       end
       if((! 1'b0))begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
@@ -5710,20 +4888,20 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_249_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_262)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_122_ <= 1'b0;
-      _zz_134_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_124 <= 1'b0;
+      _zz_136 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -5745,14 +4923,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_250_)begin
-        if(_zz_251_)begin
+      if(_zz_263)begin
+        if(_zz_264)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_252_)begin
+        if(_zz_265)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_253_)begin
+        if(_zz_266)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -5777,7 +4955,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_230_)begin
+      if(_zz_243)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -5788,10 +4966,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_231_)begin
-        case(_zz_232_)
+      if(_zz_244)begin
+        case(_zz_245)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -5799,14 +4977,8 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_154_,{_zz_153_,_zz_152_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_156,{_zz_155,_zz_154}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -5834,47 +5006,47 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_342_[0];
-          CsrPlugin_mstatus_MIE <= _zz_343_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_356[0];
+          CsrPlugin_mstatus_MIE <= _zz_357[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_345_[0];
-          CsrPlugin_mie_MTIE <= _zz_346_[0];
-          CsrPlugin_mie_MSIE <= _zz_347_[0];
+          CsrPlugin_mie_MEIE <= _zz_359[0];
+          CsrPlugin_mie_MTIE <= _zz_360[0];
+          CsrPlugin_mie_MSIE <= _zz_361[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_162_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_164 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_247_)begin
+      if(_zz_260)begin
         if(iBusWishbone_ACK)begin
-          _zz_187_ <= (_zz_187_ + (3'b001));
+          _zz_189 <= (_zz_189 + 3'b001);
         end
       end
-      _zz_188_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_190_ && _zz_191_))begin
-        _zz_189_ <= (_zz_189_ + (3'b001));
-        if(_zz_193_)begin
-          _zz_189_ <= (3'b000);
+      _zz_190 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_192 && _zz_193))begin
+        _zz_191 <= (_zz_191 + 3'b001);
+        if(_zz_195)begin
+          _zz_191 <= 3'b000;
         end
       end
-      _zz_195_ <= ((_zz_190_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_197 <= ((_zz_192 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_248_)begin
+    if(_zz_261)begin
       IBusCachedPlugin_decompressor_bufferData <= IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16];
     end
     if(IBusCachedPlugin_decompressor_output_ready)begin
-      _zz_93_ <= IBusCachedPlugin_decompressor_output_payload_pc;
-      _zz_94_ <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
-      _zz_95_ <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
-      _zz_96_ <= IBusCachedPlugin_decompressor_output_payload_isRvc;
+      _zz_93 <= IBusCachedPlugin_decompressor_output_payload_pc;
+      _zz_94 <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
+      _zz_95 <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
+      _zz_96 <= IBusCachedPlugin_decompressor_output_payload_isRvc;
     end
     if(IBusCachedPlugin_injector_decodeInput_ready)begin
       IBusCachedPlugin_injector_formal_rawInDecode <= IBusCachedPlugin_decompressor_raw;
@@ -5882,24 +5054,26 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(_zz_249_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_262)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_135_ <= _zz_40_[11 : 7];
-    _zz_136_ <= _zz_50_;
+    _zz_137 <= _zz_40[11 : 7];
+    _zz_138 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -5907,9 +5081,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_228_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_156_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_156_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_241)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_158 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_158 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -5919,21 +5093,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_250_)begin
-      if(_zz_251_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_263)begin
+      if(_zz_264)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_252_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_265)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_253_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_266)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_230_)begin
+    if(_zz_243)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -5953,36 +5127,30 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_223_)begin
-      if(_zz_245_)begin
+    if(_zz_236)begin
+      if(_zz_258)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_333_[31:0];
+          memory_DivPlugin_div_result <= _zz_347[31:0];
         end
       end
     end
-    if(_zz_246_)begin
+    if(_zz_259)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_160_ ? (~ _zz_161_) : _zz_161_) + _zz_339_);
-      memory_DivPlugin_rs2 <= ((_zz_159_ ? (~ execute_RS2) : execute_RS2) + _zz_341_);
-      memory_DivPlugin_div_needRevert <= ((_zz_160_ ^ (_zz_159_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_162 ? (~ _zz_163) : _zz_163) + _zz_353);
+      memory_DivPlugin_rs2 <= ((_zz_161 ? (~ execute_RS2) : execute_RS2) + _zz_355);
+      memory_DivPlugin_div_needRevert <= ((_zz_162 ^ (_zz_161 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      execute_to_memory_PC <= _zz_35;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_25_;
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
@@ -5990,71 +5158,29 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_54_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_RVC <= decode_IS_RVC;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_22_;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_54;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_19_;
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_25;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -6066,7 +5192,70 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_17_;
+      decode_to_execute_ALU_CTRL <= _zz_22;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_19;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
@@ -6078,22 +5267,64 @@ module VexRiscv (
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_14_;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
@@ -6101,53 +5332,8 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_11_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_8_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_5_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_3_;
-    end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_1_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -6223,7 +5409,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_344_[0];
+        CsrPlugin_mip_MSIP <= _zz_358[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -6244,7 +5430,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_834)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_348_[0];
+        CsrPlugin_mcause_interrupt <= _zz_362[0];
         CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -6275,6 +5461,1103 @@ module VexRiscv (
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_isLrsc,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire                _zz_19;
+  wire                _zz_20;
+  wire       [0:0]    _zz_21;
+  wire       [0:0]    _zz_22;
+  wire       [9:0]    _zz_23;
+  wire       [9:0]    _zz_24;
+  wire       [0:0]    _zz_25;
+  wire       [0:0]    _zz_26;
+  wire       [0:0]    _zz_27;
+  wire       [2:0]    _zz_28;
+  wire       [1:0]    _zz_29;
+  wire       [21:0]   _zz_30;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  wire                stage0_isAmo;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_isLrsc;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire                stageA_isAmo;
+  wire                stageA_isLrsc;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_isLrsc;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  reg                 stageB_lrSc_reserved;
+  wire                stageB_isAmo;
+  wire                stageB_isAmoCached;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  wire       [31:0]   stageB_requestDataBypass;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_31;
+  reg [7:0] _zz_32;
+  reg [7:0] _zz_33;
+  reg [7:0] _zz_34;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign _zz_16 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_17 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_18 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_19 = (! stageB_flusher_hold);
+  assign _zz_20 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_21 = _zz_4[0 : 0];
+  assign _zz_22 = _zz_4[1 : 1];
+  assign _zz_23 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_24 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_25 = 1'b1;
+  assign _zz_26 = (! stageB_lrSc_reserved);
+  assign _zz_27 = loader_counter_willIncrement;
+  assign _zz_28 = {2'd0, _zz_27};
+  assign _zz_29 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_30 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_30;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_34, _zz_33, _zz_32, _zz_31};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_31 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_32 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_33 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_34 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_21[0];
+  assign ways_0_tagsReadRsp_error = _zz_22[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if(_zz_16)begin
+              dataWriteCmd_valid = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_17)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_17)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_17)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_17)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_25[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_17)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_23)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign stage0_isAmo = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign stageA_isAmo = 1'b0;
+  assign stageA_isLrsc = 1'b0;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_24)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+          if(_zz_18)begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+            if(_zz_16)begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isAmo = 1'b0;
+  assign stageB_isAmoCached = 1'b0;
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  assign stageB_requestDataBypass = stageB_request_data;
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          io_mem_cmd_valid = (! memCmdSent);
+          if(_zz_18)begin
+            io_mem_cmd_valid = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+            if(_zz_16)begin
+              io_mem_cmd_valid = 1'b0;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+    if((stageB_request_isLrsc && stageB_request_wr))begin
+      io_cpu_writeBack_data = {31'd0, _zz_26};
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_17)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_28);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_isLrsc <= stageA_request_isLrsc;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_19)begin
+        if(_zz_20)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      stageB_lrSc_reserved <= 1'b0;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_19)begin
+          if(! _zz_20) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+        stageB_lrSc_reserved <= (! stageB_request_wr);
+      end
+      if(_zz_13)begin
+        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_17)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_29[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  output              io_cpu_fetch_cacheMiss,
+  output              io_cpu_fetch_error,
+  output              io_cpu_fetch_mmuRefilling,
+  output              io_cpu_fetch_mmuException,
+  input               io_cpu_fetch_isUser,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_9;
+  reg        [21:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [21:0]   _zz_15;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_11 = (! lineLoader_flushCounter[7]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_9 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_10 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_11)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_fetch_cacheMiss = (! fetchStage_hit_valid);
+  assign io_cpu_fetch_error = (fetchStage_hit_error || ((! io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute))));
+  assign io_cpu_fetch_mmuRefilling = io_cpu_fetch_mmuRsp_refilling;
+  assign io_cpu_fetch_mmuException = (((! io_cpu_fetch_mmuRsp_refilling) && io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute)));
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_12)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_11)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_12)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
   end
 
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_IMACDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_IMACDebug.v
@@ -1,13 +1,7 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:38:19
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
-
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
@@ -43,983 +37,12 @@
 `define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
 `define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_cacheMiss,
-  output              io_cpu_fetch_error,
-  output              io_cpu_fetch_mmuRefilling,
-  output              io_cpu_fetch_mmuException,
-  input               io_cpu_fetch_isUser,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire       [0:0]    _zz_14_;
-  wire       [0:0]    _zz_15_;
-  wire       [21:0]   _zz_16_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-
-  assign _zz_12_ = (! lineLoader_flushCounter[7]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_fetch_cacheMiss = (! fetchStage_hit_valid);
-  assign io_cpu_fetch_error = fetchStage_hit_error;
-  assign io_cpu_fetch_mmuRefilling = io_cpu_fetch_mmuBus_rsp_refilling;
-  assign io_cpu_fetch_mmuException = ((! io_cpu_fetch_mmuBus_rsp_refilling) && (io_cpu_fetch_mmuBus_rsp_exception || (! io_cpu_fetch_mmuBus_rsp_allowExecute)));
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [0:0]    _zz_18_;
-  wire       [0:0]    _zz_19_;
-  wire       [2:0]    _zz_20_;
-  wire       [1:0]    _zz_21_;
-  wire       [21:0]   _zz_22_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  wire       [31:0]   stageB_requestDataBypass;
-  wire                stageB_isAmo;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_23_;
-  reg [7:0] _zz_24_;
-  reg [7:0] _zz_25_;
-  reg [7:0] _zz_26_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmo)));
-  assign _zz_15_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_16_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_17_ = _zz_4_[0 : 0];
-  assign _zz_18_ = _zz_4_[1 : 1];
-  assign _zz_19_ = loader_counter_willIncrement;
-  assign _zz_20_ = {2'd0, _zz_19_};
-  assign _zz_21_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_22_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_22_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_26_, _zz_25_, _zz_24_, _zz_23_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_23_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_24_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_25_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_26_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_17_[0];
-  assign ways_0_tagsReadRsp_error = _zz_18_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  assign stageB_requestDataBypass = stageB_request_data;
-  assign stageB_isAmo = 1'b0;
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((((! stageB_request_wr) || stageB_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0))))begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_15_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_20_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_16_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_16_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_15_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_21_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1042,8 +65,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1053,34 +76,45 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
   input               reset,
-  input               debugReset 
+  input               debugReset
 );
-  wire                _zz_200_;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire                _zz_203_;
-  wire                _zz_204_;
-  wire                _zz_205_;
-  wire                _zz_206_;
-  wire       [31:0]   _zz_207_;
-  reg                 _zz_208_;
-  wire                _zz_209_;
-  wire       [31:0]   _zz_210_;
-  wire                _zz_211_;
-  wire       [31:0]   _zz_212_;
-  reg                 _zz_213_;
-  wire                _zz_214_;
-  wire                _zz_215_;
-  wire       [31:0]   _zz_216_;
-  wire                _zz_217_;
-  wire                _zz_218_;
-  reg        [31:0]   _zz_219_;
-  reg        [31:0]   _zz_220_;
-  reg        [31:0]   _zz_221_;
+  wire                _zz_202;
+  wire                _zz_203;
+  wire                _zz_204;
+  wire                _zz_205;
+  wire                _zz_206;
+  wire                _zz_207;
+  wire                _zz_208;
+  wire                _zz_209;
+  wire       [31:0]   _zz_210;
+  reg                 _zz_211;
+  wire                _zz_212;
+  wire       [31:0]   _zz_213;
+  reg                 _zz_214;
+  wire                _zz_215;
+  wire       [31:0]   _zz_216;
+  reg                 _zz_217;
+  wire                _zz_218;
+  wire                _zz_219;
+  wire       [31:0]   _zz_220;
+  wire                _zz_221;
+  wire                _zz_222;
+  wire                _zz_223;
+  wire                _zz_224;
+  wire                _zz_225;
+  wire                _zz_226;
+  wire                _zz_227;
+  wire                _zz_228;
+  wire       [3:0]    _zz_229;
+  wire                _zz_230;
+  wire                _zz_231;
+  reg        [31:0]   _zz_232;
+  reg        [31:0]   _zz_233;
+  reg        [31:0]   _zz_234;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_error;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling;
@@ -1088,454 +122,461 @@ module VexRiscv (
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire                IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_decode_physicalAddress;
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_222_;
-  wire                _zz_223_;
-  wire                _zz_224_;
-  wire                _zz_225_;
-  wire                _zz_226_;
-  wire                _zz_227_;
-  wire                _zz_228_;
-  wire                _zz_229_;
-  wire                _zz_230_;
-  wire                _zz_231_;
-  wire                _zz_232_;
-  wire                _zz_233_;
-  wire                _zz_234_;
-  wire                _zz_235_;
-  wire                _zz_236_;
-  wire                _zz_237_;
-  wire                _zz_238_;
-  wire       [1:0]    _zz_239_;
-  wire                _zz_240_;
-  wire                _zz_241_;
-  wire                _zz_242_;
-  wire                _zz_243_;
-  wire                _zz_244_;
-  wire                _zz_245_;
-  wire                _zz_246_;
-  wire                _zz_247_;
-  wire                _zz_248_;
-  wire                _zz_249_;
-  wire                _zz_250_;
-  wire       [1:0]    _zz_251_;
-  wire                _zz_252_;
-  wire                _zz_253_;
-  wire       [5:0]    _zz_254_;
-  wire                _zz_255_;
-  wire                _zz_256_;
-  wire                _zz_257_;
-  wire                _zz_258_;
-  wire                _zz_259_;
-  wire                _zz_260_;
-  wire                _zz_261_;
-  wire       [4:0]    _zz_262_;
-  wire       [1:0]    _zz_263_;
-  wire       [1:0]    _zz_264_;
-  wire       [1:0]    _zz_265_;
-  wire                _zz_266_;
-  wire       [1:0]    _zz_267_;
-  wire       [0:0]    _zz_268_;
-  wire       [0:0]    _zz_269_;
-  wire       [0:0]    _zz_270_;
-  wire       [0:0]    _zz_271_;
-  wire       [32:0]   _zz_272_;
-  wire       [31:0]   _zz_273_;
-  wire       [32:0]   _zz_274_;
-  wire       [0:0]    _zz_275_;
-  wire       [0:0]    _zz_276_;
-  wire       [0:0]    _zz_277_;
-  wire       [0:0]    _zz_278_;
-  wire       [51:0]   _zz_279_;
-  wire       [51:0]   _zz_280_;
-  wire       [51:0]   _zz_281_;
-  wire       [32:0]   _zz_282_;
-  wire       [51:0]   _zz_283_;
-  wire       [49:0]   _zz_284_;
-  wire       [51:0]   _zz_285_;
-  wire       [49:0]   _zz_286_;
-  wire       [51:0]   _zz_287_;
-  wire       [0:0]    _zz_288_;
-  wire       [0:0]    _zz_289_;
-  wire       [2:0]    _zz_290_;
-  wire       [31:0]   _zz_291_;
-  wire       [0:0]    _zz_292_;
-  wire       [0:0]    _zz_293_;
-  wire       [0:0]    _zz_294_;
-  wire       [0:0]    _zz_295_;
-  wire       [0:0]    _zz_296_;
-  wire       [0:0]    _zz_297_;
-  wire       [0:0]    _zz_298_;
-  wire       [0:0]    _zz_299_;
-  wire       [3:0]    _zz_300_;
-  wire       [2:0]    _zz_301_;
-  wire       [31:0]   _zz_302_;
-  wire       [2:0]    _zz_303_;
-  wire       [31:0]   _zz_304_;
-  wire       [31:0]   _zz_305_;
-  wire       [11:0]   _zz_306_;
-  wire       [11:0]   _zz_307_;
-  wire       [11:0]   _zz_308_;
-  wire       [31:0]   _zz_309_;
-  wire       [19:0]   _zz_310_;
-  wire       [11:0]   _zz_311_;
-  wire       [2:0]    _zz_312_;
-  wire       [2:0]    _zz_313_;
-  wire       [0:0]    _zz_314_;
-  wire       [2:0]    _zz_315_;
-  wire       [4:0]    _zz_316_;
-  wire       [11:0]   _zz_317_;
-  wire       [11:0]   _zz_318_;
-  wire       [31:0]   _zz_319_;
-  wire       [31:0]   _zz_320_;
-  wire       [31:0]   _zz_321_;
-  wire       [31:0]   _zz_322_;
-  wire       [31:0]   _zz_323_;
-  wire       [31:0]   _zz_324_;
-  wire       [31:0]   _zz_325_;
-  wire       [11:0]   _zz_326_;
-  wire       [19:0]   _zz_327_;
-  wire       [11:0]   _zz_328_;
-  wire       [2:0]    _zz_329_;
-  wire       [1:0]    _zz_330_;
-  wire       [1:0]    _zz_331_;
-  wire       [65:0]   _zz_332_;
-  wire       [65:0]   _zz_333_;
-  wire       [31:0]   _zz_334_;
-  wire       [31:0]   _zz_335_;
-  wire       [0:0]    _zz_336_;
-  wire       [5:0]    _zz_337_;
-  wire       [32:0]   _zz_338_;
-  wire       [31:0]   _zz_339_;
-  wire       [31:0]   _zz_340_;
-  wire       [32:0]   _zz_341_;
-  wire       [32:0]   _zz_342_;
-  wire       [32:0]   _zz_343_;
-  wire       [32:0]   _zz_344_;
-  wire       [0:0]    _zz_345_;
-  wire       [32:0]   _zz_346_;
-  wire       [0:0]    _zz_347_;
-  wire       [32:0]   _zz_348_;
-  wire       [0:0]    _zz_349_;
-  wire       [31:0]   _zz_350_;
-  wire       [0:0]    _zz_351_;
-  wire       [0:0]    _zz_352_;
-  wire       [0:0]    _zz_353_;
-  wire       [0:0]    _zz_354_;
-  wire       [0:0]    _zz_355_;
-  wire       [0:0]    _zz_356_;
-  wire       [0:0]    _zz_357_;
-  wire       [26:0]   _zz_358_;
-  wire                _zz_359_;
-  wire                _zz_360_;
-  wire       [1:0]    _zz_361_;
-  wire       [31:0]   _zz_362_;
-  wire       [31:0]   _zz_363_;
-  wire       [31:0]   _zz_364_;
-  wire                _zz_365_;
-  wire       [0:0]    _zz_366_;
-  wire       [13:0]   _zz_367_;
-  wire       [31:0]   _zz_368_;
-  wire       [31:0]   _zz_369_;
-  wire       [31:0]   _zz_370_;
-  wire                _zz_371_;
-  wire       [0:0]    _zz_372_;
-  wire       [7:0]    _zz_373_;
-  wire       [31:0]   _zz_374_;
-  wire       [31:0]   _zz_375_;
-  wire       [31:0]   _zz_376_;
-  wire                _zz_377_;
-  wire       [0:0]    _zz_378_;
-  wire       [1:0]    _zz_379_;
-  wire                _zz_380_;
-  wire                _zz_381_;
-  wire       [6:0]    _zz_382_;
-  wire       [4:0]    _zz_383_;
-  wire                _zz_384_;
-  wire       [4:0]    _zz_385_;
-  wire       [0:0]    _zz_386_;
-  wire       [7:0]    _zz_387_;
-  wire                _zz_388_;
-  wire       [0:0]    _zz_389_;
-  wire       [0:0]    _zz_390_;
-  wire       [31:0]   _zz_391_;
-  wire       [31:0]   _zz_392_;
-  wire       [31:0]   _zz_393_;
-  wire       [31:0]   _zz_394_;
-  wire       [0:0]    _zz_395_;
-  wire       [0:0]    _zz_396_;
-  wire       [0:0]    _zz_397_;
-  wire       [0:0]    _zz_398_;
-  wire                _zz_399_;
-  wire       [0:0]    _zz_400_;
-  wire       [26:0]   _zz_401_;
-  wire       [31:0]   _zz_402_;
-  wire       [31:0]   _zz_403_;
-  wire       [0:0]    _zz_404_;
-  wire       [0:0]    _zz_405_;
-  wire       [1:0]    _zz_406_;
-  wire       [1:0]    _zz_407_;
-  wire                _zz_408_;
-  wire       [0:0]    _zz_409_;
-  wire       [22:0]   _zz_410_;
-  wire       [31:0]   _zz_411_;
-  wire       [31:0]   _zz_412_;
-  wire       [31:0]   _zz_413_;
-  wire       [31:0]   _zz_414_;
-  wire       [31:0]   _zz_415_;
-  wire       [0:0]    _zz_416_;
-  wire       [0:0]    _zz_417_;
-  wire       [4:0]    _zz_418_;
-  wire       [4:0]    _zz_419_;
-  wire                _zz_420_;
-  wire       [0:0]    _zz_421_;
-  wire       [19:0]   _zz_422_;
-  wire       [31:0]   _zz_423_;
-  wire       [31:0]   _zz_424_;
-  wire       [31:0]   _zz_425_;
-  wire       [31:0]   _zz_426_;
-  wire       [0:0]    _zz_427_;
-  wire       [1:0]    _zz_428_;
-  wire       [31:0]   _zz_429_;
-  wire       [31:0]   _zz_430_;
-  wire       [0:0]    _zz_431_;
-  wire       [3:0]    _zz_432_;
-  wire       [3:0]    _zz_433_;
-  wire       [3:0]    _zz_434_;
-  wire                _zz_435_;
-  wire       [0:0]    _zz_436_;
-  wire       [16:0]   _zz_437_;
-  wire       [31:0]   _zz_438_;
-  wire       [31:0]   _zz_439_;
-  wire       [31:0]   _zz_440_;
-  wire       [31:0]   _zz_441_;
-  wire       [31:0]   _zz_442_;
-  wire       [31:0]   _zz_443_;
-  wire       [31:0]   _zz_444_;
-  wire                _zz_445_;
-  wire       [0:0]    _zz_446_;
-  wire       [0:0]    _zz_447_;
-  wire       [31:0]   _zz_448_;
-  wire       [31:0]   _zz_449_;
-  wire                _zz_450_;
-  wire       [0:0]    _zz_451_;
-  wire       [0:0]    _zz_452_;
-  wire       [31:0]   _zz_453_;
-  wire       [31:0]   _zz_454_;
-  wire       [0:0]    _zz_455_;
-  wire       [0:0]    _zz_456_;
-  wire       [5:0]    _zz_457_;
-  wire       [5:0]    _zz_458_;
-  wire                _zz_459_;
-  wire       [0:0]    _zz_460_;
-  wire       [13:0]   _zz_461_;
-  wire       [31:0]   _zz_462_;
-  wire       [31:0]   _zz_463_;
-  wire       [31:0]   _zz_464_;
-  wire       [31:0]   _zz_465_;
-  wire       [31:0]   _zz_466_;
-  wire       [31:0]   _zz_467_;
-  wire       [31:0]   _zz_468_;
-  wire       [31:0]   _zz_469_;
-  wire       [31:0]   _zz_470_;
-  wire       [31:0]   _zz_471_;
-  wire       [31:0]   _zz_472_;
-  wire       [31:0]   _zz_473_;
-  wire       [31:0]   _zz_474_;
-  wire       [31:0]   _zz_475_;
-  wire       [0:0]    _zz_476_;
-  wire       [3:0]    _zz_477_;
-  wire                _zz_478_;
-  wire       [1:0]    _zz_479_;
-  wire       [1:0]    _zz_480_;
-  wire                _zz_481_;
-  wire       [0:0]    _zz_482_;
-  wire       [11:0]   _zz_483_;
-  wire       [31:0]   _zz_484_;
-  wire       [31:0]   _zz_485_;
-  wire                _zz_486_;
-  wire       [0:0]    _zz_487_;
-  wire       [1:0]    _zz_488_;
-  wire       [31:0]   _zz_489_;
-  wire                _zz_490_;
-  wire                _zz_491_;
-  wire                _zz_492_;
-  wire       [1:0]    _zz_493_;
-  wire       [1:0]    _zz_494_;
-  wire                _zz_495_;
-  wire       [0:0]    _zz_496_;
-  wire       [9:0]    _zz_497_;
-  wire       [31:0]   _zz_498_;
-  wire       [31:0]   _zz_499_;
-  wire       [31:0]   _zz_500_;
-  wire                _zz_501_;
-  wire                _zz_502_;
-  wire       [31:0]   _zz_503_;
-  wire       [31:0]   _zz_504_;
-  wire       [31:0]   _zz_505_;
-  wire                _zz_506_;
-  wire                _zz_507_;
-  wire       [0:0]    _zz_508_;
-  wire       [1:0]    _zz_509_;
-  wire       [2:0]    _zz_510_;
-  wire       [2:0]    _zz_511_;
-  wire                _zz_512_;
-  wire       [0:0]    _zz_513_;
-  wire       [7:0]    _zz_514_;
-  wire       [31:0]   _zz_515_;
-  wire       [31:0]   _zz_516_;
-  wire       [31:0]   _zz_517_;
-  wire       [31:0]   _zz_518_;
-  wire       [31:0]   _zz_519_;
-  wire       [31:0]   _zz_520_;
-  wire                _zz_521_;
-  wire                _zz_522_;
-  wire                _zz_523_;
-  wire       [0:0]    _zz_524_;
-  wire       [0:0]    _zz_525_;
-  wire       [0:0]    _zz_526_;
-  wire       [3:0]    _zz_527_;
-  wire       [0:0]    _zz_528_;
-  wire       [0:0]    _zz_529_;
-  wire                _zz_530_;
-  wire       [0:0]    _zz_531_;
-  wire       [5:0]    _zz_532_;
-  wire       [31:0]   _zz_533_;
-  wire       [31:0]   _zz_534_;
-  wire       [31:0]   _zz_535_;
-  wire       [31:0]   _zz_536_;
-  wire       [31:0]   _zz_537_;
-  wire       [31:0]   _zz_538_;
-  wire       [31:0]   _zz_539_;
-  wire       [31:0]   _zz_540_;
-  wire       [31:0]   _zz_541_;
-  wire                _zz_542_;
-  wire       [0:0]    _zz_543_;
-  wire       [1:0]    _zz_544_;
-  wire       [31:0]   _zz_545_;
-  wire       [31:0]   _zz_546_;
-  wire                _zz_547_;
-  wire       [0:0]    _zz_548_;
-  wire       [0:0]    _zz_549_;
-  wire                _zz_550_;
-  wire       [0:0]    _zz_551_;
-  wire       [3:0]    _zz_552_;
-  wire       [31:0]   _zz_553_;
-  wire       [31:0]   _zz_554_;
-  wire       [31:0]   _zz_555_;
-  wire       [31:0]   _zz_556_;
-  wire       [31:0]   _zz_557_;
-  wire                _zz_558_;
-  wire       [0:0]    _zz_559_;
-  wire       [0:0]    _zz_560_;
-  wire       [0:0]    _zz_561_;
-  wire       [0:0]    _zz_562_;
-  wire                _zz_563_;
-  wire       [0:0]    _zz_564_;
-  wire       [0:0]    _zz_565_;
-  wire       [31:0]   _zz_566_;
-  wire       [31:0]   _zz_567_;
-  wire                _zz_568_;
-  wire                _zz_569_;
-  wire                _zz_570_;
-  wire       [31:0]   _zz_571_;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_3_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10_;
-  wire                decode_DO_EBREAK;
-  wire                decode_SRC_LESS_UNSIGNED;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_235;
+  wire                _zz_236;
+  wire                _zz_237;
+  wire                _zz_238;
+  wire                _zz_239;
+  wire                _zz_240;
+  wire                _zz_241;
+  wire                _zz_242;
+  wire                _zz_243;
+  wire                _zz_244;
+  wire                _zz_245;
+  wire                _zz_246;
+  wire                _zz_247;
+  wire                _zz_248;
+  wire                _zz_249;
+  wire                _zz_250;
+  wire                _zz_251;
+  wire       [1:0]    _zz_252;
+  wire                _zz_253;
+  wire                _zz_254;
+  wire                _zz_255;
+  wire                _zz_256;
+  wire                _zz_257;
+  wire                _zz_258;
+  wire                _zz_259;
+  wire                _zz_260;
+  wire                _zz_261;
+  wire                _zz_262;
+  wire                _zz_263;
+  wire       [1:0]    _zz_264;
+  wire                _zz_265;
+  wire                _zz_266;
+  wire       [5:0]    _zz_267;
+  wire                _zz_268;
+  wire                _zz_269;
+  wire                _zz_270;
+  wire                _zz_271;
+  wire                _zz_272;
+  wire                _zz_273;
+  wire                _zz_274;
+  wire       [4:0]    _zz_275;
+  wire       [1:0]    _zz_276;
+  wire       [1:0]    _zz_277;
+  wire       [1:0]    _zz_278;
+  wire                _zz_279;
+  wire       [1:0]    _zz_280;
+  wire       [51:0]   _zz_281;
+  wire       [51:0]   _zz_282;
+  wire       [51:0]   _zz_283;
+  wire       [32:0]   _zz_284;
+  wire       [51:0]   _zz_285;
+  wire       [49:0]   _zz_286;
+  wire       [51:0]   _zz_287;
+  wire       [49:0]   _zz_288;
+  wire       [51:0]   _zz_289;
+  wire       [32:0]   _zz_290;
+  wire       [31:0]   _zz_291;
+  wire       [32:0]   _zz_292;
+  wire       [0:0]    _zz_293;
+  wire       [0:0]    _zz_294;
+  wire       [0:0]    _zz_295;
+  wire       [0:0]    _zz_296;
+  wire       [0:0]    _zz_297;
+  wire       [0:0]    _zz_298;
+  wire       [0:0]    _zz_299;
+  wire       [0:0]    _zz_300;
+  wire       [0:0]    _zz_301;
+  wire       [0:0]    _zz_302;
+  wire       [2:0]    _zz_303;
+  wire       [31:0]   _zz_304;
+  wire       [0:0]    _zz_305;
+  wire       [0:0]    _zz_306;
+  wire       [0:0]    _zz_307;
+  wire       [0:0]    _zz_308;
+  wire       [0:0]    _zz_309;
+  wire       [0:0]    _zz_310;
+  wire       [0:0]    _zz_311;
+  wire       [0:0]    _zz_312;
+  wire       [0:0]    _zz_313;
+  wire       [3:0]    _zz_314;
+  wire       [2:0]    _zz_315;
+  wire       [31:0]   _zz_316;
+  wire       [2:0]    _zz_317;
+  wire       [31:0]   _zz_318;
+  wire       [31:0]   _zz_319;
+  wire       [11:0]   _zz_320;
+  wire       [11:0]   _zz_321;
+  wire       [11:0]   _zz_322;
+  wire       [31:0]   _zz_323;
+  wire       [19:0]   _zz_324;
+  wire       [11:0]   _zz_325;
+  wire       [2:0]    _zz_326;
+  wire       [2:0]    _zz_327;
+  wire       [0:0]    _zz_328;
+  wire       [2:0]    _zz_329;
+  wire       [4:0]    _zz_330;
+  wire       [11:0]   _zz_331;
+  wire       [11:0]   _zz_332;
+  wire       [31:0]   _zz_333;
+  wire       [31:0]   _zz_334;
+  wire       [31:0]   _zz_335;
+  wire       [31:0]   _zz_336;
+  wire       [31:0]   _zz_337;
+  wire       [31:0]   _zz_338;
+  wire       [31:0]   _zz_339;
+  wire       [11:0]   _zz_340;
+  wire       [19:0]   _zz_341;
+  wire       [11:0]   _zz_342;
+  wire       [2:0]    _zz_343;
+  wire       [1:0]    _zz_344;
+  wire       [1:0]    _zz_345;
+  wire       [65:0]   _zz_346;
+  wire       [65:0]   _zz_347;
+  wire       [31:0]   _zz_348;
+  wire       [31:0]   _zz_349;
+  wire       [0:0]    _zz_350;
+  wire       [5:0]    _zz_351;
+  wire       [32:0]   _zz_352;
+  wire       [31:0]   _zz_353;
+  wire       [31:0]   _zz_354;
+  wire       [32:0]   _zz_355;
+  wire       [32:0]   _zz_356;
+  wire       [32:0]   _zz_357;
+  wire       [32:0]   _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [32:0]   _zz_360;
+  wire       [0:0]    _zz_361;
+  wire       [32:0]   _zz_362;
+  wire       [0:0]    _zz_363;
+  wire       [31:0]   _zz_364;
+  wire       [0:0]    _zz_365;
+  wire       [0:0]    _zz_366;
+  wire       [0:0]    _zz_367;
+  wire       [0:0]    _zz_368;
+  wire       [0:0]    _zz_369;
+  wire       [0:0]    _zz_370;
+  wire       [0:0]    _zz_371;
+  wire       [26:0]   _zz_372;
+  wire                _zz_373;
+  wire                _zz_374;
+  wire       [1:0]    _zz_375;
+  wire       [31:0]   _zz_376;
+  wire       [31:0]   _zz_377;
+  wire       [31:0]   _zz_378;
+  wire                _zz_379;
+  wire       [0:0]    _zz_380;
+  wire       [15:0]   _zz_381;
+  wire       [31:0]   _zz_382;
+  wire       [31:0]   _zz_383;
+  wire       [31:0]   _zz_384;
+  wire                _zz_385;
+  wire       [0:0]    _zz_386;
+  wire       [9:0]    _zz_387;
+  wire       [31:0]   _zz_388;
+  wire       [31:0]   _zz_389;
+  wire       [31:0]   _zz_390;
+  wire                _zz_391;
+  wire       [0:0]    _zz_392;
+  wire       [3:0]    _zz_393;
+  wire                _zz_394;
+  wire                _zz_395;
+  wire       [6:0]    _zz_396;
+  wire       [4:0]    _zz_397;
+  wire                _zz_398;
+  wire       [4:0]    _zz_399;
+  wire       [0:0]    _zz_400;
+  wire       [7:0]    _zz_401;
+  wire                _zz_402;
+  wire       [0:0]    _zz_403;
+  wire       [0:0]    _zz_404;
+  wire       [31:0]   _zz_405;
+  wire       [0:0]    _zz_406;
+  wire       [0:0]    _zz_407;
+  wire                _zz_408;
+  wire       [0:0]    _zz_409;
+  wire       [27:0]   _zz_410;
+  wire       [31:0]   _zz_411;
+  wire                _zz_412;
+  wire                _zz_413;
+  wire                _zz_414;
+  wire       [1:0]    _zz_415;
+  wire       [1:0]    _zz_416;
+  wire                _zz_417;
+  wire       [0:0]    _zz_418;
+  wire       [23:0]   _zz_419;
+  wire       [31:0]   _zz_420;
+  wire       [31:0]   _zz_421;
+  wire       [31:0]   _zz_422;
+  wire       [31:0]   _zz_423;
+  wire                _zz_424;
+  wire                _zz_425;
+  wire       [1:0]    _zz_426;
+  wire       [1:0]    _zz_427;
+  wire                _zz_428;
+  wire       [0:0]    _zz_429;
+  wire       [20:0]   _zz_430;
+  wire       [31:0]   _zz_431;
+  wire       [31:0]   _zz_432;
+  wire       [31:0]   _zz_433;
+  wire       [31:0]   _zz_434;
+  wire                _zz_435;
+  wire       [0:0]    _zz_436;
+  wire       [0:0]    _zz_437;
+  wire                _zz_438;
+  wire       [0:0]    _zz_439;
+  wire       [0:0]    _zz_440;
+  wire                _zz_441;
+  wire       [0:0]    _zz_442;
+  wire       [17:0]   _zz_443;
+  wire       [31:0]   _zz_444;
+  wire       [31:0]   _zz_445;
+  wire       [31:0]   _zz_446;
+  wire                _zz_447;
+  wire                _zz_448;
+  wire                _zz_449;
+  wire       [0:0]    _zz_450;
+  wire       [0:0]    _zz_451;
+  wire                _zz_452;
+  wire       [0:0]    _zz_453;
+  wire       [14:0]   _zz_454;
+  wire       [31:0]   _zz_455;
+  wire                _zz_456;
+  wire       [0:0]    _zz_457;
+  wire       [0:0]    _zz_458;
+  wire                _zz_459;
+  wire       [5:0]    _zz_460;
+  wire       [5:0]    _zz_461;
+  wire                _zz_462;
+  wire       [0:0]    _zz_463;
+  wire       [11:0]   _zz_464;
+  wire       [31:0]   _zz_465;
+  wire       [31:0]   _zz_466;
+  wire       [31:0]   _zz_467;
+  wire       [31:0]   _zz_468;
+  wire                _zz_469;
+  wire       [0:0]    _zz_470;
+  wire       [2:0]    _zz_471;
+  wire                _zz_472;
+  wire                _zz_473;
+  wire       [0:0]    _zz_474;
+  wire       [3:0]    _zz_475;
+  wire       [4:0]    _zz_476;
+  wire       [4:0]    _zz_477;
+  wire                _zz_478;
+  wire       [0:0]    _zz_479;
+  wire       [8:0]    _zz_480;
+  wire       [31:0]   _zz_481;
+  wire       [31:0]   _zz_482;
+  wire       [31:0]   _zz_483;
+  wire                _zz_484;
+  wire       [0:0]    _zz_485;
+  wire       [0:0]    _zz_486;
+  wire       [31:0]   _zz_487;
+  wire       [31:0]   _zz_488;
+  wire       [31:0]   _zz_489;
+  wire       [31:0]   _zz_490;
+  wire                _zz_491;
+  wire       [0:0]    _zz_492;
+  wire       [1:0]    _zz_493;
+  wire       [0:0]    _zz_494;
+  wire       [2:0]    _zz_495;
+  wire       [0:0]    _zz_496;
+  wire       [5:0]    _zz_497;
+  wire       [1:0]    _zz_498;
+  wire       [1:0]    _zz_499;
+  wire                _zz_500;
+  wire       [0:0]    _zz_501;
+  wire       [6:0]    _zz_502;
+  wire       [31:0]   _zz_503;
+  wire       [31:0]   _zz_504;
+  wire       [31:0]   _zz_505;
+  wire       [31:0]   _zz_506;
+  wire       [31:0]   _zz_507;
+  wire       [31:0]   _zz_508;
+  wire       [31:0]   _zz_509;
+  wire       [31:0]   _zz_510;
+  wire                _zz_511;
+  wire       [31:0]   _zz_512;
+  wire       [31:0]   _zz_513;
+  wire                _zz_514;
+  wire       [0:0]    _zz_515;
+  wire       [0:0]    _zz_516;
+  wire                _zz_517;
+  wire       [0:0]    _zz_518;
+  wire       [3:0]    _zz_519;
+  wire                _zz_520;
+  wire       [0:0]    _zz_521;
+  wire       [0:0]    _zz_522;
+  wire       [0:0]    _zz_523;
+  wire       [0:0]    _zz_524;
+  wire                _zz_525;
+  wire       [0:0]    _zz_526;
+  wire       [4:0]    _zz_527;
+  wire       [31:0]   _zz_528;
+  wire       [31:0]   _zz_529;
+  wire       [31:0]   _zz_530;
+  wire       [31:0]   _zz_531;
+  wire       [31:0]   _zz_532;
+  wire       [31:0]   _zz_533;
+  wire       [31:0]   _zz_534;
+  wire       [31:0]   _zz_535;
+  wire       [31:0]   _zz_536;
+  wire                _zz_537;
+  wire       [0:0]    _zz_538;
+  wire       [1:0]    _zz_539;
+  wire       [31:0]   _zz_540;
+  wire       [31:0]   _zz_541;
+  wire       [31:0]   _zz_542;
+  wire       [31:0]   _zz_543;
+  wire       [31:0]   _zz_544;
+  wire                _zz_545;
+  wire       [4:0]    _zz_546;
+  wire       [4:0]    _zz_547;
+  wire                _zz_548;
+  wire       [0:0]    _zz_549;
+  wire       [2:0]    _zz_550;
+  wire       [31:0]   _zz_551;
+  wire       [31:0]   _zz_552;
+  wire       [31:0]   _zz_553;
+  wire                _zz_554;
+  wire       [31:0]   _zz_555;
+  wire                _zz_556;
+  wire       [0:0]    _zz_557;
+  wire       [2:0]    _zz_558;
+  wire       [0:0]    _zz_559;
+  wire       [0:0]    _zz_560;
+  wire       [2:0]    _zz_561;
+  wire       [2:0]    _zz_562;
+  wire                _zz_563;
+  wire       [0:0]    _zz_564;
+  wire       [0:0]    _zz_565;
+  wire       [31:0]   _zz_566;
+  wire       [31:0]   _zz_567;
+  wire       [31:0]   _zz_568;
+  wire       [31:0]   _zz_569;
+  wire                _zz_570;
+  wire       [0:0]    _zz_571;
+  wire       [0:0]    _zz_572;
+  wire       [31:0]   _zz_573;
+  wire       [31:0]   _zz_574;
+  wire                _zz_575;
+  wire       [0:0]    _zz_576;
+  wire       [0:0]    _zz_577;
+  wire       [0:0]    _zz_578;
+  wire       [1:0]    _zz_579;
+  wire       [1:0]    _zz_580;
+  wire       [1:0]    _zz_581;
+  wire       [0:0]    _zz_582;
+  wire       [0:0]    _zz_583;
+  wire       [31:0]   _zz_584;
+  wire       [31:0]   _zz_585;
+  wire       [31:0]   _zz_586;
+  wire       [31:0]   _zz_587;
+  wire       [31:0]   _zz_588;
+  wire       [31:0]   _zz_589;
+  wire       [31:0]   _zz_590;
+  wire       [31:0]   _zz_591;
+  wire                _zz_592;
+  wire                _zz_593;
+  wire                _zz_594;
+  wire       [31:0]   _zz_595;
+  wire       [51:0]   memory_MUL_LOW;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
   wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_DO_EBREAK;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
   wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
   wire                memory_IS_MUL;
   wire                execute_IS_MUL;
   wire                decode_IS_MUL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       [33:0]   execute_MUL_LH;
-  wire                decode_IS_RS2_SIGNED;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
   wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17_;
-  wire                decode_CSR_READ_OPCODE;
-  wire       [31:0]   execute_SHIFT_RIGHT;
-  wire                decode_MEMORY_MANAGMENT;
-  wire                decode_IS_DIV;
-  wire                execute_BRANCH_DO;
-  wire       [33:0]   memory_MUL_HH;
-  wire       [33:0]   execute_MUL_HH;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire       [51:0]   memory_MUL_LOW;
-  wire       [31:0]   memory_PC;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire                decode_IS_CSR;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire       [31:0]   execute_MUL_LL;
-  wire       [33:0]   execute_MUL_HL;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_26_;
+  wire       [31:0]   memory_PC;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -1552,11 +593,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -1564,10 +605,10 @@ module VexRiscv (
   wire                execute_BRANCH_COND_RESULT;
   wire                execute_PREDICTION_HAD_BRANCHED2;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1577,66 +618,70 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire                execute_IS_RVC;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_49_;
-  reg        [31:0]   _zz_50_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
+  wire                execute_MEMORY_LRSC;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
+  wire                decode_MEMORY_LRSC;
+  reg                 _zz_51;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_51_;
-  reg                 _zz_51__2;
-  reg                 _zz_51__1;
-  reg                 _zz_51__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52_;
-  reg        [31:0]   _zz_53_;
-  reg        [31:0]   _zz_54_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
+  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_54;
   wire       [31:0]   decode_PC;
   wire       [31:0]   decode_INSTRUCTION;
   wire                decode_IS_RVC;
@@ -1703,28 +748,47 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                DBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                DBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -1732,7 +796,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_55_;
+  reg                 _zz_55;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -1761,11 +825,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_56_;
-  wire       [3:0]    _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
-  wire                _zz_60_;
+  wire       [3:0]    _zz_56;
+  wire       [3:0]    _zz_57;
+  wire                _zz_58;
+  wire                _zz_59;
+  wire                _zz_60;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -1799,12 +863,12 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_1_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_1_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_1_halt;
-  wire                _zz_61_;
-  wire                _zz_62_;
+  wire                _zz_61;
+  wire                _zz_62;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_63_;
-  wire                _zz_64_;
-  reg                 _zz_65_;
+  wire                _zz_63;
+  wire                _zz_64;
+  reg                 _zz_65;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1835,34 +899,34 @@ module VexRiscv (
   wire                IBusCachedPlugin_decompressor_unaligned;
   wire       [31:0]   IBusCachedPlugin_decompressor_raw;
   wire                IBusCachedPlugin_decompressor_isRvc;
-  wire       [15:0]   _zz_66_;
+  wire       [15:0]   _zz_66;
   reg        [31:0]   IBusCachedPlugin_decompressor_decompressed;
-  wire       [4:0]    _zz_67_;
-  wire       [4:0]    _zz_68_;
-  wire       [11:0]   _zz_69_;
-  wire                _zz_70_;
-  reg        [11:0]   _zz_71_;
-  wire                _zz_72_;
-  reg        [9:0]    _zz_73_;
-  wire       [20:0]   _zz_74_;
-  wire                _zz_75_;
-  reg        [14:0]   _zz_76_;
-  wire                _zz_77_;
-  reg        [2:0]    _zz_78_;
-  wire                _zz_79_;
-  reg        [9:0]    _zz_80_;
-  wire       [20:0]   _zz_81_;
-  wire                _zz_82_;
-  reg        [4:0]    _zz_83_;
-  wire       [12:0]   _zz_84_;
-  wire       [4:0]    _zz_85_;
-  wire       [4:0]    _zz_86_;
-  wire       [4:0]    _zz_87_;
-  wire                _zz_88_;
-  reg        [2:0]    _zz_89_;
-  reg        [2:0]    _zz_90_;
-  wire                _zz_91_;
-  reg        [6:0]    _zz_92_;
+  wire       [4:0]    _zz_67;
+  wire       [4:0]    _zz_68;
+  wire       [11:0]   _zz_69;
+  wire                _zz_70;
+  reg        [11:0]   _zz_71;
+  wire                _zz_72;
+  reg        [9:0]    _zz_73;
+  wire       [20:0]   _zz_74;
+  wire                _zz_75;
+  reg        [14:0]   _zz_76;
+  wire                _zz_77;
+  reg        [2:0]    _zz_78;
+  wire                _zz_79;
+  reg        [9:0]    _zz_80;
+  wire       [20:0]   _zz_81;
+  wire                _zz_82;
+  reg        [4:0]    _zz_83;
+  wire       [12:0]   _zz_84;
+  wire       [4:0]    _zz_85;
+  wire       [4:0]    _zz_86;
+  wire       [4:0]    _zz_87;
+  wire                _zz_88;
+  reg        [2:0]    _zz_89;
+  reg        [2:0]    _zz_90;
+  wire                _zz_91;
+  reg        [6:0]    _zz_92;
   wire                IBusCachedPlugin_decompressor_bufferFill;
   wire                IBusCachedPlugin_injector_decodeInput_valid;
   wire                IBusCachedPlugin_injector_decodeInput_ready;
@@ -1870,22 +934,22 @@ module VexRiscv (
   wire                IBusCachedPlugin_injector_decodeInput_payload_rsp_error;
   wire       [31:0]   IBusCachedPlugin_injector_decodeInput_payload_rsp_inst;
   wire                IBusCachedPlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_93_;
-  reg        [31:0]   _zz_94_;
-  reg                 _zz_95_;
-  reg        [31:0]   _zz_96_;
-  reg                 _zz_97_;
+  reg                 _zz_93;
+  reg        [31:0]   _zz_94;
+  reg                 _zz_95;
+  reg        [31:0]   _zz_96;
+  reg                 _zz_97;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_0;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_1;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg        [31:0]   IBusCachedPlugin_injector_formal_rawInDecode;
-  wire                _zz_98_;
-  reg        [18:0]   _zz_99_;
-  wire                _zz_100_;
-  reg        [10:0]   _zz_101_;
-  wire                _zz_102_;
-  reg        [18:0]   _zz_103_;
+  wire                _zz_98;
+  reg        [18:0]   _zz_99;
+  wire                _zz_100;
+  reg        [10:0]   _zz_101;
+  wire                _zz_102;
+  reg        [18:0]   _zz_103;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1893,122 +957,117 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_104_;
+  wire       [31:0]   _zz_104;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_105_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_105;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_106_;
+  reg        [31:0]   _zz_106;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_107_;
-  reg        [31:0]   _zz_108_;
-  wire                _zz_109_;
-  reg        [31:0]   _zz_110_;
+  wire                _zz_107;
+  reg        [31:0]   _zz_108;
+  wire                _zz_109;
+  reg        [31:0]   _zz_110;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  wire       [32:0]   _zz_111_;
-  wire                _zz_112_;
-  wire                _zz_113_;
-  wire                _zz_114_;
-  wire                _zz_115_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_116_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_117_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_118_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_119_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_120_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_121_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_122_;
+  wire       [33:0]   _zz_111;
+  wire                _zz_112;
+  wire                _zz_113;
+  wire                _zz_114;
+  wire                _zz_115;
+  wire                _zz_116;
+  wire                _zz_117;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_118;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_119;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_120;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_121;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_122;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_123;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_124;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_123_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_125;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_124_;
-  reg        [31:0]   _zz_125_;
-  wire                _zz_126_;
-  reg        [19:0]   _zz_127_;
-  wire                _zz_128_;
-  reg        [19:0]   _zz_129_;
-  reg        [31:0]   _zz_130_;
+  reg        [31:0]   _zz_126;
+  reg        [31:0]   _zz_127;
+  wire                _zz_128;
+  reg        [19:0]   _zz_129;
+  wire                _zz_130;
+  reg        [19:0]   _zz_131;
+  reg        [31:0]   _zz_132;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_131_;
+  reg        [31:0]   _zz_133;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_132_;
-  reg                 _zz_133_;
-  reg                 _zz_134_;
-  reg                 _zz_135_;
-  reg        [4:0]    _zz_136_;
-  reg        [31:0]   _zz_137_;
-  wire                _zz_138_;
-  wire                _zz_139_;
-  wire                _zz_140_;
-  wire                _zz_141_;
-  wire                _zz_142_;
-  wire                _zz_143_;
+  reg        [31:0]   _zz_134;
+  reg                 _zz_135;
+  reg                 _zz_136;
+  reg                 _zz_137;
+  reg        [4:0]    _zz_138;
+  reg        [31:0]   _zz_139;
+  wire                _zz_140;
+  wire                _zz_141;
+  wire                _zz_142;
+  wire                _zz_143;
+  wire                _zz_144;
+  wire                _zz_145;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_144_;
-  reg                 _zz_145_;
-  reg                 _zz_146_;
+  wire       [2:0]    _zz_146;
+  reg                 _zz_147;
+  reg                 _zz_148;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_147_;
-  reg        [19:0]   _zz_148_;
-  wire                _zz_149_;
-  reg        [10:0]   _zz_150_;
-  wire                _zz_151_;
-  reg        [18:0]   _zz_152_;
+  wire                _zz_149;
+  reg        [19:0]   _zz_150;
+  wire                _zz_151;
+  reg        [10:0]   _zz_152;
+  wire                _zz_153;
+  reg        [18:0]   _zz_154;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
@@ -2030,9 +1089,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_153_;
-  wire                _zz_154_;
-  wire                _zz_155_;
+  wire                _zz_155;
+  wire                _zz_156;
+  wire                _zz_157;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -2045,8 +1104,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_156_;
-  wire                _zz_157_;
+  wire       [1:0]    _zz_158;
+  wire                _zz_159;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -2058,7 +1117,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2099,18 +1158,18 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_158_;
+  wire       [31:0]   _zz_160;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_159_;
-  wire                _zz_160_;
-  wire                _zz_161_;
-  reg        [32:0]   _zz_162_;
+  wire       [31:0]   _zz_161;
+  wire                _zz_162;
+  wire                _zz_163;
+  reg        [32:0]   _zz_164;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_163_;
-  wire       [31:0]   _zz_164_;
+  reg        [31:0]   _zz_165;
+  wire       [31:0]   _zz_166;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -2120,74 +1179,76 @@ module VexRiscv (
   reg                 DebugPlugin_godmode;
   reg                 DebugPlugin_haltedByBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_165_;
+  reg                 _zz_167;
   wire                DebugPlugin_allowEBreak;
-  reg                 _zz_166_;
+  reg                 _zz_168;
   reg                 DebugPlugin_resetIt_regNext;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg        [33:0]   execute_to_memory_MUL_HL;
-  reg        [31:0]   execute_to_memory_MUL_LL;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg                 decode_to_execute_IS_CSR;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg                 decode_to_execute_MEMORY_WR;
-  reg                 execute_to_memory_MEMORY_WR;
-  reg                 memory_to_writeBack_MEMORY_WR;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg                 decode_to_execute_IS_RVC;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg        [31:0]   decode_to_execute_RS1;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_RVC;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
+  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_LRSC;
   reg                 decode_to_execute_MEMORY_MANAGMENT;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
   reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
   reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
-  reg        [33:0]   execute_to_memory_MUL_LH;
   reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 memory_to_writeBack_IS_MUL;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg                 decode_to_execute_DO_EBREAK;
+  reg                 decode_to_execute_IS_CSR;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        [2:0]    _zz_167_;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 memory_to_writeBack_IS_MUL;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_DO_EBREAK;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  reg        [2:0]    _zz_169;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_3857;
   reg                 execute_CsrPlugin_csr_3858;
@@ -2212,109 +1273,110 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_3202;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_168_;
-  reg        [31:0]   _zz_169_;
-  reg        [31:0]   _zz_170_;
-  reg        [31:0]   _zz_171_;
-  reg        [31:0]   _zz_172_;
-  reg        [31:0]   _zz_173_;
-  reg        [31:0]   _zz_174_;
-  reg        [31:0]   _zz_175_;
-  reg        [31:0]   _zz_176_;
-  reg        [31:0]   _zz_177_;
-  reg        [31:0]   _zz_178_;
-  reg        [31:0]   _zz_179_;
-  reg        [31:0]   _zz_180_;
-  reg        [31:0]   _zz_181_;
-  reg        [31:0]   _zz_182_;
-  reg        [31:0]   _zz_183_;
-  reg        [31:0]   _zz_184_;
-  reg        [31:0]   _zz_185_;
-  reg        [31:0]   _zz_186_;
-  reg        [31:0]   _zz_187_;
-  reg        [31:0]   _zz_188_;
-  reg        [31:0]   _zz_189_;
-  reg        [31:0]   _zz_190_;
-  reg        [2:0]    _zz_191_;
-  reg                 _zz_192_;
+  reg        [31:0]   _zz_170;
+  reg        [31:0]   _zz_171;
+  reg        [31:0]   _zz_172;
+  reg        [31:0]   _zz_173;
+  reg        [31:0]   _zz_174;
+  reg        [31:0]   _zz_175;
+  reg        [31:0]   _zz_176;
+  reg        [31:0]   _zz_177;
+  reg        [31:0]   _zz_178;
+  reg        [31:0]   _zz_179;
+  reg        [31:0]   _zz_180;
+  reg        [31:0]   _zz_181;
+  reg        [31:0]   _zz_182;
+  reg        [31:0]   _zz_183;
+  reg        [31:0]   _zz_184;
+  reg        [31:0]   _zz_185;
+  reg        [31:0]   _zz_186;
+  reg        [31:0]   _zz_187;
+  reg        [31:0]   _zz_188;
+  reg        [31:0]   _zz_189;
+  reg        [31:0]   _zz_190;
+  reg        [31:0]   _zz_191;
+  reg        [31:0]   _zz_192;
+  reg        [2:0]    _zz_193;
+  reg                 _zz_194;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_193_;
-  wire                _zz_194_;
-  wire                _zz_195_;
-  wire                _zz_196_;
-  wire                _zz_197_;
-  wire                _zz_198_;
-  reg                 _zz_199_;
+  reg        [2:0]    _zz_195;
+  wire                _zz_196;
+  wire                _zz_197;
+  wire                _zz_198;
+  wire                _zz_199;
+  wire                _zz_200;
+  reg                 _zz_201;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_1__string;
-  reg [95:0] _zz_2__string;
-  reg [95:0] _zz_3__string;
-  reg [39:0] _zz_4__string;
-  reg [39:0] _zz_5__string;
-  reg [39:0] _zz_6__string;
-  reg [39:0] _zz_7__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_8__string;
-  reg [39:0] _zz_9__string;
-  reg [39:0] _zz_10__string;
-  reg [31:0] _zz_11__string;
-  reg [31:0] _zz_12__string;
-  reg [71:0] _zz_13__string;
-  reg [71:0] _zz_14__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
   reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_15__string;
-  reg [71:0] _zz_16__string;
-  reg [71:0] _zz_17__string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_18__string;
-  reg [39:0] _zz_19__string;
-  reg [39:0] _zz_20__string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_21__string;
-  reg [23:0] _zz_22__string;
-  reg [23:0] _zz_23__string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_24__string;
-  reg [63:0] _zz_25__string;
-  reg [63:0] _zz_26__string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [31:0] _zz_43__string;
-  reg [23:0] _zz_44__string;
-  reg [39:0] _zz_45__string;
-  reg [71:0] _zz_46__string;
-  reg [63:0] _zz_47__string;
-  reg [95:0] _zz_48__string;
-  reg [39:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52__string;
-  reg [39:0] _zz_116__string;
-  reg [95:0] _zz_117__string;
-  reg [63:0] _zz_118__string;
-  reg [71:0] _zz_119__string;
-  reg [39:0] _zz_120__string;
-  reg [23:0] _zz_121__string;
-  reg [31:0] _zz_122__string;
+  reg [31:0] _zz_52_string;
+  reg [95:0] _zz_118_string;
+  reg [63:0] _zz_119_string;
+  reg [23:0] _zz_120_string;
+  reg [39:0] _zz_121_string;
+  reg [71:0] _zz_122_string;
+  reg [31:0] _zz_123_string;
+  reg [39:0] _zz_124_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
@@ -2324,563 +1386,545 @@ module VexRiscv (
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_222_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_223_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_224_ = 1'b1;
-  assign _zz_225_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_226_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_227_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_228_ = ((_zz_202_ && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! _zz_51__2));
-  assign _zz_229_ = ((_zz_202_ && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! _zz_51__1));
-  assign _zz_230_ = ((_zz_202_ && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! _zz_51__0));
-  assign _zz_231_ = ((_zz_202_ && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_232_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_233_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_234_ = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_235_ = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00)) == 1'b0);
-  assign _zz_236_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_237_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_238_ = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_239_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_240_ = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
-  assign _zz_241_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_242_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_243_ = (1'b0 || (! 1'b1));
-  assign _zz_244_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_245_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_246_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_247_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_248_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_249_ = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_250_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_251_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_252_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_253_ = (! memory_arbitration_isStuck);
-  assign _zz_254_ = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_255_ = (iBus_cmd_valid || (_zz_191_ != (3'b000)));
-  assign _zz_256_ = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
-  assign _zz_257_ = (_zz_218_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_258_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_259_ = ((_zz_153_ && 1'b1) && (! 1'b0));
-  assign _zz_260_ = ((_zz_154_ && 1'b1) && (! 1'b0));
-  assign _zz_261_ = ((_zz_155_ && 1'b1) && (! 1'b0));
-  assign _zz_262_ = {_zz_66_[1 : 0],_zz_66_[15 : 13]};
-  assign _zz_263_ = _zz_66_[6 : 5];
-  assign _zz_264_ = _zz_66_[11 : 10];
-  assign _zz_265_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_266_ = execute_INSTRUCTION[13];
-  assign _zz_267_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_268_ = _zz_111_[30 : 30];
-  assign _zz_269_ = _zz_111_[6 : 6];
-  assign _zz_270_ = _zz_111_[18 : 18];
-  assign _zz_271_ = _zz_111_[28 : 28];
-  assign _zz_272_ = ($signed(_zz_274_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_273_ = _zz_272_[31 : 0];
-  assign _zz_274_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_275_ = _zz_111_[1 : 1];
-  assign _zz_276_ = _zz_111_[21 : 21];
-  assign _zz_277_ = _zz_111_[22 : 22];
-  assign _zz_278_ = _zz_111_[27 : 27];
-  assign _zz_279_ = ($signed(_zz_280_) + $signed(_zz_285_));
-  assign _zz_280_ = ($signed(_zz_281_) + $signed(_zz_283_));
-  assign _zz_281_ = 52'h0;
-  assign _zz_282_ = {1'b0,memory_MUL_LL};
-  assign _zz_283_ = {{19{_zz_282_[32]}}, _zz_282_};
-  assign _zz_284_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_285_ = {{2{_zz_284_[49]}}, _zz_284_};
-  assign _zz_286_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_287_ = {{2{_zz_286_[49]}}, _zz_286_};
-  assign _zz_288_ = _zz_111_[20 : 20];
-  assign _zz_289_ = _zz_111_[23 : 23];
-  assign _zz_290_ = (decode_IS_RVC ? (3'b010) : (3'b100));
-  assign _zz_291_ = {29'd0, _zz_290_};
-  assign _zz_292_ = _zz_111_[29 : 29];
-  assign _zz_293_ = _zz_111_[17 : 17];
-  assign _zz_294_ = _zz_111_[19 : 19];
-  assign _zz_295_ = _zz_111_[10 : 10];
-  assign _zz_296_ = _zz_111_[15 : 15];
-  assign _zz_297_ = _zz_111_[16 : 16];
-  assign _zz_298_ = _zz_111_[0 : 0];
-  assign _zz_299_ = _zz_111_[24 : 24];
-  assign _zz_300_ = (_zz_56_ - (4'b0001));
-  assign _zz_301_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_302_ = {29'd0, _zz_301_};
-  assign _zz_303_ = (decode_IS_RVC ? (3'b010) : (3'b100));
-  assign _zz_304_ = {29'd0, _zz_303_};
-  assign _zz_305_ = {{_zz_76_,_zz_66_[6 : 2]},12'h0};
-  assign _zz_306_ = {{{(4'b0000),_zz_66_[8 : 7]},_zz_66_[12 : 9]},(2'b00)};
-  assign _zz_307_ = {{{(4'b0000),_zz_66_[8 : 7]},_zz_66_[12 : 9]},(2'b00)};
-  assign _zz_308_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_309_ = {{_zz_99_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_310_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_311_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_312_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_313_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_314_ = execute_SRC_LESS;
-  assign _zz_315_ = (execute_IS_RVC ? (3'b010) : (3'b100));
-  assign _zz_316_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_317_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_318_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_319_ = ($signed(_zz_320_) + $signed(_zz_323_));
-  assign _zz_320_ = ($signed(_zz_321_) + $signed(_zz_322_));
-  assign _zz_321_ = execute_SRC1;
-  assign _zz_322_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_323_ = (execute_SRC_USE_SUB_LESS ? _zz_324_ : _zz_325_);
-  assign _zz_324_ = 32'h00000001;
-  assign _zz_325_ = 32'h0;
-  assign _zz_326_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_327_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_328_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_329_ = (execute_IS_RVC ? (3'b010) : (3'b100));
-  assign _zz_330_ = (_zz_156_ & (~ _zz_331_));
-  assign _zz_331_ = (_zz_156_ - (2'b01));
-  assign _zz_332_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_333_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_334_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_335_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_336_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_337_ = {5'd0, _zz_336_};
-  assign _zz_338_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_339_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_340_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_341_ = {_zz_158_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_342_ = _zz_343_;
-  assign _zz_343_ = _zz_344_;
-  assign _zz_344_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_159_) : _zz_159_)} + _zz_346_);
-  assign _zz_345_ = memory_DivPlugin_div_needRevert;
-  assign _zz_346_ = {32'd0, _zz_345_};
-  assign _zz_347_ = _zz_161_;
-  assign _zz_348_ = {32'd0, _zz_347_};
-  assign _zz_349_ = _zz_160_;
-  assign _zz_350_ = {31'd0, _zz_349_};
-  assign _zz_351_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_352_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_353_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_354_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_355_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_356_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_357_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_358_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_359_ = 1'b1;
-  assign _zz_360_ = 1'b1;
-  assign _zz_361_ = {_zz_60_,_zz_59_};
-  assign _zz_362_ = 32'h0000107f;
-  assign _zz_363_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_364_ = 32'h00002073;
-  assign _zz_365_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_366_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_367_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_368_) == 32'h00000003),{(_zz_369_ == _zz_370_),{_zz_371_,{_zz_372_,_zz_373_}}}}}};
-  assign _zz_368_ = 32'h0000505f;
-  assign _zz_369_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_370_ = 32'h00000063;
-  assign _zz_371_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_372_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_373_ = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_374_) == 32'h00001013),{(_zz_375_ == _zz_376_),{_zz_377_,{_zz_378_,_zz_379_}}}}}};
-  assign _zz_374_ = 32'hfc00307f;
-  assign _zz_375_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_376_ = 32'h00005033;
-  assign _zz_377_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_378_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_379_ = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
-  assign _zz_380_ = (_zz_66_[11 : 10] == (2'b01));
-  assign _zz_381_ = ((_zz_66_[11 : 10] == (2'b11)) && (_zz_66_[6 : 5] == (2'b00)));
-  assign _zz_382_ = 7'h0;
-  assign _zz_383_ = _zz_66_[6 : 2];
-  assign _zz_384_ = _zz_66_[12];
-  assign _zz_385_ = _zz_66_[11 : 7];
-  assign _zz_386_ = decode_INSTRUCTION[31];
-  assign _zz_387_ = decode_INSTRUCTION[19 : 12];
-  assign _zz_388_ = decode_INSTRUCTION[20];
-  assign _zz_389_ = decode_INSTRUCTION[31];
-  assign _zz_390_ = decode_INSTRUCTION[7];
-  assign _zz_391_ = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_392_ = 32'h00000004;
-  assign _zz_393_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_394_ = 32'h00000040;
-  assign _zz_395_ = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
-  assign _zz_396_ = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
-  assign _zz_397_ = ((decode_INSTRUCTION & 32'h10103050) == 32'h00100050);
-  assign _zz_398_ = (1'b0);
-  assign _zz_399_ = (_zz_113_ != (1'b0));
-  assign _zz_400_ = ((_zz_402_ == _zz_403_) != (1'b0));
-  assign _zz_401_ = {({_zz_404_,_zz_405_} != (2'b00)),{(_zz_406_ != _zz_407_),{_zz_408_,{_zz_409_,_zz_410_}}}};
-  assign _zz_402_ = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_403_ = 32'h00000020;
-  assign _zz_404_ = _zz_115_;
-  assign _zz_405_ = ((decode_INSTRUCTION & _zz_411_) == 32'h00000020);
-  assign _zz_406_ = {_zz_115_,(_zz_412_ == _zz_413_)};
-  assign _zz_407_ = (2'b00);
-  assign _zz_408_ = ((_zz_414_ == _zz_415_) != (1'b0));
-  assign _zz_409_ = ({_zz_416_,_zz_417_} != (2'b00));
-  assign _zz_410_ = {(_zz_418_ != _zz_419_),{_zz_420_,{_zz_421_,_zz_422_}}};
-  assign _zz_411_ = 32'h00000070;
-  assign _zz_412_ = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_413_ = 32'h0;
-  assign _zz_414_ = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz_415_ = 32'h00001008;
-  assign _zz_416_ = ((decode_INSTRUCTION & _zz_423_) == 32'h00001050);
-  assign _zz_417_ = ((decode_INSTRUCTION & _zz_424_) == 32'h00002050);
-  assign _zz_418_ = {(_zz_425_ == _zz_426_),{_zz_115_,{_zz_427_,_zz_428_}}};
-  assign _zz_419_ = 5'h0;
-  assign _zz_420_ = ((_zz_429_ == _zz_430_) != (1'b0));
-  assign _zz_421_ = ({_zz_431_,_zz_432_} != 5'h0);
-  assign _zz_422_ = {(_zz_433_ != _zz_434_),{_zz_435_,{_zz_436_,_zz_437_}}};
-  assign _zz_423_ = 32'h00001050;
-  assign _zz_424_ = 32'h00002050;
-  assign _zz_425_ = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_426_ = 32'h00000040;
-  assign _zz_427_ = ((decode_INSTRUCTION & _zz_438_) == 32'h00004020);
-  assign _zz_428_ = {(_zz_439_ == _zz_440_),(_zz_441_ == _zz_442_)};
-  assign _zz_429_ = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_430_ = 32'h02004020;
-  assign _zz_431_ = _zz_115_;
-  assign _zz_432_ = {(_zz_443_ == _zz_444_),{_zz_445_,{_zz_446_,_zz_447_}}};
-  assign _zz_433_ = {(_zz_448_ == _zz_449_),{_zz_450_,{_zz_451_,_zz_452_}}};
-  assign _zz_434_ = (4'b0000);
-  assign _zz_435_ = ((_zz_453_ == _zz_454_) != (1'b0));
-  assign _zz_436_ = ({_zz_455_,_zz_456_} != (2'b00));
-  assign _zz_437_ = {(_zz_457_ != _zz_458_),{_zz_459_,{_zz_460_,_zz_461_}}};
-  assign _zz_438_ = 32'h00004020;
-  assign _zz_439_ = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_440_ = 32'h00000010;
-  assign _zz_441_ = (decode_INSTRUCTION & 32'h02000020);
-  assign _zz_442_ = 32'h00000020;
-  assign _zz_443_ = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_444_ = 32'h00002010;
-  assign _zz_445_ = ((decode_INSTRUCTION & _zz_462_) == 32'h00000010);
-  assign _zz_446_ = (_zz_463_ == _zz_464_);
-  assign _zz_447_ = (_zz_465_ == _zz_466_);
-  assign _zz_448_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_449_ = 32'h0;
-  assign _zz_450_ = ((decode_INSTRUCTION & _zz_467_) == 32'h0);
-  assign _zz_451_ = (_zz_468_ == _zz_469_);
-  assign _zz_452_ = (_zz_470_ == _zz_471_);
-  assign _zz_453_ = (decode_INSTRUCTION & 32'h02004074);
-  assign _zz_454_ = 32'h02000030;
-  assign _zz_455_ = (_zz_472_ == _zz_473_);
-  assign _zz_456_ = (_zz_474_ == _zz_475_);
-  assign _zz_457_ = {_zz_114_,{_zz_476_,_zz_477_}};
-  assign _zz_458_ = 6'h0;
-  assign _zz_459_ = (_zz_478_ != (1'b0));
-  assign _zz_460_ = (_zz_479_ != _zz_480_);
-  assign _zz_461_ = {_zz_481_,{_zz_482_,_zz_483_}};
-  assign _zz_462_ = 32'h00001030;
-  assign _zz_463_ = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz_464_ = 32'h00002020;
-  assign _zz_465_ = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_466_ = 32'h00000020;
-  assign _zz_467_ = 32'h00000018;
-  assign _zz_468_ = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_469_ = 32'h00002000;
-  assign _zz_470_ = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_471_ = 32'h00001000;
-  assign _zz_472_ = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_473_ = 32'h00000020;
-  assign _zz_474_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_475_ = 32'h00000020;
-  assign _zz_476_ = (_zz_484_ == _zz_485_);
-  assign _zz_477_ = {_zz_486_,{_zz_487_,_zz_488_}};
-  assign _zz_478_ = ((decode_INSTRUCTION & _zz_489_) == 32'h00000024);
-  assign _zz_479_ = {_zz_490_,_zz_491_};
-  assign _zz_480_ = (2'b00);
-  assign _zz_481_ = (_zz_492_ != (1'b0));
-  assign _zz_482_ = (_zz_493_ != _zz_494_);
-  assign _zz_483_ = {_zz_495_,{_zz_496_,_zz_497_}};
-  assign _zz_484_ = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_485_ = 32'h00001010;
-  assign _zz_486_ = ((decode_INSTRUCTION & _zz_498_) == 32'h00002010);
-  assign _zz_487_ = (_zz_499_ == _zz_500_);
-  assign _zz_488_ = {_zz_501_,_zz_502_};
-  assign _zz_489_ = 32'h00000064;
-  assign _zz_490_ = ((decode_INSTRUCTION & _zz_503_) == 32'h10000050);
-  assign _zz_491_ = ((decode_INSTRUCTION & _zz_504_) == 32'h00000050);
-  assign _zz_492_ = ((decode_INSTRUCTION & _zz_505_) == 32'h00000050);
-  assign _zz_493_ = {_zz_506_,_zz_507_};
-  assign _zz_494_ = (2'b00);
-  assign _zz_495_ = ({_zz_508_,_zz_509_} != (3'b000));
-  assign _zz_496_ = (_zz_510_ != _zz_511_);
-  assign _zz_497_ = {_zz_512_,{_zz_513_,_zz_514_}};
-  assign _zz_498_ = 32'h00002010;
-  assign _zz_499_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_500_ = 32'h00000010;
-  assign _zz_501_ = ((decode_INSTRUCTION & _zz_515_) == 32'h00000004);
-  assign _zz_502_ = ((decode_INSTRUCTION & _zz_516_) == 32'h0);
-  assign _zz_503_ = 32'h10203050;
-  assign _zz_504_ = 32'h10103050;
-  assign _zz_505_ = 32'h00103050;
-  assign _zz_506_ = ((decode_INSTRUCTION & _zz_517_) == 32'h00005010);
-  assign _zz_507_ = ((decode_INSTRUCTION & _zz_518_) == 32'h00005020);
-  assign _zz_508_ = (_zz_519_ == _zz_520_);
-  assign _zz_509_ = {_zz_521_,_zz_522_};
-  assign _zz_510_ = {_zz_523_,{_zz_524_,_zz_525_}};
-  assign _zz_511_ = (3'b000);
-  assign _zz_512_ = ({_zz_526_,_zz_527_} != 5'h0);
-  assign _zz_513_ = (_zz_528_ != _zz_529_);
-  assign _zz_514_ = {_zz_530_,{_zz_531_,_zz_532_}};
-  assign _zz_515_ = 32'h0000000c;
-  assign _zz_516_ = 32'h00000028;
-  assign _zz_517_ = 32'h00007034;
-  assign _zz_518_ = 32'h02007064;
-  assign _zz_519_ = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_520_ = 32'h40001010;
-  assign _zz_521_ = ((decode_INSTRUCTION & _zz_533_) == 32'h00001010);
-  assign _zz_522_ = ((decode_INSTRUCTION & _zz_534_) == 32'h00001010);
-  assign _zz_523_ = ((decode_INSTRUCTION & _zz_535_) == 32'h00000040);
-  assign _zz_524_ = (_zz_536_ == _zz_537_);
-  assign _zz_525_ = (_zz_538_ == _zz_539_);
-  assign _zz_526_ = (_zz_540_ == _zz_541_);
-  assign _zz_527_ = {_zz_542_,{_zz_543_,_zz_544_}};
-  assign _zz_528_ = (_zz_545_ == _zz_546_);
-  assign _zz_529_ = (1'b0);
-  assign _zz_530_ = (_zz_547_ != (1'b0));
-  assign _zz_531_ = (_zz_548_ != _zz_549_);
-  assign _zz_532_ = {_zz_550_,{_zz_551_,_zz_552_}};
-  assign _zz_533_ = 32'h00007034;
-  assign _zz_534_ = 32'h02007054;
-  assign _zz_535_ = 32'h00000044;
-  assign _zz_536_ = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_537_ = 32'h00002010;
-  assign _zz_538_ = (decode_INSTRUCTION & 32'h40000034);
-  assign _zz_539_ = 32'h40000030;
-  assign _zz_540_ = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_541_ = 32'h00002040;
-  assign _zz_542_ = ((decode_INSTRUCTION & 32'h00001040) == 32'h00001040);
-  assign _zz_543_ = ((decode_INSTRUCTION & _zz_553_) == 32'h00000040);
-  assign _zz_544_ = {(_zz_554_ == _zz_555_),(_zz_556_ == _zz_557_)};
-  assign _zz_545_ = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_546_ = 32'h00004010;
-  assign _zz_547_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz_548_ = _zz_113_;
-  assign _zz_549_ = (1'b0);
-  assign _zz_550_ = ({_zz_558_,_zz_112_} != (2'b00));
-  assign _zz_551_ = ({_zz_559_,_zz_560_} != (2'b00));
-  assign _zz_552_ = {(_zz_561_ != _zz_562_),{_zz_563_,{_zz_564_,_zz_565_}}};
-  assign _zz_553_ = 32'h00100040;
-  assign _zz_554_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_555_ = 32'h00000040;
-  assign _zz_556_ = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_557_ = 32'h0;
-  assign _zz_558_ = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_559_ = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
-  assign _zz_560_ = _zz_112_;
-  assign _zz_561_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
-  assign _zz_562_ = (1'b0);
-  assign _zz_563_ = (((decode_INSTRUCTION & 32'h00003000) == 32'h00002000) != (1'b0));
-  assign _zz_564_ = (((decode_INSTRUCTION & _zz_566_) == 32'h00004008) != (1'b0));
-  assign _zz_565_ = (((decode_INSTRUCTION & _zz_567_) == 32'h0) != (1'b0));
-  assign _zz_566_ = 32'h00004048;
-  assign _zz_567_ = 32'h00000058;
-  assign _zz_568_ = execute_INSTRUCTION[31];
-  assign _zz_569_ = execute_INSTRUCTION[31];
-  assign _zz_570_ = execute_INSTRUCTION[7];
-  assign _zz_571_ = 32'h0;
+  assign _zz_235 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_236 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_237 = 1'b1;
+  assign _zz_238 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_239 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_240 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_241 = ((_zz_204 && IBusCachedPlugin_cache_io_cpu_fetch_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_242 = ((_zz_204 && IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_243 = ((_zz_204 && IBusCachedPlugin_cache_io_cpu_fetch_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_244 = ((_zz_204 && IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_245 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_246 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_247 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign _zz_248 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign _zz_249 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_250 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_251 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign _zz_252 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_253 = (IBusCachedPlugin_jump_pcLoad_valid && ((! decode_arbitration_isStuck) || decode_arbitration_removeIt));
+  assign _zz_254 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_255 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_256 = (1'b0 || (! 1'b1));
+  assign _zz_257 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_258 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_259 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_260 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_261 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_262 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_263 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_264 = execute_INSTRUCTION[13 : 12];
+  assign _zz_265 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_266 = (! memory_arbitration_isStuck);
+  assign _zz_267 = debug_bus_cmd_payload_address[7 : 2];
+  assign _zz_268 = (iBus_cmd_valid || (_zz_193 != 3'b000));
+  assign _zz_269 = (IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid);
+  assign _zz_270 = (_zz_231 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_271 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_272 = ((_zz_155 && 1'b1) && (! 1'b0));
+  assign _zz_273 = ((_zz_156 && 1'b1) && (! 1'b0));
+  assign _zz_274 = ((_zz_157 && 1'b1) && (! 1'b0));
+  assign _zz_275 = {_zz_66[1 : 0],_zz_66[15 : 13]};
+  assign _zz_276 = _zz_66[6 : 5];
+  assign _zz_277 = _zz_66[11 : 10];
+  assign _zz_278 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_279 = execute_INSTRUCTION[13];
+  assign _zz_280 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_281 = ($signed(_zz_282) + $signed(_zz_287));
+  assign _zz_282 = ($signed(_zz_283) + $signed(_zz_285));
+  assign _zz_283 = 52'h0;
+  assign _zz_284 = {1'b0,memory_MUL_LL};
+  assign _zz_285 = {{19{_zz_284[32]}}, _zz_284};
+  assign _zz_286 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_287 = {{2{_zz_286[49]}}, _zz_286};
+  assign _zz_288 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_289 = {{2{_zz_288[49]}}, _zz_288};
+  assign _zz_290 = ($signed(_zz_292) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_291 = _zz_290[31 : 0];
+  assign _zz_292 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_293 = _zz_111[32 : 32];
+  assign _zz_294 = _zz_111[31 : 31];
+  assign _zz_295 = _zz_111[30 : 30];
+  assign _zz_296 = _zz_111[29 : 29];
+  assign _zz_297 = _zz_111[26 : 26];
+  assign _zz_298 = _zz_111[19 : 19];
+  assign _zz_299 = _zz_111[18 : 18];
+  assign _zz_300 = _zz_111[13 : 13];
+  assign _zz_301 = _zz_111[12 : 12];
+  assign _zz_302 = _zz_111[11 : 11];
+  assign _zz_303 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_304 = {29'd0, _zz_303};
+  assign _zz_305 = _zz_111[33 : 33];
+  assign _zz_306 = _zz_111[16 : 16];
+  assign _zz_307 = _zz_111[5 : 5];
+  assign _zz_308 = _zz_111[3 : 3];
+  assign _zz_309 = _zz_111[17 : 17];
+  assign _zz_310 = _zz_111[10 : 10];
+  assign _zz_311 = _zz_111[15 : 15];
+  assign _zz_312 = _zz_111[4 : 4];
+  assign _zz_313 = _zz_111[0 : 0];
+  assign _zz_314 = (_zz_56 - 4'b0001);
+  assign _zz_315 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_316 = {29'd0, _zz_315};
+  assign _zz_317 = (decode_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_318 = {29'd0, _zz_317};
+  assign _zz_319 = {{_zz_76,_zz_66[6 : 2]},12'h0};
+  assign _zz_320 = {{{4'b0000,_zz_66[8 : 7]},_zz_66[12 : 9]},2'b00};
+  assign _zz_321 = {{{4'b0000,_zz_66[8 : 7]},_zz_66[12 : 9]},2'b00};
+  assign _zz_322 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_323 = {{_zz_99,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_324 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_325 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_326 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_327 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_328 = execute_SRC_LESS;
+  assign _zz_329 = (execute_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_330 = execute_INSTRUCTION[19 : 15];
+  assign _zz_331 = execute_INSTRUCTION[31 : 20];
+  assign _zz_332 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_333 = ($signed(_zz_334) + $signed(_zz_337));
+  assign _zz_334 = ($signed(_zz_335) + $signed(_zz_336));
+  assign _zz_335 = execute_SRC1;
+  assign _zz_336 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_337 = (execute_SRC_USE_SUB_LESS ? _zz_338 : _zz_339);
+  assign _zz_338 = 32'h00000001;
+  assign _zz_339 = 32'h0;
+  assign _zz_340 = execute_INSTRUCTION[31 : 20];
+  assign _zz_341 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_342 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_343 = (execute_IS_RVC ? 3'b010 : 3'b100);
+  assign _zz_344 = (_zz_158 & (~ _zz_345));
+  assign _zz_345 = (_zz_158 - 2'b01);
+  assign _zz_346 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_347 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_348 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_349 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_350 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_351 = {5'd0, _zz_350};
+  assign _zz_352 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_353 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_354 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_355 = {_zz_160,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_356 = _zz_357;
+  assign _zz_357 = _zz_358;
+  assign _zz_358 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_161) : _zz_161)} + _zz_360);
+  assign _zz_359 = memory_DivPlugin_div_needRevert;
+  assign _zz_360 = {32'd0, _zz_359};
+  assign _zz_361 = _zz_163;
+  assign _zz_362 = {32'd0, _zz_361};
+  assign _zz_363 = _zz_162;
+  assign _zz_364 = {31'd0, _zz_363};
+  assign _zz_365 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_366 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_367 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_368 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_369 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_370 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_371 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_372 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_373 = 1'b1;
+  assign _zz_374 = 1'b1;
+  assign _zz_375 = {_zz_60,_zz_59};
+  assign _zz_376 = 32'h0000107f;
+  assign _zz_377 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_378 = 32'h00002073;
+  assign _zz_379 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_380 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_381 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_382) == 32'h00000003),{(_zz_383 == _zz_384),{_zz_385,{_zz_386,_zz_387}}}}}};
+  assign _zz_382 = 32'h0000505f;
+  assign _zz_383 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_384 = 32'h00000063;
+  assign _zz_385 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_386 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_387 = {((decode_INSTRUCTION & 32'hf800707f) == 32'h1800202f),{((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & _zz_388) == 32'h00005013),{(_zz_389 == _zz_390),{_zz_391,{_zz_392,_zz_393}}}}}};
+  assign _zz_388 = 32'hbc00707f;
+  assign _zz_389 = (decode_INSTRUCTION & 32'hfc00307f);
+  assign _zz_390 = 32'h00001013;
+  assign _zz_391 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_392 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_393 = {((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073),{((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)}}};
+  assign _zz_394 = (_zz_66[11 : 10] == 2'b01);
+  assign _zz_395 = ((_zz_66[11 : 10] == 2'b11) && (_zz_66[6 : 5] == 2'b00));
+  assign _zz_396 = 7'h0;
+  assign _zz_397 = _zz_66[6 : 2];
+  assign _zz_398 = _zz_66[12];
+  assign _zz_399 = _zz_66[11 : 7];
+  assign _zz_400 = decode_INSTRUCTION[31];
+  assign _zz_401 = decode_INSTRUCTION[19 : 12];
+  assign _zz_402 = decode_INSTRUCTION[20];
+  assign _zz_403 = decode_INSTRUCTION[31];
+  assign _zz_404 = decode_INSTRUCTION[7];
+  assign _zz_405 = 32'h10103050;
+  assign _zz_406 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz_407 = 1'b0;
+  assign _zz_408 = (((decode_INSTRUCTION & _zz_411) == 32'h02000030) != 1'b0);
+  assign _zz_409 = ({_zz_412,_zz_413} != 2'b00);
+  assign _zz_410 = {(_zz_414 != 1'b0),{(_zz_415 != _zz_416),{_zz_417,{_zz_418,_zz_419}}}};
+  assign _zz_411 = 32'h02004074;
+  assign _zz_412 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
+  assign _zz_413 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz_414 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
+  assign _zz_415 = {(_zz_420 == _zz_421),(_zz_422 == _zz_423)};
+  assign _zz_416 = 2'b00;
+  assign _zz_417 = ({_zz_113,_zz_424} != 2'b00);
+  assign _zz_418 = (_zz_425 != 1'b0);
+  assign _zz_419 = {(_zz_426 != _zz_427),{_zz_428,{_zz_429,_zz_430}}};
+  assign _zz_420 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_421 = 32'h00001050;
+  assign _zz_422 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_423 = 32'h00002050;
+  assign _zz_424 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_425 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_426 = {(_zz_431 == _zz_432),(_zz_433 == _zz_434)};
+  assign _zz_427 = 2'b00;
+  assign _zz_428 = ({_zz_435,{_zz_436,_zz_437}} != 3'b000);
+  assign _zz_429 = (_zz_438 != 1'b0);
+  assign _zz_430 = {(_zz_439 != _zz_440),{_zz_441,{_zz_442,_zz_443}}};
+  assign _zz_431 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_432 = 32'h00005010;
+  assign _zz_433 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz_434 = 32'h00005020;
+  assign _zz_435 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz_436 = ((decode_INSTRUCTION & _zz_444) == 32'h00001010);
+  assign _zz_437 = ((decode_INSTRUCTION & _zz_445) == 32'h00001010);
+  assign _zz_438 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz_439 = ((decode_INSTRUCTION & _zz_446) == 32'h00002000);
+  assign _zz_440 = 1'b0;
+  assign _zz_441 = ({_zz_447,_zz_448} != 2'b00);
+  assign _zz_442 = (_zz_449 != 1'b0);
+  assign _zz_443 = {(_zz_450 != _zz_451),{_zz_452,{_zz_453,_zz_454}}};
+  assign _zz_444 = 32'h00007034;
+  assign _zz_445 = 32'h02007054;
+  assign _zz_446 = 32'h00003000;
+  assign _zz_447 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz_448 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz_449 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz_450 = ((decode_INSTRUCTION & _zz_455) == 32'h00000024);
+  assign _zz_451 = 1'b0;
+  assign _zz_452 = ({_zz_456,{_zz_457,_zz_458}} != 3'b000);
+  assign _zz_453 = (_zz_459 != 1'b0);
+  assign _zz_454 = {(_zz_460 != _zz_461),{_zz_462,{_zz_463,_zz_464}}};
+  assign _zz_455 = 32'h00000064;
+  assign _zz_456 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz_457 = ((decode_INSTRUCTION & _zz_465) == 32'h00000020);
+  assign _zz_458 = ((decode_INSTRUCTION & _zz_466) == 32'h08000020);
+  assign _zz_459 = ((decode_INSTRUCTION & 32'h00000008) == 32'h00000008);
+  assign _zz_460 = {(_zz_467 == _zz_468),{_zz_469,{_zz_470,_zz_471}}};
+  assign _zz_461 = 6'h0;
+  assign _zz_462 = ({_zz_472,_zz_473} != 2'b00);
+  assign _zz_463 = ({_zz_474,_zz_475} != 5'h0);
+  assign _zz_464 = {(_zz_476 != _zz_477),{_zz_478,{_zz_479,_zz_480}}};
+  assign _zz_465 = 32'h00000064;
+  assign _zz_466 = 32'h08000070;
+  assign _zz_467 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz_468 = 32'h00002040;
+  assign _zz_469 = ((decode_INSTRUCTION & _zz_481) == 32'h00001040);
+  assign _zz_470 = (_zz_482 == _zz_483);
+  assign _zz_471 = {_zz_484,{_zz_485,_zz_486}};
+  assign _zz_472 = ((decode_INSTRUCTION & _zz_487) == 32'h08000020);
+  assign _zz_473 = ((decode_INSTRUCTION & _zz_488) == 32'h00000020);
+  assign _zz_474 = (_zz_489 == _zz_490);
+  assign _zz_475 = {_zz_491,{_zz_492,_zz_493}};
+  assign _zz_476 = {_zz_116,{_zz_494,_zz_495}};
+  assign _zz_477 = 5'h0;
+  assign _zz_478 = ({_zz_496,_zz_497} != 7'h0);
+  assign _zz_479 = (_zz_498 != _zz_499);
+  assign _zz_480 = {_zz_500,{_zz_501,_zz_502}};
+  assign _zz_481 = 32'h00001040;
+  assign _zz_482 = (decode_INSTRUCTION & 32'h00100040);
+  assign _zz_483 = 32'h00000040;
+  assign _zz_484 = ((decode_INSTRUCTION & _zz_503) == 32'h00000040);
+  assign _zz_485 = (_zz_504 == _zz_505);
+  assign _zz_486 = (_zz_506 == _zz_507);
+  assign _zz_487 = 32'h08000020;
+  assign _zz_488 = 32'h00000028;
+  assign _zz_489 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_490 = 32'h00000040;
+  assign _zz_491 = ((decode_INSTRUCTION & _zz_508) == 32'h00004020);
+  assign _zz_492 = (_zz_509 == _zz_510);
+  assign _zz_493 = {_zz_116,_zz_511};
+  assign _zz_494 = (_zz_512 == _zz_513);
+  assign _zz_495 = {_zz_514,{_zz_515,_zz_516}};
+  assign _zz_496 = _zz_113;
+  assign _zz_497 = {_zz_517,{_zz_518,_zz_519}};
+  assign _zz_498 = {_zz_115,_zz_520};
+  assign _zz_499 = 2'b00;
+  assign _zz_500 = ({_zz_521,_zz_522} != 2'b00);
+  assign _zz_501 = (_zz_523 != _zz_524);
+  assign _zz_502 = {_zz_525,{_zz_526,_zz_527}};
+  assign _zz_503 = 32'h00000050;
+  assign _zz_504 = (decode_INSTRUCTION & 32'h08002008);
+  assign _zz_505 = 32'h00002008;
+  assign _zz_506 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_507 = 32'h0;
+  assign _zz_508 = 32'h00004020;
+  assign _zz_509 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_510 = 32'h00000010;
+  assign _zz_511 = ((decode_INSTRUCTION & _zz_528) == 32'h00000020);
+  assign _zz_512 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz_513 = 32'h00002010;
+  assign _zz_514 = ((decode_INSTRUCTION & _zz_529) == 32'h00000010);
+  assign _zz_515 = (_zz_530 == _zz_531);
+  assign _zz_516 = (_zz_532 == _zz_533);
+  assign _zz_517 = ((decode_INSTRUCTION & _zz_534) == 32'h00001010);
+  assign _zz_518 = (_zz_535 == _zz_536);
+  assign _zz_519 = {_zz_537,{_zz_538,_zz_539}};
+  assign _zz_520 = ((decode_INSTRUCTION & _zz_540) == 32'h00000020);
+  assign _zz_521 = _zz_115;
+  assign _zz_522 = (_zz_541 == _zz_542);
+  assign _zz_523 = (_zz_543 == _zz_544);
+  assign _zz_524 = 1'b0;
+  assign _zz_525 = (_zz_545 != 1'b0);
+  assign _zz_526 = (_zz_546 != _zz_547);
+  assign _zz_527 = {_zz_548,{_zz_549,_zz_550}};
+  assign _zz_528 = 32'h12000020;
+  assign _zz_529 = 32'h00001030;
+  assign _zz_530 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz_531 = 32'h00000020;
+  assign _zz_532 = (decode_INSTRUCTION & 32'h12002060);
+  assign _zz_533 = 32'h00002020;
+  assign _zz_534 = 32'h00001010;
+  assign _zz_535 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_536 = 32'h00002010;
+  assign _zz_537 = ((decode_INSTRUCTION & _zz_551) == 32'h00002008);
+  assign _zz_538 = (_zz_552 == _zz_553);
+  assign _zz_539 = {_zz_116,_zz_554};
+  assign _zz_540 = 32'h00000070;
+  assign _zz_541 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_542 = 32'h0;
+  assign _zz_543 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz_544 = 32'h00004010;
+  assign _zz_545 = ((decode_INSTRUCTION & _zz_555) == 32'h00002010);
+  assign _zz_546 = {_zz_556,{_zz_557,_zz_558}};
+  assign _zz_547 = 5'h0;
+  assign _zz_548 = ({_zz_559,_zz_560} != 2'b00);
+  assign _zz_549 = (_zz_561 != _zz_562);
+  assign _zz_550 = {_zz_563,{_zz_564,_zz_565}};
+  assign _zz_551 = 32'h00002008;
+  assign _zz_552 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_553 = 32'h00000010;
+  assign _zz_554 = ((decode_INSTRUCTION & _zz_566) == 32'h0);
+  assign _zz_555 = 32'h00006014;
+  assign _zz_556 = ((decode_INSTRUCTION & _zz_567) == 32'h0);
+  assign _zz_557 = (_zz_568 == _zz_569);
+  assign _zz_558 = {_zz_570,{_zz_571,_zz_572}};
+  assign _zz_559 = _zz_114;
+  assign _zz_560 = (_zz_573 == _zz_574);
+  assign _zz_561 = {_zz_575,{_zz_576,_zz_577}};
+  assign _zz_562 = 3'b000;
+  assign _zz_563 = ({_zz_578,_zz_579} != 3'b000);
+  assign _zz_564 = (_zz_580 != _zz_581);
+  assign _zz_565 = (_zz_582 != _zz_583);
+  assign _zz_566 = 32'h00000028;
+  assign _zz_567 = 32'h00000044;
+  assign _zz_568 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_569 = 32'h0;
+  assign _zz_570 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_571 = ((decode_INSTRUCTION & _zz_584) == 32'h00001000);
+  assign _zz_572 = _zz_114;
+  assign _zz_573 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_574 = 32'h0;
+  assign _zz_575 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_576 = ((decode_INSTRUCTION & _zz_585) == 32'h00002010);
+  assign _zz_577 = ((decode_INSTRUCTION & _zz_586) == 32'h40000030);
+  assign _zz_578 = _zz_113;
+  assign _zz_579 = {_zz_112,(_zz_587 == _zz_588)};
+  assign _zz_580 = {_zz_112,(_zz_589 == _zz_590)};
+  assign _zz_581 = 2'b00;
+  assign _zz_582 = ((decode_INSTRUCTION & _zz_591) == 32'h00001008);
+  assign _zz_583 = 1'b0;
+  assign _zz_584 = 32'h00005004;
+  assign _zz_585 = 32'h00002014;
+  assign _zz_586 = 32'h40000034;
+  assign _zz_587 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz_588 = 32'h00000004;
+  assign _zz_589 = (decode_INSTRUCTION & 32'h0000004c);
+  assign _zz_590 = 32'h00000004;
+  assign _zz_591 = 32'h00005048;
+  assign _zz_592 = execute_INSTRUCTION[31];
+  assign _zz_593 = execute_INSTRUCTION[31];
+  assign _zz_594 = execute_INSTRUCTION[7];
+  assign _zz_595 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_359_) begin
-      _zz_219_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_373) begin
+      _zz_232 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_360_) begin
-      _zz_220_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_374) begin
+      _zz_233 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_200_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_201_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_202_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_203_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_cacheMiss                       (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss                        ), //o
-    .io_cpu_fetch_error                           (IBusCachedPlugin_cache_io_cpu_fetch_error                            ), //o
-    .io_cpu_fetch_mmuRefilling                    (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling                     ), //o
-    .io_cpu_fetch_mmuException                    (IBusCachedPlugin_cache_io_cpu_fetch_mmuException                     ), //o
-    .io_cpu_fetch_isUser                          (_zz_204_                                                             ), //i
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_205_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_206_                                                             ), //i
-    .io_cpu_decode_pc                             (_zz_207_[31:0]                                                       ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_fill_valid                            (_zz_208_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_202                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_203                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_204                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_205                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_206                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_fetch_cacheMiss                   (IBusCachedPlugin_cache_io_cpu_fetch_cacheMiss               ), //o
+    .io_cpu_fetch_error                       (IBusCachedPlugin_cache_io_cpu_fetch_error                   ), //o
+    .io_cpu_fetch_mmuRefilling                (IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling            ), //o
+    .io_cpu_fetch_mmuException                (IBusCachedPlugin_cache_io_cpu_fetch_mmuException            ), //o
+    .io_cpu_fetch_isUser                      (_zz_207                                                     ), //i
+    .io_cpu_decode_isValid                    (_zz_208                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_209                                                     ), //i
+    .io_cpu_decode_pc                         (_zz_210[31:0]                                               ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_fill_valid                        (_zz_211                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_209_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_210_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (execute_MEMORY_WR                                           ), //i
-    .io_cpu_execute_args_data                      (_zz_106_[31:0]                                              ), //i
-    .io_cpu_execute_args_size                      (execute_DBusCachedPlugin_size[1:0]                          ), //i
-    .io_cpu_memory_isValid                         (_zz_211_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_212_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_213_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_214_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_215_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_216_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_217_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_218_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_212                                            ), //i
+    .io_cpu_execute_address                    (_zz_213[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
+    .io_cpu_execute_args_data                  (_zz_106[31:0]                                      ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
+    .io_cpu_execute_args_isLrsc                (_zz_214                                            ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_215                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_216[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_217                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_writeBack_isValid                  (_zz_218                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_219                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_220[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_221                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_222                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_223                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_224                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_225                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_226                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_227                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_228                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_229[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_230                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_231                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_361_)
+    case(_zz_375)
       2'b00 : begin
-        _zz_221_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_234 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_221_ = CsrPlugin_jumpInterface_payload;
+        _zz_234 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_221_ = BranchPlugin_jumpInterface_payload;
+        _zz_234 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_221_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_234 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_1_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_1__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_1__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_1__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_1__string = "URS1        ";
-      default : _zz_1__string = "????????????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_2__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_2__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_2__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_2__string = "URS1        ";
-      default : _zz_2__string = "????????????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_3__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_3__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_3__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_3__string = "URS1        ";
-      default : _zz_3__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4__string = "ECALL";
-      default : _zz_4__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5__string = "ECALL";
-      default : _zz_5__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6__string = "ECALL";
-      default : _zz_6__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7__string = "ECALL";
-      default : _zz_7__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2893,66 +1937,66 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_8__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8__string = "ECALL";
-      default : _zz_8__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_9_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_9__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9__string = "ECALL";
-      default : _zz_9__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_10_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_10__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10__string = "ECALL";
-      default : _zz_10__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_11_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_11__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_11__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_11__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_11__string = "JALR";
-      default : _zz_11__string = "????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_12_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_12__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_12__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_12__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_12__string = "JALR";
-      default : _zz_12__string = "????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_13_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13__string = "SRA_1    ";
-      default : _zz_13__string = "?????????";
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_14_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14__string = "SRA_1    ";
-      default : _zz_14__string = "?????????";
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2965,30 +2009,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_15_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15__string = "SRA_1    ";
-      default : _zz_15__string = "?????????";
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_16_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_16__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_16__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_16__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_16__string = "SRA_1    ";
-      default : _zz_16__string = "?????????";
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_17_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17__string = "SRA_1    ";
-      default : _zz_17__string = "?????????";
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3000,27 +2044,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_18_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18__string = "AND_1";
-      default : _zz_18__string = "?????";
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_19_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_19__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_19__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_19__string = "AND_1";
-      default : _zz_19__string = "?????";
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_20_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_20__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_20__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_20__string = "AND_1";
-      default : _zz_20__string = "?????";
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3033,30 +2077,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_21__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_21__string = "PC ";
-      default : _zz_21__string = "???";
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_22__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_22__string = "PC ";
-      default : _zz_22__string = "???";
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_23__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_23__string = "PC ";
-      default : _zz_23__string = "???";
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
     endcase
   end
   always @(*) begin
@@ -3068,27 +2112,63 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24__string = "BITWISE ";
-      default : _zz_24__string = "????????";
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_25__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_25__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_25__string = "BITWISE ";
-      default : _zz_25__string = "????????";
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_26__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_26__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_26__string = "BITWISE ";
-      default : _zz_26__string = "????????";
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3101,12 +2181,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3119,12 +2199,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3137,12 +2217,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3155,12 +2235,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -3173,12 +2253,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3191,12 +2271,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3209,12 +2289,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -3227,12 +2307,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3244,11 +2324,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3260,72 +2340,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_43__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_43__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_43__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_43__string = "JALR";
-      default : _zz_43__string = "????";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_44__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_44__string = "PC ";
-      default : _zz_44__string = "???";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_45__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_45__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_45__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_45__string = "ECALL";
-      default : _zz_45__string = "?????";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46__string = "SRA_1    ";
-      default : _zz_46__string = "?????????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_47__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_47__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_47__string = "BITWISE ";
-      default : _zz_47__string = "????????";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_48__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_48__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_48__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_48__string = "URS1        ";
-      default : _zz_48__string = "????????????";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_49__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_49__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_49__string = "AND_1";
-      default : _zz_49__string = "?????";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3338,73 +2418,82 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52__string = "JALR";
-      default : _zz_52__string = "????";
+    case(_zz_52)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
+      default : _zz_52_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_116_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_116__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_116__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_116__string = "AND_1";
-      default : _zz_116__string = "?????";
+    case(_zz_118)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_118_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_118_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_118_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_118_string = "URS1        ";
+      default : _zz_118_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_117_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_117__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_117__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_117__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_117__string = "URS1        ";
-      default : _zz_117__string = "????????????";
+    case(_zz_119)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_119_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_119_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_119_string = "BITWISE ";
+      default : _zz_119_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_118_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_118__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_118__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_118__string = "BITWISE ";
-      default : _zz_118__string = "????????";
+    case(_zz_120)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_120_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_120_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_120_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_120_string = "PC ";
+      default : _zz_120_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_119_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_119__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_119__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_119__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_119__string = "SRA_1    ";
-      default : _zz_119__string = "?????????";
+    case(_zz_121)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_121_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_121_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_121_string = "AND_1";
+      default : _zz_121_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_120_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_120__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_120__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_120__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_120__string = "ECALL";
-      default : _zz_120__string = "?????";
+    case(_zz_122)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_122_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_122_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_122_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_122_string = "SRA_1    ";
+      default : _zz_122_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_121_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_121__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_121__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_121__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_121__string = "PC ";
-      default : _zz_121__string = "???";
+    case(_zz_123)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_123_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_123_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_123_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_123_string = "JALR";
+      default : _zz_123_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_122_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_122__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_122__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_122__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_122__string = "JALR";
-      default : _zz_122__string = "????";
+    case(_zz_124)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_124_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_124_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_124_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_124_string = "ECALL";
+      default : _zz_124_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3486,71 +2575,63 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
-    endcase
-  end
   `endif
 
-  assign decode_SRC1_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
-  assign _zz_4_ = _zz_5_;
-  assign _zz_6_ = _zz_7_;
-  assign decode_ENV_CTRL = _zz_8_;
-  assign _zz_9_ = _zz_10_;
-  assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
-  assign decode_SRC_LESS_UNSIGNED = _zz_268_[0];
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign execute_REGFILE_WRITE_DATA = _zz_124_;
-  assign decode_IS_RS1_SIGNED = _zz_269_[0];
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_270_[0];
-  assign _zz_11_ = _zz_12_;
-  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign decode_IS_RS2_SIGNED = _zz_271_[0];
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_210_[1 : 0];
-  assign _zz_13_ = _zz_14_;
-  assign decode_SHIFT_CTRL = _zz_15_;
-  assign _zz_16_ = _zz_17_;
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign execute_SHIFT_RIGHT = _zz_273_;
-  assign decode_MEMORY_MANAGMENT = _zz_275_[0];
-  assign decode_IS_DIV = _zz_276_[0];
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign memory_MUL_LOW = ($signed(_zz_281) + $signed(_zz_289));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_277_[0];
-  assign decode_ALU_BITWISE_CTRL = _zz_18_;
-  assign _zz_19_ = _zz_20_;
-  assign decode_SRC2_CTRL = _zz_21_;
-  assign _zz_22_ = _zz_23_;
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_278_[0];
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_SHIFT_RIGHT = _zz_291;
+  assign execute_REGFILE_WRITE_DATA = _zz_126;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_213[1 : 0];
+  assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign memory_MUL_LOW = ($signed(_zz_279_) + $signed(_zz_287_));
-  assign memory_PC = execute_to_memory_PC;
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_288_[0];
-  assign decode_IS_CSR = _zz_289_[0];
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_293[0];
+  assign decode_IS_RS1_SIGNED = _zz_294[0];
+  assign decode_IS_DIV = _zz_295[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_296[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_297[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_298[0];
+  assign decode_MEMORY_MANAGMENT = _zz_299[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_300[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_301[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_302[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_51;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
-  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_291_);
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign decode_ALU_CTRL = _zz_24_;
-  assign _zz_25_ = _zz_26_;
+  assign decode_FORMAL_PC_NEXT = (decode_PC + _zz_304);
+  assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_292_[0];
+  assign decode_IS_EBREAK = _zz_305[0];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -3564,22 +2645,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_146_;
+  assign execute_BRANCH_COND_RESULT = _zz_148;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_293_[0];
-  assign decode_RS1_USE = _zz_294_[0];
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_306[0];
+  assign decode_RS1_USE = _zz_307[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_222_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_235)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
   end
 
@@ -3591,29 +2672,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_135_)begin
-      if((_zz_136_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_137_;
+    if(_zz_137)begin
+      if((_zz_138 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_139;
       end
     end
-    if(_zz_223_)begin
-      if(_zz_224_)begin
-        if(_zz_139_)begin
-          decode_RS2 = _zz_50_;
+    if(_zz_236)begin
+      if(_zz_237)begin
+        if(_zz_141)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_225_)begin
+    if(_zz_238)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_141_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_143)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_226_)begin
+    if(_zz_239)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_143_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_145)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -3621,29 +2702,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_135_)begin
-      if((_zz_136_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_137_;
+    if(_zz_137)begin
+      if((_zz_138 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_139;
       end
     end
-    if(_zz_223_)begin
-      if(_zz_224_)begin
-        if(_zz_138_)begin
-          decode_RS1 = _zz_50_;
+    if(_zz_236)begin
+      if(_zz_237)begin
+        if(_zz_140)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_225_)begin
+    if(_zz_238)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_140_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_142)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_226_)begin
+    if(_zz_239)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_142_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_144)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -3651,71 +2732,71 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_132_;
+          _zz_32 = _zz_134;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_227_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_240)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
   assign execute_IS_RVC = decode_to_execute_IS_RVC;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_295_[0];
-  assign decode_SRC_ADD_ZERO = _zz_296_[0];
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_308[0];
+  assign decode_SRC_ADD_ZERO = _zz_309[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_130_;
-  assign execute_SRC1 = _zz_125_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_132;
+  assign execute_SRC1 = _zz_127;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_decompressor_output_payload_rsp_inst);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_297_[0];
+    decode_REGFILE_WRITE_VALID = _zz_310[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_362_) == 32'h00001073),{(_zz_363_ == _zz_364_),{_zz_365_,{_zz_366_,_zz_367_}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_376) == 32'h00001073),{(_zz_377 == _zz_378),{_zz_379,{_zz_380,_zz_381}}}}}}} != 23'h0);
   always @ (*) begin
-    _zz_50_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_267_)
+      case(_zz_280)
         2'b00 : begin
-          _zz_50_ = _zz_334_;
+          _zz_50 = _zz_348;
         end
         default : begin
-          _zz_50_ = _zz_335_;
+          _zz_50 = _zz_349;
         end
       endcase
     end
@@ -3727,54 +2808,57 @@ module VexRiscv (
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
+  assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_298_[0];
-  assign decode_FLUSH_ALL = _zz_299_[0];
+  assign decode_MEMORY_LRSC = _zz_311[0];
+  assign decode_MEMORY_ENABLE = _zz_312[0];
+  assign decode_FLUSH_ALL = _zz_313[0];
   always @ (*) begin
-    _zz_51_ = _zz_51__2;
-    if(_zz_228_)begin
-      _zz_51_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_241)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(_zz_229_)begin
-      _zz_51__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_242)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(_zz_230_)begin
-      _zz_51__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_243)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_231_)begin
-      _zz_51__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_244)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52_;
+  assign decode_BRANCH_CTRL = _zz_52;
   always @ (*) begin
-    _zz_53_ = memory_FORMAL_PC_NEXT;
+    _zz_53 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_53_ = BranchPlugin_jumpInterface_payload;
+      _zz_53 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_54_ = decode_FORMAL_PC_NEXT;
+    _zz_54 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_54_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_54 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -3788,17 +2872,9 @@ module VexRiscv (
     if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_167_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_169)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
-      end
-      3'b011 : begin
-      end
-      3'b100 : begin
       end
       default : begin
       end
@@ -3807,20 +2883,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_133_ || _zz_134_)))begin
+    if((decode_arbitration_isValid && (_zz_135 || _zz_136)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_232_)begin
+    if(_zz_245)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3834,25 +2910,22 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_232_)begin
+    if(_zz_245)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_217_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_230 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_233_)begin
+    if(_zz_246)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_222_)begin
+    if(_zz_235)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -3861,7 +2934,10 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(_zz_234_)begin
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+    if(_zz_247)begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -3878,8 +2954,8 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_234_)begin
-      if(_zz_235_)begin
+    if(_zz_247)begin
+      if(_zz_248)begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -3890,19 +2966,19 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_234_)begin
-      if(_zz_235_)begin
+    if(_zz_247)begin
+      if(_zz_248)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
-    if(_zz_166_)begin
+    if(_zz_168)begin
       execute_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_227_)begin
+    if(_zz_240)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -3927,7 +3003,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -3958,10 +3034,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_236_)begin
+    if(_zz_249)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_237_)begin
+    if(_zz_250)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -3972,24 +3048,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_236_)begin
+    if(_zz_249)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_237_)begin
+    if(_zz_250)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_234_)begin
-      if(_zz_235_)begin
+    if(_zz_247)begin
+      if(_zz_248)begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_238_)begin
+    if(_zz_251)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -4005,15 +3081,15 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_55_ = 1'b0;
+    _zz_55 = 1'b0;
     if(DebugPlugin_godmode)begin
-      _zz_55_ = 1'b1;
+      _zz_55 = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_233_)begin
+    if(_zz_246)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -4027,21 +3103,21 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_236_)begin
+    if(_zz_249)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_237_)begin
+    if(_zz_250)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_236_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_249)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_237_)begin
-      case(_zz_239_)
+    if(_zz_250)begin
+      case(_zz_252)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4072,14 +3148,14 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_56_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_57_ = (_zz_56_ & (~ _zz_300_));
-  assign _zz_58_ = _zz_57_[3];
-  assign _zz_59_ = (_zz_57_[1] || _zz_58_);
-  assign _zz_60_ = (_zz_57_[2] || _zz_58_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_221_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
+  assign _zz_56 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_57 = (_zz_56 & (~ _zz_314));
+  assign _zz_58 = _zz_57[3];
+  assign _zz_59 = (_zz_57[1] || _zz_58);
+  assign _zz_60 = (_zz_57[2] || _zz_58);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_234;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -4099,7 +3175,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_302_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_316);
     if(IBusCachedPlugin_fetchPc_inc)begin
       IBusCachedPlugin_fetchPc_pc[1] = 1'b0;
     end
@@ -4126,15 +3202,15 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_output_payload = IBusCachedPlugin_fetchPc_pc;
   always @ (*) begin
     IBusCachedPlugin_decodePc_flushed = 1'b0;
-    if(_zz_240_)begin
+    if(_zz_253)begin
       IBusCachedPlugin_decodePc_flushed = 1'b1;
     end
   end
 
-  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_304_);
+  assign IBusCachedPlugin_decodePc_pcPlus = (IBusCachedPlugin_decodePc_pcReg + _zz_318);
   always @ (*) begin
     IBusCachedPlugin_decodePc_injectedDecode = 1'b0;
-    if((_zz_167_ != (3'b000)))begin
+    if((_zz_169 != 3'b000))begin
       IBusCachedPlugin_decodePc_injectedDecode = 1'b1;
     end
   end
@@ -4156,23 +3232,23 @@ module VexRiscv (
     end
   end
 
-  assign _zz_61_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_61_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_61_);
+  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_61);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_61);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
-    if((_zz_51_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_62_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_62_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_62_);
+  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_62);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_62);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   always @ (*) begin
@@ -4183,10 +3259,10 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_iBusRsp_flush = (IBusCachedPlugin_externalFlush || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63_;
-  assign _zz_63_ = ((1'b0 && (! _zz_64_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_64_ = _zz_65_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
+  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_64 = _zz_65;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
@@ -4203,194 +3279,194 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = IBusCachedPlugin_decompressor_input_ready;
   assign IBusCachedPlugin_decompressor_flushNext = 1'b0;
   assign IBusCachedPlugin_decompressor_consumeCurrent = 1'b0;
-  assign IBusCachedPlugin_decompressor_isInputLowRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[1 : 0] != (2'b11));
-  assign IBusCachedPlugin_decompressor_isInputHighRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[17 : 16] != (2'b11));
+  assign IBusCachedPlugin_decompressor_isInputLowRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[1 : 0] != 2'b11);
+  assign IBusCachedPlugin_decompressor_isInputHighRvc = (IBusCachedPlugin_decompressor_input_payload_rsp_inst[17 : 16] != 2'b11);
   assign IBusCachedPlugin_decompressor_throw2Bytes = (IBusCachedPlugin_decompressor_throw2BytesReg || IBusCachedPlugin_decompressor_input_payload_pc[1]);
   assign IBusCachedPlugin_decompressor_unaligned = (IBusCachedPlugin_decompressor_throw2Bytes || IBusCachedPlugin_decompressor_bufferValid);
   assign IBusCachedPlugin_decompressor_raw = (IBusCachedPlugin_decompressor_bufferValid ? {IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0],IBusCachedPlugin_decompressor_bufferData} : {IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16],(IBusCachedPlugin_decompressor_throw2Bytes ? IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16] : IBusCachedPlugin_decompressor_input_payload_rsp_inst[15 : 0])});
-  assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != (2'b11));
-  assign _zz_66_ = IBusCachedPlugin_decompressor_raw[15 : 0];
+  assign IBusCachedPlugin_decompressor_isRvc = (IBusCachedPlugin_decompressor_raw[1 : 0] != 2'b11);
+  assign _zz_66 = IBusCachedPlugin_decompressor_raw[15 : 0];
   always @ (*) begin
     IBusCachedPlugin_decompressor_decompressed = 32'h0;
-    case(_zz_262_)
-      5'b00000 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{(2'b00),_zz_66_[10 : 7]},_zz_66_[12 : 11]},_zz_66_[5]},_zz_66_[6]},(2'b00)},5'h02},(3'b000)},_zz_68_},7'h13};
+    case(_zz_275)
+      5'h0 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{{2'b00,_zz_66[10 : 7]},_zz_66[12 : 11]},_zz_66[5]},_zz_66[6]},2'b00},5'h02},3'b000},_zz_68},7'h13};
       end
-      5'b00010 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_69_,_zz_67_},(3'b010)},_zz_68_},7'h03};
+      5'h02 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_69,_zz_67},3'b010},_zz_68},7'h03};
       end
-      5'b00110 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_69_[11 : 5],_zz_68_},_zz_67_},(3'b010)},_zz_69_[4 : 0]},7'h23};
+      5'h06 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_69[11 : 5],_zz_68},_zz_67},3'b010},_zz_69[4 : 0]},7'h23};
       end
-      5'b01000 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_71_,_zz_66_[11 : 7]},(3'b000)},_zz_66_[11 : 7]},7'h13};
+      5'h08 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_71,_zz_66[11 : 7]},3'b000},_zz_66[11 : 7]},7'h13};
       end
-      5'b01001 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_74_[20],_zz_74_[10 : 1]},_zz_74_[11]},_zz_74_[19 : 12]},_zz_86_},7'h6f};
+      5'h09 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_74[20],_zz_74[10 : 1]},_zz_74[11]},_zz_74[19 : 12]},_zz_86},7'h6f};
       end
-      5'b01010 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_71_,5'h0},(3'b000)},_zz_66_[11 : 7]},7'h13};
+      5'h0a : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{_zz_71,5'h0},3'b000},_zz_66[11 : 7]},7'h13};
       end
-      5'b01011 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_66_[11 : 7] == 5'h02) ? {{{{{{{{{_zz_78_,_zz_66_[4 : 3]},_zz_66_[5]},_zz_66_[2]},_zz_66_[6]},(4'b0000)},_zz_66_[11 : 7]},(3'b000)},_zz_66_[11 : 7]},7'h13} : {{_zz_305_[31 : 12],_zz_66_[11 : 7]},7'h37});
+      5'h0b : begin
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_66[11 : 7] == 5'h02) ? {{{{{{{{{_zz_78,_zz_66[4 : 3]},_zz_66[5]},_zz_66[2]},_zz_66[6]},4'b0000},_zz_66[11 : 7]},3'b000},_zz_66[11 : 7]},7'h13} : {{_zz_319[31 : 12],_zz_66[11 : 7]},7'h37});
       end
-      5'b01100 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_66_[11 : 10] == (2'b10)) ? _zz_92_ : {{(1'b0),(_zz_380_ || _zz_381_)},5'h0}),(((! _zz_66_[11]) || _zz_88_) ? _zz_66_[6 : 2] : _zz_68_)},_zz_67_},_zz_90_},_zz_67_},(_zz_88_ ? 7'h13 : 7'h33)};
+      5'h0c : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{((_zz_66[11 : 10] == 2'b10) ? _zz_92 : {{1'b0,(_zz_394 || _zz_395)},5'h0}),(((! _zz_66[11]) || _zz_88) ? _zz_66[6 : 2] : _zz_68)},_zz_67},_zz_90},_zz_67},(_zz_88 ? 7'h13 : 7'h33)};
       end
-      5'b01101 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_81_[20],_zz_81_[10 : 1]},_zz_81_[11]},_zz_81_[19 : 12]},_zz_85_},7'h6f};
+      5'h0d : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_81[20],_zz_81[10 : 1]},_zz_81[11]},_zz_81[19 : 12]},_zz_85},7'h6f};
       end
-      5'b01110 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_84_[12],_zz_84_[10 : 5]},_zz_85_},_zz_67_},(3'b000)},_zz_84_[4 : 1]},_zz_84_[11]},7'h63};
+      5'h0e : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_84[12],_zz_84[10 : 5]},_zz_85},_zz_67},3'b000},_zz_84[4 : 1]},_zz_84[11]},7'h63};
       end
-      5'b01111 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_84_[12],_zz_84_[10 : 5]},_zz_85_},_zz_67_},(3'b001)},_zz_84_[4 : 1]},_zz_84_[11]},7'h63};
+      5'h0f : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{_zz_84[12],_zz_84[10 : 5]},_zz_85},_zz_67},3'b001},_zz_84[4 : 1]},_zz_84[11]},7'h63};
       end
-      5'b10000 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_66_[6 : 2]},_zz_66_[11 : 7]},(3'b001)},_zz_66_[11 : 7]},7'h13};
+      5'h10 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{7'h0,_zz_66[6 : 2]},_zz_66[11 : 7]},3'b001},_zz_66[11 : 7]},7'h13};
       end
-      5'b10010 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{(4'b0000),_zz_66_[3 : 2]},_zz_66_[12]},_zz_66_[6 : 4]},(2'b00)},_zz_87_},(3'b010)},_zz_66_[11 : 7]},7'h03};
+      5'h12 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{{{{4'b0000,_zz_66[3 : 2]},_zz_66[12]},_zz_66[6 : 4]},2'b00},_zz_87},3'b010},_zz_66[11 : 7]},7'h03};
       end
-      5'b10100 : begin
-        IBusCachedPlugin_decompressor_decompressed = ((_zz_66_[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_66_[6 : 2] == 5'h0) ? {{{{12'h0,_zz_66_[11 : 7]},(3'b000)},(_zz_66_[12] ? _zz_86_ : _zz_85_)},7'h67} : {{{{{_zz_382_,_zz_383_},(_zz_384_ ? _zz_385_ : _zz_85_)},(3'b000)},_zz_66_[11 : 7]},7'h33}));
+      5'h14 : begin
+        IBusCachedPlugin_decompressor_decompressed = ((_zz_66[12 : 2] == 11'h400) ? 32'h00100073 : ((_zz_66[6 : 2] == 5'h0) ? {{{{12'h0,_zz_66[11 : 7]},3'b000},(_zz_66[12] ? _zz_86 : _zz_85)},7'h67} : {{{{{_zz_396,_zz_397},(_zz_398 ? _zz_399 : _zz_85)},3'b000},_zz_66[11 : 7]},7'h33}));
       end
-      5'b10110 : begin
-        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_306_[11 : 5],_zz_66_[6 : 2]},_zz_87_},(3'b010)},_zz_307_[4 : 0]},7'h23};
+      5'h16 : begin
+        IBusCachedPlugin_decompressor_decompressed = {{{{{_zz_320[11 : 5],_zz_66[6 : 2]},_zz_87},3'b010},_zz_321[4 : 0]},7'h23};
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_67_ = {(2'b01),_zz_66_[9 : 7]};
-  assign _zz_68_ = {(2'b01),_zz_66_[4 : 2]};
-  assign _zz_69_ = {{{{5'h0,_zz_66_[5]},_zz_66_[12 : 10]},_zz_66_[6]},(2'b00)};
-  assign _zz_70_ = _zz_66_[12];
+  assign _zz_67 = {2'b01,_zz_66[9 : 7]};
+  assign _zz_68 = {2'b01,_zz_66[4 : 2]};
+  assign _zz_69 = {{{{5'h0,_zz_66[5]},_zz_66[12 : 10]},_zz_66[6]},2'b00};
+  assign _zz_70 = _zz_66[12];
   always @ (*) begin
-    _zz_71_[11] = _zz_70_;
-    _zz_71_[10] = _zz_70_;
-    _zz_71_[9] = _zz_70_;
-    _zz_71_[8] = _zz_70_;
-    _zz_71_[7] = _zz_70_;
-    _zz_71_[6] = _zz_70_;
-    _zz_71_[5] = _zz_70_;
-    _zz_71_[4 : 0] = _zz_66_[6 : 2];
+    _zz_71[11] = _zz_70;
+    _zz_71[10] = _zz_70;
+    _zz_71[9] = _zz_70;
+    _zz_71[8] = _zz_70;
+    _zz_71[7] = _zz_70;
+    _zz_71[6] = _zz_70;
+    _zz_71[5] = _zz_70;
+    _zz_71[4 : 0] = _zz_66[6 : 2];
   end
 
-  assign _zz_72_ = _zz_66_[12];
+  assign _zz_72 = _zz_66[12];
   always @ (*) begin
-    _zz_73_[9] = _zz_72_;
-    _zz_73_[8] = _zz_72_;
-    _zz_73_[7] = _zz_72_;
-    _zz_73_[6] = _zz_72_;
-    _zz_73_[5] = _zz_72_;
-    _zz_73_[4] = _zz_72_;
-    _zz_73_[3] = _zz_72_;
-    _zz_73_[2] = _zz_72_;
-    _zz_73_[1] = _zz_72_;
-    _zz_73_[0] = _zz_72_;
+    _zz_73[9] = _zz_72;
+    _zz_73[8] = _zz_72;
+    _zz_73[7] = _zz_72;
+    _zz_73[6] = _zz_72;
+    _zz_73[5] = _zz_72;
+    _zz_73[4] = _zz_72;
+    _zz_73[3] = _zz_72;
+    _zz_73[2] = _zz_72;
+    _zz_73[1] = _zz_72;
+    _zz_73[0] = _zz_72;
   end
 
-  assign _zz_74_ = {{{{{{{{_zz_73_,_zz_66_[8]},_zz_66_[10 : 9]},_zz_66_[6]},_zz_66_[7]},_zz_66_[2]},_zz_66_[11]},_zz_66_[5 : 3]},(1'b0)};
-  assign _zz_75_ = _zz_66_[12];
+  assign _zz_74 = {{{{{{{{_zz_73,_zz_66[8]},_zz_66[10 : 9]},_zz_66[6]},_zz_66[7]},_zz_66[2]},_zz_66[11]},_zz_66[5 : 3]},1'b0};
+  assign _zz_75 = _zz_66[12];
   always @ (*) begin
-    _zz_76_[14] = _zz_75_;
-    _zz_76_[13] = _zz_75_;
-    _zz_76_[12] = _zz_75_;
-    _zz_76_[11] = _zz_75_;
-    _zz_76_[10] = _zz_75_;
-    _zz_76_[9] = _zz_75_;
-    _zz_76_[8] = _zz_75_;
-    _zz_76_[7] = _zz_75_;
-    _zz_76_[6] = _zz_75_;
-    _zz_76_[5] = _zz_75_;
-    _zz_76_[4] = _zz_75_;
-    _zz_76_[3] = _zz_75_;
-    _zz_76_[2] = _zz_75_;
-    _zz_76_[1] = _zz_75_;
-    _zz_76_[0] = _zz_75_;
+    _zz_76[14] = _zz_75;
+    _zz_76[13] = _zz_75;
+    _zz_76[12] = _zz_75;
+    _zz_76[11] = _zz_75;
+    _zz_76[10] = _zz_75;
+    _zz_76[9] = _zz_75;
+    _zz_76[8] = _zz_75;
+    _zz_76[7] = _zz_75;
+    _zz_76[6] = _zz_75;
+    _zz_76[5] = _zz_75;
+    _zz_76[4] = _zz_75;
+    _zz_76[3] = _zz_75;
+    _zz_76[2] = _zz_75;
+    _zz_76[1] = _zz_75;
+    _zz_76[0] = _zz_75;
   end
 
-  assign _zz_77_ = _zz_66_[12];
+  assign _zz_77 = _zz_66[12];
   always @ (*) begin
-    _zz_78_[2] = _zz_77_;
-    _zz_78_[1] = _zz_77_;
-    _zz_78_[0] = _zz_77_;
+    _zz_78[2] = _zz_77;
+    _zz_78[1] = _zz_77;
+    _zz_78[0] = _zz_77;
   end
 
-  assign _zz_79_ = _zz_66_[12];
+  assign _zz_79 = _zz_66[12];
   always @ (*) begin
-    _zz_80_[9] = _zz_79_;
-    _zz_80_[8] = _zz_79_;
-    _zz_80_[7] = _zz_79_;
-    _zz_80_[6] = _zz_79_;
-    _zz_80_[5] = _zz_79_;
-    _zz_80_[4] = _zz_79_;
-    _zz_80_[3] = _zz_79_;
-    _zz_80_[2] = _zz_79_;
-    _zz_80_[1] = _zz_79_;
-    _zz_80_[0] = _zz_79_;
+    _zz_80[9] = _zz_79;
+    _zz_80[8] = _zz_79;
+    _zz_80[7] = _zz_79;
+    _zz_80[6] = _zz_79;
+    _zz_80[5] = _zz_79;
+    _zz_80[4] = _zz_79;
+    _zz_80[3] = _zz_79;
+    _zz_80[2] = _zz_79;
+    _zz_80[1] = _zz_79;
+    _zz_80[0] = _zz_79;
   end
 
-  assign _zz_81_ = {{{{{{{{_zz_80_,_zz_66_[8]},_zz_66_[10 : 9]},_zz_66_[6]},_zz_66_[7]},_zz_66_[2]},_zz_66_[11]},_zz_66_[5 : 3]},(1'b0)};
-  assign _zz_82_ = _zz_66_[12];
+  assign _zz_81 = {{{{{{{{_zz_80,_zz_66[8]},_zz_66[10 : 9]},_zz_66[6]},_zz_66[7]},_zz_66[2]},_zz_66[11]},_zz_66[5 : 3]},1'b0};
+  assign _zz_82 = _zz_66[12];
   always @ (*) begin
-    _zz_83_[4] = _zz_82_;
-    _zz_83_[3] = _zz_82_;
-    _zz_83_[2] = _zz_82_;
-    _zz_83_[1] = _zz_82_;
-    _zz_83_[0] = _zz_82_;
+    _zz_83[4] = _zz_82;
+    _zz_83[3] = _zz_82;
+    _zz_83[2] = _zz_82;
+    _zz_83[1] = _zz_82;
+    _zz_83[0] = _zz_82;
   end
 
-  assign _zz_84_ = {{{{{_zz_83_,_zz_66_[6 : 5]},_zz_66_[2]},_zz_66_[11 : 10]},_zz_66_[4 : 3]},(1'b0)};
-  assign _zz_85_ = 5'h0;
-  assign _zz_86_ = 5'h01;
-  assign _zz_87_ = 5'h02;
-  assign _zz_88_ = (_zz_66_[11 : 10] != (2'b11));
+  assign _zz_84 = {{{{{_zz_83,_zz_66[6 : 5]},_zz_66[2]},_zz_66[11 : 10]},_zz_66[4 : 3]},1'b0};
+  assign _zz_85 = 5'h0;
+  assign _zz_86 = 5'h01;
+  assign _zz_87 = 5'h02;
+  assign _zz_88 = (_zz_66[11 : 10] != 2'b11);
   always @ (*) begin
-    case(_zz_263_)
+    case(_zz_276)
       2'b00 : begin
-        _zz_89_ = (3'b000);
+        _zz_89 = 3'b000;
       end
       2'b01 : begin
-        _zz_89_ = (3'b100);
+        _zz_89 = 3'b100;
       end
       2'b10 : begin
-        _zz_89_ = (3'b110);
+        _zz_89 = 3'b110;
       end
       default : begin
-        _zz_89_ = (3'b111);
+        _zz_89 = 3'b111;
       end
     endcase
   end
 
   always @ (*) begin
-    case(_zz_264_)
+    case(_zz_277)
       2'b00 : begin
-        _zz_90_ = (3'b101);
+        _zz_90 = 3'b101;
       end
       2'b01 : begin
-        _zz_90_ = (3'b101);
+        _zz_90 = 3'b101;
       end
       2'b10 : begin
-        _zz_90_ = (3'b111);
+        _zz_90 = 3'b111;
       end
       default : begin
-        _zz_90_ = _zz_89_;
+        _zz_90 = _zz_89;
       end
     endcase
   end
 
-  assign _zz_91_ = _zz_66_[12];
+  assign _zz_91 = _zz_66[12];
   always @ (*) begin
-    _zz_92_[6] = _zz_91_;
-    _zz_92_[5] = _zz_91_;
-    _zz_92_[4] = _zz_91_;
-    _zz_92_[3] = _zz_91_;
-    _zz_92_[2] = _zz_91_;
-    _zz_92_[1] = _zz_91_;
-    _zz_92_[0] = _zz_91_;
+    _zz_92[6] = _zz_91;
+    _zz_92[5] = _zz_91;
+    _zz_92[4] = _zz_91;
+    _zz_92[3] = _zz_91;
+    _zz_92[2] = _zz_91;
+    _zz_92[1] = _zz_91;
+    _zz_92[0] = _zz_91;
   end
 
   assign IBusCachedPlugin_decompressor_output_valid = (IBusCachedPlugin_decompressor_input_valid && (! ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_bufferValid)) && (! IBusCachedPlugin_decompressor_isInputHighRvc))));
@@ -4400,11 +3476,11 @@ module VexRiscv (
   assign IBusCachedPlugin_decompressor_input_ready = (IBusCachedPlugin_decompressor_output_ready && (((! IBusCachedPlugin_iBusRsp_stages_1_input_valid) || IBusCachedPlugin_decompressor_flushNext) || ((! (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc)) && (! (((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc)))));
   assign IBusCachedPlugin_decompressor_bufferFill = (((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && (! IBusCachedPlugin_decompressor_isInputHighRvc)) || (IBusCachedPlugin_decompressor_bufferValid && (! IBusCachedPlugin_decompressor_isInputHighRvc))) || ((IBusCachedPlugin_decompressor_throw2Bytes && (! IBusCachedPlugin_decompressor_isRvc)) && (! IBusCachedPlugin_decompressor_isInputHighRvc)));
   assign IBusCachedPlugin_decompressor_output_ready = ((1'b0 && (! IBusCachedPlugin_injector_decodeInput_valid)) || IBusCachedPlugin_injector_decodeInput_ready);
-  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_93_;
-  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_94_;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_95_;
-  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_96_;
-  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_97_;
+  assign IBusCachedPlugin_injector_decodeInput_valid = _zz_93;
+  assign IBusCachedPlugin_injector_decodeInput_payload_pc = _zz_94;
+  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_error = _zz_95;
+  assign IBusCachedPlugin_injector_decodeInput_payload_rsp_inst = _zz_96;
+  assign IBusCachedPlugin_injector_decodeInput_payload_isRvc = _zz_97;
   assign IBusCachedPlugin_pcValids_0 = IBusCachedPlugin_injector_nextPcCalc_valids_0;
   assign IBusCachedPlugin_pcValids_1 = IBusCachedPlugin_injector_nextPcCalc_valids_1;
   assign IBusCachedPlugin_pcValids_2 = IBusCachedPlugin_injector_nextPcCalc_valids_2;
@@ -4412,88 +3488,82 @@ module VexRiscv (
   assign IBusCachedPlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
   always @ (*) begin
     decode_arbitration_isValid = IBusCachedPlugin_injector_decodeInput_valid;
-    case(_zz_167_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_169)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
       3'b011 : begin
         decode_arbitration_isValid = 1'b1;
       end
-      3'b100 : begin
-      end
       default : begin
       end
     endcase
   end
 
-  assign _zz_98_ = _zz_308_[11];
+  assign _zz_98 = _zz_322[11];
   always @ (*) begin
-    _zz_99_[18] = _zz_98_;
-    _zz_99_[17] = _zz_98_;
-    _zz_99_[16] = _zz_98_;
-    _zz_99_[15] = _zz_98_;
-    _zz_99_[14] = _zz_98_;
-    _zz_99_[13] = _zz_98_;
-    _zz_99_[12] = _zz_98_;
-    _zz_99_[11] = _zz_98_;
-    _zz_99_[10] = _zz_98_;
-    _zz_99_[9] = _zz_98_;
-    _zz_99_[8] = _zz_98_;
-    _zz_99_[7] = _zz_98_;
-    _zz_99_[6] = _zz_98_;
-    _zz_99_[5] = _zz_98_;
-    _zz_99_[4] = _zz_98_;
-    _zz_99_[3] = _zz_98_;
-    _zz_99_[2] = _zz_98_;
-    _zz_99_[1] = _zz_98_;
-    _zz_99_[0] = _zz_98_;
+    _zz_99[18] = _zz_98;
+    _zz_99[17] = _zz_98;
+    _zz_99[16] = _zz_98;
+    _zz_99[15] = _zz_98;
+    _zz_99[14] = _zz_98;
+    _zz_99[13] = _zz_98;
+    _zz_99[12] = _zz_98;
+    _zz_99[11] = _zz_98;
+    _zz_99[10] = _zz_98;
+    _zz_99[9] = _zz_98;
+    _zz_99[8] = _zz_98;
+    _zz_99[7] = _zz_98;
+    _zz_99[6] = _zz_98;
+    _zz_99[5] = _zz_98;
+    _zz_99[4] = _zz_98;
+    _zz_99[3] = _zz_98;
+    _zz_99[2] = _zz_98;
+    _zz_99[1] = _zz_98;
+    _zz_99[0] = _zz_98;
   end
 
-  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_309_[31]));
+  assign IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_323[31]));
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_100_ = _zz_310_[19];
+  assign _zz_100 = _zz_324[19];
   always @ (*) begin
-    _zz_101_[10] = _zz_100_;
-    _zz_101_[9] = _zz_100_;
-    _zz_101_[8] = _zz_100_;
-    _zz_101_[7] = _zz_100_;
-    _zz_101_[6] = _zz_100_;
-    _zz_101_[5] = _zz_100_;
-    _zz_101_[4] = _zz_100_;
-    _zz_101_[3] = _zz_100_;
-    _zz_101_[2] = _zz_100_;
-    _zz_101_[1] = _zz_100_;
-    _zz_101_[0] = _zz_100_;
+    _zz_101[10] = _zz_100;
+    _zz_101[9] = _zz_100;
+    _zz_101[8] = _zz_100;
+    _zz_101[7] = _zz_100;
+    _zz_101[6] = _zz_100;
+    _zz_101[5] = _zz_100;
+    _zz_101[4] = _zz_100;
+    _zz_101[3] = _zz_100;
+    _zz_101[2] = _zz_100;
+    _zz_101[1] = _zz_100;
+    _zz_101[0] = _zz_100;
   end
 
-  assign _zz_102_ = _zz_311_[11];
+  assign _zz_102 = _zz_325[11];
   always @ (*) begin
-    _zz_103_[18] = _zz_102_;
-    _zz_103_[17] = _zz_102_;
-    _zz_103_[16] = _zz_102_;
-    _zz_103_[15] = _zz_102_;
-    _zz_103_[14] = _zz_102_;
-    _zz_103_[13] = _zz_102_;
-    _zz_103_[12] = _zz_102_;
-    _zz_103_[11] = _zz_102_;
-    _zz_103_[10] = _zz_102_;
-    _zz_103_[9] = _zz_102_;
-    _zz_103_[8] = _zz_102_;
-    _zz_103_[7] = _zz_102_;
-    _zz_103_[6] = _zz_102_;
-    _zz_103_[5] = _zz_102_;
-    _zz_103_[4] = _zz_102_;
-    _zz_103_[3] = _zz_102_;
-    _zz_103_[2] = _zz_102_;
-    _zz_103_[1] = _zz_102_;
-    _zz_103_[0] = _zz_102_;
+    _zz_103[18] = _zz_102;
+    _zz_103[17] = _zz_102;
+    _zz_103[16] = _zz_102;
+    _zz_103[15] = _zz_102;
+    _zz_103[14] = _zz_102;
+    _zz_103[13] = _zz_102;
+    _zz_103[12] = _zz_102;
+    _zz_103[11] = _zz_102;
+    _zz_103[10] = _zz_102;
+    _zz_103[9] = _zz_102;
+    _zz_103[8] = _zz_102;
+    _zz_103[7] = _zz_102;
+    _zz_103[6] = _zz_102;
+    _zz_103[5] = _zz_102;
+    _zz_103[4] = _zz_102;
+    _zz_103[3] = _zz_102;
+    _zz_103[2] = _zz_102;
+    _zz_103[1] = _zz_102;
+    _zz_103[0] = _zz_102;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_101_,{{{_zz_386_,_zz_387_},_zz_388_},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_103_,{{{_zz_389_,_zz_390_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_101,{{{_zz_400,_zz_401},_zz_402},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_103,{{{_zz_403,_zz_404},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4502,121 +3572,142 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_201_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_202_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_203_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_204_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_203 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_204 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_205 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_204;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_207 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_231_)begin
+    if(_zz_244)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_229_)begin
+    if(_zz_242)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_208_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
-    if(_zz_229_)begin
-      _zz_208_ = 1'b1;
+    _zz_211 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_fetch_mmuRefilling));
+    if(_zz_242)begin
+      _zz_211 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_230_)begin
+    if(_zz_243)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_228_)begin
+    if(_zz_241)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_230_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_243)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_228_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_241)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_1_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_1_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_fetch_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_1_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_200_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_218_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_202 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_231 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  always @ (*) begin
+    _zz_51 = 1'b0;
+    if(decode_INSTRUCTION[25])begin
+      if(decode_MEMORY_LRSC)begin
+        _zz_51 = 1'b1;
+      end
+    end
+  end
+
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_209_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_210_ = execute_SRC_ADD;
+  assign _zz_212 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_213 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_106_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_106 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_106_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_106 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_106_ = execute_RS2[31 : 0];
+        _zz_106 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_217_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_211_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_212_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+  assign _zz_230 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
   always @ (*) begin
-    _zz_213_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_55_ && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_213_ = 1'b1;
+    _zz_214 = 1'b0;
+    if(execute_MEMORY_LRSC)begin
+      _zz_214 = 1'b1;
     end
   end
 
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_214_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_215_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_216_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_215 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_216 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_215;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_216;
+  assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  always @ (*) begin
+    _zz_217 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((_zz_55 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_217 = 1'b1;
+    end
+  end
+
+  assign _zz_218 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_219 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_220 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_241_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_254)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -4625,17 +3716,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_241_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_254)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -4643,94 +3734,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_241_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_312_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_254)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_326};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_313_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_327};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_107_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_107 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_108_[31] = _zz_107_;
-    _zz_108_[30] = _zz_107_;
-    _zz_108_[29] = _zz_107_;
-    _zz_108_[28] = _zz_107_;
-    _zz_108_[27] = _zz_107_;
-    _zz_108_[26] = _zz_107_;
-    _zz_108_[25] = _zz_107_;
-    _zz_108_[24] = _zz_107_;
-    _zz_108_[23] = _zz_107_;
-    _zz_108_[22] = _zz_107_;
-    _zz_108_[21] = _zz_107_;
-    _zz_108_[20] = _zz_107_;
-    _zz_108_[19] = _zz_107_;
-    _zz_108_[18] = _zz_107_;
-    _zz_108_[17] = _zz_107_;
-    _zz_108_[16] = _zz_107_;
-    _zz_108_[15] = _zz_107_;
-    _zz_108_[14] = _zz_107_;
-    _zz_108_[13] = _zz_107_;
-    _zz_108_[12] = _zz_107_;
-    _zz_108_[11] = _zz_107_;
-    _zz_108_[10] = _zz_107_;
-    _zz_108_[9] = _zz_107_;
-    _zz_108_[8] = _zz_107_;
-    _zz_108_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_108[31] = _zz_107;
+    _zz_108[30] = _zz_107;
+    _zz_108[29] = _zz_107;
+    _zz_108[28] = _zz_107;
+    _zz_108[27] = _zz_107;
+    _zz_108[26] = _zz_107;
+    _zz_108[25] = _zz_107;
+    _zz_108[24] = _zz_107;
+    _zz_108[23] = _zz_107;
+    _zz_108[22] = _zz_107;
+    _zz_108[21] = _zz_107;
+    _zz_108[20] = _zz_107;
+    _zz_108[19] = _zz_107;
+    _zz_108[18] = _zz_107;
+    _zz_108[17] = _zz_107;
+    _zz_108[16] = _zz_107;
+    _zz_108[15] = _zz_107;
+    _zz_108[14] = _zz_107;
+    _zz_108[13] = _zz_107;
+    _zz_108[12] = _zz_107;
+    _zz_108[11] = _zz_107;
+    _zz_108[10] = _zz_107;
+    _zz_108[9] = _zz_107;
+    _zz_108[8] = _zz_107;
+    _zz_108[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_109_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_109 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_110_[31] = _zz_109_;
-    _zz_110_[30] = _zz_109_;
-    _zz_110_[29] = _zz_109_;
-    _zz_110_[28] = _zz_109_;
-    _zz_110_[27] = _zz_109_;
-    _zz_110_[26] = _zz_109_;
-    _zz_110_[25] = _zz_109_;
-    _zz_110_[24] = _zz_109_;
-    _zz_110_[23] = _zz_109_;
-    _zz_110_[22] = _zz_109_;
-    _zz_110_[21] = _zz_109_;
-    _zz_110_[20] = _zz_109_;
-    _zz_110_[19] = _zz_109_;
-    _zz_110_[18] = _zz_109_;
-    _zz_110_[17] = _zz_109_;
-    _zz_110_[16] = _zz_109_;
-    _zz_110_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_110[31] = _zz_109;
+    _zz_110[30] = _zz_109;
+    _zz_110[29] = _zz_109;
+    _zz_110[28] = _zz_109;
+    _zz_110[27] = _zz_109;
+    _zz_110[26] = _zz_109;
+    _zz_110[25] = _zz_109;
+    _zz_110[24] = _zz_109;
+    _zz_110[23] = _zz_109;
+    _zz_110[22] = _zz_109;
+    _zz_110[21] = _zz_109;
+    _zz_110[20] = _zz_109;
+    _zz_110[19] = _zz_109;
+    _zz_110[18] = _zz_109;
+    _zz_110[17] = _zz_109;
+    _zz_110[16] = _zz_109;
+    _zz_110[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_265_)
+    case(_zz_278)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_108_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_108;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_110_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_110;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -4738,57 +3829,73 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_112_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_113_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_114_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_115_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_111_ = {({_zz_114_,(_zz_391_ == _zz_392_)} != (2'b00)),{((_zz_393_ == _zz_394_) != (1'b0)),{({_zz_395_,_zz_396_} != (2'b00)),{(_zz_397_ != _zz_398_),{_zz_399_,{_zz_400_,_zz_401_}}}}}};
-  assign _zz_116_ = _zz_111_[3 : 2];
-  assign _zz_49_ = _zz_116_;
-  assign _zz_117_ = _zz_111_[5 : 4];
-  assign _zz_48_ = _zz_117_;
-  assign _zz_118_ = _zz_111_[8 : 7];
-  assign _zz_47_ = _zz_118_;
-  assign _zz_119_ = _zz_111_[12 : 11];
-  assign _zz_46_ = _zz_119_;
-  assign _zz_120_ = _zz_111_[14 : 13];
-  assign _zz_45_ = _zz_120_;
-  assign _zz_121_ = _zz_111_[26 : 25];
-  assign _zz_44_ = _zz_121_;
-  assign _zz_122_ = _zz_111_[32 : 31];
-  assign _zz_43_ = _zz_122_;
+  assign _zz_112 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_113 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_114 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_115 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_116 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_117 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_111 = {(((decode_INSTRUCTION & _zz_405) == 32'h00100050) != 1'b0),{(_zz_117 != 1'b0),{(_zz_117 != 1'b0),{(_zz_406 != _zz_407),{_zz_408,{_zz_409,_zz_410}}}}}};
+  assign _zz_118 = _zz_111[2 : 1];
+  assign _zz_49 = _zz_118;
+  assign _zz_119 = _zz_111[7 : 6];
+  assign _zz_48 = _zz_119;
+  assign _zz_120 = _zz_111[9 : 8];
+  assign _zz_47 = _zz_120;
+  assign _zz_121 = _zz_111[21 : 20];
+  assign _zz_46 = _zz_121;
+  assign _zz_122 = _zz_111[23 : 22];
+  assign _zz_45 = _zz_122;
+  assign _zz_123 = _zz_111[25 : 24];
+  assign _zz_44 = _zz_123;
+  assign _zz_124 = _zz_111[28 : 27];
+  assign _zz_43 = _zz_124;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_219_;
-  assign decode_RegFilePlugin_rs2Data = _zz_220_;
+  assign decode_RegFilePlugin_rs1Data = _zz_232;
+  assign decode_RegFilePlugin_rs2Data = _zz_233;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_123_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_125)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_50_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_125)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_125)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -4806,13 +3913,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_124_ = execute_IntAluPlugin_bitwise;
+        _zz_126 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_124_ = {31'd0, _zz_314_};
+        _zz_126 = {31'd0, _zz_328};
       end
       default : begin
-        _zz_124_ = execute_SRC_ADD_SUB;
+        _zz_126 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -4820,87 +3927,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_125_ = execute_RS1;
+        _zz_127 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_125_ = {29'd0, _zz_315_};
+        _zz_127 = {29'd0, _zz_329};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_125_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_127 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_125_ = {27'd0, _zz_316_};
+        _zz_127 = {27'd0, _zz_330};
       end
     endcase
   end
 
-  assign _zz_126_ = _zz_317_[11];
+  assign _zz_128 = _zz_331[11];
   always @ (*) begin
-    _zz_127_[19] = _zz_126_;
-    _zz_127_[18] = _zz_126_;
-    _zz_127_[17] = _zz_126_;
-    _zz_127_[16] = _zz_126_;
-    _zz_127_[15] = _zz_126_;
-    _zz_127_[14] = _zz_126_;
-    _zz_127_[13] = _zz_126_;
-    _zz_127_[12] = _zz_126_;
-    _zz_127_[11] = _zz_126_;
-    _zz_127_[10] = _zz_126_;
-    _zz_127_[9] = _zz_126_;
-    _zz_127_[8] = _zz_126_;
-    _zz_127_[7] = _zz_126_;
-    _zz_127_[6] = _zz_126_;
-    _zz_127_[5] = _zz_126_;
-    _zz_127_[4] = _zz_126_;
-    _zz_127_[3] = _zz_126_;
-    _zz_127_[2] = _zz_126_;
-    _zz_127_[1] = _zz_126_;
-    _zz_127_[0] = _zz_126_;
+    _zz_129[19] = _zz_128;
+    _zz_129[18] = _zz_128;
+    _zz_129[17] = _zz_128;
+    _zz_129[16] = _zz_128;
+    _zz_129[15] = _zz_128;
+    _zz_129[14] = _zz_128;
+    _zz_129[13] = _zz_128;
+    _zz_129[12] = _zz_128;
+    _zz_129[11] = _zz_128;
+    _zz_129[10] = _zz_128;
+    _zz_129[9] = _zz_128;
+    _zz_129[8] = _zz_128;
+    _zz_129[7] = _zz_128;
+    _zz_129[6] = _zz_128;
+    _zz_129[5] = _zz_128;
+    _zz_129[4] = _zz_128;
+    _zz_129[3] = _zz_128;
+    _zz_129[2] = _zz_128;
+    _zz_129[1] = _zz_128;
+    _zz_129[0] = _zz_128;
   end
 
-  assign _zz_128_ = _zz_318_[11];
+  assign _zz_130 = _zz_332[11];
   always @ (*) begin
-    _zz_129_[19] = _zz_128_;
-    _zz_129_[18] = _zz_128_;
-    _zz_129_[17] = _zz_128_;
-    _zz_129_[16] = _zz_128_;
-    _zz_129_[15] = _zz_128_;
-    _zz_129_[14] = _zz_128_;
-    _zz_129_[13] = _zz_128_;
-    _zz_129_[12] = _zz_128_;
-    _zz_129_[11] = _zz_128_;
-    _zz_129_[10] = _zz_128_;
-    _zz_129_[9] = _zz_128_;
-    _zz_129_[8] = _zz_128_;
-    _zz_129_[7] = _zz_128_;
-    _zz_129_[6] = _zz_128_;
-    _zz_129_[5] = _zz_128_;
-    _zz_129_[4] = _zz_128_;
-    _zz_129_[3] = _zz_128_;
-    _zz_129_[2] = _zz_128_;
-    _zz_129_[1] = _zz_128_;
-    _zz_129_[0] = _zz_128_;
+    _zz_131[19] = _zz_130;
+    _zz_131[18] = _zz_130;
+    _zz_131[17] = _zz_130;
+    _zz_131[16] = _zz_130;
+    _zz_131[15] = _zz_130;
+    _zz_131[14] = _zz_130;
+    _zz_131[13] = _zz_130;
+    _zz_131[12] = _zz_130;
+    _zz_131[11] = _zz_130;
+    _zz_131[10] = _zz_130;
+    _zz_131[9] = _zz_130;
+    _zz_131[8] = _zz_130;
+    _zz_131[7] = _zz_130;
+    _zz_131[6] = _zz_130;
+    _zz_131[5] = _zz_130;
+    _zz_131[4] = _zz_130;
+    _zz_131[3] = _zz_130;
+    _zz_131[2] = _zz_130;
+    _zz_131[1] = _zz_130;
+    _zz_131[0] = _zz_130;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_130_ = execute_RS2;
+        _zz_132 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_130_ = {_zz_127_,execute_INSTRUCTION[31 : 20]};
+        _zz_132 = {_zz_129,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_130_ = {_zz_129_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_132 = {_zz_131,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_130_ = _zz_35_;
+        _zz_132 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_319_;
+    execute_SrcPlugin_addSub = _zz_333;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -4909,165 +4016,165 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_131_[0] = execute_SRC1[31];
-    _zz_131_[1] = execute_SRC1[30];
-    _zz_131_[2] = execute_SRC1[29];
-    _zz_131_[3] = execute_SRC1[28];
-    _zz_131_[4] = execute_SRC1[27];
-    _zz_131_[5] = execute_SRC1[26];
-    _zz_131_[6] = execute_SRC1[25];
-    _zz_131_[7] = execute_SRC1[24];
-    _zz_131_[8] = execute_SRC1[23];
-    _zz_131_[9] = execute_SRC1[22];
-    _zz_131_[10] = execute_SRC1[21];
-    _zz_131_[11] = execute_SRC1[20];
-    _zz_131_[12] = execute_SRC1[19];
-    _zz_131_[13] = execute_SRC1[18];
-    _zz_131_[14] = execute_SRC1[17];
-    _zz_131_[15] = execute_SRC1[16];
-    _zz_131_[16] = execute_SRC1[15];
-    _zz_131_[17] = execute_SRC1[14];
-    _zz_131_[18] = execute_SRC1[13];
-    _zz_131_[19] = execute_SRC1[12];
-    _zz_131_[20] = execute_SRC1[11];
-    _zz_131_[21] = execute_SRC1[10];
-    _zz_131_[22] = execute_SRC1[9];
-    _zz_131_[23] = execute_SRC1[8];
-    _zz_131_[24] = execute_SRC1[7];
-    _zz_131_[25] = execute_SRC1[6];
-    _zz_131_[26] = execute_SRC1[5];
-    _zz_131_[27] = execute_SRC1[4];
-    _zz_131_[28] = execute_SRC1[3];
-    _zz_131_[29] = execute_SRC1[2];
-    _zz_131_[30] = execute_SRC1[1];
-    _zz_131_[31] = execute_SRC1[0];
+    _zz_133[0] = execute_SRC1[31];
+    _zz_133[1] = execute_SRC1[30];
+    _zz_133[2] = execute_SRC1[29];
+    _zz_133[3] = execute_SRC1[28];
+    _zz_133[4] = execute_SRC1[27];
+    _zz_133[5] = execute_SRC1[26];
+    _zz_133[6] = execute_SRC1[25];
+    _zz_133[7] = execute_SRC1[24];
+    _zz_133[8] = execute_SRC1[23];
+    _zz_133[9] = execute_SRC1[22];
+    _zz_133[10] = execute_SRC1[21];
+    _zz_133[11] = execute_SRC1[20];
+    _zz_133[12] = execute_SRC1[19];
+    _zz_133[13] = execute_SRC1[18];
+    _zz_133[14] = execute_SRC1[17];
+    _zz_133[15] = execute_SRC1[16];
+    _zz_133[16] = execute_SRC1[15];
+    _zz_133[17] = execute_SRC1[14];
+    _zz_133[18] = execute_SRC1[13];
+    _zz_133[19] = execute_SRC1[12];
+    _zz_133[20] = execute_SRC1[11];
+    _zz_133[21] = execute_SRC1[10];
+    _zz_133[22] = execute_SRC1[9];
+    _zz_133[23] = execute_SRC1[8];
+    _zz_133[24] = execute_SRC1[7];
+    _zz_133[25] = execute_SRC1[6];
+    _zz_133[26] = execute_SRC1[5];
+    _zz_133[27] = execute_SRC1[4];
+    _zz_133[28] = execute_SRC1[3];
+    _zz_133[29] = execute_SRC1[2];
+    _zz_133[30] = execute_SRC1[1];
+    _zz_133[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_131_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_133 : execute_SRC1);
   always @ (*) begin
-    _zz_132_[0] = memory_SHIFT_RIGHT[31];
-    _zz_132_[1] = memory_SHIFT_RIGHT[30];
-    _zz_132_[2] = memory_SHIFT_RIGHT[29];
-    _zz_132_[3] = memory_SHIFT_RIGHT[28];
-    _zz_132_[4] = memory_SHIFT_RIGHT[27];
-    _zz_132_[5] = memory_SHIFT_RIGHT[26];
-    _zz_132_[6] = memory_SHIFT_RIGHT[25];
-    _zz_132_[7] = memory_SHIFT_RIGHT[24];
-    _zz_132_[8] = memory_SHIFT_RIGHT[23];
-    _zz_132_[9] = memory_SHIFT_RIGHT[22];
-    _zz_132_[10] = memory_SHIFT_RIGHT[21];
-    _zz_132_[11] = memory_SHIFT_RIGHT[20];
-    _zz_132_[12] = memory_SHIFT_RIGHT[19];
-    _zz_132_[13] = memory_SHIFT_RIGHT[18];
-    _zz_132_[14] = memory_SHIFT_RIGHT[17];
-    _zz_132_[15] = memory_SHIFT_RIGHT[16];
-    _zz_132_[16] = memory_SHIFT_RIGHT[15];
-    _zz_132_[17] = memory_SHIFT_RIGHT[14];
-    _zz_132_[18] = memory_SHIFT_RIGHT[13];
-    _zz_132_[19] = memory_SHIFT_RIGHT[12];
-    _zz_132_[20] = memory_SHIFT_RIGHT[11];
-    _zz_132_[21] = memory_SHIFT_RIGHT[10];
-    _zz_132_[22] = memory_SHIFT_RIGHT[9];
-    _zz_132_[23] = memory_SHIFT_RIGHT[8];
-    _zz_132_[24] = memory_SHIFT_RIGHT[7];
-    _zz_132_[25] = memory_SHIFT_RIGHT[6];
-    _zz_132_[26] = memory_SHIFT_RIGHT[5];
-    _zz_132_[27] = memory_SHIFT_RIGHT[4];
-    _zz_132_[28] = memory_SHIFT_RIGHT[3];
-    _zz_132_[29] = memory_SHIFT_RIGHT[2];
-    _zz_132_[30] = memory_SHIFT_RIGHT[1];
-    _zz_132_[31] = memory_SHIFT_RIGHT[0];
+    _zz_134[0] = memory_SHIFT_RIGHT[31];
+    _zz_134[1] = memory_SHIFT_RIGHT[30];
+    _zz_134[2] = memory_SHIFT_RIGHT[29];
+    _zz_134[3] = memory_SHIFT_RIGHT[28];
+    _zz_134[4] = memory_SHIFT_RIGHT[27];
+    _zz_134[5] = memory_SHIFT_RIGHT[26];
+    _zz_134[6] = memory_SHIFT_RIGHT[25];
+    _zz_134[7] = memory_SHIFT_RIGHT[24];
+    _zz_134[8] = memory_SHIFT_RIGHT[23];
+    _zz_134[9] = memory_SHIFT_RIGHT[22];
+    _zz_134[10] = memory_SHIFT_RIGHT[21];
+    _zz_134[11] = memory_SHIFT_RIGHT[20];
+    _zz_134[12] = memory_SHIFT_RIGHT[19];
+    _zz_134[13] = memory_SHIFT_RIGHT[18];
+    _zz_134[14] = memory_SHIFT_RIGHT[17];
+    _zz_134[15] = memory_SHIFT_RIGHT[16];
+    _zz_134[16] = memory_SHIFT_RIGHT[15];
+    _zz_134[17] = memory_SHIFT_RIGHT[14];
+    _zz_134[18] = memory_SHIFT_RIGHT[13];
+    _zz_134[19] = memory_SHIFT_RIGHT[12];
+    _zz_134[20] = memory_SHIFT_RIGHT[11];
+    _zz_134[21] = memory_SHIFT_RIGHT[10];
+    _zz_134[22] = memory_SHIFT_RIGHT[9];
+    _zz_134[23] = memory_SHIFT_RIGHT[8];
+    _zz_134[24] = memory_SHIFT_RIGHT[7];
+    _zz_134[25] = memory_SHIFT_RIGHT[6];
+    _zz_134[26] = memory_SHIFT_RIGHT[5];
+    _zz_134[27] = memory_SHIFT_RIGHT[4];
+    _zz_134[28] = memory_SHIFT_RIGHT[3];
+    _zz_134[29] = memory_SHIFT_RIGHT[2];
+    _zz_134[30] = memory_SHIFT_RIGHT[1];
+    _zz_134[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_133_ = 1'b0;
-    if(_zz_242_)begin
-      if(_zz_243_)begin
-        if(_zz_138_)begin
-          _zz_133_ = 1'b1;
+    _zz_135 = 1'b0;
+    if(_zz_255)begin
+      if(_zz_256)begin
+        if(_zz_140)begin
+          _zz_135 = 1'b1;
         end
       end
     end
-    if(_zz_244_)begin
-      if(_zz_245_)begin
-        if(_zz_140_)begin
-          _zz_133_ = 1'b1;
+    if(_zz_257)begin
+      if(_zz_258)begin
+        if(_zz_142)begin
+          _zz_135 = 1'b1;
         end
       end
     end
-    if(_zz_246_)begin
-      if(_zz_247_)begin
-        if(_zz_142_)begin
-          _zz_133_ = 1'b1;
+    if(_zz_259)begin
+      if(_zz_260)begin
+        if(_zz_144)begin
+          _zz_135 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_133_ = 1'b0;
+      _zz_135 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_134_ = 1'b0;
-    if(_zz_242_)begin
-      if(_zz_243_)begin
-        if(_zz_139_)begin
-          _zz_134_ = 1'b1;
+    _zz_136 = 1'b0;
+    if(_zz_255)begin
+      if(_zz_256)begin
+        if(_zz_141)begin
+          _zz_136 = 1'b1;
         end
       end
     end
-    if(_zz_244_)begin
-      if(_zz_245_)begin
-        if(_zz_141_)begin
-          _zz_134_ = 1'b1;
+    if(_zz_257)begin
+      if(_zz_258)begin
+        if(_zz_143)begin
+          _zz_136 = 1'b1;
         end
       end
     end
-    if(_zz_246_)begin
-      if(_zz_247_)begin
-        if(_zz_143_)begin
-          _zz_134_ = 1'b1;
+    if(_zz_259)begin
+      if(_zz_260)begin
+        if(_zz_145)begin
+          _zz_136 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_134_ = 1'b0;
+      _zz_136 = 1'b0;
     end
   end
 
-  assign _zz_138_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_139_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_140_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_141_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_142_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_143_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_140 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_141 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_142 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_143 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_144 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_145 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_144_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_146 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_144_ == (3'b000))) begin
-        _zz_145_ = execute_BranchPlugin_eq;
-    end else if((_zz_144_ == (3'b001))) begin
-        _zz_145_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_144_ & (3'b101)) == (3'b101)))) begin
-        _zz_145_ = (! execute_SRC_LESS);
+    if((_zz_146 == 3'b000)) begin
+        _zz_147 = execute_BranchPlugin_eq;
+    end else if((_zz_146 == 3'b001)) begin
+        _zz_147 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_146 & 3'b101) == 3'b101))) begin
+        _zz_147 = (! execute_SRC_LESS);
     end else begin
-        _zz_145_ = execute_SRC_LESS;
+        _zz_147 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_146_ = 1'b0;
+        _zz_148 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_146_ = 1'b1;
+        _zz_148 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_146_ = 1'b1;
+        _zz_148 = 1'b1;
       end
       default : begin
-        _zz_146_ = _zz_145_;
+        _zz_148 = _zz_147;
       end
     endcase
   end
@@ -5084,80 +4191,80 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_147_ = _zz_326_[11];
+  assign _zz_149 = _zz_340[11];
   always @ (*) begin
-    _zz_148_[19] = _zz_147_;
-    _zz_148_[18] = _zz_147_;
-    _zz_148_[17] = _zz_147_;
-    _zz_148_[16] = _zz_147_;
-    _zz_148_[15] = _zz_147_;
-    _zz_148_[14] = _zz_147_;
-    _zz_148_[13] = _zz_147_;
-    _zz_148_[12] = _zz_147_;
-    _zz_148_[11] = _zz_147_;
-    _zz_148_[10] = _zz_147_;
-    _zz_148_[9] = _zz_147_;
-    _zz_148_[8] = _zz_147_;
-    _zz_148_[7] = _zz_147_;
-    _zz_148_[6] = _zz_147_;
-    _zz_148_[5] = _zz_147_;
-    _zz_148_[4] = _zz_147_;
-    _zz_148_[3] = _zz_147_;
-    _zz_148_[2] = _zz_147_;
-    _zz_148_[1] = _zz_147_;
-    _zz_148_[0] = _zz_147_;
+    _zz_150[19] = _zz_149;
+    _zz_150[18] = _zz_149;
+    _zz_150[17] = _zz_149;
+    _zz_150[16] = _zz_149;
+    _zz_150[15] = _zz_149;
+    _zz_150[14] = _zz_149;
+    _zz_150[13] = _zz_149;
+    _zz_150[12] = _zz_149;
+    _zz_150[11] = _zz_149;
+    _zz_150[10] = _zz_149;
+    _zz_150[9] = _zz_149;
+    _zz_150[8] = _zz_149;
+    _zz_150[7] = _zz_149;
+    _zz_150[6] = _zz_149;
+    _zz_150[5] = _zz_149;
+    _zz_150[4] = _zz_149;
+    _zz_150[3] = _zz_149;
+    _zz_150[2] = _zz_149;
+    _zz_150[1] = _zz_149;
+    _zz_150[0] = _zz_149;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_148_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_150,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_150_,{{{_zz_568_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_152_,{{{_zz_569_,_zz_570_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_152,{{{_zz_592,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_154,{{{_zz_593,_zz_594},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_329_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_343};
         end
       end
     endcase
   end
 
-  assign _zz_149_ = _zz_327_[19];
+  assign _zz_151 = _zz_341[19];
   always @ (*) begin
-    _zz_150_[10] = _zz_149_;
-    _zz_150_[9] = _zz_149_;
-    _zz_150_[8] = _zz_149_;
-    _zz_150_[7] = _zz_149_;
-    _zz_150_[6] = _zz_149_;
-    _zz_150_[5] = _zz_149_;
-    _zz_150_[4] = _zz_149_;
-    _zz_150_[3] = _zz_149_;
-    _zz_150_[2] = _zz_149_;
-    _zz_150_[1] = _zz_149_;
-    _zz_150_[0] = _zz_149_;
+    _zz_152[10] = _zz_151;
+    _zz_152[9] = _zz_151;
+    _zz_152[8] = _zz_151;
+    _zz_152[7] = _zz_151;
+    _zz_152[6] = _zz_151;
+    _zz_152[5] = _zz_151;
+    _zz_152[4] = _zz_151;
+    _zz_152[3] = _zz_151;
+    _zz_152[2] = _zz_151;
+    _zz_152[1] = _zz_151;
+    _zz_152[0] = _zz_151;
   end
 
-  assign _zz_151_ = _zz_328_[11];
+  assign _zz_153 = _zz_342[11];
   always @ (*) begin
-    _zz_152_[18] = _zz_151_;
-    _zz_152_[17] = _zz_151_;
-    _zz_152_[16] = _zz_151_;
-    _zz_152_[15] = _zz_151_;
-    _zz_152_[14] = _zz_151_;
-    _zz_152_[13] = _zz_151_;
-    _zz_152_[12] = _zz_151_;
-    _zz_152_[11] = _zz_151_;
-    _zz_152_[10] = _zz_151_;
-    _zz_152_[9] = _zz_151_;
-    _zz_152_[8] = _zz_151_;
-    _zz_152_[7] = _zz_151_;
-    _zz_152_[6] = _zz_151_;
-    _zz_152_[5] = _zz_151_;
-    _zz_152_[4] = _zz_151_;
-    _zz_152_[3] = _zz_151_;
-    _zz_152_[2] = _zz_151_;
-    _zz_152_[1] = _zz_151_;
-    _zz_152_[0] = _zz_151_;
+    _zz_154[18] = _zz_153;
+    _zz_154[17] = _zz_153;
+    _zz_154[16] = _zz_153;
+    _zz_154[15] = _zz_153;
+    _zz_154[14] = _zz_153;
+    _zz_154[13] = _zz_153;
+    _zz_154[12] = _zz_153;
+    _zz_154[11] = _zz_153;
+    _zz_154[10] = _zz_153;
+    _zz_154[9] = _zz_153;
+    _zz_154[8] = _zz_153;
+    _zz_154[7] = _zz_153;
+    _zz_154[6] = _zz_153;
+    _zz_154[5] = _zz_153;
+    _zz_154[4] = _zz_153;
+    _zz_154[3] = _zz_153;
+    _zz_154[2] = _zz_153;
+    _zz_154[1] = _zz_153;
+    _zz_154[0] = _zz_153;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
@@ -5165,22 +4272,22 @@ module VexRiscv (
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_153_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_154_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_155_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_155 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_156 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_157 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_156_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_157_ = _zz_330_[0];
+  assign _zz_158 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_159 = _zz_344[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_232_)begin
+    if(_zz_245)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -5223,7 +4330,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -5247,7 +4354,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -5269,7 +4376,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -5364,7 +4471,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_248_)begin
+    if(_zz_261)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -5383,26 +4490,26 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_249_)begin
+    if(_zz_262)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_250_)begin
+    if(_zz_263)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_249_)begin
-      CsrPlugin_selfException_payload_code = (4'b0010);
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_262)begin
+      CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_250_)begin
+    if(_zz_263)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -5411,14 +4518,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_248_)begin
+    if(_zz_261)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_248_)begin
+    if(_zz_261)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -5427,7 +4534,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_266_)
+    case(_zz_279)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -5441,7 +4548,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_251_)
+    case(_zz_264)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -5455,7 +4562,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_251_)
+    case(_zz_264)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -5474,12 +4581,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_332_) + $signed(_zz_333_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_346) + $signed(_zz_347));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_227_)begin
-      if(_zz_252_)begin
+    if(_zz_240)begin
+      if(_zz_265)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -5487,7 +4594,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_253_)begin
+    if(_zz_266)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -5498,35 +4605,33 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_337_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_351);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_158_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_158_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_338_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_339_ : _zz_340_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_341_[31:0];
-  assign _zz_159_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_160_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_161_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_160 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_160[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_352);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_353 : _zz_354);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_355[31:0];
+  assign _zz_161 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_162 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_163 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_162_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_162_[31 : 0] = execute_RS1;
+    _zz_164[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_164[31 : 0] = execute_RS1;
   end
 
-  assign _zz_164_ = (_zz_163_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_164_ != 32'h0);
+  assign _zz_166 = (_zz_165 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_166 != 32'h0);
   always @ (*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid)begin
-      case(_zz_254_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_267)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
@@ -5539,7 +4644,7 @@ module VexRiscv (
 
   always @ (*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_165_))begin
+    if((! _zz_167))begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -5551,10 +4656,8 @@ module VexRiscv (
   always @ (*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid)begin
-      case(_zz_254_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_267)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
@@ -5566,39 +4669,39 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == (2'b11));
+  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26_ = decode_ALU_CTRL;
-  assign _zz_24_ = _zz_47_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign _zz_23_ = decode_SRC2_CTRL;
-  assign _zz_21_ = _zz_44_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_20_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_18_ = _zz_49_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_17_ = decode_SHIFT_CTRL;
-  assign _zz_14_ = execute_SHIFT_CTRL;
-  assign _zz_15_ = _zz_46_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_12_ = decode_BRANCH_CTRL;
-  assign _zz_52_ = _zz_43_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_10_ = decode_ENV_CTRL;
-  assign _zz_7_ = execute_ENV_CTRL;
-  assign _zz_5_ = memory_ENV_CTRL;
-  assign _zz_8_ = _zz_45_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_3_ = decode_SRC1_CTRL;
-  assign _zz_1_ = _zz_48_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_52 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -5617,15 +4720,7 @@ module VexRiscv (
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_167_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
-      3'b010 : begin
-      end
-      3'b011 : begin
-      end
+    case(_zz_169)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -5635,216 +4730,216 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_168_ = 32'h0;
+    _zz_170 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_168_[12 : 0] = 13'h1000;
-      _zz_168_[25 : 20] = 6'h20;
+      _zz_170[12 : 0] = 13'h1000;
+      _zz_170[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_169_ = 32'h0;
+    _zz_171 = 32'h0;
     if(execute_CsrPlugin_csr_3857)begin
-      _zz_169_[3 : 0] = (4'b1011);
+      _zz_171[3 : 0] = 4'b1011;
     end
   end
 
   always @ (*) begin
-    _zz_170_ = 32'h0;
+    _zz_172 = 32'h0;
     if(execute_CsrPlugin_csr_3858)begin
-      _zz_170_[4 : 0] = 5'h16;
+      _zz_172[4 : 0] = 5'h16;
     end
   end
 
   always @ (*) begin
-    _zz_171_ = 32'h0;
+    _zz_173 = 32'h0;
     if(execute_CsrPlugin_csr_3859)begin
-      _zz_171_[5 : 0] = 6'h21;
+      _zz_173[5 : 0] = 6'h21;
     end
   end
 
   always @ (*) begin
-    _zz_172_ = 32'h0;
+    _zz_174 = 32'h0;
     if(execute_CsrPlugin_csr_769)begin
-      _zz_172_[31 : 30] = CsrPlugin_misa_base;
-      _zz_172_[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_174[31 : 30] = CsrPlugin_misa_base;
+      _zz_174[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
   always @ (*) begin
-    _zz_173_ = 32'h0;
+    _zz_175 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_173_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_173_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_173_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_175[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_175[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_175[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_174_ = 32'h0;
+    _zz_176 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_174_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_174_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_174_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_176[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_176[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_176[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_175_ = 32'h0;
+    _zz_177 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_175_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_175_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_175_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_177[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_177[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_177[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_176_ = 32'h0;
+    _zz_178 = 32'h0;
     if(execute_CsrPlugin_csr_773)begin
-      _zz_176_[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_176_[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_178[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_178[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
   always @ (*) begin
-    _zz_177_ = 32'h0;
+    _zz_179 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_177_[31 : 0] = CsrPlugin_mepc;
+      _zz_179[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_178_ = 32'h0;
+    _zz_180 = 32'h0;
     if(execute_CsrPlugin_csr_832)begin
-      _zz_178_[31 : 0] = CsrPlugin_mscratch;
+      _zz_180[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
-    _zz_179_ = 32'h0;
+    _zz_181 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_179_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_179_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_181[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_181[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_180_ = 32'h0;
+    _zz_182 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_180_[31 : 0] = CsrPlugin_mtval;
+      _zz_182[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_181_ = 32'h0;
+    _zz_183 = 32'h0;
     if(execute_CsrPlugin_csr_2816)begin
-      _zz_181_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_183[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_182_ = 32'h0;
+    _zz_184 = 32'h0;
     if(execute_CsrPlugin_csr_2944)begin
-      _zz_182_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_184[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_183_ = 32'h0;
+    _zz_185 = 32'h0;
     if(execute_CsrPlugin_csr_2818)begin
-      _zz_183_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_185[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_184_ = 32'h0;
+    _zz_186 = 32'h0;
     if(execute_CsrPlugin_csr_2946)begin
-      _zz_184_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_186[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_185_ = 32'h0;
+    _zz_187 = 32'h0;
     if(execute_CsrPlugin_csr_3072)begin
-      _zz_185_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_187[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_186_ = 32'h0;
+    _zz_188 = 32'h0;
     if(execute_CsrPlugin_csr_3200)begin
-      _zz_186_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_188[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_187_ = 32'h0;
+    _zz_189 = 32'h0;
     if(execute_CsrPlugin_csr_3074)begin
-      _zz_187_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_189[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_188_ = 32'h0;
+    _zz_190 = 32'h0;
     if(execute_CsrPlugin_csr_3202)begin
-      _zz_188_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_190[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_189_ = 32'h0;
+    _zz_191 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_189_[31 : 0] = _zz_163_;
+      _zz_191[31 : 0] = _zz_165;
     end
   end
 
   always @ (*) begin
-    _zz_190_ = 32'h0;
+    _zz_192 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_190_[31 : 0] = _zz_164_;
+      _zz_192[31 : 0] = _zz_166;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_168_ | _zz_169_) | (_zz_170_ | _zz_171_)) | ((_zz_571_ | _zz_172_) | (_zz_173_ | _zz_174_))) | (((_zz_175_ | _zz_176_) | (_zz_177_ | _zz_178_)) | ((_zz_179_ | _zz_180_) | (_zz_181_ | _zz_182_)))) | (((_zz_183_ | _zz_184_) | (_zz_185_ | _zz_186_)) | ((_zz_187_ | _zz_188_) | (_zz_189_ | _zz_190_))));
-  assign iBusWishbone_ADR = {_zz_358_,_zz_191_};
-  assign iBusWishbone_CTI = ((_zz_191_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((((_zz_170 | _zz_171) | (_zz_172 | _zz_173)) | ((_zz_595 | _zz_174) | (_zz_175 | _zz_176))) | (((_zz_177 | _zz_178) | (_zz_179 | _zz_180)) | ((_zz_181 | _zz_182) | (_zz_183 | _zz_184)))) | (((_zz_185 | _zz_186) | (_zz_187 | _zz_188)) | ((_zz_189 | _zz_190) | (_zz_191 | _zz_192))));
+  assign iBusWishbone_ADR = {_zz_372,_zz_193};
+  assign iBusWishbone_CTI = ((_zz_193 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_255_)begin
+    if(_zz_268)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_255_)begin
+    if(_zz_268)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_192_;
+  assign iBus_rsp_valid = _zz_194;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_198_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_194_ = dBus_cmd_valid;
-  assign _zz_196_ = dBus_cmd_payload_wr;
-  assign _zz_197_ = (_zz_193_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_195_ && (_zz_196_ || _zz_197_));
-  assign dBusWishbone_ADR = ((_zz_198_ ? {{dBus_cmd_payload_address[31 : 5],_zz_193_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_198_ ? (_zz_197_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_196_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_196_;
+  assign _zz_200 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_196 = dBus_cmd_valid;
+  assign _zz_198 = dBus_cmd_payload_wr;
+  assign _zz_199 = (_zz_195 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_197 && (_zz_198 || _zz_199));
+  assign dBusWishbone_ADR = ((_zz_200 ? {{dBus_cmd_payload_address[31 : 5],_zz_195},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_200 ? (_zz_199 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_198 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_198;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_195_ = (_zz_194_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_194_;
-  assign dBusWishbone_STB = _zz_194_;
-  assign dBus_rsp_valid = _zz_199_;
+  assign _zz_197 = (_zz_196 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_196;
+  assign dBusWishbone_STB = _zz_196;
+  assign dBus_rsp_valid = _zz_201;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -5854,27 +4949,27 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
       IBusCachedPlugin_decodePc_pcReg <= externalResetVector;
-      _zz_65_ <= 1'b0;
+      _zz_65 <= 1'b0;
       IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       IBusCachedPlugin_decompressor_throw2BytesReg <= 1'b0;
-      _zz_93_ <= 1'b0;
+      _zz_93 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_104_;
+      IBusCachedPlugin_rspCounter <= _zz_104;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_105_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_105;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_123_ <= 1'b1;
-      _zz_135_ <= 1'b0;
-      CsrPlugin_misa_base <= (2'b01);
+      _zz_125 <= 1'b1;
+      _zz_137 <= 1'b0;
+      CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0000042;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -5890,17 +4985,15 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_163_ <= 32'h0;
+      _zz_165 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_167_ <= (3'b000);
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_191_ <= (3'b000);
-      _zz_192_ <= 1'b0;
-      _zz_193_ <= (3'b000);
-      _zz_199_ <= 1'b0;
+      _zz_169 <= 3'b000;
+      _zz_193 <= 3'b000;
+      _zz_194 <= 1'b0;
+      _zz_195 <= 3'b000;
+      _zz_201 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -5924,14 +5017,14 @@ module VexRiscv (
       if((decode_arbitration_isFiring && (! IBusCachedPlugin_decodePc_injectedDecode)))begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_decodePc_pcPlus;
       end
-      if(_zz_240_)begin
+      if(_zz_253)begin
         IBusCachedPlugin_decodePc_pcReg <= IBusCachedPlugin_jump_pcLoad_payload;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_65_ <= 1'b0;
+        _zz_65 <= 1'b0;
       end
-      if(_zz_63_)begin
-        _zz_65_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_63)begin
+        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if((IBusCachedPlugin_decompressor_output_valid && IBusCachedPlugin_decompressor_output_ready))begin
         IBusCachedPlugin_decompressor_throw2BytesReg <= ((((! IBusCachedPlugin_decompressor_unaligned) && IBusCachedPlugin_decompressor_isInputLowRvc) && IBusCachedPlugin_decompressor_isInputHighRvc) || (IBusCachedPlugin_decompressor_bufferValid && IBusCachedPlugin_decompressor_isInputHighRvc));
@@ -5939,7 +5032,7 @@ module VexRiscv (
       if((IBusCachedPlugin_decompressor_output_ready && IBusCachedPlugin_decompressor_input_valid))begin
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
-      if(_zz_256_)begin
+      if(_zz_269)begin
         if(IBusCachedPlugin_decompressor_bufferFill)begin
           IBusCachedPlugin_decompressor_bufferValid <= 1'b1;
         end
@@ -5949,10 +5042,10 @@ module VexRiscv (
         IBusCachedPlugin_decompressor_bufferValid <= 1'b0;
       end
       if(decode_arbitration_removeIt)begin
-        _zz_93_ <= 1'b0;
+        _zz_93 <= 1'b0;
       end
       if(IBusCachedPlugin_decompressor_output_ready)begin
-        _zz_93_ <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
+        _zz_93 <= (IBusCachedPlugin_decompressor_output_valid && (! IBusCachedPlugin_externalFlush));
       end
       if((! 1'b0))begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b1;
@@ -5981,20 +5074,20 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_257_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_270)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_123_ <= 1'b0;
-      _zz_135_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_125 <= 1'b0;
+      _zz_137 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -6016,14 +5109,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_258_)begin
-        if(_zz_259_)begin
+      if(_zz_271)begin
+        if(_zz_272)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_260_)begin
+        if(_zz_273)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_261_)begin
+        if(_zz_274)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -6048,7 +5141,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_236_)begin
+      if(_zz_249)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -6059,10 +5152,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_237_)begin
-        case(_zz_239_)
+      if(_zz_250)begin
+        case(_zz_252)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -6070,14 +5163,8 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_155_,{_zz_154_,_zz_153_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_157,{_zz_156,_zz_155}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -6096,25 +5183,25 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_167_)
+      case(_zz_169)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_167_ <= (3'b001);
+            _zz_169 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_167_ <= (3'b010);
+          _zz_169 <= 3'b010;
         end
         3'b010 : begin
-          _zz_167_ <= (3'b011);
+          _zz_169 <= 3'b011;
         end
         3'b011 : begin
           if((! decode_arbitration_isStuck))begin
-            _zz_167_ <= (3'b100);
+            _zz_169 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_167_ <= (3'b000);
+          _zz_169 <= 3'b000;
         end
         default : begin
         end
@@ -6128,47 +5215,47 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_351_[0];
-          CsrPlugin_mstatus_MIE <= _zz_352_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_365[0];
+          CsrPlugin_mstatus_MIE <= _zz_366[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_354_[0];
-          CsrPlugin_mie_MTIE <= _zz_355_[0];
-          CsrPlugin_mie_MSIE <= _zz_356_[0];
+          CsrPlugin_mie_MEIE <= _zz_368[0];
+          CsrPlugin_mie_MTIE <= _zz_369[0];
+          CsrPlugin_mie_MSIE <= _zz_370[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_163_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_165 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_255_)begin
+      if(_zz_268)begin
         if(iBusWishbone_ACK)begin
-          _zz_191_ <= (_zz_191_ + (3'b001));
+          _zz_193 <= (_zz_193 + 3'b001);
         end
       end
-      _zz_192_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_194_ && _zz_195_))begin
-        _zz_193_ <= (_zz_193_ + (3'b001));
-        if(_zz_197_)begin
-          _zz_193_ <= (3'b000);
+      _zz_194 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_196 && _zz_197))begin
+        _zz_195 <= (_zz_195 + 3'b001);
+        if(_zz_199)begin
+          _zz_195 <= 3'b000;
         end
       end
-      _zz_199_ <= ((_zz_194_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_201 <= ((_zz_196 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_256_)begin
+    if(_zz_269)begin
       IBusCachedPlugin_decompressor_bufferData <= IBusCachedPlugin_decompressor_input_payload_rsp_inst[31 : 16];
     end
     if(IBusCachedPlugin_decompressor_output_ready)begin
-      _zz_94_ <= IBusCachedPlugin_decompressor_output_payload_pc;
-      _zz_95_ <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
-      _zz_96_ <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
-      _zz_97_ <= IBusCachedPlugin_decompressor_output_payload_isRvc;
+      _zz_94 <= IBusCachedPlugin_decompressor_output_payload_pc;
+      _zz_95 <= IBusCachedPlugin_decompressor_output_payload_rsp_error;
+      _zz_96 <= IBusCachedPlugin_decompressor_output_payload_rsp_inst;
+      _zz_97 <= IBusCachedPlugin_decompressor_output_payload_isRvc;
     end
     if(IBusCachedPlugin_injector_decodeInput_ready)begin
       IBusCachedPlugin_injector_formal_rawInDecode <= IBusCachedPlugin_decompressor_raw;
@@ -6176,24 +5263,26 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
     end
-    if(_zz_257_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_270)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    _zz_136_ <= _zz_40_[11 : 7];
-    _zz_137_ <= _zz_50_;
+    _zz_138 <= _zz_40[11 : 7];
+    _zz_139 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -6201,9 +5290,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_232_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_157_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_157_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_245)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_159 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_159 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -6213,21 +5302,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_258_)begin
-      if(_zz_259_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_271)begin
+      if(_zz_272)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_260_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_273)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_261_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_274)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_236_)begin
+    if(_zz_249)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -6247,22 +5336,76 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_227_)begin
-      if(_zz_252_)begin
+    if(_zz_240)begin
+      if(_zz_265)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_342_[31:0];
+          memory_DivPlugin_div_result <= _zz_356[31:0];
         end
       end
     end
-    if(_zz_253_)begin
+    if(_zz_266)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_161_ ? (~ _zz_162_) : _zz_162_) + _zz_348_);
-      memory_DivPlugin_rs2 <= ((_zz_160_ ? (~ execute_RS2) : execute_RS2) + _zz_350_);
-      memory_DivPlugin_div_needRevert <= ((_zz_161_ ^ (_zz_160_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_163 ? (~ _zz_164) : _zz_164) + _zz_362);
+      memory_DivPlugin_rs2 <= ((_zz_162 ? (~ execute_RS2) : execute_RS2) + _zz_364);
+      memory_DivPlugin_div_needRevert <= ((_zz_163 ^ (_zz_162 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PC <= decode_PC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_PC <= _zz_35;
+    end
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RVC <= decode_IS_RVC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_54;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_25;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_CTRL <= _zz_22;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_19;
+    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
@@ -6273,49 +5416,13 @@ module VexRiscv (
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_25_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_54_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_53_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
-    end
-    if((! execute_arbitration_isStuck))begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
@@ -6327,88 +5434,37 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_22_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_19_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RVC <= decode_IS_RVC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
+      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_16_;
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_13_;
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+      execute_to_memory_ENV_CTRL <= _zz_3;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_11_;
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
@@ -6420,34 +5476,79 @@ module VexRiscv (
       memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_9_;
-    end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_6_;
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_4_;
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_2_;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
     end
-    if((_zz_167_ != (3'b000)))begin
-      _zz_96_ <= IBusCachedPlugin_injectionPort_payload;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+    end
+    if((_zz_169 != 3'b000))begin
+      _zz_96 <= IBusCachedPlugin_injectionPort_payload;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -6523,7 +5624,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_353_[0];
+        CsrPlugin_mip_MSIP <= _zz_367[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -6544,7 +5645,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_834)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_357_[0];
+        CsrPlugin_mcause_interrupt <= _zz_371[0];
         CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -6583,12 +5684,12 @@ module VexRiscv (
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
-    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != (4'b0000)) || IBusCachedPlugin_incomingInstruction);
+    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
     if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50_;
+      DebugPlugin_busReadDataReg <= _zz_50;
     end
-    _zz_165_ <= debug_bus_cmd_payload_address[2];
-    if(_zz_234_)begin
+    _zz_167 <= debug_bus_cmd_payload_address[2];
+    if(_zz_247)begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -6601,14 +5702,14 @@ module VexRiscv (
       DebugPlugin_stepIt <= 1'b0;
       DebugPlugin_godmode <= 1'b0;
       DebugPlugin_haltedByBreak <= 1'b0;
-      _zz_166_ <= 1'b0;
+      _zz_168 <= 1'b0;
     end else begin
       if((DebugPlugin_haltIt && (! DebugPlugin_isPipBusy)))begin
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid)begin
-        case(_zz_254_)
-          6'b000000 : begin
+        case(_zz_267)
+          6'h0 : begin
             if(debug_bus_cmd_payload_wr)begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
               if(debug_bus_cmd_payload_data[16])begin
@@ -6631,24 +5732,1119 @@ module VexRiscv (
               end
             end
           end
-          6'b000001 : begin
-          end
           default : begin
           end
         endcase
       end
-      if(_zz_234_)begin
-        if(_zz_235_)begin
+      if(_zz_247)begin
+        if(_zz_248)begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_238_)begin
+      if(_zz_251)begin
         if(decode_arbitration_isValid)begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
-      _zz_166_ <= (DebugPlugin_stepIt && decode_arbitration_isFiring);
+      _zz_168 <= (DebugPlugin_stepIt && decode_arbitration_isFiring);
+    end
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_isLrsc,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire                _zz_19;
+  wire                _zz_20;
+  wire       [0:0]    _zz_21;
+  wire       [0:0]    _zz_22;
+  wire       [9:0]    _zz_23;
+  wire       [9:0]    _zz_24;
+  wire       [0:0]    _zz_25;
+  wire       [0:0]    _zz_26;
+  wire       [0:0]    _zz_27;
+  wire       [2:0]    _zz_28;
+  wire       [1:0]    _zz_29;
+  wire       [21:0]   _zz_30;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  wire                stage0_isAmo;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_isLrsc;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire                stageA_isAmo;
+  wire                stageA_isLrsc;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_isLrsc;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  reg                 stageB_lrSc_reserved;
+  wire                stageB_isAmo;
+  wire                stageB_isAmoCached;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  wire       [31:0]   stageB_requestDataBypass;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_31;
+  reg [7:0] _zz_32;
+  reg [7:0] _zz_33;
+  reg [7:0] _zz_34;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign _zz_16 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_17 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_18 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_19 = (! stageB_flusher_hold);
+  assign _zz_20 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_21 = _zz_4[0 : 0];
+  assign _zz_22 = _zz_4[1 : 1];
+  assign _zz_23 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_24 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_25 = 1'b1;
+  assign _zz_26 = (! stageB_lrSc_reserved);
+  assign _zz_27 = loader_counter_willIncrement;
+  assign _zz_28 = {2'd0, _zz_27};
+  assign _zz_29 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_30 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_30;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_34, _zz_33, _zz_32, _zz_31};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_31 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_32 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_33 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_34 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_21[0];
+  assign ways_0_tagsReadRsp_error = _zz_22[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if(_zz_16)begin
+              dataWriteCmd_valid = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_17)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_17)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_17)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_17)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_25[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_17)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_23)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign stage0_isAmo = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign stageA_isAmo = 1'b0;
+  assign stageA_isLrsc = 1'b0;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_24)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+          if(_zz_18)begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+            if(_zz_16)begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isAmo = 1'b0;
+  assign stageB_isAmoCached = 1'b0;
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  assign stageB_requestDataBypass = stageB_request_data;
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          io_mem_cmd_valid = (! memCmdSent);
+          if(_zz_18)begin
+            io_mem_cmd_valid = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+            if(_zz_16)begin
+              io_mem_cmd_valid = 1'b0;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+    if((stageB_request_isLrsc && stageB_request_wr))begin
+      io_cpu_writeBack_data = {31'd0, _zz_26};
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_17)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_28);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_isLrsc <= stageA_request_isLrsc;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_19)begin
+        if(_zz_20)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      stageB_lrSc_reserved <= 1'b0;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_19)begin
+          if(! _zz_20) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+        stageB_lrSc_reserved <= (! stageB_request_wr);
+      end
+      if(_zz_13)begin
+        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_17)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_29[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  output              io_cpu_fetch_cacheMiss,
+  output              io_cpu_fetch_error,
+  output              io_cpu_fetch_mmuRefilling,
+  output              io_cpu_fetch_mmuException,
+  input               io_cpu_fetch_isUser,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_9;
+  reg        [21:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [21:0]   _zz_15;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_11 = (! lineLoader_flushCounter[7]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_9 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_10 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_11)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_fetch_cacheMiss = (! fetchStage_hit_valid);
+  assign io_cpu_fetch_error = (fetchStage_hit_error || ((! io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute))));
+  assign io_cpu_fetch_mmuRefilling = io_cpu_fetch_mmuRsp_refilling;
+  assign io_cpu_fetch_mmuException = (((! io_cpu_fetch_mmuRsp_refilling) && io_cpu_fetch_mmuRsp_isPaging) && (io_cpu_fetch_mmuRsp_exception || (! io_cpu_fetch_mmuRsp_allowExecute)));
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_12)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_11)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_12)begin
+      lineLoader_flushCounter <= 8'h0;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Linux.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Linux.v
@@ -1,30 +1,7 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:38:57
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
-
-`define Src2CtrlEnum_defaultEncoding_type [1:0]
-`define Src2CtrlEnum_defaultEncoding_RS 2'b00
-`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
-`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
-`define Src2CtrlEnum_defaultEncoding_PC 2'b11
-
-`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
-
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
-
-`define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
@@ -38,10 +15,33 @@
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
+`define ShiftCtrlEnum_defaultEncoding_type [1:0]
+`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+
+`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+
+`define Src2CtrlEnum_defaultEncoding_type [1:0]
+`define Src2CtrlEnum_defaultEncoding_RS 2'b00
+`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
+`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
+`define Src2CtrlEnum_defaultEncoding_PC 2'b11
+
 `define AluCtrlEnum_defaultEncoding_type [1:0]
 `define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
 `define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
 `define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
+
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
 `define MmuPlugin_shared_State_defaultEncoding_type [2:0]
 `define MmuPlugin_shared_State_defaultEncoding_IDLE 3'b000
@@ -50,1148 +50,6 @@
 `define MmuPlugin_shared_State_defaultEncoding_L0_CMD 3'b011
 `define MmuPlugin_shared_State_defaultEncoding_L0_RSP 3'b100
 
-
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire       [0:0]    _zz_14_;
-  wire       [0:0]    _zz_15_;
-  wire       [21:0]   _zz_16_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-
-  assign _zz_12_ = (! lineLoader_flushCounter[7]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_isLrsc,
-  input               io_cpu_execute_args_isAmo,
-  input               io_cpu_execute_args_amoCtrl_swap,
-  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  input               io_cpu_writeBack_clearLrsc,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire                _zz_17_;
-  wire                _zz_18_;
-  wire                _zz_19_;
-  wire                _zz_20_;
-  wire       [2:0]    _zz_21_;
-  wire       [0:0]    _zz_22_;
-  wire       [0:0]    _zz_23_;
-  wire       [31:0]   _zz_24_;
-  wire       [31:0]   _zz_25_;
-  wire       [31:0]   _zz_26_;
-  wire       [31:0]   _zz_27_;
-  wire       [1:0]    _zz_28_;
-  wire       [31:0]   _zz_29_;
-  wire       [1:0]    _zz_30_;
-  wire       [1:0]    _zz_31_;
-  wire       [0:0]    _zz_32_;
-  wire       [0:0]    _zz_33_;
-  wire       [2:0]    _zz_34_;
-  wire       [1:0]    _zz_35_;
-  wire       [21:0]   _zz_36_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg                 stageA_request_isLrsc;
-  reg                 stageA_request_isAmo;
-  reg                 stageA_request_amoCtrl_swap;
-  reg        [2:0]    stageA_request_amoCtrl_alu;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_request_isLrsc;
-  reg                 stageB_request_isAmo;
-  reg                 stageB_request_amoCtrl_swap;
-  reg        [2:0]    stageB_request_amoCtrl_alu;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  reg                 stageB_lrsc_reserved;
-  reg        [31:0]   stageB_requestDataBypass;
-  wire                stageB_amo_compare;
-  wire                stageB_amo_unsigned;
-  wire       [31:0]   stageB_amo_addSub;
-  wire                stageB_amo_less;
-  wire                stageB_amo_selectRf;
-  reg        [31:0]   stageB_amo_result;
-  reg                 stageB_amo_resultRegValid;
-  reg        [31:0]   stageB_amo_resultReg;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_37_;
-  reg [7:0] _zz_38_;
-  reg [7:0] _zz_39_;
-  reg [7:0] _zz_40_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign _zz_15_ = (! stageB_amo_resultRegValid);
-  assign _zz_16_ = (stageB_request_isLrsc && (! stageB_lrsc_reserved));
-  assign _zz_17_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_18_ = (stageB_request_isLrsc && (! stageB_lrsc_reserved));
-  assign _zz_19_ = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0)));
-  assign _zz_20_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_21_ = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,(2'b00)});
-  assign _zz_22_ = _zz_4_[0 : 0];
-  assign _zz_23_ = _zz_4_[1 : 1];
-  assign _zz_24_ = ($signed(_zz_25_) + $signed(_zz_29_));
-  assign _zz_25_ = ($signed(_zz_26_) + $signed(_zz_27_));
-  assign _zz_26_ = stageB_request_data;
-  assign _zz_27_ = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
-  assign _zz_28_ = (stageB_amo_compare ? _zz_30_ : _zz_31_);
-  assign _zz_29_ = {{30{_zz_28_[1]}}, _zz_28_};
-  assign _zz_30_ = (2'b01);
-  assign _zz_31_ = (2'b00);
-  assign _zz_32_ = (! stageB_lrsc_reserved);
-  assign _zz_33_ = loader_counter_willIncrement;
-  assign _zz_34_ = {2'd0, _zz_33_};
-  assign _zz_35_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_36_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_36_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_40_, _zz_39_, _zz_38_, _zz_37_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_37_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_38_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_39_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_40_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_22_[0];
-  assign ways_0_tagsReadRsp_error = _zz_23_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              dataWriteCmd_valid = 1'b0;
-            end
-          end
-          if(_zz_16_)begin
-            dataWriteCmd_valid = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-        if(_zz_18_)begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              io_cpu_writeBack_haltIt = 1'b1;
-            end
-          end
-          if(_zz_16_)begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    stageB_requestDataBypass = stageB_request_data;
-    if(stageB_request_isAmo)begin
-      stageB_requestDataBypass = stageB_amo_resultReg;
-    end
-  end
-
-  assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
-  assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == (2'b11));
-  assign stageB_amo_addSub = _zz_24_;
-  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
-  assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  always @ (*) begin
-    case(_zz_21_)
-      3'b000 : begin
-        stageB_amo_result = stageB_amo_addSub;
-      end
-      3'b001 : begin
-        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
-      end
-      3'b010 : begin
-        stageB_amo_result = (stageB_request_data | stageB_dataMux);
-      end
-      3'b011 : begin
-        stageB_amo_result = (stageB_request_data & stageB_dataMux);
-      end
-      default : begin
-        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if(_zz_19_)begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-        if(_zz_18_)begin
-          io_mem_cmd_valid = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              io_mem_cmd_valid = 1'b0;
-            end
-          end
-          if(_zz_19_)begin
-            io_mem_cmd_valid = 1'b0;
-          end
-          if(_zz_16_)begin
-            io_mem_cmd_valid = 1'b0;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_32_};
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_17_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_34_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
-      stageA_request_isAmo <= io_cpu_execute_args_isAmo;
-      stageA_request_amoCtrl_swap <= io_cpu_execute_args_amoCtrl_swap;
-      stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-      stageB_request_isLrsc <= stageA_request_isLrsc;
-      stageB_request_isAmo <= stageA_request_isAmo;
-      stageB_request_amoCtrl_swap <= stageA_request_amoCtrl_swap;
-      stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_20_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    stageB_amo_resultRegValid <= 1'b1;
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_amo_resultRegValid <= 1'b0;
-    end
-    stageB_amo_resultReg <= stageB_amo_result;
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_lrsc_reserved <= 1'b0;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_20_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(((((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && (! io_cpu_redo)) && stageB_request_isLrsc) && (! stageB_request_wr)))begin
-        stageB_lrsc_reserved <= 1'b1;
-      end
-      if(io_cpu_writeBack_clearLrsc)begin
-        stageB_lrsc_reserved <= 1'b0;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_17_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_35_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1207,8 +65,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1218,69 +76,74 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset 
+  input               reset
 );
-  wire                _zz_197_;
-  wire                _zz_198_;
-  wire                _zz_199_;
-  wire                _zz_200_;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire                _zz_203_;
-  reg                 _zz_204_;
-  reg                 _zz_205_;
-  reg        [31:0]   _zz_206_;
-  reg                 _zz_207_;
-  reg        [31:0]   _zz_208_;
-  reg        [1:0]    _zz_209_;
-  reg                 _zz_210_;
-  reg                 _zz_211_;
-  wire                _zz_212_;
-  wire       [2:0]    _zz_213_;
-  reg                 _zz_214_;
-  wire       [31:0]   _zz_215_;
-  reg                 _zz_216_;
-  reg                 _zz_217_;
-  wire                _zz_218_;
-  wire       [31:0]   _zz_219_;
-  wire                _zz_220_;
-  wire                _zz_221_;
-  reg        [31:0]   _zz_222_;
-  reg        [31:0]   _zz_223_;
-  reg        [31:0]   _zz_224_;
-  reg                 _zz_225_;
-  reg                 _zz_226_;
-  reg                 _zz_227_;
-  reg        [9:0]    _zz_228_;
-  reg        [9:0]    _zz_229_;
-  reg        [9:0]    _zz_230_;
-  reg        [9:0]    _zz_231_;
-  reg                 _zz_232_;
-  reg                 _zz_233_;
-  reg                 _zz_234_;
-  reg                 _zz_235_;
-  reg                 _zz_236_;
-  reg                 _zz_237_;
-  reg                 _zz_238_;
-  reg        [9:0]    _zz_239_;
-  reg        [9:0]    _zz_240_;
-  reg        [9:0]    _zz_241_;
-  reg        [9:0]    _zz_242_;
-  reg                 _zz_243_;
-  reg                 _zz_244_;
-  reg                 _zz_245_;
-  reg                 _zz_246_;
+  wire                _zz_205;
+  wire                _zz_206;
+  wire                _zz_207;
+  wire                _zz_208;
+  wire                _zz_209;
+  wire                _zz_210;
+  wire                _zz_211;
+  wire                _zz_212;
+  reg                 _zz_213;
+  reg                 _zz_214;
+  reg        [31:0]   _zz_215;
+  reg                 _zz_216;
+  reg        [31:0]   _zz_217;
+  reg        [1:0]    _zz_218;
+  reg                 _zz_219;
+  reg                 _zz_220;
+  wire                _zz_221;
+  wire       [2:0]    _zz_222;
+  reg                 _zz_223;
+  wire       [31:0]   _zz_224;
+  reg                 _zz_225;
+  reg                 _zz_226;
+  wire                _zz_227;
+  wire       [31:0]   _zz_228;
+  wire                _zz_229;
+  wire                _zz_230;
+  wire                _zz_231;
+  wire                _zz_232;
+  wire                _zz_233;
+  wire                _zz_234;
+  wire                _zz_235;
+  wire                _zz_236;
+  wire       [3:0]    _zz_237;
+  wire                _zz_238;
+  wire                _zz_239;
+  reg        [31:0]   _zz_240;
+  reg        [31:0]   _zz_241;
+  reg        [31:0]   _zz_242;
+  reg                 _zz_243;
+  reg                 _zz_244;
+  reg                 _zz_245;
+  reg        [9:0]    _zz_246;
+  reg        [9:0]    _zz_247;
+  reg        [9:0]    _zz_248;
+  reg        [9:0]    _zz_249;
+  reg                 _zz_250;
+  reg                 _zz_251;
+  reg                 _zz_252;
+  reg                 _zz_253;
+  reg                 _zz_254;
+  reg                 _zz_255;
+  reg                 _zz_256;
+  reg        [9:0]    _zz_257;
+  reg        [9:0]    _zz_258;
+  reg        [9:0]    _zz_259;
+  reg        [9:0]    _zz_260;
+  reg                 _zz_261;
+  reg                 _zz_262;
+  reg                 _zz_263;
+  reg                 _zz_264;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -1290,543 +153,535 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_247_;
-  wire                _zz_248_;
-  wire                _zz_249_;
-  wire                _zz_250_;
-  wire                _zz_251_;
-  wire                _zz_252_;
-  wire                _zz_253_;
-  wire                _zz_254_;
-  wire                _zz_255_;
-  wire                _zz_256_;
-  wire                _zz_257_;
-  wire                _zz_258_;
-  wire                _zz_259_;
-  wire                _zz_260_;
-  wire       [1:0]    _zz_261_;
-  wire                _zz_262_;
-  wire                _zz_263_;
-  wire                _zz_264_;
-  wire                _zz_265_;
-  wire                _zz_266_;
-  wire                _zz_267_;
-  wire                _zz_268_;
-  wire                _zz_269_;
-  wire                _zz_270_;
-  wire                _zz_271_;
-  wire                _zz_272_;
-  wire                _zz_273_;
-  wire                _zz_274_;
-  wire                _zz_275_;
-  wire                _zz_276_;
-  wire       [1:0]    _zz_277_;
-  wire                _zz_278_;
-  wire                _zz_279_;
-  wire                _zz_280_;
-  wire                _zz_281_;
-  wire                _zz_282_;
-  wire                _zz_283_;
-  wire                _zz_284_;
-  wire                _zz_285_;
-  wire                _zz_286_;
-  wire                _zz_287_;
-  wire                _zz_288_;
-  wire                _zz_289_;
-  wire                _zz_290_;
-  wire                _zz_291_;
-  wire                _zz_292_;
-  wire                _zz_293_;
-  wire                _zz_294_;
-  wire                _zz_295_;
-  wire                _zz_296_;
-  wire                _zz_297_;
-  wire                _zz_298_;
-  wire                _zz_299_;
-  wire                _zz_300_;
-  wire                _zz_301_;
-  wire                _zz_302_;
-  wire       [1:0]    _zz_303_;
-  wire                _zz_304_;
-  wire       [1:0]    _zz_305_;
-  wire       [0:0]    _zz_306_;
-  wire       [0:0]    _zz_307_;
-  wire       [0:0]    _zz_308_;
-  wire       [32:0]   _zz_309_;
-  wire       [31:0]   _zz_310_;
-  wire       [32:0]   _zz_311_;
-  wire       [0:0]    _zz_312_;
-  wire       [0:0]    _zz_313_;
-  wire       [0:0]    _zz_314_;
-  wire       [0:0]    _zz_315_;
-  wire       [0:0]    _zz_316_;
-  wire       [0:0]    _zz_317_;
-  wire       [0:0]    _zz_318_;
-  wire       [51:0]   _zz_319_;
-  wire       [51:0]   _zz_320_;
-  wire       [51:0]   _zz_321_;
-  wire       [32:0]   _zz_322_;
-  wire       [51:0]   _zz_323_;
-  wire       [49:0]   _zz_324_;
-  wire       [51:0]   _zz_325_;
-  wire       [49:0]   _zz_326_;
-  wire       [51:0]   _zz_327_;
-  wire       [0:0]    _zz_328_;
-  wire       [0:0]    _zz_329_;
-  wire       [0:0]    _zz_330_;
-  wire       [0:0]    _zz_331_;
-  wire       [0:0]    _zz_332_;
-  wire       [0:0]    _zz_333_;
-  wire       [0:0]    _zz_334_;
-  wire       [0:0]    _zz_335_;
-  wire       [0:0]    _zz_336_;
-  wire       [0:0]    _zz_337_;
-  wire       [4:0]    _zz_338_;
-  wire       [2:0]    _zz_339_;
-  wire       [31:0]   _zz_340_;
-  wire       [11:0]   _zz_341_;
-  wire       [31:0]   _zz_342_;
-  wire       [19:0]   _zz_343_;
-  wire       [11:0]   _zz_344_;
-  wire       [31:0]   _zz_345_;
-  wire       [31:0]   _zz_346_;
-  wire       [19:0]   _zz_347_;
-  wire       [11:0]   _zz_348_;
-  wire       [2:0]    _zz_349_;
-  wire       [2:0]    _zz_350_;
-  wire       [0:0]    _zz_351_;
-  wire       [1:0]    _zz_352_;
-  wire       [0:0]    _zz_353_;
-  wire       [1:0]    _zz_354_;
-  wire       [0:0]    _zz_355_;
-  wire       [0:0]    _zz_356_;
-  wire       [0:0]    _zz_357_;
-  wire       [0:0]    _zz_358_;
-  wire       [0:0]    _zz_359_;
-  wire       [0:0]    _zz_360_;
-  wire       [0:0]    _zz_361_;
-  wire       [0:0]    _zz_362_;
-  wire       [0:0]    _zz_363_;
-  wire       [2:0]    _zz_364_;
-  wire       [4:0]    _zz_365_;
-  wire       [11:0]   _zz_366_;
-  wire       [11:0]   _zz_367_;
-  wire       [31:0]   _zz_368_;
-  wire       [31:0]   _zz_369_;
-  wire       [31:0]   _zz_370_;
-  wire       [31:0]   _zz_371_;
-  wire       [31:0]   _zz_372_;
-  wire       [31:0]   _zz_373_;
-  wire       [31:0]   _zz_374_;
-  wire       [11:0]   _zz_375_;
-  wire       [19:0]   _zz_376_;
-  wire       [11:0]   _zz_377_;
-  wire       [31:0]   _zz_378_;
-  wire       [31:0]   _zz_379_;
-  wire       [31:0]   _zz_380_;
-  wire       [11:0]   _zz_381_;
-  wire       [19:0]   _zz_382_;
-  wire       [11:0]   _zz_383_;
-  wire       [2:0]    _zz_384_;
-  wire       [1:0]    _zz_385_;
-  wire       [1:0]    _zz_386_;
-  wire       [65:0]   _zz_387_;
-  wire       [65:0]   _zz_388_;
-  wire       [31:0]   _zz_389_;
-  wire       [31:0]   _zz_390_;
-  wire       [0:0]    _zz_391_;
-  wire       [5:0]    _zz_392_;
-  wire       [32:0]   _zz_393_;
-  wire       [31:0]   _zz_394_;
-  wire       [31:0]   _zz_395_;
-  wire       [32:0]   _zz_396_;
-  wire       [32:0]   _zz_397_;
-  wire       [32:0]   _zz_398_;
-  wire       [32:0]   _zz_399_;
-  wire       [0:0]    _zz_400_;
-  wire       [32:0]   _zz_401_;
-  wire       [0:0]    _zz_402_;
-  wire       [32:0]   _zz_403_;
-  wire       [0:0]    _zz_404_;
-  wire       [31:0]   _zz_405_;
-  wire       [0:0]    _zz_406_;
-  wire       [0:0]    _zz_407_;
-  wire       [0:0]    _zz_408_;
-  wire       [0:0]    _zz_409_;
-  wire       [0:0]    _zz_410_;
-  wire       [0:0]    _zz_411_;
-  wire       [0:0]    _zz_412_;
-  wire       [0:0]    _zz_413_;
-  wire       [0:0]    _zz_414_;
-  wire       [0:0]    _zz_415_;
-  wire       [0:0]    _zz_416_;
-  wire       [0:0]    _zz_417_;
-  wire       [0:0]    _zz_418_;
-  wire       [0:0]    _zz_419_;
-  wire       [0:0]    _zz_420_;
-  wire       [0:0]    _zz_421_;
-  wire       [0:0]    _zz_422_;
-  wire       [0:0]    _zz_423_;
-  wire       [0:0]    _zz_424_;
-  wire       [0:0]    _zz_425_;
-  wire       [0:0]    _zz_426_;
-  wire       [0:0]    _zz_427_;
-  wire       [0:0]    _zz_428_;
-  wire       [0:0]    _zz_429_;
-  wire       [0:0]    _zz_430_;
-  wire       [0:0]    _zz_431_;
-  wire       [0:0]    _zz_432_;
-  wire       [0:0]    _zz_433_;
-  wire       [0:0]    _zz_434_;
-  wire       [0:0]    _zz_435_;
-  wire       [0:0]    _zz_436_;
-  wire       [0:0]    _zz_437_;
-  wire       [0:0]    _zz_438_;
-  wire       [0:0]    _zz_439_;
-  wire       [0:0]    _zz_440_;
-  wire       [0:0]    _zz_441_;
-  wire       [0:0]    _zz_442_;
-  wire       [0:0]    _zz_443_;
-  wire       [0:0]    _zz_444_;
-  wire       [0:0]    _zz_445_;
-  wire       [0:0]    _zz_446_;
-  wire       [0:0]    _zz_447_;
-  wire       [0:0]    _zz_448_;
-  wire       [0:0]    _zz_449_;
-  wire       [0:0]    _zz_450_;
-  wire       [26:0]   _zz_451_;
-  wire                _zz_452_;
-  wire                _zz_453_;
-  wire       [2:0]    _zz_454_;
-  wire       [31:0]   _zz_455_;
-  wire       [31:0]   _zz_456_;
-  wire       [31:0]   _zz_457_;
-  wire                _zz_458_;
-  wire       [0:0]    _zz_459_;
-  wire       [17:0]   _zz_460_;
-  wire       [31:0]   _zz_461_;
-  wire       [31:0]   _zz_462_;
-  wire       [31:0]   _zz_463_;
-  wire                _zz_464_;
-  wire       [0:0]    _zz_465_;
-  wire       [11:0]   _zz_466_;
-  wire       [31:0]   _zz_467_;
-  wire       [31:0]   _zz_468_;
-  wire       [31:0]   _zz_469_;
-  wire                _zz_470_;
-  wire       [0:0]    _zz_471_;
-  wire       [5:0]    _zz_472_;
-  wire       [31:0]   _zz_473_;
-  wire       [31:0]   _zz_474_;
-  wire       [31:0]   _zz_475_;
-  wire                _zz_476_;
-  wire                _zz_477_;
-  wire                _zz_478_;
-  wire                _zz_479_;
-  wire                _zz_480_;
-  wire       [31:0]   _zz_481_;
-  wire       [31:0]   _zz_482_;
-  wire                _zz_483_;
-  wire       [0:0]    _zz_484_;
-  wire       [2:0]    _zz_485_;
-  wire       [31:0]   _zz_486_;
-  wire       [31:0]   _zz_487_;
-  wire                _zz_488_;
-  wire       [1:0]    _zz_489_;
-  wire       [1:0]    _zz_490_;
-  wire                _zz_491_;
-  wire       [0:0]    _zz_492_;
-  wire       [28:0]   _zz_493_;
-  wire       [31:0]   _zz_494_;
-  wire       [31:0]   _zz_495_;
-  wire       [31:0]   _zz_496_;
-  wire                _zz_497_;
-  wire       [0:0]    _zz_498_;
-  wire       [0:0]    _zz_499_;
-  wire       [31:0]   _zz_500_;
-  wire                _zz_501_;
-  wire                _zz_502_;
-  wire       [0:0]    _zz_503_;
-  wire       [1:0]    _zz_504_;
-  wire       [2:0]    _zz_505_;
-  wire       [2:0]    _zz_506_;
-  wire                _zz_507_;
-  wire       [0:0]    _zz_508_;
-  wire       [26:0]   _zz_509_;
-  wire       [31:0]   _zz_510_;
-  wire       [31:0]   _zz_511_;
-  wire       [31:0]   _zz_512_;
-  wire       [31:0]   _zz_513_;
-  wire       [31:0]   _zz_514_;
-  wire       [31:0]   _zz_515_;
-  wire       [31:0]   _zz_516_;
-  wire       [31:0]   _zz_517_;
-  wire       [31:0]   _zz_518_;
-  wire                _zz_519_;
-  wire                _zz_520_;
-  wire       [0:0]    _zz_521_;
-  wire       [0:0]    _zz_522_;
-  wire       [0:0]    _zz_523_;
-  wire       [0:0]    _zz_524_;
-  wire       [1:0]    _zz_525_;
-  wire       [1:0]    _zz_526_;
-  wire                _zz_527_;
-  wire       [0:0]    _zz_528_;
-  wire       [24:0]   _zz_529_;
-  wire       [31:0]   _zz_530_;
-  wire       [31:0]   _zz_531_;
-  wire       [31:0]   _zz_532_;
-  wire       [31:0]   _zz_533_;
-  wire       [31:0]   _zz_534_;
-  wire       [31:0]   _zz_535_;
-  wire                _zz_536_;
-  wire       [0:0]    _zz_537_;
-  wire       [0:0]    _zz_538_;
-  wire                _zz_539_;
-  wire       [0:0]    _zz_540_;
-  wire       [21:0]   _zz_541_;
-  wire       [31:0]   _zz_542_;
-  wire       [31:0]   _zz_543_;
-  wire                _zz_544_;
-  wire                _zz_545_;
-  wire       [0:0]    _zz_546_;
-  wire       [4:0]    _zz_547_;
-  wire       [0:0]    _zz_548_;
-  wire       [3:0]    _zz_549_;
-  wire       [0:0]    _zz_550_;
-  wire       [0:0]    _zz_551_;
-  wire                _zz_552_;
-  wire       [0:0]    _zz_553_;
-  wire       [17:0]   _zz_554_;
-  wire       [31:0]   _zz_555_;
-  wire       [31:0]   _zz_556_;
-  wire       [31:0]   _zz_557_;
-  wire       [31:0]   _zz_558_;
-  wire                _zz_559_;
-  wire       [0:0]    _zz_560_;
-  wire       [2:0]    _zz_561_;
-  wire       [31:0]   _zz_562_;
-  wire       [31:0]   _zz_563_;
-  wire                _zz_564_;
-  wire       [0:0]    _zz_565_;
-  wire       [1:0]    _zz_566_;
-  wire       [0:0]    _zz_567_;
-  wire       [2:0]    _zz_568_;
-  wire       [0:0]    _zz_569_;
-  wire       [0:0]    _zz_570_;
-  wire                _zz_571_;
-  wire       [0:0]    _zz_572_;
-  wire       [15:0]   _zz_573_;
-  wire       [31:0]   _zz_574_;
-  wire       [31:0]   _zz_575_;
-  wire       [31:0]   _zz_576_;
-  wire                _zz_577_;
-  wire       [0:0]    _zz_578_;
-  wire       [0:0]    _zz_579_;
-  wire       [31:0]   _zz_580_;
-  wire       [31:0]   _zz_581_;
-  wire       [31:0]   _zz_582_;
-  wire                _zz_583_;
-  wire       [31:0]   _zz_584_;
-  wire       [31:0]   _zz_585_;
-  wire                _zz_586_;
-  wire       [0:0]    _zz_587_;
-  wire       [0:0]    _zz_588_;
-  wire       [31:0]   _zz_589_;
-  wire       [31:0]   _zz_590_;
-  wire                _zz_591_;
-  wire       [0:0]    _zz_592_;
-  wire       [0:0]    _zz_593_;
-  wire                _zz_594_;
-  wire       [0:0]    _zz_595_;
-  wire       [13:0]   _zz_596_;
-  wire       [31:0]   _zz_597_;
-  wire       [31:0]   _zz_598_;
-  wire       [31:0]   _zz_599_;
-  wire       [31:0]   _zz_600_;
-  wire       [31:0]   _zz_601_;
-  wire       [31:0]   _zz_602_;
-  wire       [31:0]   _zz_603_;
-  wire       [31:0]   _zz_604_;
-  wire       [31:0]   _zz_605_;
-  wire       [31:0]   _zz_606_;
-  wire       [31:0]   _zz_607_;
-  wire       [31:0]   _zz_608_;
-  wire       [0:0]    _zz_609_;
-  wire       [0:0]    _zz_610_;
-  wire                _zz_611_;
-  wire       [0:0]    _zz_612_;
-  wire       [11:0]   _zz_613_;
-  wire       [31:0]   _zz_614_;
-  wire       [31:0]   _zz_615_;
-  wire                _zz_616_;
-  wire                _zz_617_;
-  wire       [31:0]   _zz_618_;
-  wire       [31:0]   _zz_619_;
-  wire                _zz_620_;
-  wire       [4:0]    _zz_621_;
-  wire       [4:0]    _zz_622_;
-  wire                _zz_623_;
-  wire       [0:0]    _zz_624_;
-  wire       [7:0]    _zz_625_;
-  wire       [31:0]   _zz_626_;
-  wire       [31:0]   _zz_627_;
-  wire                _zz_628_;
-  wire       [0:0]    _zz_629_;
-  wire       [1:0]    _zz_630_;
-  wire       [0:0]    _zz_631_;
-  wire       [2:0]    _zz_632_;
-  wire       [0:0]    _zz_633_;
-  wire       [0:0]    _zz_634_;
-  wire       [0:0]    _zz_635_;
-  wire       [0:0]    _zz_636_;
-  wire                _zz_637_;
-  wire       [0:0]    _zz_638_;
-  wire       [4:0]    _zz_639_;
-  wire       [31:0]   _zz_640_;
-  wire       [31:0]   _zz_641_;
-  wire       [31:0]   _zz_642_;
-  wire                _zz_643_;
-  wire       [31:0]   _zz_644_;
-  wire       [31:0]   _zz_645_;
-  wire                _zz_646_;
-  wire       [0:0]    _zz_647_;
-  wire       [0:0]    _zz_648_;
-  wire       [31:0]   _zz_649_;
-  wire       [31:0]   _zz_650_;
-  wire       [31:0]   _zz_651_;
-  wire       [31:0]   _zz_652_;
-  wire                _zz_653_;
-  wire       [0:0]    _zz_654_;
-  wire       [0:0]    _zz_655_;
-  wire                _zz_656_;
-  wire       [0:0]    _zz_657_;
-  wire       [2:0]    _zz_658_;
-  wire       [31:0]   _zz_659_;
-  wire       [31:0]   _zz_660_;
-  wire       [31:0]   _zz_661_;
-  wire       [31:0]   _zz_662_;
-  wire       [31:0]   _zz_663_;
-  wire       [31:0]   _zz_664_;
-  wire       [31:0]   _zz_665_;
-  wire       [31:0]   _zz_666_;
-  wire       [31:0]   _zz_667_;
-  wire       [0:0]    _zz_668_;
-  wire       [0:0]    _zz_669_;
-  wire       [1:0]    _zz_670_;
-  wire       [1:0]    _zz_671_;
-  wire                _zz_672_;
-  wire       [0:0]    _zz_673_;
-  wire       [0:0]    _zz_674_;
-  wire       [31:0]   _zz_675_;
-  wire       [31:0]   _zz_676_;
-  wire       [31:0]   _zz_677_;
-  wire       [31:0]   _zz_678_;
-  wire       [31:0]   _zz_679_;
-  wire       [31:0]   _zz_680_;
-  wire       [31:0]   _zz_681_;
-  wire       [31:0]   _zz_682_;
-  wire       [0:0]    _zz_683_;
-  wire       [0:0]    _zz_684_;
-  wire       [0:0]    _zz_685_;
-  wire       [0:0]    _zz_686_;
-  wire                _zz_687_;
-  wire                _zz_688_;
-  wire                _zz_689_;
-  wire       [31:0]   _zz_690_;
-  wire                decode_IS_RS2_SIGNED;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_3_;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire                execute_BRANCH_DO;
-  wire                decode_CSR_READ_OPCODE;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_265;
+  wire                _zz_266;
+  wire                _zz_267;
+  wire                _zz_268;
+  wire                _zz_269;
+  wire                _zz_270;
+  wire                _zz_271;
+  wire                _zz_272;
+  wire                _zz_273;
+  wire                _zz_274;
+  wire                _zz_275;
+  wire                _zz_276;
+  wire                _zz_277;
+  wire                _zz_278;
+  wire       [1:0]    _zz_279;
+  wire                _zz_280;
+  wire                _zz_281;
+  wire                _zz_282;
+  wire                _zz_283;
+  wire                _zz_284;
+  wire                _zz_285;
+  wire                _zz_286;
+  wire                _zz_287;
+  wire                _zz_288;
+  wire                _zz_289;
+  wire                _zz_290;
+  wire                _zz_291;
+  wire                _zz_292;
+  wire                _zz_293;
+  wire                _zz_294;
+  wire       [1:0]    _zz_295;
+  wire                _zz_296;
+  wire                _zz_297;
+  wire                _zz_298;
+  wire                _zz_299;
+  wire                _zz_300;
+  wire                _zz_301;
+  wire                _zz_302;
+  wire                _zz_303;
+  wire                _zz_304;
+  wire                _zz_305;
+  wire                _zz_306;
+  wire                _zz_307;
+  wire                _zz_308;
+  wire                _zz_309;
+  wire                _zz_310;
+  wire                _zz_311;
+  wire                _zz_312;
+  wire                _zz_313;
+  wire                _zz_314;
+  wire                _zz_315;
+  wire                _zz_316;
+  wire                _zz_317;
+  wire                _zz_318;
+  wire                _zz_319;
+  wire       [1:0]    _zz_320;
+  wire                _zz_321;
+  wire       [1:0]    _zz_322;
+  wire       [51:0]   _zz_323;
+  wire       [51:0]   _zz_324;
+  wire       [51:0]   _zz_325;
+  wire       [32:0]   _zz_326;
+  wire       [51:0]   _zz_327;
+  wire       [49:0]   _zz_328;
+  wire       [51:0]   _zz_329;
+  wire       [49:0]   _zz_330;
+  wire       [51:0]   _zz_331;
+  wire       [32:0]   _zz_332;
+  wire       [31:0]   _zz_333;
+  wire       [32:0]   _zz_334;
+  wire       [0:0]    _zz_335;
+  wire       [0:0]    _zz_336;
+  wire       [0:0]    _zz_337;
+  wire       [0:0]    _zz_338;
+  wire       [0:0]    _zz_339;
+  wire       [0:0]    _zz_340;
+  wire       [0:0]    _zz_341;
+  wire       [0:0]    _zz_342;
+  wire       [0:0]    _zz_343;
+  wire       [0:0]    _zz_344;
+  wire       [0:0]    _zz_345;
+  wire       [0:0]    _zz_346;
+  wire       [0:0]    _zz_347;
+  wire       [0:0]    _zz_348;
+  wire       [0:0]    _zz_349;
+  wire       [0:0]    _zz_350;
+  wire       [0:0]    _zz_351;
+  wire       [0:0]    _zz_352;
+  wire       [0:0]    _zz_353;
+  wire       [0:0]    _zz_354;
+  wire       [4:0]    _zz_355;
+  wire       [2:0]    _zz_356;
+  wire       [31:0]   _zz_357;
+  wire       [11:0]   _zz_358;
+  wire       [31:0]   _zz_359;
+  wire       [19:0]   _zz_360;
+  wire       [11:0]   _zz_361;
+  wire       [31:0]   _zz_362;
+  wire       [31:0]   _zz_363;
+  wire       [19:0]   _zz_364;
+  wire       [11:0]   _zz_365;
+  wire       [2:0]    _zz_366;
+  wire       [2:0]    _zz_367;
+  wire       [0:0]    _zz_368;
+  wire       [1:0]    _zz_369;
+  wire       [0:0]    _zz_370;
+  wire       [1:0]    _zz_371;
+  wire       [0:0]    _zz_372;
+  wire       [0:0]    _zz_373;
+  wire       [0:0]    _zz_374;
+  wire       [0:0]    _zz_375;
+  wire       [0:0]    _zz_376;
+  wire       [0:0]    _zz_377;
+  wire       [0:0]    _zz_378;
+  wire       [0:0]    _zz_379;
+  wire       [1:0]    _zz_380;
+  wire       [0:0]    _zz_381;
+  wire       [2:0]    _zz_382;
+  wire       [4:0]    _zz_383;
+  wire       [11:0]   _zz_384;
+  wire       [11:0]   _zz_385;
+  wire       [31:0]   _zz_386;
+  wire       [31:0]   _zz_387;
+  wire       [31:0]   _zz_388;
+  wire       [31:0]   _zz_389;
+  wire       [31:0]   _zz_390;
+  wire       [31:0]   _zz_391;
+  wire       [31:0]   _zz_392;
+  wire       [11:0]   _zz_393;
+  wire       [19:0]   _zz_394;
+  wire       [11:0]   _zz_395;
+  wire       [31:0]   _zz_396;
+  wire       [31:0]   _zz_397;
+  wire       [31:0]   _zz_398;
+  wire       [11:0]   _zz_399;
+  wire       [19:0]   _zz_400;
+  wire       [11:0]   _zz_401;
+  wire       [2:0]    _zz_402;
+  wire       [1:0]    _zz_403;
+  wire       [1:0]    _zz_404;
+  wire       [65:0]   _zz_405;
+  wire       [65:0]   _zz_406;
+  wire       [31:0]   _zz_407;
+  wire       [31:0]   _zz_408;
+  wire       [0:0]    _zz_409;
+  wire       [5:0]    _zz_410;
+  wire       [32:0]   _zz_411;
+  wire       [31:0]   _zz_412;
+  wire       [31:0]   _zz_413;
+  wire       [32:0]   _zz_414;
+  wire       [32:0]   _zz_415;
+  wire       [32:0]   _zz_416;
+  wire       [32:0]   _zz_417;
+  wire       [0:0]    _zz_418;
+  wire       [32:0]   _zz_419;
+  wire       [0:0]    _zz_420;
+  wire       [32:0]   _zz_421;
+  wire       [0:0]    _zz_422;
+  wire       [31:0]   _zz_423;
+  wire       [0:0]    _zz_424;
+  wire       [0:0]    _zz_425;
+  wire       [0:0]    _zz_426;
+  wire       [0:0]    _zz_427;
+  wire       [0:0]    _zz_428;
+  wire       [0:0]    _zz_429;
+  wire       [0:0]    _zz_430;
+  wire       [0:0]    _zz_431;
+  wire       [0:0]    _zz_432;
+  wire       [0:0]    _zz_433;
+  wire       [0:0]    _zz_434;
+  wire       [0:0]    _zz_435;
+  wire       [0:0]    _zz_436;
+  wire       [0:0]    _zz_437;
+  wire       [0:0]    _zz_438;
+  wire       [0:0]    _zz_439;
+  wire       [0:0]    _zz_440;
+  wire       [0:0]    _zz_441;
+  wire       [0:0]    _zz_442;
+  wire       [0:0]    _zz_443;
+  wire       [0:0]    _zz_444;
+  wire       [0:0]    _zz_445;
+  wire       [0:0]    _zz_446;
+  wire       [0:0]    _zz_447;
+  wire       [0:0]    _zz_448;
+  wire       [0:0]    _zz_449;
+  wire       [0:0]    _zz_450;
+  wire       [0:0]    _zz_451;
+  wire       [0:0]    _zz_452;
+  wire       [0:0]    _zz_453;
+  wire       [0:0]    _zz_454;
+  wire       [0:0]    _zz_455;
+  wire       [0:0]    _zz_456;
+  wire       [0:0]    _zz_457;
+  wire       [0:0]    _zz_458;
+  wire       [0:0]    _zz_459;
+  wire       [0:0]    _zz_460;
+  wire       [0:0]    _zz_461;
+  wire       [0:0]    _zz_462;
+  wire       [0:0]    _zz_463;
+  wire       [0:0]    _zz_464;
+  wire       [0:0]    _zz_465;
+  wire       [0:0]    _zz_466;
+  wire       [0:0]    _zz_467;
+  wire       [0:0]    _zz_468;
+  wire       [26:0]   _zz_469;
+  wire                _zz_470;
+  wire                _zz_471;
+  wire       [2:0]    _zz_472;
+  wire       [31:0]   _zz_473;
+  wire       [31:0]   _zz_474;
+  wire       [31:0]   _zz_475;
+  wire                _zz_476;
+  wire       [0:0]    _zz_477;
+  wire       [17:0]   _zz_478;
+  wire       [31:0]   _zz_479;
+  wire       [31:0]   _zz_480;
+  wire       [31:0]   _zz_481;
+  wire                _zz_482;
+  wire       [0:0]    _zz_483;
+  wire       [11:0]   _zz_484;
+  wire       [31:0]   _zz_485;
+  wire       [31:0]   _zz_486;
+  wire       [31:0]   _zz_487;
+  wire                _zz_488;
+  wire       [0:0]    _zz_489;
+  wire       [5:0]    _zz_490;
+  wire       [31:0]   _zz_491;
+  wire       [31:0]   _zz_492;
+  wire       [31:0]   _zz_493;
+  wire                _zz_494;
+  wire                _zz_495;
+  wire                _zz_496;
+  wire                _zz_497;
+  wire                _zz_498;
+  wire       [31:0]   _zz_499;
+  wire       [31:0]   _zz_500;
+  wire                _zz_501;
+  wire       [0:0]    _zz_502;
+  wire       [0:0]    _zz_503;
+  wire                _zz_504;
+  wire       [0:0]    _zz_505;
+  wire       [27:0]   _zz_506;
+  wire       [31:0]   _zz_507;
+  wire                _zz_508;
+  wire                _zz_509;
+  wire       [0:0]    _zz_510;
+  wire       [0:0]    _zz_511;
+  wire       [0:0]    _zz_512;
+  wire       [0:0]    _zz_513;
+  wire                _zz_514;
+  wire       [0:0]    _zz_515;
+  wire       [23:0]   _zz_516;
+  wire       [31:0]   _zz_517;
+  wire       [31:0]   _zz_518;
+  wire                _zz_519;
+  wire                _zz_520;
+  wire       [0:0]    _zz_521;
+  wire       [1:0]    _zz_522;
+  wire       [0:0]    _zz_523;
+  wire       [0:0]    _zz_524;
+  wire                _zz_525;
+  wire       [0:0]    _zz_526;
+  wire       [20:0]   _zz_527;
+  wire       [31:0]   _zz_528;
+  wire       [31:0]   _zz_529;
+  wire       [31:0]   _zz_530;
+  wire       [31:0]   _zz_531;
+  wire       [31:0]   _zz_532;
+  wire       [31:0]   _zz_533;
+  wire       [31:0]   _zz_534;
+  wire       [31:0]   _zz_535;
+  wire       [0:0]    _zz_536;
+  wire       [0:0]    _zz_537;
+  wire       [0:0]    _zz_538;
+  wire       [0:0]    _zz_539;
+  wire                _zz_540;
+  wire       [0:0]    _zz_541;
+  wire       [17:0]   _zz_542;
+  wire       [31:0]   _zz_543;
+  wire       [31:0]   _zz_544;
+  wire       [31:0]   _zz_545;
+  wire       [31:0]   _zz_546;
+  wire       [31:0]   _zz_547;
+  wire                _zz_548;
+  wire       [3:0]    _zz_549;
+  wire       [3:0]    _zz_550;
+  wire                _zz_551;
+  wire       [0:0]    _zz_552;
+  wire       [14:0]   _zz_553;
+  wire       [31:0]   _zz_554;
+  wire       [31:0]   _zz_555;
+  wire                _zz_556;
+  wire       [0:0]    _zz_557;
+  wire       [0:0]    _zz_558;
+  wire       [31:0]   _zz_559;
+  wire       [31:0]   _zz_560;
+  wire                _zz_561;
+  wire       [5:0]    _zz_562;
+  wire       [5:0]    _zz_563;
+  wire                _zz_564;
+  wire       [0:0]    _zz_565;
+  wire       [11:0]   _zz_566;
+  wire       [31:0]   _zz_567;
+  wire       [31:0]   _zz_568;
+  wire       [31:0]   _zz_569;
+  wire       [31:0]   _zz_570;
+  wire                _zz_571;
+  wire       [0:0]    _zz_572;
+  wire       [2:0]    _zz_573;
+  wire                _zz_574;
+  wire       [0:0]    _zz_575;
+  wire       [0:0]    _zz_576;
+  wire       [0:0]    _zz_577;
+  wire       [3:0]    _zz_578;
+  wire       [4:0]    _zz_579;
+  wire       [4:0]    _zz_580;
+  wire                _zz_581;
+  wire       [0:0]    _zz_582;
+  wire       [8:0]    _zz_583;
+  wire       [31:0]   _zz_584;
+  wire       [31:0]   _zz_585;
+  wire       [31:0]   _zz_586;
+  wire                _zz_587;
+  wire       [0:0]    _zz_588;
+  wire       [0:0]    _zz_589;
+  wire       [31:0]   _zz_590;
+  wire       [31:0]   _zz_591;
+  wire       [31:0]   _zz_592;
+  wire       [31:0]   _zz_593;
+  wire       [31:0]   _zz_594;
+  wire       [31:0]   _zz_595;
+  wire       [31:0]   _zz_596;
+  wire                _zz_597;
+  wire       [0:0]    _zz_598;
+  wire       [1:0]    _zz_599;
+  wire       [0:0]    _zz_600;
+  wire       [2:0]    _zz_601;
+  wire       [0:0]    _zz_602;
+  wire       [5:0]    _zz_603;
+  wire       [1:0]    _zz_604;
+  wire       [1:0]    _zz_605;
+  wire                _zz_606;
+  wire       [0:0]    _zz_607;
+  wire       [6:0]    _zz_608;
+  wire       [31:0]   _zz_609;
+  wire       [31:0]   _zz_610;
+  wire       [31:0]   _zz_611;
+  wire       [31:0]   _zz_612;
+  wire       [31:0]   _zz_613;
+  wire       [31:0]   _zz_614;
+  wire       [31:0]   _zz_615;
+  wire       [31:0]   _zz_616;
+  wire                _zz_617;
+  wire       [31:0]   _zz_618;
+  wire       [31:0]   _zz_619;
+  wire                _zz_620;
+  wire       [0:0]    _zz_621;
+  wire       [0:0]    _zz_622;
+  wire                _zz_623;
+  wire       [0:0]    _zz_624;
+  wire       [3:0]    _zz_625;
+  wire                _zz_626;
+  wire       [0:0]    _zz_627;
+  wire       [0:0]    _zz_628;
+  wire       [0:0]    _zz_629;
+  wire       [0:0]    _zz_630;
+  wire                _zz_631;
+  wire       [0:0]    _zz_632;
+  wire       [4:0]    _zz_633;
+  wire       [31:0]   _zz_634;
+  wire       [31:0]   _zz_635;
+  wire       [31:0]   _zz_636;
+  wire       [31:0]   _zz_637;
+  wire       [31:0]   _zz_638;
+  wire       [31:0]   _zz_639;
+  wire       [31:0]   _zz_640;
+  wire       [31:0]   _zz_641;
+  wire       [31:0]   _zz_642;
+  wire                _zz_643;
+  wire       [0:0]    _zz_644;
+  wire       [1:0]    _zz_645;
+  wire       [31:0]   _zz_646;
+  wire       [31:0]   _zz_647;
+  wire       [31:0]   _zz_648;
+  wire       [31:0]   _zz_649;
+  wire       [31:0]   _zz_650;
+  wire                _zz_651;
+  wire       [4:0]    _zz_652;
+  wire       [4:0]    _zz_653;
+  wire                _zz_654;
+  wire       [0:0]    _zz_655;
+  wire       [2:0]    _zz_656;
+  wire       [31:0]   _zz_657;
+  wire       [31:0]   _zz_658;
+  wire       [31:0]   _zz_659;
+  wire                _zz_660;
+  wire       [31:0]   _zz_661;
+  wire                _zz_662;
+  wire       [0:0]    _zz_663;
+  wire       [2:0]    _zz_664;
+  wire       [0:0]    _zz_665;
+  wire       [0:0]    _zz_666;
+  wire       [2:0]    _zz_667;
+  wire       [2:0]    _zz_668;
+  wire                _zz_669;
+  wire       [0:0]    _zz_670;
+  wire       [0:0]    _zz_671;
+  wire       [31:0]   _zz_672;
+  wire       [31:0]   _zz_673;
+  wire       [31:0]   _zz_674;
+  wire       [31:0]   _zz_675;
+  wire                _zz_676;
+  wire       [0:0]    _zz_677;
+  wire       [0:0]    _zz_678;
+  wire       [31:0]   _zz_679;
+  wire       [31:0]   _zz_680;
+  wire                _zz_681;
+  wire       [0:0]    _zz_682;
+  wire       [0:0]    _zz_683;
+  wire       [0:0]    _zz_684;
+  wire       [1:0]    _zz_685;
+  wire       [1:0]    _zz_686;
+  wire       [1:0]    _zz_687;
+  wire       [0:0]    _zz_688;
+  wire       [0:0]    _zz_689;
+  wire       [31:0]   _zz_690;
+  wire       [31:0]   _zz_691;
+  wire       [31:0]   _zz_692;
+  wire       [31:0]   _zz_693;
+  wire       [31:0]   _zz_694;
+  wire       [31:0]   _zz_695;
+  wire       [31:0]   _zz_696;
+  wire       [31:0]   _zz_697;
+  wire                _zz_698;
+  wire                _zz_699;
+  wire                _zz_700;
+  wire       [31:0]   _zz_701;
+  wire       [51:0]   memory_MUL_LOW;
   wire       [33:0]   memory_MUL_HH;
   wire       [33:0]   execute_MUL_HH;
-  wire                decode_IS_RS1_SIGNED;
-  wire                decode_MEMORY_AMO;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
-  wire       [31:0]   memory_PC;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire                execute_IS_DBUS_SHARING;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire                decode_SRC_LESS_UNSIGNED;
   wire                memory_IS_SFENCE_VMA;
   wire                execute_IS_SFENCE_VMA;
   wire                decode_IS_SFENCE_VMA;
-  wire                decode_MEMORY_LRSC;
+  wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire       [31:0]   execute_MUL_LL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_6_;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_IS_CSR;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire                decode_IS_DIV;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire                memory_MEMORY_WR;
-  wire                decode_MEMORY_WR;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                execute_IS_DBUS_SHARING;
-  wire       [33:0]   execute_MUL_HL;
-  wire       [51:0]   memory_MUL_LOW;
-  wire                decode_MEMORY_MANAGMENT;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14_;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_23_;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire                memory_IS_MUL;
-  wire                execute_IS_MUL;
-  wire                decode_IS_MUL;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_26_;
-  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   memory_PC;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -1841,11 +696,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -1853,10 +708,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1866,46 +721,46 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_49_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
   wire                writeBack_IS_SFENCE_VMA;
   wire                writeBack_IS_DBUS_SHARING;
   wire                memory_IS_DBUS_SHARING;
-  reg        [31:0]   _zz_50_;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
@@ -1914,24 +769,28 @@ module VexRiscv (
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_AMO;
   wire                execute_MEMORY_LRSC;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
+  wire                decode_MEMORY_AMO;
+  wire                decode_MEMORY_LRSC;
+  reg                 _zz_51;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_51_;
-  reg                 _zz_51__2;
-  reg                 _zz_51__1;
-  reg                 _zz_51__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53_;
-  reg        [31:0]   _zz_54_;
-  reg        [31:0]   _zz_55_;
+  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_54;
+  reg        [31:0]   _zz_55;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -1947,7 +806,7 @@ module VexRiscv (
   wire                decode_arbitration_isMoving;
   wire                decode_arbitration_isFiring;
   reg                 execute_arbitration_haltItself;
-  wire                execute_arbitration_haltByOther;
+  reg                 execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
   wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
@@ -1996,28 +855,63 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   reg        [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  reg                 IBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   reg                 IBusCachedPlugin_mmuBus_rsp_exception;
   reg                 IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_0_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_0_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_1_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_1_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_2_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_2_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_3_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_3_physical;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  reg                 DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  reg                 DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   reg        [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  reg                 DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
   reg                 DBusCachedPlugin_mmuBus_rsp_exception;
   reg                 DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_0_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_0_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_1_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_1_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_2_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_2_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_3_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_3_physical;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -2067,12 +961,12 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [4:0]    _zz_56_;
-  wire       [4:0]    _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
-  wire                _zz_60_;
-  wire                _zz_61_;
+  wire       [4:0]    _zz_56;
+  wire       [4:0]    _zz_57;
+  wire                _zz_58;
+  wire                _zz_59;
+  wire                _zz_60;
+  wire                _zz_61;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -2109,16 +1003,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_62_;
-  wire                _zz_63_;
-  wire                _zz_64_;
+  wire                _zz_62;
+  wire                _zz_63;
+  wire                _zz_64;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_65_;
-  wire                _zz_66_;
-  reg                 _zz_67_;
-  wire                _zz_68_;
-  reg                 _zz_69_;
-  reg        [31:0]   _zz_70_;
+  wire                _zz_65;
+  wire                _zz_66;
+  reg                 _zz_67;
+  wire                _zz_68;
+  reg                 _zz_69;
+  reg        [31:0]   _zz_70;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -2131,17 +1025,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_71_;
-  reg        [18:0]   _zz_72_;
-  wire                _zz_73_;
-  reg        [10:0]   _zz_74_;
-  wire                _zz_75_;
-  reg        [18:0]   _zz_76_;
-  reg                 _zz_77_;
-  wire                _zz_78_;
-  reg        [10:0]   _zz_79_;
-  wire                _zz_80_;
-  reg        [18:0]   _zz_81_;
+  wire                _zz_71;
+  reg        [18:0]   _zz_72;
+  wire                _zz_73;
+  reg        [10:0]   _zz_74;
+  wire                _zz_75;
+  reg        [18:0]   _zz_76;
+  reg                 _zz_77;
+  wire                _zz_78;
+  reg        [10:0]   _zz_79;
+  wire                _zz_80;
+  reg        [18:0]   _zz_81;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -2149,7 +1043,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_82_;
+  wire       [31:0]   _zz_82;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -2157,62 +1051,56 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_83_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_83;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_84_;
+  reg        [31:0]   _zz_84;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_85_;
-  reg        [31:0]   _zz_86_;
-  wire                _zz_87_;
-  reg        [31:0]   _zz_88_;
+  wire                _zz_85;
+  reg        [31:0]   _zz_86;
+  wire                _zz_87;
+  reg        [31:0]   _zz_88;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
   reg                 DBusCachedPlugin_forceDatapath;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
   reg                 MmuPlugin_satp_mode;
+  reg        [8:0]    MmuPlugin_satp_asid;
   reg        [19:0]   MmuPlugin_satp_ppn;
   reg                 MmuPlugin_ports_0_cache_0_valid;
   reg                 MmuPlugin_ports_0_cache_0_exception;
@@ -2258,14 +1146,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowWrite;
   reg                 MmuPlugin_ports_0_cache_3_allowExecute;
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
-  wire                MmuPlugin_ports_0_cacheHits_0;
-  wire                MmuPlugin_ports_0_cacheHits_1;
-  wire                MmuPlugin_ports_0_cacheHits_2;
-  wire                MmuPlugin_ports_0_cacheHits_3;
+  wire                MmuPlugin_ports_0_dirty;
+  reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
+  reg        [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
-  wire                _zz_89_;
-  wire                _zz_90_;
-  wire       [1:0]    _zz_91_;
+  wire                _zz_89;
+  wire                _zz_90;
+  wire                _zz_91;
+  wire       [1:0]    _zz_92;
   wire                MmuPlugin_ports_0_cacheLine_valid;
   wire                MmuPlugin_ports_0_cacheLine_exception;
   wire                MmuPlugin_ports_0_cacheLine_superPage;
@@ -2283,7 +1171,6 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_ports_0_entryToReplace_value;
   wire                MmuPlugin_ports_0_entryToReplace_willOverflowIfInc;
   wire                MmuPlugin_ports_0_entryToReplace_willOverflow;
-  reg                 MmuPlugin_ports_0_requireMmuLockup;
   reg                 MmuPlugin_ports_1_cache_0_valid;
   reg                 MmuPlugin_ports_1_cache_0_exception;
   reg                 MmuPlugin_ports_1_cache_0_superPage;
@@ -2328,14 +1215,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowWrite;
   reg                 MmuPlugin_ports_1_cache_3_allowExecute;
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
-  wire                MmuPlugin_ports_1_cacheHits_0;
-  wire                MmuPlugin_ports_1_cacheHits_1;
-  wire                MmuPlugin_ports_1_cacheHits_2;
-  wire                MmuPlugin_ports_1_cacheHits_3;
+  wire                MmuPlugin_ports_1_dirty;
+  reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
+  reg        [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
-  wire                _zz_92_;
-  wire                _zz_93_;
-  wire       [1:0]    _zz_94_;
+  wire                _zz_93;
+  wire                _zz_94;
+  wire                _zz_95;
+  wire       [1:0]    _zz_96;
   wire                MmuPlugin_ports_1_cacheLine_valid;
   wire                MmuPlugin_ports_1_cacheLine_exception;
   wire                MmuPlugin_ports_1_cacheLine_superPage;
@@ -2353,11 +1240,14 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_ports_1_entryToReplace_value;
   wire                MmuPlugin_ports_1_entryToReplace_willOverflowIfInc;
   wire                MmuPlugin_ports_1_entryToReplace_willOverflow;
-  reg                 MmuPlugin_ports_1_requireMmuLockup;
-  reg        `MmuPlugin_shared_State_defaultEncoding_type MmuPlugin_shared_state_1_;
+  reg        `MmuPlugin_shared_State_defaultEncoding_type MmuPlugin_shared_state_1;
   reg        [9:0]    MmuPlugin_shared_vpn_0;
   reg        [9:0]    MmuPlugin_shared_vpn_1;
-  reg        [0:0]    MmuPlugin_shared_portId;
+  reg        [1:0]    MmuPlugin_shared_portSortedOh;
+  reg                 MmuPlugin_shared_dBusRspStaged_valid;
+  reg        [31:0]   MmuPlugin_shared_dBusRspStaged_payload_data;
+  reg                 MmuPlugin_shared_dBusRspStaged_payload_error;
+  reg                 MmuPlugin_shared_dBusRspStaged_payload_redo;
   wire                MmuPlugin_shared_dBusRsp_pte_V;
   wire                MmuPlugin_shared_dBusRsp_pte_R;
   wire                MmuPlugin_shared_dBusRsp_pte_W;
@@ -2382,75 +1272,82 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_shared_pteBuffer_RSW;
   reg        [9:0]    MmuPlugin_shared_pteBuffer_PPN0;
   reg        [11:0]   MmuPlugin_shared_pteBuffer_PPN1;
-  wire       [34:0]   _zz_95_;
-  wire                _zz_96_;
-  wire                _zz_97_;
-  wire                _zz_98_;
-  wire                _zz_99_;
-  wire                _zz_100_;
-  wire                _zz_101_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_102_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_103_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_104_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_105_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_106_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_107_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_108_;
+  reg        [1:0]    _zz_97;
+  wire       [1:0]    _zz_98;
+  reg        [1:0]    _zz_99;
+  wire       [1:0]    MmuPlugin_shared_refills;
+  wire       [1:0]    _zz_100;
+  reg        [1:0]    _zz_101;
+  wire       [31:0]   _zz_102;
+  wire       [34:0]   _zz_103;
+  wire                _zz_104;
+  wire                _zz_105;
+  wire                _zz_106;
+  wire                _zz_107;
+  wire                _zz_108;
+  wire                _zz_109;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_110;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_111;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_112;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_113;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_114;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_115;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_116;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_109_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_117;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_110_;
-  reg        [31:0]   _zz_111_;
-  wire                _zz_112_;
-  reg        [19:0]   _zz_113_;
-  wire                _zz_114_;
-  reg        [19:0]   _zz_115_;
-  reg        [31:0]   _zz_116_;
+  reg        [31:0]   _zz_118;
+  reg        [31:0]   _zz_119;
+  wire                _zz_120;
+  reg        [19:0]   _zz_121;
+  wire                _zz_122;
+  reg        [19:0]   _zz_123;
+  reg        [31:0]   _zz_124;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_117_;
+  reg        [31:0]   _zz_125;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_118_;
-  reg                 _zz_119_;
-  reg                 _zz_120_;
-  reg                 _zz_121_;
-  reg        [4:0]    _zz_122_;
-  reg        [31:0]   _zz_123_;
-  wire                _zz_124_;
-  wire                _zz_125_;
-  wire                _zz_126_;
-  wire                _zz_127_;
-  wire                _zz_128_;
-  wire                _zz_129_;
+  reg        [31:0]   _zz_126;
+  reg                 _zz_127;
+  reg                 _zz_128;
+  reg                 _zz_129;
+  reg        [4:0]    _zz_130;
+  reg        [31:0]   _zz_131;
+  wire                _zz_132;
+  wire                _zz_133;
+  wire                _zz_134;
+  wire                _zz_135;
+  wire                _zz_136;
+  wire                _zz_137;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_130_;
-  reg                 _zz_131_;
-  reg                 _zz_132_;
-  wire                _zz_133_;
-  reg        [19:0]   _zz_134_;
-  wire                _zz_135_;
-  reg        [10:0]   _zz_136_;
-  wire                _zz_137_;
-  reg        [18:0]   _zz_138_;
-  reg                 _zz_139_;
+  wire       [2:0]    _zz_138;
+  reg                 _zz_139;
+  reg                 _zz_140;
+  wire                _zz_141;
+  reg        [19:0]   _zz_142;
+  wire                _zz_143;
+  reg        [10:0]   _zz_144;
+  wire                _zz_145;
+  reg        [18:0]   _zz_146;
+  reg                 _zz_147;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_140_;
-  reg        [19:0]   _zz_141_;
-  wire                _zz_142_;
-  reg        [10:0]   _zz_143_;
-  wire                _zz_144_;
-  reg        [18:0]   _zz_145_;
+  wire                _zz_148;
+  reg        [19:0]   _zz_149;
+  wire                _zz_150;
+  reg        [10:0]   _zz_151;
+  wire                _zz_152;
+  reg        [18:0]   _zz_153;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_146_;
+  reg        [1:0]    _zz_154;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -2507,12 +1404,12 @@ module VexRiscv (
   reg        [21:0]   CsrPlugin_satp_PPN;
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
-  wire                _zz_147_;
-  wire                _zz_148_;
-  wire                _zz_149_;
-  wire                _zz_150_;
-  wire                _zz_151_;
-  wire                _zz_152_;
+  wire                _zz_155;
+  wire                _zz_156;
+  wire                _zz_157;
+  wire                _zz_158;
+  wire                _zz_159;
+  wire                _zz_160;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -2525,8 +1422,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_153_;
-  wire                _zz_154_;
+  wire       [1:0]    _zz_161;
+  wire                _zz_162;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -2538,7 +1435,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2579,88 +1476,89 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_155_;
+  wire       [31:0]   _zz_163;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_156_;
-  wire                _zz_157_;
-  wire                _zz_158_;
-  reg        [32:0]   _zz_159_;
+  wire       [31:0]   _zz_164;
+  wire                _zz_165;
+  wire                _zz_166;
+  reg        [32:0]   _zz_167;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_160_;
-  wire       [31:0]   _zz_161_;
-  reg        [31:0]   _zz_162_;
-  wire       [31:0]   _zz_163_;
-  reg        [33:0]   execute_to_memory_MUL_LH;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 memory_to_writeBack_IS_MUL;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        [33:0]   execute_to_memory_MUL_HL;
-  reg                 execute_to_memory_IS_DBUS_SHARING;
-  reg                 memory_to_writeBack_IS_DBUS_SHARING;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 decode_to_execute_MEMORY_WR;
-  reg                 execute_to_memory_MEMORY_WR;
-  reg                 memory_to_writeBack_MEMORY_WR;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg                 decode_to_execute_IS_CSR;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg        [31:0]   execute_to_memory_MUL_LL;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg                 decode_to_execute_MEMORY_LRSC;
-  reg                 decode_to_execute_IS_SFENCE_VMA;
-  reg                 execute_to_memory_IS_SFENCE_VMA;
-  reg                 memory_to_writeBack_IS_SFENCE_VMA;
+  reg        [31:0]   _zz_168;
+  wire       [31:0]   _zz_169;
+  reg        [31:0]   _zz_170;
+  wire       [31:0]   _zz_171;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 decode_to_execute_MEMORY_AMO;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
+  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_LRSC;
+  reg                 decode_to_execute_MEMORY_AMO;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_IS_SFENCE_VMA;
+  reg                 execute_to_memory_IS_SFENCE_VMA;
+  reg                 memory_to_writeBack_IS_SFENCE_VMA;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 memory_to_writeBack_IS_MUL;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg                 execute_to_memory_IS_DBUS_SHARING;
+  reg                 memory_to_writeBack_IS_DBUS_SHARING;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_256;
@@ -2689,1015 +1587,872 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_4032;
   reg                 execute_CsrPlugin_csr_2496;
   reg                 execute_CsrPlugin_csr_3520;
-  reg        [31:0]   _zz_164_;
-  reg        [31:0]   _zz_165_;
-  reg        [31:0]   _zz_166_;
-  reg        [31:0]   _zz_167_;
-  reg        [31:0]   _zz_168_;
-  reg        [31:0]   _zz_169_;
-  reg        [31:0]   _zz_170_;
-  reg        [31:0]   _zz_171_;
-  reg        [31:0]   _zz_172_;
-  reg        [31:0]   _zz_173_;
-  reg        [31:0]   _zz_174_;
-  reg        [31:0]   _zz_175_;
-  reg        [31:0]   _zz_176_;
-  reg        [31:0]   _zz_177_;
-  reg        [31:0]   _zz_178_;
-  reg        [31:0]   _zz_179_;
-  reg        [31:0]   _zz_180_;
-  reg        [31:0]   _zz_181_;
-  reg        [31:0]   _zz_182_;
-  reg        [31:0]   _zz_183_;
-  reg        [31:0]   _zz_184_;
-  reg        [31:0]   _zz_185_;
-  reg        [31:0]   _zz_186_;
-  reg        [31:0]   _zz_187_;
-  reg        [2:0]    _zz_188_;
-  reg                 _zz_189_;
+  reg        [31:0]   _zz_172;
+  reg        [31:0]   _zz_173;
+  reg        [31:0]   _zz_174;
+  reg        [31:0]   _zz_175;
+  reg        [31:0]   _zz_176;
+  reg        [31:0]   _zz_177;
+  reg        [31:0]   _zz_178;
+  reg        [31:0]   _zz_179;
+  reg        [31:0]   _zz_180;
+  reg        [31:0]   _zz_181;
+  reg        [31:0]   _zz_182;
+  reg        [31:0]   _zz_183;
+  reg        [31:0]   _zz_184;
+  reg        [31:0]   _zz_185;
+  reg        [31:0]   _zz_186;
+  reg        [31:0]   _zz_187;
+  reg        [31:0]   _zz_188;
+  reg        [31:0]   _zz_189;
+  reg        [31:0]   _zz_190;
+  reg        [31:0]   _zz_191;
+  reg        [31:0]   _zz_192;
+  reg        [31:0]   _zz_193;
+  reg        [31:0]   _zz_194;
+  reg        [31:0]   _zz_195;
+  reg        [2:0]    _zz_196;
+  reg                 _zz_197;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_190_;
-  wire                _zz_191_;
-  wire                _zz_192_;
-  wire                _zz_193_;
-  wire                _zz_194_;
-  wire                _zz_195_;
-  reg                 _zz_196_;
+  reg        [2:0]    _zz_198;
+  wire                _zz_199;
+  wire                _zz_200;
+  wire                _zz_201;
+  wire                _zz_202;
+  wire                _zz_203;
+  reg                 _zz_204;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_1__string;
-  reg [23:0] _zz_2__string;
-  reg [23:0] _zz_3__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_4__string;
-  reg [39:0] _zz_5__string;
-  reg [39:0] _zz_6__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_7__string;
-  reg [95:0] _zz_8__string;
-  reg [95:0] _zz_9__string;
-  reg [71:0] _zz_10__string;
-  reg [71:0] _zz_11__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12__string;
-  reg [71:0] _zz_13__string;
-  reg [71:0] _zz_14__string;
-  reg [39:0] _zz_15__string;
-  reg [39:0] _zz_16__string;
-  reg [39:0] _zz_17__string;
-  reg [39:0] _zz_18__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_19__string;
-  reg [39:0] _zz_20__string;
-  reg [39:0] _zz_21__string;
-  reg [31:0] _zz_22__string;
-  reg [31:0] _zz_23__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
   reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_24__string;
-  reg [63:0] _zz_25__string;
-  reg [63:0] _zz_26__string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [71:0] _zz_43__string;
-  reg [95:0] _zz_44__string;
-  reg [31:0] _zz_45__string;
-  reg [63:0] _zz_46__string;
-  reg [39:0] _zz_47__string;
-  reg [39:0] _zz_48__string;
-  reg [23:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52__string;
-  reg [47:0] MmuPlugin_shared_state_1__string;
-  reg [23:0] _zz_102__string;
-  reg [39:0] _zz_103__string;
-  reg [39:0] _zz_104__string;
-  reg [63:0] _zz_105__string;
-  reg [31:0] _zz_106__string;
-  reg [95:0] _zz_107__string;
-  reg [71:0] _zz_108__string;
+  reg [31:0] _zz_52_string;
+  reg [47:0] MmuPlugin_shared_state_1_string;
+  reg [95:0] _zz_110_string;
+  reg [63:0] _zz_111_string;
+  reg [23:0] _zz_112_string;
+  reg [39:0] _zz_113_string;
+  reg [71:0] _zz_114_string;
+  reg [31:0] _zz_115_string;
+  reg [39:0] _zz_116_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_247_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_248_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_249_ = 1'b1;
-  assign _zz_250_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_251_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_252_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_253_ = ((_zz_201_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_51__2));
-  assign _zz_254_ = ((_zz_201_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_51__1));
-  assign _zz_255_ = ((_zz_201_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_51__0));
-  assign _zz_256_ = ((_zz_201_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_257_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_258_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_259_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_260_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_261_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_262_ = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != (3'b000)));
-  assign _zz_263_ = (! dataCache_1__io_cpu_redo);
-  assign _zz_264_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_265_ = ((MmuPlugin_dBusAccess_rsp_valid && (! MmuPlugin_dBusAccess_rsp_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign _zz_266_ = (MmuPlugin_shared_portId == (1'b1));
-  assign _zz_267_ = (MmuPlugin_shared_portId == (1'b0));
-  assign _zz_268_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_269_ = (1'b0 || (! 1'b1));
-  assign _zz_270_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_271_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_272_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_273_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_274_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_275_ = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_276_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_277_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_278_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_279_ = (! memory_arbitration_isStuck);
-  assign _zz_280_ = (iBus_cmd_valid || (_zz_188_ != (3'b000)));
-  assign _zz_281_ = (_zz_221_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_282_ = (IBusCachedPlugin_mmuBus_cmd_isValid && IBusCachedPlugin_mmuBus_rsp_refilling);
-  assign _zz_283_ = (DBusCachedPlugin_mmuBus_cmd_isValid && DBusCachedPlugin_mmuBus_rsp_refilling);
-  assign _zz_284_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b00));
-  assign _zz_285_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b01));
-  assign _zz_286_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b10));
-  assign _zz_287_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b11));
-  assign _zz_288_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b00));
-  assign _zz_289_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b01));
-  assign _zz_290_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b10));
-  assign _zz_291_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b11));
-  assign _zz_292_ = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == (2'b01))) || (CsrPlugin_privilege < (2'b01)));
-  assign _zz_293_ = ((_zz_147_ && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign _zz_294_ = ((_zz_148_ && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign _zz_295_ = ((_zz_149_ && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign _zz_296_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_297_ = ((_zz_147_ && 1'b1) && (! (CsrPlugin_mideleg_ST != (1'b0))));
-  assign _zz_298_ = ((_zz_148_ && 1'b1) && (! (CsrPlugin_mideleg_SS != (1'b0))));
-  assign _zz_299_ = ((_zz_149_ && 1'b1) && (! (CsrPlugin_mideleg_SE != (1'b0))));
-  assign _zz_300_ = ((_zz_150_ && 1'b1) && (! 1'b0));
-  assign _zz_301_ = ((_zz_151_ && 1'b1) && (! 1'b0));
-  assign _zz_302_ = ((_zz_152_ && 1'b1) && (! 1'b0));
-  assign _zz_303_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_304_ = execute_INSTRUCTION[13];
-  assign _zz_305_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_306_ = _zz_95_[15 : 15];
-  assign _zz_307_ = _zz_95_[20 : 20];
-  assign _zz_308_ = _zz_95_[18 : 18];
-  assign _zz_309_ = ($signed(_zz_311_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_310_ = _zz_309_[31 : 0];
-  assign _zz_311_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_312_ = _zz_95_[2 : 2];
-  assign _zz_313_ = _zz_95_[33 : 33];
-  assign _zz_314_ = _zz_95_[10 : 10];
-  assign _zz_315_ = _zz_95_[3 : 3];
-  assign _zz_316_ = _zz_95_[32 : 32];
-  assign _zz_317_ = _zz_95_[4 : 4];
-  assign _zz_318_ = _zz_95_[23 : 23];
-  assign _zz_319_ = ($signed(_zz_320_) + $signed(_zz_325_));
-  assign _zz_320_ = ($signed(_zz_321_) + $signed(_zz_323_));
-  assign _zz_321_ = 52'h0;
-  assign _zz_322_ = {1'b0,memory_MUL_LL};
-  assign _zz_323_ = {{19{_zz_322_[32]}}, _zz_322_};
-  assign _zz_324_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_325_ = {{2{_zz_324_[49]}}, _zz_324_};
-  assign _zz_326_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_327_ = {{2{_zz_326_[49]}}, _zz_326_};
-  assign _zz_328_ = _zz_95_[24 : 24];
-  assign _zz_329_ = _zz_95_[9 : 9];
-  assign _zz_330_ = _zz_95_[25 : 25];
-  assign _zz_331_ = _zz_95_[19 : 19];
-  assign _zz_332_ = _zz_95_[21 : 21];
-  assign _zz_333_ = _zz_95_[13 : 13];
-  assign _zz_334_ = _zz_95_[14 : 14];
-  assign _zz_335_ = _zz_95_[22 : 22];
-  assign _zz_336_ = _zz_95_[8 : 8];
-  assign _zz_337_ = _zz_95_[7 : 7];
-  assign _zz_338_ = (_zz_56_ - 5'h01);
-  assign _zz_339_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_340_ = {29'd0, _zz_339_};
-  assign _zz_341_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_342_ = {{_zz_72_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_343_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_344_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_345_ = {{_zz_74_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_346_ = {{_zz_76_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_347_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_348_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_349_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_350_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_351_ = MmuPlugin_ports_0_entryToReplace_willIncrement;
-  assign _zz_352_ = {1'd0, _zz_351_};
-  assign _zz_353_ = MmuPlugin_ports_1_entryToReplace_willIncrement;
-  assign _zz_354_ = {1'd0, _zz_353_};
-  assign _zz_355_ = MmuPlugin_dBusAccess_rsp_payload_data[0 : 0];
-  assign _zz_356_ = MmuPlugin_dBusAccess_rsp_payload_data[1 : 1];
-  assign _zz_357_ = MmuPlugin_dBusAccess_rsp_payload_data[2 : 2];
-  assign _zz_358_ = MmuPlugin_dBusAccess_rsp_payload_data[3 : 3];
-  assign _zz_359_ = MmuPlugin_dBusAccess_rsp_payload_data[4 : 4];
-  assign _zz_360_ = MmuPlugin_dBusAccess_rsp_payload_data[5 : 5];
-  assign _zz_361_ = MmuPlugin_dBusAccess_rsp_payload_data[6 : 6];
-  assign _zz_362_ = MmuPlugin_dBusAccess_rsp_payload_data[7 : 7];
-  assign _zz_363_ = execute_SRC_LESS;
-  assign _zz_364_ = (3'b100);
-  assign _zz_365_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_366_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_367_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_368_ = ($signed(_zz_369_) + $signed(_zz_372_));
-  assign _zz_369_ = ($signed(_zz_370_) + $signed(_zz_371_));
-  assign _zz_370_ = execute_SRC1;
-  assign _zz_371_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_372_ = (execute_SRC_USE_SUB_LESS ? _zz_373_ : _zz_374_);
-  assign _zz_373_ = 32'h00000001;
-  assign _zz_374_ = 32'h0;
-  assign _zz_375_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_376_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_377_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_378_ = {_zz_134_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_379_ = {{_zz_136_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_380_ = {{_zz_138_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_381_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_382_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_383_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_384_ = (3'b100);
-  assign _zz_385_ = (_zz_153_ & (~ _zz_386_));
-  assign _zz_386_ = (_zz_153_ - (2'b01));
-  assign _zz_387_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_388_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_389_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_390_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_391_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_392_ = {5'd0, _zz_391_};
-  assign _zz_393_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_394_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_395_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_396_ = {_zz_155_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_397_ = _zz_398_;
-  assign _zz_398_ = _zz_399_;
-  assign _zz_399_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_156_) : _zz_156_)} + _zz_401_);
-  assign _zz_400_ = memory_DivPlugin_div_needRevert;
-  assign _zz_401_ = {32'd0, _zz_400_};
-  assign _zz_402_ = _zz_158_;
-  assign _zz_403_ = {32'd0, _zz_402_};
-  assign _zz_404_ = _zz_157_;
-  assign _zz_405_ = {31'd0, _zz_404_};
-  assign _zz_406_ = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_407_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_408_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_409_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_410_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_411_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_412_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_413_ = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_414_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_415_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_416_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_417_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_418_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_419_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_420_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_421_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_422_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_423_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_424_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_425_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_426_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_427_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_428_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_429_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_430_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_431_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_432_ = execute_CsrPlugin_writeData[13 : 13];
-  assign _zz_433_ = execute_CsrPlugin_writeData[4 : 4];
-  assign _zz_434_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_435_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_436_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_437_ = execute_CsrPlugin_writeData[12 : 12];
-  assign _zz_438_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_439_ = execute_CsrPlugin_writeData[6 : 6];
-  assign _zz_440_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_441_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_442_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_443_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_444_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_445_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_446_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_447_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_448_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_449_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_450_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_451_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_452_ = 1'b1;
-  assign _zz_453_ = 1'b1;
-  assign _zz_454_ = {_zz_59_,{_zz_61_,_zz_60_}};
-  assign _zz_455_ = 32'h0000107f;
-  assign _zz_456_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_457_ = 32'h00002073;
-  assign _zz_458_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_459_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_460_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_461_) == 32'h00000003),{(_zz_462_ == _zz_463_),{_zz_464_,{_zz_465_,_zz_466_}}}}}};
-  assign _zz_461_ = 32'h0000505f;
-  assign _zz_462_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_463_ = 32'h00000063;
-  assign _zz_464_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_465_ = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
-  assign _zz_466_ = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_467_) == 32'h0000500f),{(_zz_468_ == _zz_469_),{_zz_470_,{_zz_471_,_zz_472_}}}}}};
-  assign _zz_467_ = 32'h01f0707f;
-  assign _zz_468_ = (decode_INSTRUCTION & 32'hbc00707f);
-  assign _zz_469_ = 32'h00005013;
-  assign _zz_470_ = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
-  assign _zz_471_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_472_ = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_473_) == 32'h12000073),{(_zz_474_ == _zz_475_),{_zz_476_,_zz_477_}}}}};
-  assign _zz_473_ = 32'hfe007fff;
-  assign _zz_474_ = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_475_ = 32'h10200073;
-  assign _zz_476_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_477_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz_478_ = decode_INSTRUCTION[31];
-  assign _zz_479_ = decode_INSTRUCTION[31];
-  assign _zz_480_ = decode_INSTRUCTION[7];
-  assign _zz_481_ = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_482_ = 32'h00002040;
-  assign _zz_483_ = ((decode_INSTRUCTION & _zz_494_) == 32'h00001040);
-  assign _zz_484_ = (_zz_495_ == _zz_496_);
-  assign _zz_485_ = {_zz_497_,{_zz_498_,_zz_499_}};
-  assign _zz_486_ = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz_487_ = 32'h10000008;
-  assign _zz_488_ = ((decode_INSTRUCTION & _zz_500_) == 32'h02004020);
-  assign _zz_489_ = {_zz_501_,_zz_502_};
-  assign _zz_490_ = (2'b00);
-  assign _zz_491_ = ({_zz_503_,_zz_504_} != (3'b000));
-  assign _zz_492_ = (_zz_505_ != _zz_506_);
-  assign _zz_493_ = {_zz_507_,{_zz_508_,_zz_509_}};
-  assign _zz_494_ = 32'h00001040;
-  assign _zz_495_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_496_ = 32'h00000040;
-  assign _zz_497_ = ((decode_INSTRUCTION & _zz_510_) == 32'h00000040);
-  assign _zz_498_ = (_zz_511_ == _zz_512_);
-  assign _zz_499_ = (_zz_513_ == _zz_514_);
-  assign _zz_500_ = 32'h02004064;
-  assign _zz_501_ = ((decode_INSTRUCTION & _zz_515_) == 32'h00005010);
-  assign _zz_502_ = ((decode_INSTRUCTION & _zz_516_) == 32'h00005020);
-  assign _zz_503_ = (_zz_517_ == _zz_518_);
-  assign _zz_504_ = {_zz_519_,_zz_520_};
-  assign _zz_505_ = {_zz_100_,{_zz_521_,_zz_522_}};
-  assign _zz_506_ = (3'b000);
-  assign _zz_507_ = ({_zz_523_,_zz_524_} != (2'b00));
-  assign _zz_508_ = (_zz_525_ != _zz_526_);
-  assign _zz_509_ = {_zz_527_,{_zz_528_,_zz_529_}};
-  assign _zz_510_ = 32'h02400040;
-  assign _zz_511_ = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_512_ = 32'h0;
-  assign _zz_513_ = (decode_INSTRUCTION & 32'h18002008);
-  assign _zz_514_ = 32'h10002008;
-  assign _zz_515_ = 32'h00007034;
-  assign _zz_516_ = 32'h02007064;
-  assign _zz_517_ = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_518_ = 32'h40001010;
-  assign _zz_519_ = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
-  assign _zz_520_ = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
-  assign _zz_521_ = _zz_101_;
-  assign _zz_522_ = ((decode_INSTRUCTION & _zz_530_) == 32'h00000004);
-  assign _zz_523_ = _zz_101_;
-  assign _zz_524_ = ((decode_INSTRUCTION & _zz_531_) == 32'h00000004);
-  assign _zz_525_ = {_zz_100_,(_zz_532_ == _zz_533_)};
-  assign _zz_526_ = (2'b00);
-  assign _zz_527_ = ((_zz_534_ == _zz_535_) != (1'b0));
-  assign _zz_528_ = (_zz_536_ != (1'b0));
-  assign _zz_529_ = {(_zz_537_ != _zz_538_),{_zz_539_,{_zz_540_,_zz_541_}}};
-  assign _zz_530_ = 32'h00002014;
-  assign _zz_531_ = 32'h0000004c;
-  assign _zz_532_ = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_533_ = 32'h00000004;
-  assign _zz_534_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_535_ = 32'h00000040;
-  assign _zz_536_ = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_537_ = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
-  assign _zz_538_ = (1'b0);
-  assign _zz_539_ = ({(_zz_542_ == _zz_543_),{_zz_544_,_zz_545_}} != (3'b000));
-  assign _zz_540_ = ({_zz_100_,{_zz_546_,_zz_547_}} != 7'h0);
-  assign _zz_541_ = {({_zz_548_,_zz_549_} != 5'h0),{(_zz_550_ != _zz_551_),{_zz_552_,{_zz_553_,_zz_554_}}}};
-  assign _zz_542_ = (decode_INSTRUCTION & 32'h08000020);
-  assign _zz_543_ = 32'h08000020;
-  assign _zz_544_ = ((decode_INSTRUCTION & _zz_555_) == 32'h00000020);
-  assign _zz_545_ = ((decode_INSTRUCTION & _zz_556_) == 32'h00000020);
-  assign _zz_546_ = (_zz_557_ == _zz_558_);
-  assign _zz_547_ = {_zz_559_,{_zz_560_,_zz_561_}};
-  assign _zz_548_ = (_zz_562_ == _zz_563_);
-  assign _zz_549_ = {_zz_564_,{_zz_565_,_zz_566_}};
-  assign _zz_550_ = _zz_99_;
-  assign _zz_551_ = (1'b0);
-  assign _zz_552_ = ({_zz_567_,_zz_568_} != (4'b0000));
-  assign _zz_553_ = (_zz_569_ != _zz_570_);
-  assign _zz_554_ = {_zz_571_,{_zz_572_,_zz_573_}};
-  assign _zz_555_ = 32'h10000020;
-  assign _zz_556_ = 32'h00000028;
-  assign _zz_557_ = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_558_ = 32'h00001010;
-  assign _zz_559_ = ((decode_INSTRUCTION & _zz_574_) == 32'h00002010);
-  assign _zz_560_ = (_zz_575_ == _zz_576_);
-  assign _zz_561_ = {_zz_577_,{_zz_578_,_zz_579_}};
-  assign _zz_562_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_563_ = 32'h0;
-  assign _zz_564_ = ((decode_INSTRUCTION & _zz_580_) == 32'h0);
-  assign _zz_565_ = (_zz_581_ == _zz_582_);
-  assign _zz_566_ = {_zz_583_,_zz_97_};
-  assign _zz_567_ = (_zz_584_ == _zz_585_);
-  assign _zz_568_ = {_zz_586_,{_zz_587_,_zz_588_}};
-  assign _zz_569_ = (_zz_589_ == _zz_590_);
-  assign _zz_570_ = (1'b0);
-  assign _zz_571_ = (_zz_591_ != (1'b0));
-  assign _zz_572_ = (_zz_592_ != _zz_593_);
-  assign _zz_573_ = {_zz_594_,{_zz_595_,_zz_596_}};
-  assign _zz_574_ = 32'h00002010;
-  assign _zz_575_ = (decode_INSTRUCTION & 32'h00002008);
-  assign _zz_576_ = 32'h00002008;
-  assign _zz_577_ = ((decode_INSTRUCTION & _zz_597_) == 32'h00000010);
-  assign _zz_578_ = _zz_98_;
-  assign _zz_579_ = (_zz_598_ == _zz_599_);
-  assign _zz_580_ = 32'h00000018;
-  assign _zz_581_ = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_582_ = 32'h00002000;
-  assign _zz_583_ = ((decode_INSTRUCTION & _zz_600_) == 32'h00001000);
-  assign _zz_584_ = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_585_ = 32'h00000020;
-  assign _zz_586_ = ((decode_INSTRUCTION & _zz_601_) == 32'h00000020);
-  assign _zz_587_ = (_zz_602_ == _zz_603_);
-  assign _zz_588_ = (_zz_604_ == _zz_605_);
-  assign _zz_589_ = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz_590_ = 32'h00000008;
-  assign _zz_591_ = ((decode_INSTRUCTION & _zz_606_) == 32'h00004010);
-  assign _zz_592_ = (_zz_607_ == _zz_608_);
-  assign _zz_593_ = (1'b0);
-  assign _zz_594_ = (_zz_99_ != (1'b0));
-  assign _zz_595_ = (_zz_609_ != _zz_610_);
-  assign _zz_596_ = {_zz_611_,{_zz_612_,_zz_613_}};
-  assign _zz_597_ = 32'h00000050;
-  assign _zz_598_ = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_599_ = 32'h0;
-  assign _zz_600_ = 32'h00005004;
-  assign _zz_601_ = 32'h00000064;
-  assign _zz_602_ = (decode_INSTRUCTION & 32'h08000070);
-  assign _zz_603_ = 32'h08000020;
-  assign _zz_604_ = (decode_INSTRUCTION & 32'h10000070);
-  assign _zz_605_ = 32'h00000020;
-  assign _zz_606_ = 32'h00004014;
-  assign _zz_607_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_608_ = 32'h00002010;
-  assign _zz_609_ = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_610_ = (1'b0);
-  assign _zz_611_ = ({(_zz_614_ == _zz_615_),{_zz_616_,_zz_617_}} != (3'b000));
-  assign _zz_612_ = ((_zz_618_ == _zz_619_) != (1'b0));
-  assign _zz_613_ = {(_zz_620_ != (1'b0)),{(_zz_621_ != _zz_622_),{_zz_623_,{_zz_624_,_zz_625_}}}};
-  assign _zz_614_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_615_ = 32'h00000040;
-  assign _zz_616_ = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_617_ = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
-  assign _zz_618_ = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_619_ = 32'h00001000;
-  assign _zz_620_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_621_ = {(_zz_626_ == _zz_627_),{_zz_628_,{_zz_629_,_zz_630_}}};
-  assign _zz_622_ = 5'h0;
-  assign _zz_623_ = ({_zz_98_,{_zz_631_,_zz_632_}} != 5'h0);
-  assign _zz_624_ = ({_zz_633_,_zz_634_} != (2'b00));
-  assign _zz_625_ = {(_zz_635_ != _zz_636_),{_zz_637_,{_zz_638_,_zz_639_}}};
-  assign _zz_626_ = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_627_ = 32'h00000040;
-  assign _zz_628_ = ((decode_INSTRUCTION & _zz_640_) == 32'h00004020);
-  assign _zz_629_ = (_zz_641_ == _zz_642_);
-  assign _zz_630_ = {_zz_98_,_zz_643_};
-  assign _zz_631_ = (_zz_644_ == _zz_645_);
-  assign _zz_632_ = {_zz_646_,{_zz_647_,_zz_648_}};
-  assign _zz_633_ = _zz_97_;
-  assign _zz_634_ = (_zz_649_ == _zz_650_);
-  assign _zz_635_ = (_zz_651_ == _zz_652_);
-  assign _zz_636_ = (1'b0);
-  assign _zz_637_ = (_zz_653_ != (1'b0));
-  assign _zz_638_ = (_zz_654_ != _zz_655_);
-  assign _zz_639_ = {_zz_656_,{_zz_657_,_zz_658_}};
-  assign _zz_640_ = 32'h00004020;
-  assign _zz_641_ = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_642_ = 32'h00000010;
-  assign _zz_643_ = ((decode_INSTRUCTION & _zz_659_) == 32'h00000020);
-  assign _zz_644_ = (decode_INSTRUCTION & 32'h00002030);
-  assign _zz_645_ = 32'h00002010;
-  assign _zz_646_ = ((decode_INSTRUCTION & _zz_660_) == 32'h00000010);
-  assign _zz_647_ = (_zz_661_ == _zz_662_);
-  assign _zz_648_ = (_zz_663_ == _zz_664_);
-  assign _zz_649_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_650_ = 32'h0;
-  assign _zz_651_ = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz_652_ = 32'h00001008;
-  assign _zz_653_ = ((decode_INSTRUCTION & _zz_665_) == 32'h00000050);
-  assign _zz_654_ = (_zz_666_ == _zz_667_);
-  assign _zz_655_ = (1'b0);
-  assign _zz_656_ = ({_zz_668_,_zz_669_} != (2'b00));
-  assign _zz_657_ = (_zz_670_ != _zz_671_);
-  assign _zz_658_ = {_zz_672_,{_zz_673_,_zz_674_}};
-  assign _zz_659_ = 32'h02000028;
-  assign _zz_660_ = 32'h00001030;
-  assign _zz_661_ = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_662_ = 32'h00000020;
-  assign _zz_663_ = (decode_INSTRUCTION & 32'h02002068);
-  assign _zz_664_ = 32'h00002020;
-  assign _zz_665_ = 32'h02203050;
-  assign _zz_666_ = (decode_INSTRUCTION & 32'h02403050);
-  assign _zz_667_ = 32'h00000050;
-  assign _zz_668_ = ((decode_INSTRUCTION & _zz_675_) == 32'h00002000);
-  assign _zz_669_ = ((decode_INSTRUCTION & _zz_676_) == 32'h00001000);
-  assign _zz_670_ = {(_zz_677_ == _zz_678_),(_zz_679_ == _zz_680_)};
-  assign _zz_671_ = (2'b00);
-  assign _zz_672_ = ((_zz_681_ == _zz_682_) != (1'b0));
-  assign _zz_673_ = ({_zz_683_,_zz_684_} != (2'b00));
-  assign _zz_674_ = ({_zz_685_,_zz_686_} != (2'b00));
-  assign _zz_675_ = 32'h00002010;
-  assign _zz_676_ = 32'h00005000;
-  assign _zz_677_ = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_678_ = 32'h00001050;
-  assign _zz_679_ = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_680_ = 32'h00002050;
-  assign _zz_681_ = (decode_INSTRUCTION & 32'h02003050);
-  assign _zz_682_ = 32'h02000050;
-  assign _zz_683_ = _zz_96_;
-  assign _zz_684_ = ((decode_INSTRUCTION & 32'h00000070) == 32'h00000020);
-  assign _zz_685_ = _zz_96_;
-  assign _zz_686_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz_687_ = execute_INSTRUCTION[31];
-  assign _zz_688_ = execute_INSTRUCTION[31];
-  assign _zz_689_ = execute_INSTRUCTION[7];
-  assign _zz_690_ = 32'h0;
+  assign _zz_265 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_266 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_267 = 1'b1;
+  assign _zz_268 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_269 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_270 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_271 = ((_zz_210 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_272 = ((_zz_210 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_273 = ((_zz_210 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_274 = ((_zz_210 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_275 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_276 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_277 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_278 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_279 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_280 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign _zz_281 = (! dataCache_1_io_cpu_execute_refilling);
+  assign _zz_282 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_283 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign _zz_284 = MmuPlugin_shared_portSortedOh[0];
+  assign _zz_285 = MmuPlugin_shared_portSortedOh[1];
+  assign _zz_286 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_287 = (1'b0 || (! 1'b1));
+  assign _zz_288 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_289 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_290 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_291 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_292 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_293 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_294 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_295 = execute_INSTRUCTION[13 : 12];
+  assign _zz_296 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_297 = (! memory_arbitration_isStuck);
+  assign _zz_298 = (iBus_cmd_valid || (_zz_196 != 3'b000));
+  assign _zz_299 = (_zz_239 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_300 = (MmuPlugin_shared_refills != 2'b00);
+  assign _zz_301 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign _zz_302 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign _zz_303 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign _zz_304 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign _zz_305 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign _zz_306 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign _zz_307 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign _zz_308 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign _zz_309 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign _zz_310 = ((_zz_155 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign _zz_311 = ((_zz_156 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign _zz_312 = ((_zz_157 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign _zz_313 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_314 = ((_zz_155 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign _zz_315 = ((_zz_156 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign _zz_316 = ((_zz_157 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign _zz_317 = ((_zz_158 && 1'b1) && (! 1'b0));
+  assign _zz_318 = ((_zz_159 && 1'b1) && (! 1'b0));
+  assign _zz_319 = ((_zz_160 && 1'b1) && (! 1'b0));
+  assign _zz_320 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_321 = execute_INSTRUCTION[13];
+  assign _zz_322 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_323 = ($signed(_zz_324) + $signed(_zz_329));
+  assign _zz_324 = ($signed(_zz_325) + $signed(_zz_327));
+  assign _zz_325 = 52'h0;
+  assign _zz_326 = {1'b0,memory_MUL_LL};
+  assign _zz_327 = {{19{_zz_326[32]}}, _zz_326};
+  assign _zz_328 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_329 = {{2{_zz_328[49]}}, _zz_328};
+  assign _zz_330 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_331 = {{2{_zz_330[49]}}, _zz_330};
+  assign _zz_332 = ($signed(_zz_334) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_333 = _zz_332[31 : 0];
+  assign _zz_334 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_335 = _zz_103[34 : 34];
+  assign _zz_336 = _zz_103[33 : 33];
+  assign _zz_337 = _zz_103[32 : 32];
+  assign _zz_338 = _zz_103[31 : 31];
+  assign _zz_339 = _zz_103[28 : 28];
+  assign _zz_340 = _zz_103[21 : 21];
+  assign _zz_341 = _zz_103[20 : 20];
+  assign _zz_342 = _zz_103[19 : 19];
+  assign _zz_343 = _zz_103[13 : 13];
+  assign _zz_344 = _zz_103[12 : 12];
+  assign _zz_345 = _zz_103[11 : 11];
+  assign _zz_346 = _zz_103[17 : 17];
+  assign _zz_347 = _zz_103[5 : 5];
+  assign _zz_348 = _zz_103[3 : 3];
+  assign _zz_349 = _zz_103[18 : 18];
+  assign _zz_350 = _zz_103[10 : 10];
+  assign _zz_351 = _zz_103[16 : 16];
+  assign _zz_352 = _zz_103[15 : 15];
+  assign _zz_353 = _zz_103[4 : 4];
+  assign _zz_354 = _zz_103[0 : 0];
+  assign _zz_355 = (_zz_56 - 5'h01);
+  assign _zz_356 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_357 = {29'd0, _zz_356};
+  assign _zz_358 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_359 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_360 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_361 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_362 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_363 = {{_zz_76,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_364 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_365 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_366 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_367 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_368 = MmuPlugin_ports_0_entryToReplace_willIncrement;
+  assign _zz_369 = {1'd0, _zz_368};
+  assign _zz_370 = MmuPlugin_ports_1_entryToReplace_willIncrement;
+  assign _zz_371 = {1'd0, _zz_370};
+  assign _zz_372 = MmuPlugin_shared_dBusRspStaged_payload_data[0 : 0];
+  assign _zz_373 = MmuPlugin_shared_dBusRspStaged_payload_data[1 : 1];
+  assign _zz_374 = MmuPlugin_shared_dBusRspStaged_payload_data[2 : 2];
+  assign _zz_375 = MmuPlugin_shared_dBusRspStaged_payload_data[3 : 3];
+  assign _zz_376 = MmuPlugin_shared_dBusRspStaged_payload_data[4 : 4];
+  assign _zz_377 = MmuPlugin_shared_dBusRspStaged_payload_data[5 : 5];
+  assign _zz_378 = MmuPlugin_shared_dBusRspStaged_payload_data[6 : 6];
+  assign _zz_379 = MmuPlugin_shared_dBusRspStaged_payload_data[7 : 7];
+  assign _zz_380 = (_zz_99 - 2'b01);
+  assign _zz_381 = execute_SRC_LESS;
+  assign _zz_382 = 3'b100;
+  assign _zz_383 = execute_INSTRUCTION[19 : 15];
+  assign _zz_384 = execute_INSTRUCTION[31 : 20];
+  assign _zz_385 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_386 = ($signed(_zz_387) + $signed(_zz_390));
+  assign _zz_387 = ($signed(_zz_388) + $signed(_zz_389));
+  assign _zz_388 = execute_SRC1;
+  assign _zz_389 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_390 = (execute_SRC_USE_SUB_LESS ? _zz_391 : _zz_392);
+  assign _zz_391 = 32'h00000001;
+  assign _zz_392 = 32'h0;
+  assign _zz_393 = execute_INSTRUCTION[31 : 20];
+  assign _zz_394 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_395 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_396 = {_zz_142,execute_INSTRUCTION[31 : 20]};
+  assign _zz_397 = {{_zz_144,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_398 = {{_zz_146,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_399 = execute_INSTRUCTION[31 : 20];
+  assign _zz_400 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_401 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_402 = 3'b100;
+  assign _zz_403 = (_zz_161 & (~ _zz_404));
+  assign _zz_404 = (_zz_161 - 2'b01);
+  assign _zz_405 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_406 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_407 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_408 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_409 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_410 = {5'd0, _zz_409};
+  assign _zz_411 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_412 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_413 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_414 = {_zz_163,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_415 = _zz_416;
+  assign _zz_416 = _zz_417;
+  assign _zz_417 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_164) : _zz_164)} + _zz_419);
+  assign _zz_418 = memory_DivPlugin_div_needRevert;
+  assign _zz_419 = {32'd0, _zz_418};
+  assign _zz_420 = _zz_166;
+  assign _zz_421 = {32'd0, _zz_420};
+  assign _zz_422 = _zz_165;
+  assign _zz_423 = {31'd0, _zz_422};
+  assign _zz_424 = execute_CsrPlugin_writeData[19 : 19];
+  assign _zz_425 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_426 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_427 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_428 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_429 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_430 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_431 = execute_CsrPlugin_writeData[19 : 19];
+  assign _zz_432 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_433 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_434 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_435 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_436 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_437 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_438 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_439 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_440 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_441 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_442 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_443 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_444 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_445 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_446 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_447 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_448 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_449 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_450 = execute_CsrPlugin_writeData[4 : 4];
+  assign _zz_451 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_452 = execute_CsrPlugin_writeData[6 : 6];
+  assign _zz_453 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_454 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_455 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_456 = execute_CsrPlugin_writeData[12 : 12];
+  assign _zz_457 = execute_CsrPlugin_writeData[13 : 13];
+  assign _zz_458 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_459 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_460 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_461 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_462 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_463 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_464 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_465 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_466 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_467 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_468 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_469 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_470 = 1'b1;
+  assign _zz_471 = 1'b1;
+  assign _zz_472 = {_zz_59,{_zz_61,_zz_60}};
+  assign _zz_473 = 32'h0000107f;
+  assign _zz_474 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_475 = 32'h00002073;
+  assign _zz_476 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_477 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_478 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_479) == 32'h00000003),{(_zz_480 == _zz_481),{_zz_482,{_zz_483,_zz_484}}}}}};
+  assign _zz_479 = 32'h0000505f;
+  assign _zz_480 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_481 = 32'h00000063;
+  assign _zz_482 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_483 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
+  assign _zz_484 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_485) == 32'h0000500f),{(_zz_486 == _zz_487),{_zz_488,{_zz_489,_zz_490}}}}}};
+  assign _zz_485 = 32'h01f0707f;
+  assign _zz_486 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_487 = 32'h00005013;
+  assign _zz_488 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
+  assign _zz_489 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_490 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_491) == 32'h12000073),{(_zz_492 == _zz_493),{_zz_494,_zz_495}}}}};
+  assign _zz_491 = 32'hfe007fff;
+  assign _zz_492 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_493 = 32'h10200073;
+  assign _zz_494 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_495 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_496 = decode_INSTRUCTION[31];
+  assign _zz_497 = decode_INSTRUCTION[31];
+  assign _zz_498 = decode_INSTRUCTION[7];
+  assign _zz_499 = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz_500 = 32'h02004020;
+  assign _zz_501 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz_502 = ((decode_INSTRUCTION & 32'h02203050) == 32'h00000050);
+  assign _zz_503 = 1'b0;
+  assign _zz_504 = (((decode_INSTRUCTION & _zz_507) == 32'h00000050) != 1'b0);
+  assign _zz_505 = ({_zz_508,_zz_509} != 2'b00);
+  assign _zz_506 = {({_zz_510,_zz_511} != 2'b00),{(_zz_512 != _zz_513),{_zz_514,{_zz_515,_zz_516}}}};
+  assign _zz_507 = 32'h02403050;
+  assign _zz_508 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz_509 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz_510 = _zz_105;
+  assign _zz_511 = ((decode_INSTRUCTION & _zz_517) == 32'h00000004);
+  assign _zz_512 = ((decode_INSTRUCTION & _zz_518) == 32'h00000040);
+  assign _zz_513 = 1'b0;
+  assign _zz_514 = ({_zz_519,_zz_520} != 2'b00);
+  assign _zz_515 = ({_zz_521,_zz_522} != 3'b000);
+  assign _zz_516 = {(_zz_523 != _zz_524),{_zz_525,{_zz_526,_zz_527}}};
+  assign _zz_517 = 32'h0000001c;
+  assign _zz_518 = 32'h00000058;
+  assign _zz_519 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz_520 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz_521 = ((decode_INSTRUCTION & _zz_528) == 32'h40001010);
+  assign _zz_522 = {(_zz_529 == _zz_530),(_zz_531 == _zz_532)};
+  assign _zz_523 = ((decode_INSTRUCTION & _zz_533) == 32'h00001000);
+  assign _zz_524 = 1'b0;
+  assign _zz_525 = ((_zz_534 == _zz_535) != 1'b0);
+  assign _zz_526 = ({_zz_536,_zz_537} != 2'b00);
+  assign _zz_527 = {(_zz_538 != _zz_539),{_zz_540,{_zz_541,_zz_542}}};
+  assign _zz_528 = 32'h40003054;
+  assign _zz_529 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_530 = 32'h00001010;
+  assign _zz_531 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz_532 = 32'h00001010;
+  assign _zz_533 = 32'h00001000;
+  assign _zz_534 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz_535 = 32'h00002000;
+  assign _zz_536 = ((decode_INSTRUCTION & _zz_543) == 32'h00002000);
+  assign _zz_537 = ((decode_INSTRUCTION & _zz_544) == 32'h00001000);
+  assign _zz_538 = ((decode_INSTRUCTION & _zz_545) == 32'h02000050);
+  assign _zz_539 = 1'b0;
+  assign _zz_540 = ((_zz_546 == _zz_547) != 1'b0);
+  assign _zz_541 = (_zz_548 != 1'b0);
+  assign _zz_542 = {(_zz_549 != _zz_550),{_zz_551,{_zz_552,_zz_553}}};
+  assign _zz_543 = 32'h00002010;
+  assign _zz_544 = 32'h00005000;
+  assign _zz_545 = 32'h02003050;
+  assign _zz_546 = (decode_INSTRUCTION & 32'h00004048);
+  assign _zz_547 = 32'h00004008;
+  assign _zz_548 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz_549 = {(_zz_554 == _zz_555),{_zz_556,{_zz_557,_zz_558}}};
+  assign _zz_550 = 4'b0000;
+  assign _zz_551 = ((_zz_559 == _zz_560) != 1'b0);
+  assign _zz_552 = (_zz_561 != 1'b0);
+  assign _zz_553 = {(_zz_562 != _zz_563),{_zz_564,{_zz_565,_zz_566}}};
+  assign _zz_554 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz_555 = 32'h00000020;
+  assign _zz_556 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz_557 = ((decode_INSTRUCTION & _zz_567) == 32'h08000020);
+  assign _zz_558 = ((decode_INSTRUCTION & _zz_568) == 32'h00000020);
+  assign _zz_559 = (decode_INSTRUCTION & 32'h10000008);
+  assign _zz_560 = 32'h00000008;
+  assign _zz_561 = ((decode_INSTRUCTION & 32'h10000008) == 32'h10000008);
+  assign _zz_562 = {(_zz_569 == _zz_570),{_zz_571,{_zz_572,_zz_573}}};
+  assign _zz_563 = 6'h0;
+  assign _zz_564 = ({_zz_574,{_zz_575,_zz_576}} != 3'b000);
+  assign _zz_565 = ({_zz_577,_zz_578} != 5'h0);
+  assign _zz_566 = {(_zz_579 != _zz_580),{_zz_581,{_zz_582,_zz_583}}};
+  assign _zz_567 = 32'h08000070;
+  assign _zz_568 = 32'h10000070;
+  assign _zz_569 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz_570 = 32'h00002040;
+  assign _zz_571 = ((decode_INSTRUCTION & _zz_584) == 32'h00001040);
+  assign _zz_572 = (_zz_585 == _zz_586);
+  assign _zz_573 = {_zz_587,{_zz_588,_zz_589}};
+  assign _zz_574 = ((decode_INSTRUCTION & _zz_590) == 32'h08000020);
+  assign _zz_575 = (_zz_591 == _zz_592);
+  assign _zz_576 = (_zz_593 == _zz_594);
+  assign _zz_577 = (_zz_595 == _zz_596);
+  assign _zz_578 = {_zz_597,{_zz_598,_zz_599}};
+  assign _zz_579 = {_zz_108,{_zz_600,_zz_601}};
+  assign _zz_580 = 5'h0;
+  assign _zz_581 = ({_zz_602,_zz_603} != 7'h0);
+  assign _zz_582 = (_zz_604 != _zz_605);
+  assign _zz_583 = {_zz_606,{_zz_607,_zz_608}};
+  assign _zz_584 = 32'h00001040;
+  assign _zz_585 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_586 = 32'h00000040;
+  assign _zz_587 = ((decode_INSTRUCTION & _zz_609) == 32'h00000040);
+  assign _zz_588 = (_zz_610 == _zz_611);
+  assign _zz_589 = (_zz_612 == _zz_613);
+  assign _zz_590 = 32'h08000020;
+  assign _zz_591 = (decode_INSTRUCTION & 32'h10000020);
+  assign _zz_592 = 32'h00000020;
+  assign _zz_593 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_594 = 32'h00000020;
+  assign _zz_595 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_596 = 32'h00000040;
+  assign _zz_597 = ((decode_INSTRUCTION & _zz_614) == 32'h00004020);
+  assign _zz_598 = (_zz_615 == _zz_616);
+  assign _zz_599 = {_zz_108,_zz_617};
+  assign _zz_600 = (_zz_618 == _zz_619);
+  assign _zz_601 = {_zz_620,{_zz_621,_zz_622}};
+  assign _zz_602 = _zz_105;
+  assign _zz_603 = {_zz_623,{_zz_624,_zz_625}};
+  assign _zz_604 = {_zz_107,_zz_626};
+  assign _zz_605 = 2'b00;
+  assign _zz_606 = ({_zz_627,_zz_628} != 2'b00);
+  assign _zz_607 = (_zz_629 != _zz_630);
+  assign _zz_608 = {_zz_631,{_zz_632,_zz_633}};
+  assign _zz_609 = 32'h02400040;
+  assign _zz_610 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_611 = 32'h0;
+  assign _zz_612 = (decode_INSTRUCTION & 32'h18002008);
+  assign _zz_613 = 32'h10002008;
+  assign _zz_614 = 32'h00004020;
+  assign _zz_615 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_616 = 32'h00000010;
+  assign _zz_617 = ((decode_INSTRUCTION & _zz_634) == 32'h00000020);
+  assign _zz_618 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz_619 = 32'h00002010;
+  assign _zz_620 = ((decode_INSTRUCTION & _zz_635) == 32'h00000010);
+  assign _zz_621 = (_zz_636 == _zz_637);
+  assign _zz_622 = (_zz_638 == _zz_639);
+  assign _zz_623 = ((decode_INSTRUCTION & _zz_640) == 32'h00001010);
+  assign _zz_624 = (_zz_641 == _zz_642);
+  assign _zz_625 = {_zz_643,{_zz_644,_zz_645}};
+  assign _zz_626 = ((decode_INSTRUCTION & _zz_646) == 32'h00000020);
+  assign _zz_627 = _zz_107;
+  assign _zz_628 = (_zz_647 == _zz_648);
+  assign _zz_629 = (_zz_649 == _zz_650);
+  assign _zz_630 = 1'b0;
+  assign _zz_631 = (_zz_651 != 1'b0);
+  assign _zz_632 = (_zz_652 != _zz_653);
+  assign _zz_633 = {_zz_654,{_zz_655,_zz_656}};
+  assign _zz_634 = 32'h02000028;
+  assign _zz_635 = 32'h00001030;
+  assign _zz_636 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz_637 = 32'h00000020;
+  assign _zz_638 = (decode_INSTRUCTION & 32'h02002068);
+  assign _zz_639 = 32'h00002020;
+  assign _zz_640 = 32'h00001010;
+  assign _zz_641 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_642 = 32'h00002010;
+  assign _zz_643 = ((decode_INSTRUCTION & _zz_657) == 32'h00002008);
+  assign _zz_644 = (_zz_658 == _zz_659);
+  assign _zz_645 = {_zz_108,_zz_660};
+  assign _zz_646 = 32'h00000070;
+  assign _zz_647 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_648 = 32'h0;
+  assign _zz_649 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz_650 = 32'h00004010;
+  assign _zz_651 = ((decode_INSTRUCTION & _zz_661) == 32'h00002010);
+  assign _zz_652 = {_zz_662,{_zz_663,_zz_664}};
+  assign _zz_653 = 5'h0;
+  assign _zz_654 = ({_zz_665,_zz_666} != 2'b00);
+  assign _zz_655 = (_zz_667 != _zz_668);
+  assign _zz_656 = {_zz_669,{_zz_670,_zz_671}};
+  assign _zz_657 = 32'h00002008;
+  assign _zz_658 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_659 = 32'h00000010;
+  assign _zz_660 = ((decode_INSTRUCTION & _zz_672) == 32'h0);
+  assign _zz_661 = 32'h00006014;
+  assign _zz_662 = ((decode_INSTRUCTION & _zz_673) == 32'h0);
+  assign _zz_663 = (_zz_674 == _zz_675);
+  assign _zz_664 = {_zz_676,{_zz_677,_zz_678}};
+  assign _zz_665 = _zz_106;
+  assign _zz_666 = (_zz_679 == _zz_680);
+  assign _zz_667 = {_zz_681,{_zz_682,_zz_683}};
+  assign _zz_668 = 3'b000;
+  assign _zz_669 = ({_zz_684,_zz_685} != 3'b000);
+  assign _zz_670 = (_zz_686 != _zz_687);
+  assign _zz_671 = (_zz_688 != _zz_689);
+  assign _zz_672 = 32'h00000028;
+  assign _zz_673 = 32'h00000044;
+  assign _zz_674 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_675 = 32'h0;
+  assign _zz_676 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_677 = ((decode_INSTRUCTION & _zz_690) == 32'h00001000);
+  assign _zz_678 = _zz_106;
+  assign _zz_679 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_680 = 32'h0;
+  assign _zz_681 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_682 = ((decode_INSTRUCTION & _zz_691) == 32'h00002010);
+  assign _zz_683 = ((decode_INSTRUCTION & _zz_692) == 32'h40000030);
+  assign _zz_684 = _zz_105;
+  assign _zz_685 = {_zz_104,(_zz_693 == _zz_694)};
+  assign _zz_686 = {_zz_104,(_zz_695 == _zz_696)};
+  assign _zz_687 = 2'b00;
+  assign _zz_688 = ((decode_INSTRUCTION & _zz_697) == 32'h00001008);
+  assign _zz_689 = 1'b0;
+  assign _zz_690 = 32'h00005004;
+  assign _zz_691 = 32'h00002014;
+  assign _zz_692 = 32'h40000034;
+  assign _zz_693 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz_694 = 32'h00000004;
+  assign _zz_695 = (decode_INSTRUCTION & 32'h0000004c);
+  assign _zz_696 = 32'h00000004;
+  assign _zz_697 = 32'h00005048;
+  assign _zz_698 = execute_INSTRUCTION[31];
+  assign _zz_699 = execute_INSTRUCTION[31];
+  assign _zz_700 = execute_INSTRUCTION[7];
+  assign _zz_701 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_452_) begin
-      _zz_222_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_470) begin
+      _zz_240 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_453_) begin
-      _zz_223_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_471) begin
+      _zz_241 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_197_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_198_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_199_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_200_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_201_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_202_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_203_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_204_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_205                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_206                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_207                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_208                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_209                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]           ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_210                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_211                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_212                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_213                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_205_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_206_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (_zz_207_                                                    ), //i
-    .io_cpu_execute_args_data                      (_zz_208_[31:0]                                              ), //i
-    .io_cpu_execute_args_size                      (_zz_209_[1:0]                                               ), //i
-    .io_cpu_execute_args_isLrsc                    (_zz_210_                                                    ), //i
-    .io_cpu_execute_args_isAmo                     (_zz_211_                                                    ), //i
-    .io_cpu_execute_args_amoCtrl_swap              (_zz_212_                                                    ), //i
-    .io_cpu_execute_args_amoCtrl_alu               (_zz_213_[2:0]                                               ), //i
-    .io_cpu_memory_isValid                         (_zz_214_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_215_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_216_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_217_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_218_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_219_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_writeBack_clearLrsc                    (contextSwitching                                            ), //i
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_220_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_221_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_214                                            ), //i
+    .io_cpu_execute_address                    (_zz_215[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (_zz_216                                            ), //i
+    .io_cpu_execute_args_data                  (_zz_217[31:0]                                      ), //i
+    .io_cpu_execute_args_size                  (_zz_218[1:0]                                       ), //i
+    .io_cpu_execute_args_isLrsc                (_zz_219                                            ), //i
+    .io_cpu_execute_args_isAmo                 (_zz_220                                            ), //i
+    .io_cpu_execute_args_amoCtrl_swap          (_zz_221                                            ), //i
+    .io_cpu_execute_args_amoCtrl_alu           (_zz_222[2:0]                                       ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_223                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_224[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_225                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]  ), //i
+    .io_cpu_writeBack_isValid                  (_zz_226                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_227                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_228[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_229                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_230                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_231                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_232                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_233                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_234                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_235                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_236                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_237[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_238                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_239                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_454_)
+    case(_zz_472)
       3'b000 : begin
-        _zz_224_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_242 = DBusCachedPlugin_redoBranch_payload;
       end
       3'b001 : begin
-        _zz_224_ = CsrPlugin_jumpInterface_payload;
+        _zz_242 = CsrPlugin_jumpInterface_payload;
       end
       3'b010 : begin
-        _zz_224_ = BranchPlugin_jumpInterface_payload;
+        _zz_242 = BranchPlugin_jumpInterface_payload;
       end
       3'b011 : begin
-        _zz_224_ = CsrPlugin_redoInterface_payload;
+        _zz_242 = CsrPlugin_redoInterface_payload;
       end
       default : begin
-        _zz_224_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_242 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_91_)
+    case(_zz_92)
       2'b00 : begin
-        _zz_225_ = MmuPlugin_ports_0_cache_0_valid;
-        _zz_226_ = MmuPlugin_ports_0_cache_0_exception;
-        _zz_227_ = MmuPlugin_ports_0_cache_0_superPage;
-        _zz_228_ = MmuPlugin_ports_0_cache_0_virtualAddress_0;
-        _zz_229_ = MmuPlugin_ports_0_cache_0_virtualAddress_1;
-        _zz_230_ = MmuPlugin_ports_0_cache_0_physicalAddress_0;
-        _zz_231_ = MmuPlugin_ports_0_cache_0_physicalAddress_1;
-        _zz_232_ = MmuPlugin_ports_0_cache_0_allowRead;
-        _zz_233_ = MmuPlugin_ports_0_cache_0_allowWrite;
-        _zz_234_ = MmuPlugin_ports_0_cache_0_allowExecute;
-        _zz_235_ = MmuPlugin_ports_0_cache_0_allowUser;
+        _zz_243 = MmuPlugin_ports_0_cache_0_valid;
+        _zz_244 = MmuPlugin_ports_0_cache_0_exception;
+        _zz_245 = MmuPlugin_ports_0_cache_0_superPage;
+        _zz_246 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
+        _zz_247 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
+        _zz_248 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
+        _zz_249 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
+        _zz_250 = MmuPlugin_ports_0_cache_0_allowRead;
+        _zz_251 = MmuPlugin_ports_0_cache_0_allowWrite;
+        _zz_252 = MmuPlugin_ports_0_cache_0_allowExecute;
+        _zz_253 = MmuPlugin_ports_0_cache_0_allowUser;
       end
       2'b01 : begin
-        _zz_225_ = MmuPlugin_ports_0_cache_1_valid;
-        _zz_226_ = MmuPlugin_ports_0_cache_1_exception;
-        _zz_227_ = MmuPlugin_ports_0_cache_1_superPage;
-        _zz_228_ = MmuPlugin_ports_0_cache_1_virtualAddress_0;
-        _zz_229_ = MmuPlugin_ports_0_cache_1_virtualAddress_1;
-        _zz_230_ = MmuPlugin_ports_0_cache_1_physicalAddress_0;
-        _zz_231_ = MmuPlugin_ports_0_cache_1_physicalAddress_1;
-        _zz_232_ = MmuPlugin_ports_0_cache_1_allowRead;
-        _zz_233_ = MmuPlugin_ports_0_cache_1_allowWrite;
-        _zz_234_ = MmuPlugin_ports_0_cache_1_allowExecute;
-        _zz_235_ = MmuPlugin_ports_0_cache_1_allowUser;
+        _zz_243 = MmuPlugin_ports_0_cache_1_valid;
+        _zz_244 = MmuPlugin_ports_0_cache_1_exception;
+        _zz_245 = MmuPlugin_ports_0_cache_1_superPage;
+        _zz_246 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
+        _zz_247 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
+        _zz_248 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
+        _zz_249 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
+        _zz_250 = MmuPlugin_ports_0_cache_1_allowRead;
+        _zz_251 = MmuPlugin_ports_0_cache_1_allowWrite;
+        _zz_252 = MmuPlugin_ports_0_cache_1_allowExecute;
+        _zz_253 = MmuPlugin_ports_0_cache_1_allowUser;
       end
       2'b10 : begin
-        _zz_225_ = MmuPlugin_ports_0_cache_2_valid;
-        _zz_226_ = MmuPlugin_ports_0_cache_2_exception;
-        _zz_227_ = MmuPlugin_ports_0_cache_2_superPage;
-        _zz_228_ = MmuPlugin_ports_0_cache_2_virtualAddress_0;
-        _zz_229_ = MmuPlugin_ports_0_cache_2_virtualAddress_1;
-        _zz_230_ = MmuPlugin_ports_0_cache_2_physicalAddress_0;
-        _zz_231_ = MmuPlugin_ports_0_cache_2_physicalAddress_1;
-        _zz_232_ = MmuPlugin_ports_0_cache_2_allowRead;
-        _zz_233_ = MmuPlugin_ports_0_cache_2_allowWrite;
-        _zz_234_ = MmuPlugin_ports_0_cache_2_allowExecute;
-        _zz_235_ = MmuPlugin_ports_0_cache_2_allowUser;
+        _zz_243 = MmuPlugin_ports_0_cache_2_valid;
+        _zz_244 = MmuPlugin_ports_0_cache_2_exception;
+        _zz_245 = MmuPlugin_ports_0_cache_2_superPage;
+        _zz_246 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
+        _zz_247 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
+        _zz_248 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
+        _zz_249 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
+        _zz_250 = MmuPlugin_ports_0_cache_2_allowRead;
+        _zz_251 = MmuPlugin_ports_0_cache_2_allowWrite;
+        _zz_252 = MmuPlugin_ports_0_cache_2_allowExecute;
+        _zz_253 = MmuPlugin_ports_0_cache_2_allowUser;
       end
       default : begin
-        _zz_225_ = MmuPlugin_ports_0_cache_3_valid;
-        _zz_226_ = MmuPlugin_ports_0_cache_3_exception;
-        _zz_227_ = MmuPlugin_ports_0_cache_3_superPage;
-        _zz_228_ = MmuPlugin_ports_0_cache_3_virtualAddress_0;
-        _zz_229_ = MmuPlugin_ports_0_cache_3_virtualAddress_1;
-        _zz_230_ = MmuPlugin_ports_0_cache_3_physicalAddress_0;
-        _zz_231_ = MmuPlugin_ports_0_cache_3_physicalAddress_1;
-        _zz_232_ = MmuPlugin_ports_0_cache_3_allowRead;
-        _zz_233_ = MmuPlugin_ports_0_cache_3_allowWrite;
-        _zz_234_ = MmuPlugin_ports_0_cache_3_allowExecute;
-        _zz_235_ = MmuPlugin_ports_0_cache_3_allowUser;
+        _zz_243 = MmuPlugin_ports_0_cache_3_valid;
+        _zz_244 = MmuPlugin_ports_0_cache_3_exception;
+        _zz_245 = MmuPlugin_ports_0_cache_3_superPage;
+        _zz_246 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
+        _zz_247 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
+        _zz_248 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
+        _zz_249 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
+        _zz_250 = MmuPlugin_ports_0_cache_3_allowRead;
+        _zz_251 = MmuPlugin_ports_0_cache_3_allowWrite;
+        _zz_252 = MmuPlugin_ports_0_cache_3_allowExecute;
+        _zz_253 = MmuPlugin_ports_0_cache_3_allowUser;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_94_)
+    case(_zz_96)
       2'b00 : begin
-        _zz_236_ = MmuPlugin_ports_1_cache_0_valid;
-        _zz_237_ = MmuPlugin_ports_1_cache_0_exception;
-        _zz_238_ = MmuPlugin_ports_1_cache_0_superPage;
-        _zz_239_ = MmuPlugin_ports_1_cache_0_virtualAddress_0;
-        _zz_240_ = MmuPlugin_ports_1_cache_0_virtualAddress_1;
-        _zz_241_ = MmuPlugin_ports_1_cache_0_physicalAddress_0;
-        _zz_242_ = MmuPlugin_ports_1_cache_0_physicalAddress_1;
-        _zz_243_ = MmuPlugin_ports_1_cache_0_allowRead;
-        _zz_244_ = MmuPlugin_ports_1_cache_0_allowWrite;
-        _zz_245_ = MmuPlugin_ports_1_cache_0_allowExecute;
-        _zz_246_ = MmuPlugin_ports_1_cache_0_allowUser;
+        _zz_254 = MmuPlugin_ports_1_cache_0_valid;
+        _zz_255 = MmuPlugin_ports_1_cache_0_exception;
+        _zz_256 = MmuPlugin_ports_1_cache_0_superPage;
+        _zz_257 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
+        _zz_258 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
+        _zz_259 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
+        _zz_260 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
+        _zz_261 = MmuPlugin_ports_1_cache_0_allowRead;
+        _zz_262 = MmuPlugin_ports_1_cache_0_allowWrite;
+        _zz_263 = MmuPlugin_ports_1_cache_0_allowExecute;
+        _zz_264 = MmuPlugin_ports_1_cache_0_allowUser;
       end
       2'b01 : begin
-        _zz_236_ = MmuPlugin_ports_1_cache_1_valid;
-        _zz_237_ = MmuPlugin_ports_1_cache_1_exception;
-        _zz_238_ = MmuPlugin_ports_1_cache_1_superPage;
-        _zz_239_ = MmuPlugin_ports_1_cache_1_virtualAddress_0;
-        _zz_240_ = MmuPlugin_ports_1_cache_1_virtualAddress_1;
-        _zz_241_ = MmuPlugin_ports_1_cache_1_physicalAddress_0;
-        _zz_242_ = MmuPlugin_ports_1_cache_1_physicalAddress_1;
-        _zz_243_ = MmuPlugin_ports_1_cache_1_allowRead;
-        _zz_244_ = MmuPlugin_ports_1_cache_1_allowWrite;
-        _zz_245_ = MmuPlugin_ports_1_cache_1_allowExecute;
-        _zz_246_ = MmuPlugin_ports_1_cache_1_allowUser;
+        _zz_254 = MmuPlugin_ports_1_cache_1_valid;
+        _zz_255 = MmuPlugin_ports_1_cache_1_exception;
+        _zz_256 = MmuPlugin_ports_1_cache_1_superPage;
+        _zz_257 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
+        _zz_258 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
+        _zz_259 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
+        _zz_260 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
+        _zz_261 = MmuPlugin_ports_1_cache_1_allowRead;
+        _zz_262 = MmuPlugin_ports_1_cache_1_allowWrite;
+        _zz_263 = MmuPlugin_ports_1_cache_1_allowExecute;
+        _zz_264 = MmuPlugin_ports_1_cache_1_allowUser;
       end
       2'b10 : begin
-        _zz_236_ = MmuPlugin_ports_1_cache_2_valid;
-        _zz_237_ = MmuPlugin_ports_1_cache_2_exception;
-        _zz_238_ = MmuPlugin_ports_1_cache_2_superPage;
-        _zz_239_ = MmuPlugin_ports_1_cache_2_virtualAddress_0;
-        _zz_240_ = MmuPlugin_ports_1_cache_2_virtualAddress_1;
-        _zz_241_ = MmuPlugin_ports_1_cache_2_physicalAddress_0;
-        _zz_242_ = MmuPlugin_ports_1_cache_2_physicalAddress_1;
-        _zz_243_ = MmuPlugin_ports_1_cache_2_allowRead;
-        _zz_244_ = MmuPlugin_ports_1_cache_2_allowWrite;
-        _zz_245_ = MmuPlugin_ports_1_cache_2_allowExecute;
-        _zz_246_ = MmuPlugin_ports_1_cache_2_allowUser;
+        _zz_254 = MmuPlugin_ports_1_cache_2_valid;
+        _zz_255 = MmuPlugin_ports_1_cache_2_exception;
+        _zz_256 = MmuPlugin_ports_1_cache_2_superPage;
+        _zz_257 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
+        _zz_258 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
+        _zz_259 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
+        _zz_260 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
+        _zz_261 = MmuPlugin_ports_1_cache_2_allowRead;
+        _zz_262 = MmuPlugin_ports_1_cache_2_allowWrite;
+        _zz_263 = MmuPlugin_ports_1_cache_2_allowExecute;
+        _zz_264 = MmuPlugin_ports_1_cache_2_allowUser;
       end
       default : begin
-        _zz_236_ = MmuPlugin_ports_1_cache_3_valid;
-        _zz_237_ = MmuPlugin_ports_1_cache_3_exception;
-        _zz_238_ = MmuPlugin_ports_1_cache_3_superPage;
-        _zz_239_ = MmuPlugin_ports_1_cache_3_virtualAddress_0;
-        _zz_240_ = MmuPlugin_ports_1_cache_3_virtualAddress_1;
-        _zz_241_ = MmuPlugin_ports_1_cache_3_physicalAddress_0;
-        _zz_242_ = MmuPlugin_ports_1_cache_3_physicalAddress_1;
-        _zz_243_ = MmuPlugin_ports_1_cache_3_allowRead;
-        _zz_244_ = MmuPlugin_ports_1_cache_3_allowWrite;
-        _zz_245_ = MmuPlugin_ports_1_cache_3_allowExecute;
-        _zz_246_ = MmuPlugin_ports_1_cache_3_allowUser;
+        _zz_254 = MmuPlugin_ports_1_cache_3_valid;
+        _zz_255 = MmuPlugin_ports_1_cache_3_exception;
+        _zz_256 = MmuPlugin_ports_1_cache_3_superPage;
+        _zz_257 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
+        _zz_258 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
+        _zz_259 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
+        _zz_260 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
+        _zz_261 = MmuPlugin_ports_1_cache_3_allowRead;
+        _zz_262 = MmuPlugin_ports_1_cache_3_allowWrite;
+        _zz_263 = MmuPlugin_ports_1_cache_3_allowExecute;
+        _zz_264 = MmuPlugin_ports_1_cache_3_allowUser;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_1_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_1__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_1__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_1__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_1__string = "PC ";
-      default : _zz_1__string = "???";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_2__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_2__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_2__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_2__string = "PC ";
-      default : _zz_2__string = "???";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_3__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_3__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_3__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_3__string = "PC ";
-      default : _zz_3__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_4__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_4__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_4__string = "AND_1";
-      default : _zz_4__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_5__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_5__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_5__string = "AND_1";
-      default : _zz_5__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_6__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_6__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_6__string = "AND_1";
-      default : _zz_6__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_7__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_7__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_7__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_7__string = "URS1        ";
-      default : _zz_7__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_8__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_8__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_8__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_8__string = "URS1        ";
-      default : _zz_8__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_9__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_9__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_9__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_9__string = "URS1        ";
-      default : _zz_9__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10__string = "SRA_1    ";
-      default : _zz_10__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_11_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11__string = "SRA_1    ";
-      default : _zz_11__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12__string = "SRA_1    ";
-      default : _zz_12__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13__string = "SRA_1    ";
-      default : _zz_13__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14__string = "SRA_1    ";
-      default : _zz_14__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_15__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_15__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_15__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_15__string = "ECALL";
-      default : _zz_15__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_16__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_16__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_16__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_16__string = "ECALL";
-      default : _zz_16__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_17__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_17__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_17__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_17__string = "ECALL";
-      default : _zz_17__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_18__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_18__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_18__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_18__string = "ECALL";
-      default : _zz_18__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3710,48 +2465,170 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_19_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_19__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_19__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_19__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_19__string = "ECALL";
-      default : _zz_19__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_20_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_20__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_20__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_20__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_20__string = "ECALL";
-      default : _zz_20__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_21__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_21__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_21__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_21__string = "ECALL";
-      default : _zz_21__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_22__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_22__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_22__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_22__string = "JALR";
-      default : _zz_22__string = "????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_23__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_23__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_23__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_23__string = "JALR";
-      default : _zz_23__string = "????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
     endcase
   end
   always @(*) begin
@@ -3763,27 +2640,63 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24__string = "BITWISE ";
-      default : _zz_24__string = "????????";
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_25__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_25__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_25__string = "BITWISE ";
-      default : _zz_25__string = "????????";
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_26__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_26__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_26__string = "BITWISE ";
-      default : _zz_26__string = "????????";
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3796,12 +2709,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3814,12 +2727,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3832,12 +2745,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3850,12 +2763,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -3868,12 +2781,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3886,12 +2799,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3904,12 +2817,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -3922,12 +2835,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3939,11 +2852,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3955,72 +2868,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_43__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_43__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_43__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_43__string = "SRA_1    ";
-      default : _zz_43__string = "?????????";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_44__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_44__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_44__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_44__string = "URS1        ";
-      default : _zz_44__string = "????????????";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_45__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_45__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_45__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_45__string = "JALR";
-      default : _zz_45__string = "????";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_46__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_46__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_46__string = "BITWISE ";
-      default : _zz_46__string = "????????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_47__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_47__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_47__string = "AND_1";
-      default : _zz_47__string = "?????";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_48__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_48__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_48__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_48__string = "ECALL";
-      default : _zz_48__string = "?????";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_49__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_49__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_49__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_49__string = "PC ";
-      default : _zz_49__string = "???";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4033,83 +2946,92 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52__string = "JALR";
-      default : _zz_52__string = "????";
+    case(_zz_52)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
+      default : _zz_52_string = "????";
     endcase
   end
   always @(*) begin
-    case(MmuPlugin_shared_state_1_)
-      `MmuPlugin_shared_State_defaultEncoding_IDLE : MmuPlugin_shared_state_1__string = "IDLE  ";
-      `MmuPlugin_shared_State_defaultEncoding_L1_CMD : MmuPlugin_shared_state_1__string = "L1_CMD";
-      `MmuPlugin_shared_State_defaultEncoding_L1_RSP : MmuPlugin_shared_state_1__string = "L1_RSP";
-      `MmuPlugin_shared_State_defaultEncoding_L0_CMD : MmuPlugin_shared_state_1__string = "L0_CMD";
-      `MmuPlugin_shared_State_defaultEncoding_L0_RSP : MmuPlugin_shared_state_1__string = "L0_RSP";
-      default : MmuPlugin_shared_state_1__string = "??????";
+    case(MmuPlugin_shared_state_1)
+      `MmuPlugin_shared_State_defaultEncoding_IDLE : MmuPlugin_shared_state_1_string = "IDLE  ";
+      `MmuPlugin_shared_State_defaultEncoding_L1_CMD : MmuPlugin_shared_state_1_string = "L1_CMD";
+      `MmuPlugin_shared_State_defaultEncoding_L1_RSP : MmuPlugin_shared_state_1_string = "L1_RSP";
+      `MmuPlugin_shared_State_defaultEncoding_L0_CMD : MmuPlugin_shared_state_1_string = "L0_CMD";
+      `MmuPlugin_shared_State_defaultEncoding_L0_RSP : MmuPlugin_shared_state_1_string = "L0_RSP";
+      default : MmuPlugin_shared_state_1_string = "??????";
     endcase
   end
   always @(*) begin
-    case(_zz_102_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_102__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_102__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_102__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_102__string = "PC ";
-      default : _zz_102__string = "???";
+    case(_zz_110)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_110_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_110_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_110_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_110_string = "URS1        ";
+      default : _zz_110_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_103_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_103__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_103__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_103__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_103__string = "ECALL";
-      default : _zz_103__string = "?????";
+    case(_zz_111)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_111_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_111_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_111_string = "BITWISE ";
+      default : _zz_111_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_104_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_104__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_104__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_104__string = "AND_1";
-      default : _zz_104__string = "?????";
+    case(_zz_112)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_112_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_112_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_112_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_112_string = "PC ";
+      default : _zz_112_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_105_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_105__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_105__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_105__string = "BITWISE ";
-      default : _zz_105__string = "????????";
+    case(_zz_113)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_113_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_113_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_113_string = "AND_1";
+      default : _zz_113_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_106_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_106__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_106__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_106__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_106__string = "JALR";
-      default : _zz_106__string = "????";
+    case(_zz_114)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_114_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_114_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_114_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_114_string = "SRA_1    ";
+      default : _zz_114_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_107_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_107__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_107__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_107__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_107__string = "URS1        ";
-      default : _zz_107__string = "????????????";
+    case(_zz_115)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_115_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_115_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_115_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_115_string = "JALR";
+      default : _zz_115_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_108_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_108__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_108__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_108__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_108__string = "SRA_1    ";
-      default : _zz_108__string = "?????????";
+    case(_zz_116)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_116_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_116_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_116_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_116_string = "ECALL";
+      default : _zz_116_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4118,6 +3040,41 @@ module VexRiscv (
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
       `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -4156,109 +3113,64 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
   `endif
 
-  assign decode_IS_RS2_SIGNED = _zz_306_[0];
-  assign decode_SRC2_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign memory_MUL_LOW = ($signed(_zz_323) + $signed(_zz_331));
   assign memory_MUL_HH = execute_to_memory_MUL_HH;
   assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign decode_IS_RS1_SIGNED = _zz_307_[0];
-  assign decode_MEMORY_AMO = _zz_308_[0];
-  assign execute_SHIFT_RIGHT = _zz_310_;
-  assign memory_PC = execute_to_memory_PC;
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_SHIFT_RIGHT = _zz_333;
+  assign execute_REGFILE_WRITE_DATA = _zz_118;
+  assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_215[1 : 0];
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_335[0];
+  assign decode_IS_RS1_SIGNED = _zz_336[0];
+  assign decode_IS_DIV = _zz_337[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_338[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_339[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_340[0];
   assign memory_IS_SFENCE_VMA = execute_to_memory_IS_SFENCE_VMA;
   assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
-  assign decode_IS_SFENCE_VMA = _zz_312_[0];
-  assign decode_MEMORY_LRSC = _zz_313_[0];
+  assign decode_IS_SFENCE_VMA = _zz_341[0];
+  assign decode_MEMORY_MANAGMENT = _zz_342[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_343[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_344[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_345[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_51;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign decode_ALU_BITWISE_CTRL = _zz_4_;
-  assign _zz_5_ = _zz_6_;
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_206_[1 : 0];
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_314_[0];
-  assign decode_IS_CSR = _zz_315_[0];
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign decode_IS_DIV = _zz_316_[0];
-  assign decode_SRC_LESS_UNSIGNED = _zz_317_[0];
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_318_[0];
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
-  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign memory_MUL_LOW = ($signed(_zz_319_) + $signed(_zz_327_));
-  assign decode_MEMORY_MANAGMENT = _zz_328_[0];
-  assign decode_SRC1_CTRL = _zz_7_;
-  assign _zz_8_ = _zz_9_;
-  assign _zz_10_ = _zz_11_;
-  assign decode_SHIFT_CTRL = _zz_12_;
-  assign _zz_13_ = _zz_14_;
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_329_[0];
-  assign _zz_15_ = _zz_16_;
-  assign _zz_17_ = _zz_18_;
-  assign decode_ENV_CTRL = _zz_19_;
-  assign _zz_20_ = _zz_21_;
-  assign _zz_22_ = _zz_23_;
-  assign execute_REGFILE_WRITE_DATA = _zz_110_;
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_330_[0];
-  assign decode_ALU_CTRL = _zz_24_;
-  assign _zz_25_ = _zz_26_;
-  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign memory_PC = execute_to_memory_PC;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -4272,25 +3184,25 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_132_;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_331_[0];
-  assign decode_RS1_USE = _zz_332_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_140;
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_346[0];
+  assign decode_RS1_USE = _zz_347[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_247_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_265)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
     if(DBusCachedPlugin_forceDatapath)begin
-      _zz_31_ = MmuPlugin_dBusAccess_cmd_payload_address;
+      _zz_31 = MmuPlugin_dBusAccess_cmd_payload_address;
     end
   end
 
@@ -4302,29 +3214,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_121_)begin
-      if((_zz_122_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_123_;
+    if(_zz_129)begin
+      if((_zz_130 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_131;
       end
     end
-    if(_zz_248_)begin
-      if(_zz_249_)begin
-        if(_zz_125_)begin
-          decode_RS2 = _zz_50_;
+    if(_zz_266)begin
+      if(_zz_267)begin
+        if(_zz_133)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_250_)begin
+    if(_zz_268)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_127_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_135)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_251_)begin
+    if(_zz_269)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_129_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_137)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -4332,29 +3244,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_121_)begin
-      if((_zz_122_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_123_;
+    if(_zz_129)begin
+      if((_zz_130 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_131;
       end
     end
-    if(_zz_248_)begin
-      if(_zz_249_)begin
-        if(_zz_124_)begin
-          decode_RS1 = _zz_50_;
+    if(_zz_266)begin
+      if(_zz_267)begin
+        if(_zz_132)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_250_)begin
+    if(_zz_268)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_126_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_134)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_251_)begin
+    if(_zz_269)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_128_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_136)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -4362,73 +3274,73 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_118_;
+          _zz_32 = _zz_126;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_252_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_270)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_333_[0];
-  assign decode_SRC_ADD_ZERO = _zz_334_[0];
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_348[0];
+  assign decode_SRC_ADD_ZERO = _zz_349[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_116_;
-  assign execute_SRC1 = _zz_111_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_124;
+  assign execute_SRC1 = _zz_119;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_335_[0];
+    decode_REGFILE_WRITE_VALID = _zz_350[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_455_) == 32'h00001073),{(_zz_456_ == _zz_457_),{_zz_458_,{_zz_459_,_zz_460_}}}}}}} != 25'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_473) == 32'h00001073),{(_zz_474 == _zz_475),{_zz_476,{_zz_477,_zz_478}}}}}}} != 25'h0);
   assign writeBack_IS_SFENCE_VMA = memory_to_writeBack_IS_SFENCE_VMA;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
   always @ (*) begin
-    _zz_50_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_305_)
+      case(_zz_322)
         2'b00 : begin
-          _zz_50_ = _zz_389_;
+          _zz_50 = _zz_407;
         end
         default : begin
-          _zz_50_ = _zz_390_;
+          _zz_50 = _zz_408;
         end
       endcase
     end
@@ -4442,62 +3354,65 @@ module VexRiscv (
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
   assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_336_[0];
-  assign decode_FLUSH_ALL = _zz_337_[0];
+  assign decode_MEMORY_AMO = _zz_351[0];
+  assign decode_MEMORY_LRSC = _zz_352[0];
+  assign decode_MEMORY_ENABLE = _zz_353[0];
+  assign decode_FLUSH_ALL = _zz_354[0];
   always @ (*) begin
-    _zz_51_ = _zz_51__2;
-    if(_zz_253_)begin
-      _zz_51_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_271)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(_zz_254_)begin
-      _zz_51__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_272)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(_zz_255_)begin
-      _zz_51__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_273)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_256_)begin
-      _zz_51__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_274)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52_;
+  assign decode_BRANCH_CTRL = _zz_52;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_53_ = execute_FORMAL_PC_NEXT;
+    _zz_53 = execute_FORMAL_PC_NEXT;
     if(CsrPlugin_redoInterface_valid)begin
-      _zz_53_ = CsrPlugin_redoInterface_payload;
+      _zz_53 = CsrPlugin_redoInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_54_ = memory_FORMAL_PC_NEXT;
+    _zz_54 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_54_ = BranchPlugin_jumpInterface_payload;
+      _zz_54 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_55_ = decode_FORMAL_PC_NEXT;
+    _zz_55 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_55_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_55 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -4516,20 +3431,20 @@ module VexRiscv (
     if(MmuPlugin_dBusAccess_cmd_valid)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if((decode_arbitration_isValid && (_zz_119_ || _zz_120_)))begin
+    if((decode_arbitration_isValid && (_zz_127 || _zz_128)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_257_)begin
+    if(_zz_275)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -4543,32 +3458,35 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_257_)begin
+    if(_zz_275)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_220_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_238 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_258_)begin
+    if(_zz_276)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_247_)begin
+    if(_zz_265)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  assign execute_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    execute_arbitration_haltByOther = 1'b0;
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+  end
+
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
     if(CsrPlugin_selfException_valid)begin
@@ -4586,7 +3504,7 @@ module VexRiscv (
       execute_arbitration_flushNext = 1'b1;
     end
     if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
+      if(execute_CsrPlugin_writeInstruction)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -4594,7 +3512,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_252_)begin
+    if(_zz_270)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -4625,7 +3543,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -4656,10 +3574,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_259_)begin
+    if(_zz_277)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_260_)begin
+    if(_zz_278)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -4670,13 +3588,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_259_)begin
+    if(_zz_277)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_260_)begin
+    if(_zz_278)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -4690,7 +3608,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_258_)begin
+    if(_zz_276)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -4698,21 +3616,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_259_)begin
+    if(_zz_277)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_260_)begin
+    if(_zz_278)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_259_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_277)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_260_)begin
-      case(_zz_261_)
+    if(_zz_278)begin
+      case(_zz_279)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4728,15 +3646,15 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != 5'h0);
-  assign _zz_56_ = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
-  assign _zz_57_ = (_zz_56_ & (~ _zz_338_));
-  assign _zz_58_ = _zz_57_[3];
-  assign _zz_59_ = _zz_57_[4];
-  assign _zz_60_ = (_zz_57_[1] || _zz_58_);
-  assign _zz_61_ = (_zz_57_[2] || _zz_58_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_224_;
+  assign _zz_56 = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
+  assign _zz_57 = (_zz_56 & (~ _zz_355));
+  assign _zz_58 = _zz_57[3];
+  assign _zz_59 = _zz_57[4];
+  assign _zz_60 = (_zz_57[1] || _zz_58);
+  assign _zz_61 = (_zz_57[2] || _zz_58);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_242;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -4756,7 +3674,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_340_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_357);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -4796,44 +3714,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_62_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_62_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_62_);
+  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_62);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_62);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_63_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_63_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_63_);
+  assign _zz_63 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_63);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_63);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_51_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_64_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_64_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_64_);
+  assign _zz_64 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_64);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_64);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_65_;
-  assign _zz_65_ = ((1'b0 && (! _zz_66_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_66_ = _zz_67_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_66_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_65;
+  assign _zz_65 = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_66 = _zz_67;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_66;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_68_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_68_ = _zz_69_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_68_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_70_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_68)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_68 = _zz_69;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_68;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_70;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -4847,125 +3765,125 @@ module VexRiscv (
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_71_ = _zz_341_[11];
+  assign _zz_71 = _zz_358[11];
   always @ (*) begin
-    _zz_72_[18] = _zz_71_;
-    _zz_72_[17] = _zz_71_;
-    _zz_72_[16] = _zz_71_;
-    _zz_72_[15] = _zz_71_;
-    _zz_72_[14] = _zz_71_;
-    _zz_72_[13] = _zz_71_;
-    _zz_72_[12] = _zz_71_;
-    _zz_72_[11] = _zz_71_;
-    _zz_72_[10] = _zz_71_;
-    _zz_72_[9] = _zz_71_;
-    _zz_72_[8] = _zz_71_;
-    _zz_72_[7] = _zz_71_;
-    _zz_72_[6] = _zz_71_;
-    _zz_72_[5] = _zz_71_;
-    _zz_72_[4] = _zz_71_;
-    _zz_72_[3] = _zz_71_;
-    _zz_72_[2] = _zz_71_;
-    _zz_72_[1] = _zz_71_;
-    _zz_72_[0] = _zz_71_;
+    _zz_72[18] = _zz_71;
+    _zz_72[17] = _zz_71;
+    _zz_72[16] = _zz_71;
+    _zz_72[15] = _zz_71;
+    _zz_72[14] = _zz_71;
+    _zz_72[13] = _zz_71;
+    _zz_72[12] = _zz_71;
+    _zz_72[11] = _zz_71;
+    _zz_72[10] = _zz_71;
+    _zz_72[9] = _zz_71;
+    _zz_72[8] = _zz_71;
+    _zz_72[7] = _zz_71;
+    _zz_72[6] = _zz_71;
+    _zz_72[5] = _zz_71;
+    _zz_72[4] = _zz_71;
+    _zz_72[3] = _zz_71;
+    _zz_72[2] = _zz_71;
+    _zz_72[1] = _zz_71;
+    _zz_72[0] = _zz_71;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_342_[31]));
-    if(_zz_77_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_359[31]));
+    if(_zz_77)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_73_ = _zz_343_[19];
+  assign _zz_73 = _zz_360[19];
   always @ (*) begin
-    _zz_74_[10] = _zz_73_;
-    _zz_74_[9] = _zz_73_;
-    _zz_74_[8] = _zz_73_;
-    _zz_74_[7] = _zz_73_;
-    _zz_74_[6] = _zz_73_;
-    _zz_74_[5] = _zz_73_;
-    _zz_74_[4] = _zz_73_;
-    _zz_74_[3] = _zz_73_;
-    _zz_74_[2] = _zz_73_;
-    _zz_74_[1] = _zz_73_;
-    _zz_74_[0] = _zz_73_;
+    _zz_74[10] = _zz_73;
+    _zz_74[9] = _zz_73;
+    _zz_74[8] = _zz_73;
+    _zz_74[7] = _zz_73;
+    _zz_74[6] = _zz_73;
+    _zz_74[5] = _zz_73;
+    _zz_74[4] = _zz_73;
+    _zz_74[3] = _zz_73;
+    _zz_74[2] = _zz_73;
+    _zz_74[1] = _zz_73;
+    _zz_74[0] = _zz_73;
   end
 
-  assign _zz_75_ = _zz_344_[11];
+  assign _zz_75 = _zz_361[11];
   always @ (*) begin
-    _zz_76_[18] = _zz_75_;
-    _zz_76_[17] = _zz_75_;
-    _zz_76_[16] = _zz_75_;
-    _zz_76_[15] = _zz_75_;
-    _zz_76_[14] = _zz_75_;
-    _zz_76_[13] = _zz_75_;
-    _zz_76_[12] = _zz_75_;
-    _zz_76_[11] = _zz_75_;
-    _zz_76_[10] = _zz_75_;
-    _zz_76_[9] = _zz_75_;
-    _zz_76_[8] = _zz_75_;
-    _zz_76_[7] = _zz_75_;
-    _zz_76_[6] = _zz_75_;
-    _zz_76_[5] = _zz_75_;
-    _zz_76_[4] = _zz_75_;
-    _zz_76_[3] = _zz_75_;
-    _zz_76_[2] = _zz_75_;
-    _zz_76_[1] = _zz_75_;
-    _zz_76_[0] = _zz_75_;
+    _zz_76[18] = _zz_75;
+    _zz_76[17] = _zz_75;
+    _zz_76[16] = _zz_75;
+    _zz_76[15] = _zz_75;
+    _zz_76[14] = _zz_75;
+    _zz_76[13] = _zz_75;
+    _zz_76[12] = _zz_75;
+    _zz_76[11] = _zz_75;
+    _zz_76[10] = _zz_75;
+    _zz_76[9] = _zz_75;
+    _zz_76[8] = _zz_75;
+    _zz_76[7] = _zz_75;
+    _zz_76[6] = _zz_75;
+    _zz_76[5] = _zz_75;
+    _zz_76[4] = _zz_75;
+    _zz_76[3] = _zz_75;
+    _zz_76[2] = _zz_75;
+    _zz_76[1] = _zz_75;
+    _zz_76[0] = _zz_75;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_77_ = _zz_345_[1];
+        _zz_77 = _zz_362[1];
       end
       default : begin
-        _zz_77_ = _zz_346_[1];
+        _zz_77 = _zz_363[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_78_ = _zz_347_[19];
+  assign _zz_78 = _zz_364[19];
   always @ (*) begin
-    _zz_79_[10] = _zz_78_;
-    _zz_79_[9] = _zz_78_;
-    _zz_79_[8] = _zz_78_;
-    _zz_79_[7] = _zz_78_;
-    _zz_79_[6] = _zz_78_;
-    _zz_79_[5] = _zz_78_;
-    _zz_79_[4] = _zz_78_;
-    _zz_79_[3] = _zz_78_;
-    _zz_79_[2] = _zz_78_;
-    _zz_79_[1] = _zz_78_;
-    _zz_79_[0] = _zz_78_;
+    _zz_79[10] = _zz_78;
+    _zz_79[9] = _zz_78;
+    _zz_79[8] = _zz_78;
+    _zz_79[7] = _zz_78;
+    _zz_79[6] = _zz_78;
+    _zz_79[5] = _zz_78;
+    _zz_79[4] = _zz_78;
+    _zz_79[3] = _zz_78;
+    _zz_79[2] = _zz_78;
+    _zz_79[1] = _zz_78;
+    _zz_79[0] = _zz_78;
   end
 
-  assign _zz_80_ = _zz_348_[11];
+  assign _zz_80 = _zz_365[11];
   always @ (*) begin
-    _zz_81_[18] = _zz_80_;
-    _zz_81_[17] = _zz_80_;
-    _zz_81_[16] = _zz_80_;
-    _zz_81_[15] = _zz_80_;
-    _zz_81_[14] = _zz_80_;
-    _zz_81_[13] = _zz_80_;
-    _zz_81_[12] = _zz_80_;
-    _zz_81_[11] = _zz_80_;
-    _zz_81_[10] = _zz_80_;
-    _zz_81_[9] = _zz_80_;
-    _zz_81_[8] = _zz_80_;
-    _zz_81_[7] = _zz_80_;
-    _zz_81_[6] = _zz_80_;
-    _zz_81_[5] = _zz_80_;
-    _zz_81_[4] = _zz_80_;
-    _zz_81_[3] = _zz_80_;
-    _zz_81_[2] = _zz_80_;
-    _zz_81_[1] = _zz_80_;
-    _zz_81_[0] = _zz_80_;
+    _zz_81[18] = _zz_80;
+    _zz_81[17] = _zz_80;
+    _zz_81[16] = _zz_80;
+    _zz_81[15] = _zz_80;
+    _zz_81[14] = _zz_80;
+    _zz_81[13] = _zz_80;
+    _zz_81[12] = _zz_80;
+    _zz_81[11] = _zz_80;
+    _zz_81[10] = _zz_80;
+    _zz_81[9] = _zz_80;
+    _zz_81[8] = _zz_80;
+    _zz_81[7] = _zz_80;
+    _zz_81[6] = _zz_80;
+    _zz_81[5] = _zz_80;
+    _zz_81[4] = _zz_80;
+    _zz_81[3] = _zz_80;
+    _zz_81[2] = _zz_80;
+    _zz_81[1] = _zz_80;
+    _zz_81[0] = _zz_80;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_79_,{{{_zz_478_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_81_,{{{_zz_479_,_zz_480_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_79,{{{_zz_496,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_81,{{{_zz_497,_zz_498},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -4974,111 +3892,127 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_198_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_199_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_200_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_201_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_202_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_203_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_206 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_207 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_208 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_207;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_210 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_211 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_212 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_256_)begin
+    if(_zz_274)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_254_)begin
+    if(_zz_272)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_204_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_254_)begin
-      _zz_204_ = 1'b1;
+    _zz_213 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_272)begin
+      _zz_213 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_255_)begin
+    if(_zz_273)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_253_)begin
+    if(_zz_271)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_255_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_273)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_253_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_271)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_197_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_221_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_205 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_239 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  always @ (*) begin
+    _zz_51 = 1'b0;
+    if(decode_INSTRUCTION[25])begin
+      if(decode_MEMORY_LRSC)begin
+        _zz_51 = 1'b1;
+      end
+      if(decode_MEMORY_AMO)begin
+        _zz_51 = 1'b1;
+      end
+    end
+  end
+
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
-    _zz_205_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+    _zz_214 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
-        if(_zz_263_)begin
-          _zz_205_ = 1'b1;
+      if(_zz_280)begin
+        if(_zz_281)begin
+          _zz_214 = 1'b1;
         end
       end
     end
   end
 
   always @ (*) begin
-    _zz_206_ = execute_SRC_ADD;
+    _zz_215 = execute_SRC_ADD;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
-        _zz_206_ = MmuPlugin_dBusAccess_cmd_payload_address;
+      if(_zz_280)begin
+        _zz_215 = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
   end
 
   always @ (*) begin
-    _zz_207_ = execute_MEMORY_WR;
+    _zz_216 = execute_MEMORY_WR;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
-        _zz_207_ = MmuPlugin_dBusAccess_cmd_payload_write;
+      if(_zz_280)begin
+        _zz_216 = MmuPlugin_dBusAccess_cmd_payload_write;
       end
     end
   end
@@ -5086,97 +4020,98 @@ module VexRiscv (
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_84_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_84 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_84_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_84 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_84_ = execute_RS2[31 : 0];
+        _zz_84 = execute_RS2[31 : 0];
       end
     endcase
   end
 
   always @ (*) begin
-    _zz_208_ = _zz_84_;
+    _zz_217 = _zz_84;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
-        _zz_208_ = MmuPlugin_dBusAccess_cmd_payload_data;
+      if(_zz_280)begin
+        _zz_217 = MmuPlugin_dBusAccess_cmd_payload_data;
       end
     end
   end
 
   always @ (*) begin
-    _zz_209_ = execute_DBusCachedPlugin_size;
+    _zz_218 = execute_DBusCachedPlugin_size;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
-        _zz_209_ = MmuPlugin_dBusAccess_cmd_payload_size;
+      if(_zz_280)begin
+        _zz_218 = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
-  assign _zz_220_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_238 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
   always @ (*) begin
-    _zz_210_ = 1'b0;
+    _zz_219 = 1'b0;
     if(execute_MEMORY_LRSC)begin
-      _zz_210_ = 1'b1;
+      _zz_219 = 1'b1;
     end
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
-        _zz_210_ = 1'b0;
+      if(_zz_280)begin
+        _zz_219 = 1'b0;
       end
     end
   end
 
   always @ (*) begin
-    _zz_211_ = execute_MEMORY_AMO;
+    _zz_220 = execute_MEMORY_AMO;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
-        _zz_211_ = 1'b0;
+      if(_zz_280)begin
+        _zz_220 = 1'b0;
       end
     end
   end
 
-  assign _zz_213_ = execute_INSTRUCTION[31 : 29];
-  assign _zz_212_ = execute_INSTRUCTION[27];
+  assign _zz_222 = execute_INSTRUCTION[31 : 29];
+  assign _zz_221 = execute_INSTRUCTION[27];
   always @ (*) begin
-    _zz_214_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+    _zz_223 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
     if(memory_IS_DBUS_SHARING)begin
-      _zz_214_ = 1'b1;
+      _zz_223 = 1'b1;
     end
   end
 
-  assign _zz_215_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
+  assign _zz_224 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_223;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_224;
   always @ (*) begin
-    DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+    DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
     if(memory_IS_DBUS_SHARING)begin
-      DBusCachedPlugin_mmuBus_cmd_bypassTranslation = 1'b1;
+      DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b1;
+    end
+  end
+
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  always @ (*) begin
+    _zz_225 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_225 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_216_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_216_ = 1'b1;
-    end
-  end
-
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  always @ (*) begin
-    _zz_217_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    _zz_226 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_IS_DBUS_SHARING)begin
-      _zz_217_ = 1'b1;
+      _zz_226 = 1'b1;
     end
   end
 
-  assign _zz_218_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_219_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_227 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_228 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_264_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_282)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -5185,17 +4120,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_264_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_282)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -5203,94 +4138,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_264_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_349_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_282)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_366};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_350_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_367};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_85_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_86_[31] = _zz_85_;
-    _zz_86_[30] = _zz_85_;
-    _zz_86_[29] = _zz_85_;
-    _zz_86_[28] = _zz_85_;
-    _zz_86_[27] = _zz_85_;
-    _zz_86_[26] = _zz_85_;
-    _zz_86_[25] = _zz_85_;
-    _zz_86_[24] = _zz_85_;
-    _zz_86_[23] = _zz_85_;
-    _zz_86_[22] = _zz_85_;
-    _zz_86_[21] = _zz_85_;
-    _zz_86_[20] = _zz_85_;
-    _zz_86_[19] = _zz_85_;
-    _zz_86_[18] = _zz_85_;
-    _zz_86_[17] = _zz_85_;
-    _zz_86_[16] = _zz_85_;
-    _zz_86_[15] = _zz_85_;
-    _zz_86_[14] = _zz_85_;
-    _zz_86_[13] = _zz_85_;
-    _zz_86_[12] = _zz_85_;
-    _zz_86_[11] = _zz_85_;
-    _zz_86_[10] = _zz_85_;
-    _zz_86_[9] = _zz_85_;
-    _zz_86_[8] = _zz_85_;
-    _zz_86_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_86[31] = _zz_85;
+    _zz_86[30] = _zz_85;
+    _zz_86[29] = _zz_85;
+    _zz_86[28] = _zz_85;
+    _zz_86[27] = _zz_85;
+    _zz_86[26] = _zz_85;
+    _zz_86[25] = _zz_85;
+    _zz_86[24] = _zz_85;
+    _zz_86[23] = _zz_85;
+    _zz_86[22] = _zz_85;
+    _zz_86[21] = _zz_85;
+    _zz_86[20] = _zz_85;
+    _zz_86[19] = _zz_85;
+    _zz_86[18] = _zz_85;
+    _zz_86[17] = _zz_85;
+    _zz_86[16] = _zz_85;
+    _zz_86[15] = _zz_85;
+    _zz_86[14] = _zz_85;
+    _zz_86[13] = _zz_85;
+    _zz_86[12] = _zz_85;
+    _zz_86[11] = _zz_85;
+    _zz_86[10] = _zz_85;
+    _zz_86[9] = _zz_85;
+    _zz_86[8] = _zz_85;
+    _zz_86[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_87_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_87 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_88_[31] = _zz_87_;
-    _zz_88_[30] = _zz_87_;
-    _zz_88_[29] = _zz_87_;
-    _zz_88_[28] = _zz_87_;
-    _zz_88_[27] = _zz_87_;
-    _zz_88_[26] = _zz_87_;
-    _zz_88_[25] = _zz_87_;
-    _zz_88_[24] = _zz_87_;
-    _zz_88_[23] = _zz_87_;
-    _zz_88_[22] = _zz_87_;
-    _zz_88_[21] = _zz_87_;
-    _zz_88_[20] = _zz_87_;
-    _zz_88_[19] = _zz_87_;
-    _zz_88_[18] = _zz_87_;
-    _zz_88_[17] = _zz_87_;
-    _zz_88_[16] = _zz_87_;
-    _zz_88_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_88[31] = _zz_87;
+    _zz_88[30] = _zz_87;
+    _zz_88[29] = _zz_87;
+    _zz_88[28] = _zz_87;
+    _zz_88[27] = _zz_87;
+    _zz_88[26] = _zz_87;
+    _zz_88[25] = _zz_87;
+    _zz_88[24] = _zz_87;
+    _zz_88[23] = _zz_87;
+    _zz_88[22] = _zz_87;
+    _zz_88[21] = _zz_87;
+    _zz_88[20] = _zz_87;
+    _zz_88[19] = _zz_87;
+    _zz_88[18] = _zz_87;
+    _zz_88[17] = _zz_87;
+    _zz_88[16] = _zz_87;
+    _zz_88[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_303_)
+    case(_zz_320)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_88_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_88;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -5301,8 +4236,8 @@ module VexRiscv (
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
-        if(_zz_263_)begin
+      if(_zz_280)begin
+        if(_zz_281)begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
@@ -5312,228 +4247,272 @@ module VexRiscv (
   always @ (*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_262_)begin
+      if(_zz_280)begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
-  assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1__io_cpu_writeBack_isWrite)) && (dataCache_1__io_cpu_redo || (! dataCache_1__io_cpu_writeBack_haltIt)));
-  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1__io_cpu_writeBack_data;
-  assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1__io_cpu_writeBack_unalignedAccess || dataCache_1__io_cpu_writeBack_accessError);
-  assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1__io_cpu_redo;
-  assign MmuPlugin_ports_0_cacheHits_0 = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_1 = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_2 = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_3 = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHit = ({MmuPlugin_ports_0_cacheHits_3,{MmuPlugin_ports_0_cacheHits_2,{MmuPlugin_ports_0_cacheHits_1,MmuPlugin_ports_0_cacheHits_0}}} != (4'b0000));
-  assign _zz_89_ = (MmuPlugin_ports_0_cacheHits_1 || MmuPlugin_ports_0_cacheHits_3);
-  assign _zz_90_ = (MmuPlugin_ports_0_cacheHits_2 || MmuPlugin_ports_0_cacheHits_3);
-  assign _zz_91_ = {_zz_90_,_zz_89_};
-  assign MmuPlugin_ports_0_cacheLine_valid = _zz_225_;
-  assign MmuPlugin_ports_0_cacheLine_exception = _zz_226_;
-  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_227_;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_228_;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_229_;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_230_;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_231_;
-  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_232_;
-  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_233_;
-  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_234_;
-  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_235_;
+  assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
+  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1_io_cpu_writeBack_data;
+  assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1_io_cpu_writeBack_unalignedAccess || dataCache_1_io_cpu_writeBack_accessError);
+  assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1_io_cpu_redo;
+  assign MmuPlugin_ports_0_dirty = 1'b0;
+  always @ (*) begin
+    MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
+    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+      MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
+    end
+    if((CsrPlugin_privilege == 2'b11))begin
+      MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    MmuPlugin_ports_0_cacheHitsCalc[0] = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[1] = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[2] = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[3] = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+  end
+
+  assign MmuPlugin_ports_0_cacheHit = (MmuPlugin_ports_0_cacheHitsCalc != 4'b0000);
+  assign _zz_89 = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign _zz_90 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_89);
+  assign _zz_91 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_89);
+  assign _zz_92 = {_zz_91,_zz_90};
+  assign MmuPlugin_ports_0_cacheLine_valid = _zz_243;
+  assign MmuPlugin_ports_0_cacheLine_exception = _zz_244;
+  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_245;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_246;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_247;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_248;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_249;
+  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_250;
+  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_251;
+  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_252;
+  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_253;
   always @ (*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(_zz_265_)begin
-      if(_zz_266_)begin
+    if(_zz_283)begin
+      if(_zz_284)begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
   end
 
   assign MmuPlugin_ports_0_entryToReplace_willClear = 1'b0;
-  assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == (2'b11));
+  assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_0_entryToReplace_willOverflow = (MmuPlugin_ports_0_entryToReplace_willOverflowIfInc && MmuPlugin_ports_0_entryToReplace_willIncrement);
   always @ (*) begin
-    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_352_);
+    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_369);
     if(MmuPlugin_ports_0_entryToReplace_willClear)begin
-      MmuPlugin_ports_0_entryToReplace_valueNext = (2'b00);
+      MmuPlugin_ports_0_entryToReplace_valueNext = 2'b00;
     end
   end
 
   always @ (*) begin
-    MmuPlugin_ports_0_requireMmuLockup = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == (2'b11))))begin
-      MmuPlugin_ports_0_requireMmuLockup = 1'b0;
-    end
-    if((CsrPlugin_privilege == (2'b11)))begin
-      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == (2'b11))))begin
-        MmuPlugin_ports_0_requireMmuLockup = 1'b0;
-      end
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_virtualAddress[11 : 0]};
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+      IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_exception = (MmuPlugin_ports_0_cacheHit && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == (2'b01))) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == (2'b00)))));
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_refilling = (! MmuPlugin_ports_0_cacheHit);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-    end
-  end
-
-  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = (((DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1011)) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1110))) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1111)));
-  assign MmuPlugin_ports_1_cacheHits_0 = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_1 = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_2 = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_3 = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHit = ({MmuPlugin_ports_1_cacheHits_3,{MmuPlugin_ports_1_cacheHits_2,{MmuPlugin_ports_1_cacheHits_1,MmuPlugin_ports_1_cacheHits_0}}} != (4'b0000));
-  assign _zz_92_ = (MmuPlugin_ports_1_cacheHits_1 || MmuPlugin_ports_1_cacheHits_3);
-  assign _zz_93_ = (MmuPlugin_ports_1_cacheHits_2 || MmuPlugin_ports_1_cacheHits_3);
-  assign _zz_94_ = {_zz_93_,_zz_92_};
-  assign MmuPlugin_ports_1_cacheLine_valid = _zz_236_;
-  assign MmuPlugin_ports_1_cacheLine_exception = _zz_237_;
-  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_238_;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_239_;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_240_;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_241_;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_242_;
-  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_243_;
-  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_244_;
-  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_245_;
-  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_246_;
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(_zz_265_)begin
-      if(_zz_267_)begin
-        MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
-      end
-    end
-  end
-
-  assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
-  assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == (2'b11));
-  assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_354_);
-    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
-      MmuPlugin_ports_1_entryToReplace_valueNext = (2'b00);
-    end
-  end
-
-  always @ (*) begin
-    MmuPlugin_ports_1_requireMmuLockup = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == (2'b11))))begin
-      MmuPlugin_ports_1_requireMmuLockup = 1'b0;
-    end
-    if((CsrPlugin_privilege == (2'b11)))begin
-      MmuPlugin_ports_1_requireMmuLockup = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_virtualAddress[11 : 0]};
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_exception = (MmuPlugin_ports_1_cacheHit && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == (2'b01))) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == (2'b00)))));
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_0_dirty) && MmuPlugin_ports_0_cacheHit) && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_refilling = (! MmuPlugin_ports_1_cacheHit);
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_0_dirty || (! MmuPlugin_ports_0_cacheHit));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = (((IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1011)) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1110))) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1111)));
-  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_355_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_356_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_357_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_358_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_359_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_360_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_361_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_362_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_dBusAccess_rsp_payload_data[9 : 8];
-  assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_dBusAccess_rsp_payload_data[19 : 10];
-  assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_dBusAccess_rsp_payload_data[31 : 20];
-  assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_dBusAccess_rsp_payload_error);
+  always @ (*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+    end
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = (((IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1011) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1110)) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1111));
+  assign IBusCachedPlugin_mmuBus_rsp_bypassTranslation = (! MmuPlugin_ports_0_requireMmuLockupCalc);
+  assign IBusCachedPlugin_mmuBus_rsp_ways_0_sel = MmuPlugin_ports_0_cacheHitsCalc[0];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_0_physical = {{MmuPlugin_ports_0_cache_0_physicalAddress_1,(MmuPlugin_ports_0_cache_0_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_0_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_1_sel = MmuPlugin_ports_0_cacheHitsCalc[1];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_1_physical = {{MmuPlugin_ports_0_cache_1_physicalAddress_1,(MmuPlugin_ports_0_cache_1_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_1_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_2_sel = MmuPlugin_ports_0_cacheHitsCalc[2];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_0_cache_2_physicalAddress_1,(MmuPlugin_ports_0_cache_2_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_2_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_0_cache_3_physicalAddress_1,(MmuPlugin_ports_0_cache_3_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_3_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign MmuPlugin_ports_1_dirty = 1'b0;
+  always @ (*) begin
+    MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
+    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+      MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
+    end
+    if((CsrPlugin_privilege == 2'b11))begin
+      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11)))begin
+        MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
+      end
+    end
+  end
+
+  always @ (*) begin
+    MmuPlugin_ports_1_cacheHitsCalc[0] = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[1] = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[2] = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[3] = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+  end
+
+  assign MmuPlugin_ports_1_cacheHit = (MmuPlugin_ports_1_cacheHitsCalc != 4'b0000);
+  assign _zz_93 = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign _zz_94 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_93);
+  assign _zz_95 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_93);
+  assign _zz_96 = {_zz_95,_zz_94};
+  assign MmuPlugin_ports_1_cacheLine_valid = _zz_254;
+  assign MmuPlugin_ports_1_cacheLine_exception = _zz_255;
+  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_256;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_257;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_258;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_259;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_260;
+  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_261;
+  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_262;
+  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_263;
+  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_264;
+  always @ (*) begin
+    MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
+    if(_zz_283)begin
+      if(_zz_285)begin
+        MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
+      end
+    end
+  end
+
+  assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
+  assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
+  always @ (*) begin
+    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_371);
+    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
+      MmuPlugin_ports_1_entryToReplace_valueNext = 2'b00;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_1_dirty) && MmuPlugin_ports_1_cacheHit) && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_1_dirty || (! MmuPlugin_ports_1_cacheHit));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+    end
+  end
+
+  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = (((DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1011) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1110)) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1111));
+  assign DBusCachedPlugin_mmuBus_rsp_bypassTranslation = (! MmuPlugin_ports_1_requireMmuLockupCalc);
+  assign DBusCachedPlugin_mmuBus_rsp_ways_0_sel = MmuPlugin_ports_1_cacheHitsCalc[0];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_0_physical = {{MmuPlugin_ports_1_cache_0_physicalAddress_1,(MmuPlugin_ports_1_cache_0_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_0_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_1_sel = MmuPlugin_ports_1_cacheHitsCalc[1];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_1_physical = {{MmuPlugin_ports_1_cache_1_physicalAddress_1,(MmuPlugin_ports_1_cache_1_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_1_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_2_sel = MmuPlugin_ports_1_cacheHitsCalc[2];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_1_cache_2_physicalAddress_1,(MmuPlugin_ports_1_cache_2_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_2_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_1_cache_3_physicalAddress_1,(MmuPlugin_ports_1_cache_3_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_3_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_372[0];
+  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_373[0];
+  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_374[0];
+  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_375[0];
+  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_376[0];
+  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_377[0];
+  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_378[0];
+  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_379[0];
+  assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_shared_dBusRspStaged_payload_data[9 : 8];
+  assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_shared_dBusRspStaged_payload_data[19 : 10];
+  assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
+  assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -5550,19 +4529,19 @@ module VexRiscv (
   end
 
   assign MmuPlugin_dBusAccess_cmd_payload_write = 1'b0;
-  assign MmuPlugin_dBusAccess_cmd_payload_size = (2'b10);
+  assign MmuPlugin_dBusAccess_cmd_payload_size = 2'b10;
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_payload_address = 32'h0;
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},(2'b00)};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},2'b00};
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{{MmuPlugin_shared_pteBuffer_PPN1[9 : 0],MmuPlugin_shared_pteBuffer_PPN0},MmuPlugin_shared_vpn_0},(2'b00)};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{{MmuPlugin_shared_pteBuffer_PPN1[9 : 0],MmuPlugin_shared_pteBuffer_PPN0},MmuPlugin_shared_vpn_0},2'b00};
       end
       default : begin
       end
@@ -5570,46 +4549,77 @@ module VexRiscv (
   end
 
   assign MmuPlugin_dBusAccess_cmd_payload_data = 32'h0;
-  assign MmuPlugin_dBusAccess_cmd_payload_writeMask = (4'bxxxx);
-  assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1_ != `MmuPlugin_shared_State_defaultEncoding_IDLE) && (MmuPlugin_shared_portId == (1'b1)));
-  assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1_ != `MmuPlugin_shared_State_defaultEncoding_IDLE) && (MmuPlugin_shared_portId == (1'b0)));
-  assign _zz_96_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_97_ = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_98_ = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_99_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_100_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_101_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_95_ = {({(_zz_481_ == _zz_482_),{_zz_483_,{_zz_484_,_zz_485_}}} != 6'h0),{((_zz_486_ == _zz_487_) != (1'b0)),{(_zz_488_ != (1'b0)),{(_zz_489_ != _zz_490_),{_zz_491_,{_zz_492_,_zz_493_}}}}}};
-  assign _zz_102_ = _zz_95_[1 : 0];
-  assign _zz_49_ = _zz_102_;
-  assign _zz_103_ = _zz_95_[6 : 5];
-  assign _zz_48_ = _zz_103_;
-  assign _zz_104_ = _zz_95_[12 : 11];
-  assign _zz_47_ = _zz_104_;
-  assign _zz_105_ = _zz_95_[17 : 16];
-  assign _zz_46_ = _zz_105_;
-  assign _zz_106_ = _zz_95_[27 : 26];
-  assign _zz_45_ = _zz_106_;
-  assign _zz_107_ = _zz_95_[29 : 28];
-  assign _zz_44_ = _zz_107_;
-  assign _zz_108_ = _zz_95_[31 : 30];
-  assign _zz_43_ = _zz_108_;
+  assign MmuPlugin_dBusAccess_cmd_payload_writeMask = 4'bxxxx;
+  always @ (*) begin
+    _zz_97[0] = (((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit));
+    _zz_97[1] = (((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit));
+  end
+
+  assign _zz_98 = _zz_97;
+  always @ (*) begin
+    _zz_99[0] = _zz_98[1];
+    _zz_99[1] = _zz_98[0];
+  end
+
+  assign _zz_100 = (_zz_99 & (~ _zz_380));
+  always @ (*) begin
+    _zz_101[0] = _zz_100[1];
+    _zz_101[1] = _zz_100[0];
+  end
+
+  assign MmuPlugin_shared_refills = _zz_101;
+  assign _zz_102 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[0]);
+  assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[1]);
+  assign _zz_104 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_105 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_106 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_107 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_108 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_109 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_103 = {(_zz_109 != 1'b0),{(_zz_109 != 1'b0),{((_zz_499 == _zz_500) != 1'b0),{(_zz_501 != 1'b0),{(_zz_502 != _zz_503),{_zz_504,{_zz_505,_zz_506}}}}}}};
+  assign _zz_110 = _zz_103[2 : 1];
+  assign _zz_49 = _zz_110;
+  assign _zz_111 = _zz_103[7 : 6];
+  assign _zz_48 = _zz_111;
+  assign _zz_112 = _zz_103[9 : 8];
+  assign _zz_47 = _zz_112;
+  assign _zz_113 = _zz_103[23 : 22];
+  assign _zz_46 = _zz_113;
+  assign _zz_114 = _zz_103[25 : 24];
+  assign _zz_45 = _zz_114;
+  assign _zz_115 = _zz_103[27 : 26];
+  assign _zz_44 = _zz_115;
+  assign _zz_116 = _zz_103[30 : 29];
+  assign _zz_43 = _zz_116;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_222_;
-  assign decode_RegFilePlugin_rs2Data = _zz_223_;
+  assign decode_RegFilePlugin_rs1Data = _zz_240;
+  assign decode_RegFilePlugin_rs2Data = _zz_241;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_109_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_117)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_50_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_117)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_117)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -5627,13 +4637,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_110_ = execute_IntAluPlugin_bitwise;
+        _zz_118 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_110_ = {31'd0, _zz_363_};
+        _zz_118 = {31'd0, _zz_381};
       end
       default : begin
-        _zz_110_ = execute_SRC_ADD_SUB;
+        _zz_118 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -5641,87 +4651,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_111_ = execute_RS1;
+        _zz_119 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_111_ = {29'd0, _zz_364_};
+        _zz_119 = {29'd0, _zz_382};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_111_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_119 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_111_ = {27'd0, _zz_365_};
+        _zz_119 = {27'd0, _zz_383};
       end
     endcase
   end
 
-  assign _zz_112_ = _zz_366_[11];
+  assign _zz_120 = _zz_384[11];
   always @ (*) begin
-    _zz_113_[19] = _zz_112_;
-    _zz_113_[18] = _zz_112_;
-    _zz_113_[17] = _zz_112_;
-    _zz_113_[16] = _zz_112_;
-    _zz_113_[15] = _zz_112_;
-    _zz_113_[14] = _zz_112_;
-    _zz_113_[13] = _zz_112_;
-    _zz_113_[12] = _zz_112_;
-    _zz_113_[11] = _zz_112_;
-    _zz_113_[10] = _zz_112_;
-    _zz_113_[9] = _zz_112_;
-    _zz_113_[8] = _zz_112_;
-    _zz_113_[7] = _zz_112_;
-    _zz_113_[6] = _zz_112_;
-    _zz_113_[5] = _zz_112_;
-    _zz_113_[4] = _zz_112_;
-    _zz_113_[3] = _zz_112_;
-    _zz_113_[2] = _zz_112_;
-    _zz_113_[1] = _zz_112_;
-    _zz_113_[0] = _zz_112_;
+    _zz_121[19] = _zz_120;
+    _zz_121[18] = _zz_120;
+    _zz_121[17] = _zz_120;
+    _zz_121[16] = _zz_120;
+    _zz_121[15] = _zz_120;
+    _zz_121[14] = _zz_120;
+    _zz_121[13] = _zz_120;
+    _zz_121[12] = _zz_120;
+    _zz_121[11] = _zz_120;
+    _zz_121[10] = _zz_120;
+    _zz_121[9] = _zz_120;
+    _zz_121[8] = _zz_120;
+    _zz_121[7] = _zz_120;
+    _zz_121[6] = _zz_120;
+    _zz_121[5] = _zz_120;
+    _zz_121[4] = _zz_120;
+    _zz_121[3] = _zz_120;
+    _zz_121[2] = _zz_120;
+    _zz_121[1] = _zz_120;
+    _zz_121[0] = _zz_120;
   end
 
-  assign _zz_114_ = _zz_367_[11];
+  assign _zz_122 = _zz_385[11];
   always @ (*) begin
-    _zz_115_[19] = _zz_114_;
-    _zz_115_[18] = _zz_114_;
-    _zz_115_[17] = _zz_114_;
-    _zz_115_[16] = _zz_114_;
-    _zz_115_[15] = _zz_114_;
-    _zz_115_[14] = _zz_114_;
-    _zz_115_[13] = _zz_114_;
-    _zz_115_[12] = _zz_114_;
-    _zz_115_[11] = _zz_114_;
-    _zz_115_[10] = _zz_114_;
-    _zz_115_[9] = _zz_114_;
-    _zz_115_[8] = _zz_114_;
-    _zz_115_[7] = _zz_114_;
-    _zz_115_[6] = _zz_114_;
-    _zz_115_[5] = _zz_114_;
-    _zz_115_[4] = _zz_114_;
-    _zz_115_[3] = _zz_114_;
-    _zz_115_[2] = _zz_114_;
-    _zz_115_[1] = _zz_114_;
-    _zz_115_[0] = _zz_114_;
+    _zz_123[19] = _zz_122;
+    _zz_123[18] = _zz_122;
+    _zz_123[17] = _zz_122;
+    _zz_123[16] = _zz_122;
+    _zz_123[15] = _zz_122;
+    _zz_123[14] = _zz_122;
+    _zz_123[13] = _zz_122;
+    _zz_123[12] = _zz_122;
+    _zz_123[11] = _zz_122;
+    _zz_123[10] = _zz_122;
+    _zz_123[9] = _zz_122;
+    _zz_123[8] = _zz_122;
+    _zz_123[7] = _zz_122;
+    _zz_123[6] = _zz_122;
+    _zz_123[5] = _zz_122;
+    _zz_123[4] = _zz_122;
+    _zz_123[3] = _zz_122;
+    _zz_123[2] = _zz_122;
+    _zz_123[1] = _zz_122;
+    _zz_123[0] = _zz_122;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_116_ = execute_RS2;
+        _zz_124 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_116_ = {_zz_113_,execute_INSTRUCTION[31 : 20]};
+        _zz_124 = {_zz_121,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_116_ = {_zz_115_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_124 = {_zz_123,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_116_ = _zz_35_;
+        _zz_124 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_368_;
+    execute_SrcPlugin_addSub = _zz_386;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -5730,246 +4740,246 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_117_[0] = execute_SRC1[31];
-    _zz_117_[1] = execute_SRC1[30];
-    _zz_117_[2] = execute_SRC1[29];
-    _zz_117_[3] = execute_SRC1[28];
-    _zz_117_[4] = execute_SRC1[27];
-    _zz_117_[5] = execute_SRC1[26];
-    _zz_117_[6] = execute_SRC1[25];
-    _zz_117_[7] = execute_SRC1[24];
-    _zz_117_[8] = execute_SRC1[23];
-    _zz_117_[9] = execute_SRC1[22];
-    _zz_117_[10] = execute_SRC1[21];
-    _zz_117_[11] = execute_SRC1[20];
-    _zz_117_[12] = execute_SRC1[19];
-    _zz_117_[13] = execute_SRC1[18];
-    _zz_117_[14] = execute_SRC1[17];
-    _zz_117_[15] = execute_SRC1[16];
-    _zz_117_[16] = execute_SRC1[15];
-    _zz_117_[17] = execute_SRC1[14];
-    _zz_117_[18] = execute_SRC1[13];
-    _zz_117_[19] = execute_SRC1[12];
-    _zz_117_[20] = execute_SRC1[11];
-    _zz_117_[21] = execute_SRC1[10];
-    _zz_117_[22] = execute_SRC1[9];
-    _zz_117_[23] = execute_SRC1[8];
-    _zz_117_[24] = execute_SRC1[7];
-    _zz_117_[25] = execute_SRC1[6];
-    _zz_117_[26] = execute_SRC1[5];
-    _zz_117_[27] = execute_SRC1[4];
-    _zz_117_[28] = execute_SRC1[3];
-    _zz_117_[29] = execute_SRC1[2];
-    _zz_117_[30] = execute_SRC1[1];
-    _zz_117_[31] = execute_SRC1[0];
+    _zz_125[0] = execute_SRC1[31];
+    _zz_125[1] = execute_SRC1[30];
+    _zz_125[2] = execute_SRC1[29];
+    _zz_125[3] = execute_SRC1[28];
+    _zz_125[4] = execute_SRC1[27];
+    _zz_125[5] = execute_SRC1[26];
+    _zz_125[6] = execute_SRC1[25];
+    _zz_125[7] = execute_SRC1[24];
+    _zz_125[8] = execute_SRC1[23];
+    _zz_125[9] = execute_SRC1[22];
+    _zz_125[10] = execute_SRC1[21];
+    _zz_125[11] = execute_SRC1[20];
+    _zz_125[12] = execute_SRC1[19];
+    _zz_125[13] = execute_SRC1[18];
+    _zz_125[14] = execute_SRC1[17];
+    _zz_125[15] = execute_SRC1[16];
+    _zz_125[16] = execute_SRC1[15];
+    _zz_125[17] = execute_SRC1[14];
+    _zz_125[18] = execute_SRC1[13];
+    _zz_125[19] = execute_SRC1[12];
+    _zz_125[20] = execute_SRC1[11];
+    _zz_125[21] = execute_SRC1[10];
+    _zz_125[22] = execute_SRC1[9];
+    _zz_125[23] = execute_SRC1[8];
+    _zz_125[24] = execute_SRC1[7];
+    _zz_125[25] = execute_SRC1[6];
+    _zz_125[26] = execute_SRC1[5];
+    _zz_125[27] = execute_SRC1[4];
+    _zz_125[28] = execute_SRC1[3];
+    _zz_125[29] = execute_SRC1[2];
+    _zz_125[30] = execute_SRC1[1];
+    _zz_125[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_117_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_125 : execute_SRC1);
   always @ (*) begin
-    _zz_118_[0] = memory_SHIFT_RIGHT[31];
-    _zz_118_[1] = memory_SHIFT_RIGHT[30];
-    _zz_118_[2] = memory_SHIFT_RIGHT[29];
-    _zz_118_[3] = memory_SHIFT_RIGHT[28];
-    _zz_118_[4] = memory_SHIFT_RIGHT[27];
-    _zz_118_[5] = memory_SHIFT_RIGHT[26];
-    _zz_118_[6] = memory_SHIFT_RIGHT[25];
-    _zz_118_[7] = memory_SHIFT_RIGHT[24];
-    _zz_118_[8] = memory_SHIFT_RIGHT[23];
-    _zz_118_[9] = memory_SHIFT_RIGHT[22];
-    _zz_118_[10] = memory_SHIFT_RIGHT[21];
-    _zz_118_[11] = memory_SHIFT_RIGHT[20];
-    _zz_118_[12] = memory_SHIFT_RIGHT[19];
-    _zz_118_[13] = memory_SHIFT_RIGHT[18];
-    _zz_118_[14] = memory_SHIFT_RIGHT[17];
-    _zz_118_[15] = memory_SHIFT_RIGHT[16];
-    _zz_118_[16] = memory_SHIFT_RIGHT[15];
-    _zz_118_[17] = memory_SHIFT_RIGHT[14];
-    _zz_118_[18] = memory_SHIFT_RIGHT[13];
-    _zz_118_[19] = memory_SHIFT_RIGHT[12];
-    _zz_118_[20] = memory_SHIFT_RIGHT[11];
-    _zz_118_[21] = memory_SHIFT_RIGHT[10];
-    _zz_118_[22] = memory_SHIFT_RIGHT[9];
-    _zz_118_[23] = memory_SHIFT_RIGHT[8];
-    _zz_118_[24] = memory_SHIFT_RIGHT[7];
-    _zz_118_[25] = memory_SHIFT_RIGHT[6];
-    _zz_118_[26] = memory_SHIFT_RIGHT[5];
-    _zz_118_[27] = memory_SHIFT_RIGHT[4];
-    _zz_118_[28] = memory_SHIFT_RIGHT[3];
-    _zz_118_[29] = memory_SHIFT_RIGHT[2];
-    _zz_118_[30] = memory_SHIFT_RIGHT[1];
-    _zz_118_[31] = memory_SHIFT_RIGHT[0];
+    _zz_126[0] = memory_SHIFT_RIGHT[31];
+    _zz_126[1] = memory_SHIFT_RIGHT[30];
+    _zz_126[2] = memory_SHIFT_RIGHT[29];
+    _zz_126[3] = memory_SHIFT_RIGHT[28];
+    _zz_126[4] = memory_SHIFT_RIGHT[27];
+    _zz_126[5] = memory_SHIFT_RIGHT[26];
+    _zz_126[6] = memory_SHIFT_RIGHT[25];
+    _zz_126[7] = memory_SHIFT_RIGHT[24];
+    _zz_126[8] = memory_SHIFT_RIGHT[23];
+    _zz_126[9] = memory_SHIFT_RIGHT[22];
+    _zz_126[10] = memory_SHIFT_RIGHT[21];
+    _zz_126[11] = memory_SHIFT_RIGHT[20];
+    _zz_126[12] = memory_SHIFT_RIGHT[19];
+    _zz_126[13] = memory_SHIFT_RIGHT[18];
+    _zz_126[14] = memory_SHIFT_RIGHT[17];
+    _zz_126[15] = memory_SHIFT_RIGHT[16];
+    _zz_126[16] = memory_SHIFT_RIGHT[15];
+    _zz_126[17] = memory_SHIFT_RIGHT[14];
+    _zz_126[18] = memory_SHIFT_RIGHT[13];
+    _zz_126[19] = memory_SHIFT_RIGHT[12];
+    _zz_126[20] = memory_SHIFT_RIGHT[11];
+    _zz_126[21] = memory_SHIFT_RIGHT[10];
+    _zz_126[22] = memory_SHIFT_RIGHT[9];
+    _zz_126[23] = memory_SHIFT_RIGHT[8];
+    _zz_126[24] = memory_SHIFT_RIGHT[7];
+    _zz_126[25] = memory_SHIFT_RIGHT[6];
+    _zz_126[26] = memory_SHIFT_RIGHT[5];
+    _zz_126[27] = memory_SHIFT_RIGHT[4];
+    _zz_126[28] = memory_SHIFT_RIGHT[3];
+    _zz_126[29] = memory_SHIFT_RIGHT[2];
+    _zz_126[30] = memory_SHIFT_RIGHT[1];
+    _zz_126[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_119_ = 1'b0;
-    if(_zz_268_)begin
-      if(_zz_269_)begin
-        if(_zz_124_)begin
-          _zz_119_ = 1'b1;
+    _zz_127 = 1'b0;
+    if(_zz_286)begin
+      if(_zz_287)begin
+        if(_zz_132)begin
+          _zz_127 = 1'b1;
         end
       end
     end
-    if(_zz_270_)begin
-      if(_zz_271_)begin
-        if(_zz_126_)begin
-          _zz_119_ = 1'b1;
+    if(_zz_288)begin
+      if(_zz_289)begin
+        if(_zz_134)begin
+          _zz_127 = 1'b1;
         end
       end
     end
-    if(_zz_272_)begin
-      if(_zz_273_)begin
-        if(_zz_128_)begin
-          _zz_119_ = 1'b1;
+    if(_zz_290)begin
+      if(_zz_291)begin
+        if(_zz_136)begin
+          _zz_127 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_119_ = 1'b0;
+      _zz_127 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_120_ = 1'b0;
-    if(_zz_268_)begin
-      if(_zz_269_)begin
-        if(_zz_125_)begin
-          _zz_120_ = 1'b1;
+    _zz_128 = 1'b0;
+    if(_zz_286)begin
+      if(_zz_287)begin
+        if(_zz_133)begin
+          _zz_128 = 1'b1;
         end
       end
     end
-    if(_zz_270_)begin
-      if(_zz_271_)begin
-        if(_zz_127_)begin
-          _zz_120_ = 1'b1;
+    if(_zz_288)begin
+      if(_zz_289)begin
+        if(_zz_135)begin
+          _zz_128 = 1'b1;
         end
       end
     end
-    if(_zz_272_)begin
-      if(_zz_273_)begin
-        if(_zz_129_)begin
-          _zz_120_ = 1'b1;
+    if(_zz_290)begin
+      if(_zz_291)begin
+        if(_zz_137)begin
+          _zz_128 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_120_ = 1'b0;
+      _zz_128 = 1'b0;
     end
   end
 
-  assign _zz_124_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_125_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_126_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_127_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_128_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_129_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_132 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_133 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_134 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_135 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_136 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_137 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_130_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_138 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_130_ == (3'b000))) begin
-        _zz_131_ = execute_BranchPlugin_eq;
-    end else if((_zz_130_ == (3'b001))) begin
-        _zz_131_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_130_ & (3'b101)) == (3'b101)))) begin
-        _zz_131_ = (! execute_SRC_LESS);
+    if((_zz_138 == 3'b000)) begin
+        _zz_139 = execute_BranchPlugin_eq;
+    end else if((_zz_138 == 3'b001)) begin
+        _zz_139 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_138 & 3'b101) == 3'b101))) begin
+        _zz_139 = (! execute_SRC_LESS);
     end else begin
-        _zz_131_ = execute_SRC_LESS;
+        _zz_139 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_132_ = 1'b0;
+        _zz_140 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_132_ = 1'b1;
+        _zz_140 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_132_ = 1'b1;
+        _zz_140 = 1'b1;
       end
       default : begin
-        _zz_132_ = _zz_131_;
+        _zz_140 = _zz_139;
       end
     endcase
   end
 
-  assign _zz_133_ = _zz_375_[11];
+  assign _zz_141 = _zz_393[11];
   always @ (*) begin
-    _zz_134_[19] = _zz_133_;
-    _zz_134_[18] = _zz_133_;
-    _zz_134_[17] = _zz_133_;
-    _zz_134_[16] = _zz_133_;
-    _zz_134_[15] = _zz_133_;
-    _zz_134_[14] = _zz_133_;
-    _zz_134_[13] = _zz_133_;
-    _zz_134_[12] = _zz_133_;
-    _zz_134_[11] = _zz_133_;
-    _zz_134_[10] = _zz_133_;
-    _zz_134_[9] = _zz_133_;
-    _zz_134_[8] = _zz_133_;
-    _zz_134_[7] = _zz_133_;
-    _zz_134_[6] = _zz_133_;
-    _zz_134_[5] = _zz_133_;
-    _zz_134_[4] = _zz_133_;
-    _zz_134_[3] = _zz_133_;
-    _zz_134_[2] = _zz_133_;
-    _zz_134_[1] = _zz_133_;
-    _zz_134_[0] = _zz_133_;
+    _zz_142[19] = _zz_141;
+    _zz_142[18] = _zz_141;
+    _zz_142[17] = _zz_141;
+    _zz_142[16] = _zz_141;
+    _zz_142[15] = _zz_141;
+    _zz_142[14] = _zz_141;
+    _zz_142[13] = _zz_141;
+    _zz_142[12] = _zz_141;
+    _zz_142[11] = _zz_141;
+    _zz_142[10] = _zz_141;
+    _zz_142[9] = _zz_141;
+    _zz_142[8] = _zz_141;
+    _zz_142[7] = _zz_141;
+    _zz_142[6] = _zz_141;
+    _zz_142[5] = _zz_141;
+    _zz_142[4] = _zz_141;
+    _zz_142[3] = _zz_141;
+    _zz_142[2] = _zz_141;
+    _zz_142[1] = _zz_141;
+    _zz_142[0] = _zz_141;
   end
 
-  assign _zz_135_ = _zz_376_[19];
+  assign _zz_143 = _zz_394[19];
   always @ (*) begin
-    _zz_136_[10] = _zz_135_;
-    _zz_136_[9] = _zz_135_;
-    _zz_136_[8] = _zz_135_;
-    _zz_136_[7] = _zz_135_;
-    _zz_136_[6] = _zz_135_;
-    _zz_136_[5] = _zz_135_;
-    _zz_136_[4] = _zz_135_;
-    _zz_136_[3] = _zz_135_;
-    _zz_136_[2] = _zz_135_;
-    _zz_136_[1] = _zz_135_;
-    _zz_136_[0] = _zz_135_;
+    _zz_144[10] = _zz_143;
+    _zz_144[9] = _zz_143;
+    _zz_144[8] = _zz_143;
+    _zz_144[7] = _zz_143;
+    _zz_144[6] = _zz_143;
+    _zz_144[5] = _zz_143;
+    _zz_144[4] = _zz_143;
+    _zz_144[3] = _zz_143;
+    _zz_144[2] = _zz_143;
+    _zz_144[1] = _zz_143;
+    _zz_144[0] = _zz_143;
   end
 
-  assign _zz_137_ = _zz_377_[11];
+  assign _zz_145 = _zz_395[11];
   always @ (*) begin
-    _zz_138_[18] = _zz_137_;
-    _zz_138_[17] = _zz_137_;
-    _zz_138_[16] = _zz_137_;
-    _zz_138_[15] = _zz_137_;
-    _zz_138_[14] = _zz_137_;
-    _zz_138_[13] = _zz_137_;
-    _zz_138_[12] = _zz_137_;
-    _zz_138_[11] = _zz_137_;
-    _zz_138_[10] = _zz_137_;
-    _zz_138_[9] = _zz_137_;
-    _zz_138_[8] = _zz_137_;
-    _zz_138_[7] = _zz_137_;
-    _zz_138_[6] = _zz_137_;
-    _zz_138_[5] = _zz_137_;
-    _zz_138_[4] = _zz_137_;
-    _zz_138_[3] = _zz_137_;
-    _zz_138_[2] = _zz_137_;
-    _zz_138_[1] = _zz_137_;
-    _zz_138_[0] = _zz_137_;
+    _zz_146[18] = _zz_145;
+    _zz_146[17] = _zz_145;
+    _zz_146[16] = _zz_145;
+    _zz_146[15] = _zz_145;
+    _zz_146[14] = _zz_145;
+    _zz_146[13] = _zz_145;
+    _zz_146[12] = _zz_145;
+    _zz_146[11] = _zz_145;
+    _zz_146[10] = _zz_145;
+    _zz_146[9] = _zz_145;
+    _zz_146[8] = _zz_145;
+    _zz_146[7] = _zz_145;
+    _zz_146[6] = _zz_145;
+    _zz_146[5] = _zz_145;
+    _zz_146[4] = _zz_145;
+    _zz_146[3] = _zz_145;
+    _zz_146[2] = _zz_145;
+    _zz_146[1] = _zz_145;
+    _zz_146[0] = _zz_145;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_139_ = (_zz_378_[1] ^ execute_RS1[1]);
+        _zz_147 = (_zz_396[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_139_ = _zz_379_[1];
+        _zz_147 = _zz_397[1];
       end
       default : begin
-        _zz_139_ = _zz_380_[1];
+        _zz_147 = _zz_398[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_139_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_147);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -5981,176 +4991,176 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_140_ = _zz_381_[11];
+  assign _zz_148 = _zz_399[11];
   always @ (*) begin
-    _zz_141_[19] = _zz_140_;
-    _zz_141_[18] = _zz_140_;
-    _zz_141_[17] = _zz_140_;
-    _zz_141_[16] = _zz_140_;
-    _zz_141_[15] = _zz_140_;
-    _zz_141_[14] = _zz_140_;
-    _zz_141_[13] = _zz_140_;
-    _zz_141_[12] = _zz_140_;
-    _zz_141_[11] = _zz_140_;
-    _zz_141_[10] = _zz_140_;
-    _zz_141_[9] = _zz_140_;
-    _zz_141_[8] = _zz_140_;
-    _zz_141_[7] = _zz_140_;
-    _zz_141_[6] = _zz_140_;
-    _zz_141_[5] = _zz_140_;
-    _zz_141_[4] = _zz_140_;
-    _zz_141_[3] = _zz_140_;
-    _zz_141_[2] = _zz_140_;
-    _zz_141_[1] = _zz_140_;
-    _zz_141_[0] = _zz_140_;
+    _zz_149[19] = _zz_148;
+    _zz_149[18] = _zz_148;
+    _zz_149[17] = _zz_148;
+    _zz_149[16] = _zz_148;
+    _zz_149[15] = _zz_148;
+    _zz_149[14] = _zz_148;
+    _zz_149[13] = _zz_148;
+    _zz_149[12] = _zz_148;
+    _zz_149[11] = _zz_148;
+    _zz_149[10] = _zz_148;
+    _zz_149[9] = _zz_148;
+    _zz_149[8] = _zz_148;
+    _zz_149[7] = _zz_148;
+    _zz_149[6] = _zz_148;
+    _zz_149[5] = _zz_148;
+    _zz_149[4] = _zz_148;
+    _zz_149[3] = _zz_148;
+    _zz_149[2] = _zz_148;
+    _zz_149[1] = _zz_148;
+    _zz_149[0] = _zz_148;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_141_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_149,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_143_,{{{_zz_687_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_145_,{{{_zz_688_,_zz_689_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_151,{{{_zz_698,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_153,{{{_zz_699,_zz_700},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_384_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_402};
         end
       end
     endcase
   end
 
-  assign _zz_142_ = _zz_382_[19];
+  assign _zz_150 = _zz_400[19];
   always @ (*) begin
-    _zz_143_[10] = _zz_142_;
-    _zz_143_[9] = _zz_142_;
-    _zz_143_[8] = _zz_142_;
-    _zz_143_[7] = _zz_142_;
-    _zz_143_[6] = _zz_142_;
-    _zz_143_[5] = _zz_142_;
-    _zz_143_[4] = _zz_142_;
-    _zz_143_[3] = _zz_142_;
-    _zz_143_[2] = _zz_142_;
-    _zz_143_[1] = _zz_142_;
-    _zz_143_[0] = _zz_142_;
+    _zz_151[10] = _zz_150;
+    _zz_151[9] = _zz_150;
+    _zz_151[8] = _zz_150;
+    _zz_151[7] = _zz_150;
+    _zz_151[6] = _zz_150;
+    _zz_151[5] = _zz_150;
+    _zz_151[4] = _zz_150;
+    _zz_151[3] = _zz_150;
+    _zz_151[2] = _zz_150;
+    _zz_151[1] = _zz_150;
+    _zz_151[0] = _zz_150;
   end
 
-  assign _zz_144_ = _zz_383_[11];
+  assign _zz_152 = _zz_401[11];
   always @ (*) begin
-    _zz_145_[18] = _zz_144_;
-    _zz_145_[17] = _zz_144_;
-    _zz_145_[16] = _zz_144_;
-    _zz_145_[15] = _zz_144_;
-    _zz_145_[14] = _zz_144_;
-    _zz_145_[13] = _zz_144_;
-    _zz_145_[12] = _zz_144_;
-    _zz_145_[11] = _zz_144_;
-    _zz_145_[10] = _zz_144_;
-    _zz_145_[9] = _zz_144_;
-    _zz_145_[8] = _zz_144_;
-    _zz_145_[7] = _zz_144_;
-    _zz_145_[6] = _zz_144_;
-    _zz_145_[5] = _zz_144_;
-    _zz_145_[4] = _zz_144_;
-    _zz_145_[3] = _zz_144_;
-    _zz_145_[2] = _zz_144_;
-    _zz_145_[1] = _zz_144_;
-    _zz_145_[0] = _zz_144_;
+    _zz_153[18] = _zz_152;
+    _zz_153[17] = _zz_152;
+    _zz_153[16] = _zz_152;
+    _zz_153[15] = _zz_152;
+    _zz_153[14] = _zz_152;
+    _zz_153[13] = _zz_152;
+    _zz_153[12] = _zz_152;
+    _zz_153[11] = _zz_152;
+    _zz_153[10] = _zz_152;
+    _zz_153[9] = _zz_152;
+    _zz_153[8] = _zz_152;
+    _zz_153[7] = _zz_152;
+    _zz_153[6] = _zz_152;
+    _zz_153[5] = _zz_152;
+    _zz_153[4] = _zz_152;
+    _zz_153[3] = _zz_152;
+    _zz_153[2] = _zz_152;
+    _zz_153[1] = _zz_152;
+    _zz_153[0] = _zz_152;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = _zz_146_;
+    CsrPlugin_privilege = _zz_154;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
   always @ (*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
     if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
+      if(execute_CsrPlugin_writeInstruction)begin
         CsrPlugin_redoInterface_valid = 1'b1;
       end
     end
   end
 
   assign CsrPlugin_redoInterface_payload = decode_PC;
-  assign _zz_147_ = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_148_ = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_149_ = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_150_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_151_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_152_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_155 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_156 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_157 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_158 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_159 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_160 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   always @ (*) begin
-    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
-      4'b1000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0010 : begin
-        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b1101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0000 : begin
+        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
         if(((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0010 : begin
+        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0100 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0101 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
         if(((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b0000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0111 : begin
+        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1000 : begin
+        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1001 : begin
+        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1100 : begin
+        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1101 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1111 : begin
+        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       default : begin
@@ -6159,11 +5169,11 @@ module VexRiscv (
   end
 
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_153_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_154_ = _zz_385_[0];
+  assign _zz_161 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_162 = _zz_403[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_257_)begin
+    if(_zz_275)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -6209,7 +5219,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -6233,7 +5243,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_stvec_mode;
@@ -6261,7 +5271,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -6372,7 +5382,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_274_)begin
+    if(_zz_292)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -6391,29 +5401,29 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_275_)begin
+    if(_zz_293)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_276_)begin
+    if(_zz_294)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_275_)begin
-      CsrPlugin_selfException_payload_code = (4'b0010);
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_293)begin
+      CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_276_)begin
+    if(_zz_294)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         2'b01 : begin
-          CsrPlugin_selfException_payload_code = (4'b1001);
+          CsrPlugin_selfException_payload_code = 4'b1001;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -6422,14 +5432,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_274_)begin
+    if(_zz_292)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_274_)begin
+    if(_zz_292)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -6447,7 +5457,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_304_)
+    case(_zz_321)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -6461,7 +5471,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_277_)
+    case(_zz_295)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -6475,7 +5485,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_277_)
+    case(_zz_295)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -6494,12 +5504,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_387_) + $signed(_zz_388_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_405) + $signed(_zz_406));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_252_)begin
-      if(_zz_278_)begin
+    if(_zz_270)begin
+      if(_zz_296)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -6507,7 +5517,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_279_)begin
+    if(_zz_297)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -6518,61 +5528,61 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_392_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_410);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_155_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_155_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_393_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_394_ : _zz_395_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_396_[31:0];
-  assign _zz_156_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_157_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_158_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_163 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_163[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_411);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_412 : _zz_413);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_414[31:0];
+  assign _zz_164 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_165 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_166 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_159_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_159_[31 : 0] = execute_RS1;
+    _zz_167[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_167[31 : 0] = execute_RS1;
   end
 
-  assign _zz_161_ = (_zz_160_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_161_ != 32'h0);
-  assign _zz_163_ = (_zz_162_ & externalInterruptArray_regNext);
-  assign externalInterruptS = (_zz_163_ != 32'h0);
-  assign _zz_26_ = decode_ALU_CTRL;
-  assign _zz_24_ = _zz_46_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign _zz_23_ = decode_BRANCH_CTRL;
-  assign _zz_52_ = _zz_45_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_21_ = decode_ENV_CTRL;
-  assign _zz_18_ = execute_ENV_CTRL;
-  assign _zz_16_ = memory_ENV_CTRL;
-  assign _zz_19_ = _zz_48_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_14_ = decode_SHIFT_CTRL;
-  assign _zz_11_ = execute_SHIFT_CTRL;
-  assign _zz_12_ = _zz_43_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9_ = decode_SRC1_CTRL;
-  assign _zz_7_ = _zz_44_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_6_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_4_ = _zz_47_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_3_ = decode_SRC2_CTRL;
-  assign _zz_1_ = _zz_49_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_169 = (_zz_168 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_169 != 32'h0);
+  assign _zz_171 = (_zz_170 & externalInterruptArray_regNext);
+  assign externalInterruptS = (_zz_171 != 32'h0);
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_52 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -6590,245 +5600,246 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_164_ = 32'h0;
+    _zz_172 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_164_[12 : 0] = 13'h1000;
-      _zz_164_[25 : 20] = 6'h20;
+      _zz_172[12 : 0] = 13'h1000;
+      _zz_172[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_165_ = 32'h0;
+    _zz_173 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_165_[19 : 19] = MmuPlugin_status_mxr;
-      _zz_165_[18 : 18] = MmuPlugin_status_sum;
-      _zz_165_[17 : 17] = MmuPlugin_status_mprv;
-      _zz_165_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_165_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_165_[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_165_[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_165_[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_165_[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_173[19 : 19] = MmuPlugin_status_mxr;
+      _zz_173[18 : 18] = MmuPlugin_status_sum;
+      _zz_173[17 : 17] = MmuPlugin_status_mprv;
+      _zz_173[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_173[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_173[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_173[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_173[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_173[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @ (*) begin
-    _zz_166_ = 32'h0;
+    _zz_174 = 32'h0;
     if(execute_CsrPlugin_csr_256)begin
-      _zz_166_[19 : 19] = MmuPlugin_status_mxr;
-      _zz_166_[18 : 18] = MmuPlugin_status_sum;
-      _zz_166_[17 : 17] = MmuPlugin_status_mprv;
-      _zz_166_[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_166_[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_166_[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_174[19 : 19] = MmuPlugin_status_mxr;
+      _zz_174[18 : 18] = MmuPlugin_status_sum;
+      _zz_174[17 : 17] = MmuPlugin_status_mprv;
+      _zz_174[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_174[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_174[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @ (*) begin
-    _zz_167_ = 32'h0;
+    _zz_175 = 32'h0;
     if(execute_CsrPlugin_csr_384)begin
-      _zz_167_[31 : 31] = MmuPlugin_satp_mode;
-      _zz_167_[19 : 0] = MmuPlugin_satp_ppn;
+      _zz_175[31 : 31] = MmuPlugin_satp_mode;
+      _zz_175[30 : 22] = MmuPlugin_satp_asid;
+      _zz_175[19 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
   always @ (*) begin
-    _zz_168_ = 32'h0;
+    _zz_176 = 32'h0;
     if(execute_CsrPlugin_csr_3857)begin
-      _zz_168_[0 : 0] = (1'b1);
+      _zz_176[0 : 0] = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_169_ = 32'h0;
+    _zz_177 = 32'h0;
     if(execute_CsrPlugin_csr_3858)begin
-      _zz_169_[1 : 0] = (2'b10);
+      _zz_177[1 : 0] = 2'b10;
     end
   end
 
   always @ (*) begin
-    _zz_170_ = 32'h0;
+    _zz_178 = 32'h0;
     if(execute_CsrPlugin_csr_3859)begin
-      _zz_170_[1 : 0] = (2'b11);
+      _zz_178[1 : 0] = 2'b11;
     end
   end
 
   always @ (*) begin
-    _zz_171_ = 32'h0;
+    _zz_179 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_171_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_171_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_171_[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_171_[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_171_[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_171_[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_179[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_179[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_179[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_179[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_179[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_179[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @ (*) begin
-    _zz_172_ = 32'h0;
+    _zz_180 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_172_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_172_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_172_[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_172_[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_172_[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_172_[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_180[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_180[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_180[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_180[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_180[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_180[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @ (*) begin
-    _zz_173_ = 32'h0;
+    _zz_181 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_173_[31 : 0] = CsrPlugin_mepc;
+      _zz_181[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_174_ = 32'h0;
+    _zz_182 = 32'h0;
     if(execute_CsrPlugin_csr_832)begin
-      _zz_174_[31 : 0] = CsrPlugin_mscratch;
+      _zz_182[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
-    _zz_175_ = 32'h0;
+    _zz_183 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_175_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_175_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_183[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_183[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_176_ = 32'h0;
+    _zz_184 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_176_[31 : 0] = CsrPlugin_mtval;
+      _zz_184[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_177_ = 32'h0;
+    _zz_185 = 32'h0;
     if(execute_CsrPlugin_csr_324)begin
-      _zz_177_[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_177_[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_177_[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_185[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_185[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_185[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @ (*) begin
-    _zz_178_ = 32'h0;
+    _zz_186 = 32'h0;
     if(execute_CsrPlugin_csr_260)begin
-      _zz_178_[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_178_[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_178_[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_186[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_186[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_186[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @ (*) begin
-    _zz_179_ = 32'h0;
+    _zz_187 = 32'h0;
     if(execute_CsrPlugin_csr_261)begin
-      _zz_179_[31 : 2] = CsrPlugin_stvec_base;
-      _zz_179_[1 : 0] = CsrPlugin_stvec_mode;
+      _zz_187[31 : 2] = CsrPlugin_stvec_base;
+      _zz_187[1 : 0] = CsrPlugin_stvec_mode;
     end
   end
 
   always @ (*) begin
-    _zz_180_ = 32'h0;
+    _zz_188 = 32'h0;
     if(execute_CsrPlugin_csr_321)begin
-      _zz_180_[31 : 0] = CsrPlugin_sepc;
+      _zz_188[31 : 0] = CsrPlugin_sepc;
     end
   end
 
   always @ (*) begin
-    _zz_181_ = 32'h0;
+    _zz_189 = 32'h0;
     if(execute_CsrPlugin_csr_320)begin
-      _zz_181_[31 : 0] = CsrPlugin_sscratch;
+      _zz_189[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
   always @ (*) begin
-    _zz_182_ = 32'h0;
+    _zz_190 = 32'h0;
     if(execute_CsrPlugin_csr_322)begin
-      _zz_182_[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_182_[3 : 0] = CsrPlugin_scause_exceptionCode;
+      _zz_190[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_190[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_183_ = 32'h0;
+    _zz_191 = 32'h0;
     if(execute_CsrPlugin_csr_323)begin
-      _zz_183_[31 : 0] = CsrPlugin_stval;
+      _zz_191[31 : 0] = CsrPlugin_stval;
     end
   end
 
   always @ (*) begin
-    _zz_184_ = 32'h0;
+    _zz_192 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_184_[31 : 0] = _zz_160_;
+      _zz_192[31 : 0] = _zz_168;
     end
   end
 
   always @ (*) begin
-    _zz_185_ = 32'h0;
+    _zz_193 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_185_[31 : 0] = _zz_161_;
+      _zz_193[31 : 0] = _zz_169;
     end
   end
 
   always @ (*) begin
-    _zz_186_ = 32'h0;
+    _zz_194 = 32'h0;
     if(execute_CsrPlugin_csr_2496)begin
-      _zz_186_[31 : 0] = _zz_162_;
+      _zz_194[31 : 0] = _zz_170;
     end
   end
 
   always @ (*) begin
-    _zz_187_ = 32'h0;
+    _zz_195 = 32'h0;
     if(execute_CsrPlugin_csr_3520)begin
-      _zz_187_[31 : 0] = _zz_163_;
+      _zz_195[31 : 0] = _zz_171;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_164_ | _zz_165_) | (_zz_166_ | _zz_167_)) | ((_zz_168_ | _zz_169_) | (_zz_170_ | _zz_690_))) | (((_zz_171_ | _zz_172_) | (_zz_173_ | _zz_174_)) | ((_zz_175_ | _zz_176_) | (_zz_177_ | _zz_178_)))) | ((((_zz_179_ | _zz_180_) | (_zz_181_ | _zz_182_)) | ((_zz_183_ | _zz_184_) | (_zz_185_ | _zz_186_))) | _zz_187_));
-  assign iBusWishbone_ADR = {_zz_451_,_zz_188_};
-  assign iBusWishbone_CTI = ((_zz_188_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((((_zz_172 | _zz_173) | (_zz_174 | _zz_175)) | ((_zz_176 | _zz_177) | (_zz_178 | _zz_701))) | (((_zz_179 | _zz_180) | (_zz_181 | _zz_182)) | ((_zz_183 | _zz_184) | (_zz_185 | _zz_186)))) | ((((_zz_187 | _zz_188) | (_zz_189 | _zz_190)) | ((_zz_191 | _zz_192) | (_zz_193 | _zz_194))) | _zz_195));
+  assign iBusWishbone_ADR = {_zz_469,_zz_196};
+  assign iBusWishbone_CTI = ((_zz_196 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_280_)begin
+    if(_zz_298)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_280_)begin
+    if(_zz_298)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_189_;
+  assign iBus_rsp_valid = _zz_197;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_195_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_191_ = dBus_cmd_valid;
-  assign _zz_193_ = dBus_cmd_payload_wr;
-  assign _zz_194_ = (_zz_190_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_192_ && (_zz_193_ || _zz_194_));
-  assign dBusWishbone_ADR = ((_zz_195_ ? {{dBus_cmd_payload_address[31 : 5],_zz_190_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_195_ ? (_zz_194_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_193_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_193_;
+  assign _zz_203 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_199 = dBus_cmd_valid;
+  assign _zz_201 = dBus_cmd_payload_wr;
+  assign _zz_202 = (_zz_198 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_200 && (_zz_201 || _zz_202));
+  assign dBusWishbone_ADR = ((_zz_203 ? {{dBus_cmd_payload_address[31 : 5],_zz_198},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_203 ? (_zz_202 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_201 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_201;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_192_ = (_zz_191_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_191_;
-  assign dBusWishbone_STB = _zz_191_;
-  assign dBus_rsp_valid = _zz_196_;
+  assign _zz_200 = (_zz_199 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_199;
+  assign dBusWishbone_STB = _zz_199;
+  assign dBus_rsp_valid = _zz_204;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -6837,18 +5848,18 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_67_ <= 1'b0;
-      _zz_69_ <= 1'b0;
+      _zz_67 <= 1'b0;
+      _zz_69 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_82_;
+      IBusCachedPlugin_rspCounter <= _zz_82;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_83_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_83;
       DBusCachedPlugin_rspCounter <= 32'h0;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
@@ -6858,19 +5869,20 @@ module VexRiscv (
       MmuPlugin_ports_0_cache_1_valid <= 1'b0;
       MmuPlugin_ports_0_cache_2_valid <= 1'b0;
       MmuPlugin_ports_0_cache_3_valid <= 1'b0;
-      MmuPlugin_ports_0_entryToReplace_value <= (2'b00);
+      MmuPlugin_ports_0_entryToReplace_value <= 2'b00;
       MmuPlugin_ports_1_cache_0_valid <= 1'b0;
       MmuPlugin_ports_1_cache_1_valid <= 1'b0;
       MmuPlugin_ports_1_cache_2_valid <= 1'b0;
       MmuPlugin_ports_1_cache_3_valid <= 1'b0;
-      MmuPlugin_ports_1_entryToReplace_value <= (2'b00);
-      MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-      _zz_109_ <= 1'b1;
-      _zz_121_ <= 1'b0;
-      _zz_146_ <= (2'b11);
+      MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
+      MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+      MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
+      _zz_117 <= 1'b1;
+      _zz_129 <= 1'b0;
+      _zz_154 <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -6891,7 +5903,7 @@ module VexRiscv (
       CsrPlugin_mideleg_SS <= 1'b0;
       CsrPlugin_sstatus_SIE <= 1'b0;
       CsrPlugin_sstatus_SPIE <= 1'b0;
-      CsrPlugin_sstatus_SPP <= (1'b1);
+      CsrPlugin_sstatus_SPP <= 1'b1;
       CsrPlugin_sip_SEIP_SOFT <= 1'b0;
       CsrPlugin_sip_STIP <= 1'b0;
       CsrPlugin_sip_SSIP <= 1'b0;
@@ -6910,19 +5922,17 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_160_ <= 32'h0;
-      _zz_162_ <= 32'h0;
+      _zz_168 <= 32'h0;
+      _zz_170 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       execute_to_memory_IS_DBUS_SHARING <= 1'b0;
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_188_ <= (3'b000);
-      _zz_189_ <= 1'b0;
-      _zz_190_ <= (3'b000);
-      _zz_196_ <= 1'b0;
+      _zz_196 <= 3'b000;
+      _zz_197 <= 1'b0;
+      _zz_198 <= 3'b000;
+      _zz_204 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -6944,16 +5954,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67_ <= 1'b0;
+        _zz_67 <= 1'b0;
       end
-      if(_zz_65_)begin
-        _zz_67_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_65)begin
+        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_69_ <= 1'b0;
+        _zz_69 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_69_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_69 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -7000,14 +6010,14 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_281_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_299)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
@@ -7042,71 +6052,69 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
       end
-      case(MmuPlugin_shared_state_1_)
+      MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
+      case(MmuPlugin_shared_state_1)
         `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-          if(_zz_282_)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
-          end
-          if(_zz_283_)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
+          if(_zz_300)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
           if(MmuPlugin_dBusAccess_cmd_ready)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
-          if(MmuPlugin_dBusAccess_rsp_valid)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
+          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             if((MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception))begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
             end
-            if(MmuPlugin_dBusAccess_rsp_payload_redo)begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
             end
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
           if(MmuPlugin_dBusAccess_cmd_ready)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
           end
         end
         default : begin
-          if(MmuPlugin_dBusAccess_rsp_valid)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-            if(MmuPlugin_dBusAccess_rsp_payload_redo)begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
+          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             end
           end
         end
       endcase
-      if(_zz_265_)begin
-        if(_zz_266_)begin
-          if(_zz_284_)begin
+      if(_zz_283)begin
+        if(_zz_284)begin
+          if(_zz_301)begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(_zz_285_)begin
+          if(_zz_302)begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(_zz_286_)begin
+          if(_zz_303)begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(_zz_287_)begin
+          if(_zz_304)begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(_zz_267_)begin
-          if(_zz_288_)begin
+        if(_zz_285)begin
+          if(_zz_305)begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(_zz_289_)begin
+          if(_zz_306)begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(_zz_290_)begin
+          if(_zz_307)begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(_zz_291_)begin
+          if(_zz_308)begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
@@ -7121,8 +6129,8 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_109_ <= 1'b0;
-      _zz_121_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_117 <= 1'b0;
+      _zz_129 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -7144,34 +6152,34 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_292_)begin
-        if(_zz_293_)begin
+      if(_zz_309)begin
+        if(_zz_310)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_294_)begin
+        if(_zz_311)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_295_)begin
+        if(_zz_312)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(_zz_296_)begin
-        if(_zz_297_)begin
+      if(_zz_313)begin
+        if(_zz_314)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_298_)begin
+        if(_zz_315)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_299_)begin
+        if(_zz_316)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_300_)begin
+        if(_zz_317)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_301_)begin
+        if(_zz_318)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_302_)begin
+        if(_zz_319)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -7196,8 +6204,8 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_259_)begin
-        _zz_146_ <= CsrPlugin_targetPrivilege;
+      if(_zz_277)begin
+        _zz_154 <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b01 : begin
             CsrPlugin_sstatus_SIE <= 1'b0;
@@ -7213,37 +6221,31 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_260_)begin
-        case(_zz_261_)
+      if(_zz_278)begin
+        case(_zz_279)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_146_ <= CsrPlugin_mstatus_MPP;
+            _zz_154 <= CsrPlugin_mstatus_MPP;
           end
           2'b01 : begin
-            CsrPlugin_sstatus_SPP <= (1'b0);
+            CsrPlugin_sstatus_SPP <= 1'b0;
             CsrPlugin_sstatus_SIE <= CsrPlugin_sstatus_SPIE;
             CsrPlugin_sstatus_SPIE <= 1'b1;
-            _zz_146_ <= {(1'b0),CsrPlugin_sstatus_SPP};
+            _zz_154 <= {1'b0,CsrPlugin_sstatus_SPP};
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_152_,{_zz_151_,{_zz_150_,{_zz_149_,{_zz_148_,_zz_147_}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_160,{_zz_159,{_zz_158,{_zz_157,{_zz_156,_zz_155}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
       if((! memory_arbitration_isStuck))begin
         execute_to_memory_IS_DBUS_SHARING <= execute_IS_DBUS_SHARING;
       end
       if((! writeBack_arbitration_isStuck))begin
         memory_to_writeBack_IS_DBUS_SHARING <= memory_IS_DBUS_SHARING;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
       end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
@@ -7268,115 +6270,125 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_406_[0];
-          MmuPlugin_status_sum <= _zz_407_[0];
-          MmuPlugin_status_mprv <= _zz_408_[0];
+          MmuPlugin_status_mxr <= _zz_424[0];
+          MmuPlugin_status_sum <= _zz_425[0];
+          MmuPlugin_status_mprv <= _zz_426[0];
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_409_[0];
-          CsrPlugin_mstatus_MIE <= _zz_410_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_427[0];
+          CsrPlugin_mstatus_MIE <= _zz_428[0];
           CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_411_[0];
-          CsrPlugin_sstatus_SIE <= _zz_412_[0];
+          CsrPlugin_sstatus_SPIE <= _zz_429[0];
+          CsrPlugin_sstatus_SIE <= _zz_430[0];
         end
       end
       if(execute_CsrPlugin_csr_256)begin
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_413_[0];
-          MmuPlugin_status_sum <= _zz_414_[0];
-          MmuPlugin_status_mprv <= _zz_415_[0];
+          MmuPlugin_status_mxr <= _zz_431[0];
+          MmuPlugin_status_sum <= _zz_432[0];
+          MmuPlugin_status_mprv <= _zz_433[0];
           CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_416_[0];
-          CsrPlugin_sstatus_SIE <= _zz_417_[0];
+          CsrPlugin_sstatus_SPIE <= _zz_434[0];
+          CsrPlugin_sstatus_SIE <= _zz_435[0];
         end
       end
       if(execute_CsrPlugin_csr_384)begin
+        if(execute_CsrPlugin_writeInstruction)begin
+          MmuPlugin_ports_0_cache_0_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_1_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_2_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_3_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_0_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_1_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_2_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_3_valid <= 1'b0;
+        end
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_satp_mode <= _zz_418_[0];
+          MmuPlugin_satp_mode <= _zz_436[0];
         end
       end
       if(execute_CsrPlugin_csr_836)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_420_[0];
-          CsrPlugin_sip_SSIP <= _zz_421_[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_422_[0];
+          CsrPlugin_sip_STIP <= _zz_438[0];
+          CsrPlugin_sip_SSIP <= _zz_439[0];
+          CsrPlugin_sip_SEIP_SOFT <= _zz_440[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_423_[0];
-          CsrPlugin_mie_MTIE <= _zz_424_[0];
-          CsrPlugin_mie_MSIE <= _zz_425_[0];
-          CsrPlugin_sie_SEIE <= _zz_426_[0];
-          CsrPlugin_sie_STIE <= _zz_427_[0];
-          CsrPlugin_sie_SSIE <= _zz_428_[0];
+          CsrPlugin_mie_MEIE <= _zz_441[0];
+          CsrPlugin_mie_MTIE <= _zz_442[0];
+          CsrPlugin_mie_MSIE <= _zz_443[0];
+          CsrPlugin_sie_SEIE <= _zz_444[0];
+          CsrPlugin_sie_STIE <= _zz_445[0];
+          CsrPlugin_sie_SSIE <= _zz_446[0];
         end
       end
       if(execute_CsrPlugin_csr_770)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_medeleg_EU <= _zz_429_[0];
-          CsrPlugin_medeleg_II <= _zz_430_[0];
-          CsrPlugin_medeleg_LAF <= _zz_431_[0];
-          CsrPlugin_medeleg_LPF <= _zz_432_[0];
-          CsrPlugin_medeleg_LAM <= _zz_433_[0];
-          CsrPlugin_medeleg_SAF <= _zz_434_[0];
-          CsrPlugin_medeleg_IAF <= _zz_435_[0];
-          CsrPlugin_medeleg_ES <= _zz_436_[0];
-          CsrPlugin_medeleg_IPF <= _zz_437_[0];
-          CsrPlugin_medeleg_SPF <= _zz_438_[0];
-          CsrPlugin_medeleg_SAM <= _zz_439_[0];
-          CsrPlugin_medeleg_IAM <= _zz_440_[0];
+          CsrPlugin_medeleg_IAM <= _zz_447[0];
+          CsrPlugin_medeleg_IAF <= _zz_448[0];
+          CsrPlugin_medeleg_II <= _zz_449[0];
+          CsrPlugin_medeleg_LAM <= _zz_450[0];
+          CsrPlugin_medeleg_LAF <= _zz_451[0];
+          CsrPlugin_medeleg_SAM <= _zz_452[0];
+          CsrPlugin_medeleg_SAF <= _zz_453[0];
+          CsrPlugin_medeleg_EU <= _zz_454[0];
+          CsrPlugin_medeleg_ES <= _zz_455[0];
+          CsrPlugin_medeleg_IPF <= _zz_456[0];
+          CsrPlugin_medeleg_LPF <= _zz_457[0];
+          CsrPlugin_medeleg_SPF <= _zz_458[0];
         end
       end
       if(execute_CsrPlugin_csr_771)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mideleg_SE <= _zz_441_[0];
-          CsrPlugin_mideleg_ST <= _zz_442_[0];
-          CsrPlugin_mideleg_SS <= _zz_443_[0];
+          CsrPlugin_mideleg_SE <= _zz_459[0];
+          CsrPlugin_mideleg_ST <= _zz_460[0];
+          CsrPlugin_mideleg_SS <= _zz_461[0];
         end
       end
       if(execute_CsrPlugin_csr_324)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_444_[0];
-          CsrPlugin_sip_SSIP <= _zz_445_[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_446_[0];
+          CsrPlugin_sip_STIP <= _zz_462[0];
+          CsrPlugin_sip_SSIP <= _zz_463[0];
+          CsrPlugin_sip_SEIP_SOFT <= _zz_464[0];
         end
       end
       if(execute_CsrPlugin_csr_260)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sie_SEIE <= _zz_447_[0];
-          CsrPlugin_sie_STIE <= _zz_448_[0];
-          CsrPlugin_sie_SSIE <= _zz_449_[0];
+          CsrPlugin_sie_SEIE <= _zz_465[0];
+          CsrPlugin_sie_STIE <= _zz_466[0];
+          CsrPlugin_sie_SSIE <= _zz_467[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_160_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_168 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_2496)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_162_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_170 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_280_)begin
+      if(_zz_298)begin
         if(iBusWishbone_ACK)begin
-          _zz_188_ <= (_zz_188_ + (3'b001));
+          _zz_196 <= (_zz_196 + 3'b001);
         end
       end
-      _zz_189_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_191_ && _zz_192_))begin
-        _zz_190_ <= (_zz_190_ + (3'b001));
-        if(_zz_194_)begin
-          _zz_190_ <= (3'b000);
+      _zz_197 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_199 && _zz_200))begin
+        _zz_198 <= (_zz_198 + 3'b001);
+        if(_zz_202)begin
+          _zz_198 <= 3'b000;
         end
       end
-      _zz_196_ <= ((_zz_191_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_204 <= ((_zz_199 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_70_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_70 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -7384,23 +6396,28 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_281_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_299)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if((MmuPlugin_dBusAccess_rsp_valid && (! MmuPlugin_dBusAccess_rsp_payload_redo)))begin
+    MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
+    MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
+    MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
+    if((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)))begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -7413,17 +6430,12 @@ module VexRiscv (
       MmuPlugin_shared_pteBuffer_PPN0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
       MmuPlugin_shared_pteBuffer_PPN1 <= MmuPlugin_shared_dBusRsp_pte_PPN1;
     end
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-        if(_zz_282_)begin
-          MmuPlugin_shared_vpn_1 <= IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22];
-          MmuPlugin_shared_vpn_0 <= IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12];
-          MmuPlugin_shared_portId <= (1'b0);
-        end
-        if(_zz_283_)begin
-          MmuPlugin_shared_vpn_1 <= DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22];
-          MmuPlugin_shared_vpn_0 <= DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12];
-          MmuPlugin_shared_portId <= (1'b1);
+        if(_zz_300)begin
+          MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
+          MmuPlugin_shared_vpn_1 <= _zz_102[31 : 22];
+          MmuPlugin_shared_vpn_0 <= _zz_102[21 : 12];
         end
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -7435,10 +6447,10 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(_zz_265_)begin
-      if(_zz_266_)begin
-        if(_zz_284_)begin
-          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+    if(_zz_283)begin
+      if(_zz_284)begin
+        if(_zz_301)begin
+          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7447,10 +6459,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_285_)begin
-          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_302)begin
+          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7459,10 +6471,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_286_)begin
-          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_303)begin
+          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7471,10 +6483,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_287_)begin
-          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_304)begin
+          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7483,12 +6495,12 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
-      if(_zz_267_)begin
-        if(_zz_288_)begin
-          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+      if(_zz_285)begin
+        if(_zz_305)begin
+          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7497,10 +6509,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_289_)begin
-          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_306)begin
+          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7509,10 +6521,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_290_)begin
-          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_307)begin
+          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7521,10 +6533,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_291_)begin
-          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_308)begin
+          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7533,12 +6545,12 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
     end
-    _zz_122_ <= _zz_40_[11 : 7];
-    _zz_123_ <= _zz_50_;
+    _zz_130 <= _zz_40[11 : 7];
+    _zz_131 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -7547,9 +6559,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_257_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_154_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_154_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_275)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_162 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_162 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -7563,47 +6575,47 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_292_)begin
-      if(_zz_293_)begin
-        CsrPlugin_interrupt_code <= (4'b0101);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
+    if(_zz_309)begin
+      if(_zz_310)begin
+        CsrPlugin_interrupt_code <= 4'b0101;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_294_)begin
-        CsrPlugin_interrupt_code <= (4'b0001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
+      if(_zz_311)begin
+        CsrPlugin_interrupt_code <= 4'b0001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_295_)begin
-        CsrPlugin_interrupt_code <= (4'b1001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
-      end
-    end
-    if(_zz_296_)begin
-      if(_zz_297_)begin
-        CsrPlugin_interrupt_code <= (4'b0101);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_298_)begin
-        CsrPlugin_interrupt_code <= (4'b0001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_299_)begin
-        CsrPlugin_interrupt_code <= (4'b1001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_300_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_301_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_302_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_312)begin
+        CsrPlugin_interrupt_code <= 4'b1001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(_zz_259_)begin
+    if(_zz_313)begin
+      if(_zz_314)begin
+        CsrPlugin_interrupt_code <= 4'b0101;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_315)begin
+        CsrPlugin_interrupt_code <= 4'b0001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_316)begin
+        CsrPlugin_interrupt_code <= 4'b1001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_317)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_318)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_319)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+    end
+    if(_zz_277)begin
       case(CsrPlugin_targetPrivilege)
         2'b01 : begin
           CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
@@ -7631,42 +6643,57 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_252_)begin
-      if(_zz_278_)begin
+    if(_zz_270)begin
+      if(_zz_296)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_397_[31:0];
+          memory_DivPlugin_div_result <= _zz_415[31:0];
         end
       end
     end
-    if(_zz_279_)begin
+    if(_zz_297)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_158_ ? (~ _zz_159_) : _zz_159_) + _zz_403_);
-      memory_DivPlugin_rs2 <= ((_zz_157_ ? (~ execute_RS2) : execute_RS2) + _zz_405_);
-      memory_DivPlugin_div_needRevert <= ((_zz_158_ ^ (_zz_157_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_166 ? (~ _zz_167) : _zz_167) + _zz_421);
+      memory_DivPlugin_rs2 <= ((_zz_165 ? (~ execute_RS2) : execute_RS2) + _zz_423);
+      memory_DivPlugin_div_needRevert <= ((_zz_166 ^ (_zz_165 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PC <= decode_PC;
+    end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      execute_to_memory_PC <= _zz_35;
+    end
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_25_;
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_55;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_53;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_25;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -7678,67 +6705,10 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_22_;
+      decode_to_execute_ALU_CTRL <= _zz_22;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_20_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_17_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_15_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_8_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SRC2_CTRL <= _zz_19;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
@@ -7750,37 +6720,31 @@ module VexRiscv (
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+    end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_5_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_55_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_53_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54_;
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
@@ -7792,22 +6756,100 @@ module VexRiscv (
       memory_to_writeBack_IS_SFENCE_VMA <= memory_IS_SFENCE_VMA;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
     end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MUL_HH <= execute_MUL_HH;
@@ -7815,29 +6857,8 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MUL_HH <= memory_MUL_HH;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_2_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -7925,12 +6946,13 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_384)begin
       if(execute_CsrPlugin_writeEnable)begin
+        MmuPlugin_satp_asid <= execute_CsrPlugin_writeData[30 : 22];
         MmuPlugin_satp_ppn <= execute_CsrPlugin_writeData[19 : 0];
       end
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_419_[0];
+        CsrPlugin_mip_MSIP <= _zz_437[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -7967,7 +6989,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_322)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_scause_interrupt <= _zz_450_[0];
+        CsrPlugin_scause_interrupt <= _zz_468[0];
         CsrPlugin_scause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -7978,6 +7000,1271 @@ module VexRiscv (
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_isLrsc,
+  input               io_cpu_execute_args_isAmo,
+  input               io_cpu_execute_args_amoCtrl_swap,
+  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_memory_mmuRsp_ways_0_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
+  input               io_cpu_memory_mmuRsp_ways_1_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
+  input               io_cpu_memory_mmuRsp_ways_2_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
+  input               io_cpu_memory_mmuRsp_ways_3_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire                _zz_19;
+  wire                _zz_20;
+  wire                _zz_21;
+  wire                _zz_22;
+  wire       [2:0]    _zz_23;
+  wire       [0:0]    _zz_24;
+  wire       [0:0]    _zz_25;
+  wire       [9:0]    _zz_26;
+  wire       [9:0]    _zz_27;
+  wire       [31:0]   _zz_28;
+  wire       [31:0]   _zz_29;
+  wire       [31:0]   _zz_30;
+  wire       [31:0]   _zz_31;
+  wire       [1:0]    _zz_32;
+  wire       [31:0]   _zz_33;
+  wire       [1:0]    _zz_34;
+  wire       [1:0]    _zz_35;
+  wire       [0:0]    _zz_36;
+  wire       [0:0]    _zz_37;
+  wire       [0:0]    _zz_38;
+  wire       [2:0]    _zz_39;
+  wire       [1:0]    _zz_40;
+  wire       [21:0]   _zz_41;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_isLrsc;
+  reg                 stageA_request_isAmo;
+  reg                 stageA_request_amoCtrl_swap;
+  reg        [2:0]    stageA_request_amoCtrl_alu;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_isLrsc;
+  reg                 stageB_request_isAmo;
+  reg                 stageB_request_amoCtrl_swap;
+  reg        [2:0]    stageB_request_amoCtrl_alu;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_mmuRsp_ways_0_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_0_physical;
+  reg                 stageB_mmuRsp_ways_1_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_1_physical;
+  reg                 stageB_mmuRsp_ways_2_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_2_physical;
+  reg                 stageB_mmuRsp_ways_3_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_3_physical;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  reg                 stageB_lrSc_reserved;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  reg        [31:0]   stageB_requestDataBypass;
+  wire                stageB_amo_compare;
+  wire                stageB_amo_unsigned;
+  wire       [31:0]   stageB_amo_addSub;
+  wire                stageB_amo_less;
+  wire                stageB_amo_selectRf;
+  reg        [31:0]   stageB_amo_result;
+  reg        [31:0]   stageB_amo_resultReg;
+  reg                 stageB_amo_internal_resultRegValid;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_42;
+  reg [7:0] _zz_43;
+  reg [7:0] _zz_44;
+  reg [7:0] _zz_45;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign _zz_16 = (! stageB_amo_internal_resultRegValid);
+  assign _zz_17 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_18 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_19 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_20 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign _zz_21 = (! stageB_flusher_hold);
+  assign _zz_22 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_23 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  assign _zz_24 = _zz_4[0 : 0];
+  assign _zz_25 = _zz_4[1 : 1];
+  assign _zz_26 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_27 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_28 = ($signed(_zz_29) + $signed(_zz_33));
+  assign _zz_29 = ($signed(_zz_30) + $signed(_zz_31));
+  assign _zz_30 = stageB_request_data;
+  assign _zz_31 = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
+  assign _zz_32 = (stageB_amo_compare ? _zz_34 : _zz_35);
+  assign _zz_33 = {{30{_zz_32[1]}}, _zz_32};
+  assign _zz_34 = 2'b01;
+  assign _zz_35 = 2'b00;
+  assign _zz_36 = 1'b1;
+  assign _zz_37 = (! stageB_lrSc_reserved);
+  assign _zz_38 = loader_counter_willIncrement;
+  assign _zz_39 = {2'd0, _zz_38};
+  assign _zz_40 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_41 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_41;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_45, _zz_44, _zz_43, _zz_42};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_42 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_43 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_44 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_45 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_24[0];
+  assign ways_0_tagsReadRsp_error = _zz_25[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                dataWriteCmd_valid = 1'b0;
+              end
+            end
+            if(_zz_17)begin
+              dataWriteCmd_valid = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_36[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_26)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_27)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+          if(_zz_19)begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                io_cpu_writeBack_haltIt = 1'b1;
+              end
+            end
+            if(_zz_17)begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  always @ (*) begin
+    stageB_requestDataBypass = stageB_request_data;
+    if(stageB_request_isAmo)begin
+      stageB_requestDataBypass = stageB_amo_resultReg;
+    end
+  end
+
+  assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
+  assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == 2'b11);
+  assign stageB_amo_addSub = _zz_28;
+  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
+  assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
+  always @ (*) begin
+    case(_zz_23)
+      3'b000 : begin
+        stageB_amo_result = stageB_amo_addSub;
+      end
+      3'b001 : begin
+        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
+      end
+      3'b010 : begin
+        stageB_amo_result = (stageB_request_data | stageB_dataMux);
+      end
+      3'b011 : begin
+        stageB_amo_result = (stageB_request_data & stageB_dataMux);
+      end
+      default : begin
+        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if(_zz_20)begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          io_mem_cmd_valid = (! memCmdSent);
+          if(_zz_19)begin
+            io_mem_cmd_valid = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                io_mem_cmd_valid = 1'b0;
+              end
+            end
+            if(_zz_20)begin
+              io_mem_cmd_valid = 1'b0;
+            end
+            if(_zz_17)begin
+              io_mem_cmd_valid = 1'b0;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+    if((stageB_request_isLrsc && stageB_request_wr))begin
+      io_cpu_writeBack_data = {31'd0, _zz_37};
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_18)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_39);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
+      stageA_request_isAmo <= io_cpu_execute_args_isAmo;
+      stageA_request_amoCtrl_swap <= io_cpu_execute_args_amoCtrl_swap;
+      stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_isLrsc <= stageA_request_isLrsc;
+      stageB_request_isAmo <= stageA_request_isAmo;
+      stageB_request_amoCtrl_swap <= stageA_request_amoCtrl_swap;
+      stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+      stageB_mmuRsp_ways_0_sel <= io_cpu_memory_mmuRsp_ways_0_sel;
+      stageB_mmuRsp_ways_0_physical <= io_cpu_memory_mmuRsp_ways_0_physical;
+      stageB_mmuRsp_ways_1_sel <= io_cpu_memory_mmuRsp_ways_1_sel;
+      stageB_mmuRsp_ways_1_physical <= io_cpu_memory_mmuRsp_ways_1_physical;
+      stageB_mmuRsp_ways_2_sel <= io_cpu_memory_mmuRsp_ways_2_sel;
+      stageB_mmuRsp_ways_2_physical <= io_cpu_memory_mmuRsp_ways_2_physical;
+      stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
+      stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_21)begin
+        if(_zz_22)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
+    stageB_amo_resultReg <= stageB_amo_result;
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      stageB_lrSc_reserved <= 1'b0;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_21)begin
+          if(! _zz_22) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+        stageB_lrSc_reserved <= (! stageB_request_wr);
+      end
+      if(_zz_13)begin
+        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_18)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_40[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  input               io_cpu_fetch_mmuRsp_ways_0_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
+  input               io_cpu_fetch_mmuRsp_ways_1_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
+  input               io_cpu_fetch_mmuRsp_ways_2_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
+  input               io_cpu_fetch_mmuRsp_ways_3_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_9;
+  reg        [21:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [21:0]   _zz_15;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_mmuRsp_ways_0_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_0_physical;
+  reg                 decodeStage_mmuRsp_ways_1_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_1_physical;
+  reg                 decodeStage_mmuRsp_ways_2_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_2_physical;
+  reg                 decodeStage_mmuRsp_ways_3_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_3_physical;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_11 = (! lineLoader_flushCounter[7]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_9 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_10 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_11)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_12)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_11)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_12)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+      decodeStage_mmuRsp_ways_0_sel <= io_cpu_fetch_mmuRsp_ways_0_sel;
+      decodeStage_mmuRsp_ways_0_physical <= io_cpu_fetch_mmuRsp_ways_0_physical;
+      decodeStage_mmuRsp_ways_1_sel <= io_cpu_fetch_mmuRsp_ways_1_sel;
+      decodeStage_mmuRsp_ways_1_physical <= io_cpu_fetch_mmuRsp_ways_1_physical;
+      decodeStage_mmuRsp_ways_2_sel <= io_cpu_fetch_mmuRsp_ways_2_sel;
+      decodeStage_mmuRsp_ways_2_physical <= io_cpu_fetch_mmuRsp_ways_2_physical;
+      decodeStage_mmuRsp_ways_3_sel <= io_cpu_fetch_mmuRsp_ways_3_sel;
+      decodeStage_mmuRsp_ways_3_physical <= io_cpu_fetch_mmuRsp_ways_3_physical;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
   end
 
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxDebug.v
@@ -1,12 +1,13 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:39:05
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
 
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
+`define EnvCtrlEnum_defaultEncoding_type [1:0]
+`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
+`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
+`define EnvCtrlEnum_defaultEncoding_WFI 2'b10
+`define EnvCtrlEnum_defaultEncoding_ECALL 2'b11
 
 `define BranchCtrlEnum_defaultEncoding_type [1:0]
 `define BranchCtrlEnum_defaultEncoding_INC 2'b00
@@ -14,34 +15,33 @@
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
-`define Src2CtrlEnum_defaultEncoding_type [1:0]
-`define Src2CtrlEnum_defaultEncoding_RS 2'b00
-`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
-`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
-`define Src2CtrlEnum_defaultEncoding_PC 2'b11
-
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
-
-`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
-
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
 `define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
 `define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
 `define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
 `define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
-`define EnvCtrlEnum_defaultEncoding_type [1:0]
-`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
-`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
-`define EnvCtrlEnum_defaultEncoding_WFI 2'b10
-`define EnvCtrlEnum_defaultEncoding_ECALL 2'b11
+`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+
+`define Src2CtrlEnum_defaultEncoding_type [1:0]
+`define Src2CtrlEnum_defaultEncoding_RS 2'b00
+`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
+`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
+`define Src2CtrlEnum_defaultEncoding_PC 2'b11
+
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
+
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
 `define MmuPlugin_shared_State_defaultEncoding_type [2:0]
 `define MmuPlugin_shared_State_defaultEncoding_IDLE 3'b000
@@ -50,1153 +50,6 @@
 `define MmuPlugin_shared_State_defaultEncoding_L0_CMD 3'b011
 `define MmuPlugin_shared_State_defaultEncoding_L0_RSP 3'b100
 
-
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_10_,
-  input      [31:0]   _zz_11_,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_12_;
-  reg        [31:0]   _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire       [0:0]    _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [21:0]   _zz_18_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-
-  assign _zz_14_ = (! lineLoader_flushCounter[7]);
-  assign _zz_15_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_16_ = _zz_7_[0 : 0];
-  assign _zz_17_ = _zz_7_[1 : 1];
-  assign _zz_18_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_18_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_12_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_13_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_14_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_12_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_16_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_17_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_13_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_15_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_14_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_15_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-    if((_zz_10_ != (3'b000)))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_11_;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_isLrsc,
-  input               io_cpu_execute_args_isAmo,
-  input               io_cpu_execute_args_amoCtrl_swap,
-  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  input               io_cpu_writeBack_clearLrsc,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire                _zz_17_;
-  wire                _zz_18_;
-  wire                _zz_19_;
-  wire                _zz_20_;
-  wire       [2:0]    _zz_21_;
-  wire       [0:0]    _zz_22_;
-  wire       [0:0]    _zz_23_;
-  wire       [31:0]   _zz_24_;
-  wire       [31:0]   _zz_25_;
-  wire       [31:0]   _zz_26_;
-  wire       [31:0]   _zz_27_;
-  wire       [1:0]    _zz_28_;
-  wire       [31:0]   _zz_29_;
-  wire       [1:0]    _zz_30_;
-  wire       [1:0]    _zz_31_;
-  wire       [0:0]    _zz_32_;
-  wire       [0:0]    _zz_33_;
-  wire       [2:0]    _zz_34_;
-  wire       [1:0]    _zz_35_;
-  wire       [21:0]   _zz_36_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg                 stageA_request_isLrsc;
-  reg                 stageA_request_isAmo;
-  reg                 stageA_request_amoCtrl_swap;
-  reg        [2:0]    stageA_request_amoCtrl_alu;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_request_isLrsc;
-  reg                 stageB_request_isAmo;
-  reg                 stageB_request_amoCtrl_swap;
-  reg        [2:0]    stageB_request_amoCtrl_alu;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  reg                 stageB_lrsc_reserved;
-  reg        [31:0]   stageB_requestDataBypass;
-  wire                stageB_amo_compare;
-  wire                stageB_amo_unsigned;
-  wire       [31:0]   stageB_amo_addSub;
-  wire                stageB_amo_less;
-  wire                stageB_amo_selectRf;
-  reg        [31:0]   stageB_amo_result;
-  reg                 stageB_amo_resultRegValid;
-  reg        [31:0]   stageB_amo_resultReg;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_37_;
-  reg [7:0] _zz_38_;
-  reg [7:0] _zz_39_;
-  reg [7:0] _zz_40_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign _zz_15_ = (! stageB_amo_resultRegValid);
-  assign _zz_16_ = (stageB_request_isLrsc && (! stageB_lrsc_reserved));
-  assign _zz_17_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_18_ = (stageB_request_isLrsc && (! stageB_lrsc_reserved));
-  assign _zz_19_ = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0)));
-  assign _zz_20_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_21_ = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,(2'b00)});
-  assign _zz_22_ = _zz_4_[0 : 0];
-  assign _zz_23_ = _zz_4_[1 : 1];
-  assign _zz_24_ = ($signed(_zz_25_) + $signed(_zz_29_));
-  assign _zz_25_ = ($signed(_zz_26_) + $signed(_zz_27_));
-  assign _zz_26_ = stageB_request_data;
-  assign _zz_27_ = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
-  assign _zz_28_ = (stageB_amo_compare ? _zz_30_ : _zz_31_);
-  assign _zz_29_ = {{30{_zz_28_[1]}}, _zz_28_};
-  assign _zz_30_ = (2'b01);
-  assign _zz_31_ = (2'b00);
-  assign _zz_32_ = (! stageB_lrsc_reserved);
-  assign _zz_33_ = loader_counter_willIncrement;
-  assign _zz_34_ = {2'd0, _zz_33_};
-  assign _zz_35_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_36_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_36_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_40_, _zz_39_, _zz_38_, _zz_37_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_37_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_38_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_39_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_40_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_22_[0];
-  assign ways_0_tagsReadRsp_error = _zz_23_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              dataWriteCmd_valid = 1'b0;
-            end
-          end
-          if(_zz_16_)begin
-            dataWriteCmd_valid = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-        if(_zz_18_)begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              io_cpu_writeBack_haltIt = 1'b1;
-            end
-          end
-          if(_zz_16_)begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    stageB_requestDataBypass = stageB_request_data;
-    if(stageB_request_isAmo)begin
-      stageB_requestDataBypass = stageB_amo_resultReg;
-    end
-  end
-
-  assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
-  assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == (2'b11));
-  assign stageB_amo_addSub = _zz_24_;
-  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
-  assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  always @ (*) begin
-    case(_zz_21_)
-      3'b000 : begin
-        stageB_amo_result = stageB_amo_addSub;
-      end
-      3'b001 : begin
-        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
-      end
-      3'b010 : begin
-        stageB_amo_result = (stageB_request_data | stageB_dataMux);
-      end
-      3'b011 : begin
-        stageB_amo_result = (stageB_request_data & stageB_dataMux);
-      end
-      default : begin
-        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if(_zz_19_)begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-        if(_zz_18_)begin
-          io_mem_cmd_valid = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              io_mem_cmd_valid = 1'b0;
-            end
-          end
-          if(_zz_19_)begin
-            io_mem_cmd_valid = 1'b0;
-          end
-          if(_zz_16_)begin
-            io_mem_cmd_valid = 1'b0;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_32_};
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_17_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_34_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
-      stageA_request_isAmo <= io_cpu_execute_args_isAmo;
-      stageA_request_amoCtrl_swap <= io_cpu_execute_args_amoCtrl_swap;
-      stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-      stageB_request_isLrsc <= stageA_request_isLrsc;
-      stageB_request_isAmo <= stageA_request_isAmo;
-      stageB_request_amoCtrl_swap <= stageA_request_amoCtrl_swap;
-      stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_20_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    stageB_amo_resultRegValid <= 1'b1;
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_amo_resultRegValid <= 1'b0;
-    end
-    stageB_amo_resultReg <= stageB_amo_result;
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_lrsc_reserved <= 1'b0;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_20_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(((((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && (! io_cpu_redo)) && stageB_request_isLrsc) && (! stageB_request_wr)))begin
-        stageB_lrsc_reserved <= 1'b1;
-      end
-      if(io_cpu_writeBack_clearLrsc)begin
-        stageB_lrsc_reserved <= 1'b0;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_17_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_35_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1219,8 +72,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1230,70 +83,75 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
   input               reset,
-  input               debugReset 
+  input               debugReset
 );
-  wire                _zz_200_;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire                _zz_203_;
-  wire                _zz_204_;
-  wire                _zz_205_;
-  wire                _zz_206_;
-  reg                 _zz_207_;
-  reg                 _zz_208_;
-  reg        [31:0]   _zz_209_;
-  reg                 _zz_210_;
-  reg        [31:0]   _zz_211_;
-  reg        [1:0]    _zz_212_;
-  reg                 _zz_213_;
-  reg                 _zz_214_;
-  wire                _zz_215_;
-  wire       [2:0]    _zz_216_;
-  reg                 _zz_217_;
-  wire       [31:0]   _zz_218_;
-  reg                 _zz_219_;
-  reg                 _zz_220_;
-  wire                _zz_221_;
-  wire       [31:0]   _zz_222_;
-  wire                _zz_223_;
-  wire                _zz_224_;
-  reg        [31:0]   _zz_225_;
-  reg        [31:0]   _zz_226_;
-  reg        [31:0]   _zz_227_;
-  reg                 _zz_228_;
-  reg                 _zz_229_;
-  reg                 _zz_230_;
-  reg        [9:0]    _zz_231_;
-  reg        [9:0]    _zz_232_;
-  reg        [9:0]    _zz_233_;
-  reg        [9:0]    _zz_234_;
-  reg                 _zz_235_;
-  reg                 _zz_236_;
-  reg                 _zz_237_;
-  reg                 _zz_238_;
-  reg                 _zz_239_;
-  reg                 _zz_240_;
-  reg                 _zz_241_;
-  reg        [9:0]    _zz_242_;
-  reg        [9:0]    _zz_243_;
-  reg        [9:0]    _zz_244_;
-  reg        [9:0]    _zz_245_;
-  reg                 _zz_246_;
-  reg                 _zz_247_;
-  reg                 _zz_248_;
-  reg                 _zz_249_;
+  wire                _zz_208;
+  wire                _zz_209;
+  wire                _zz_210;
+  wire                _zz_211;
+  wire                _zz_212;
+  wire                _zz_213;
+  wire                _zz_214;
+  wire                _zz_215;
+  reg                 _zz_216;
+  reg                 _zz_217;
+  reg        [31:0]   _zz_218;
+  reg                 _zz_219;
+  reg        [31:0]   _zz_220;
+  reg        [1:0]    _zz_221;
+  reg                 _zz_222;
+  reg                 _zz_223;
+  wire                _zz_224;
+  wire       [2:0]    _zz_225;
+  reg                 _zz_226;
+  wire       [31:0]   _zz_227;
+  reg                 _zz_228;
+  reg                 _zz_229;
+  wire                _zz_230;
+  wire       [31:0]   _zz_231;
+  wire                _zz_232;
+  wire                _zz_233;
+  wire                _zz_234;
+  wire                _zz_235;
+  wire                _zz_236;
+  wire                _zz_237;
+  wire                _zz_238;
+  wire                _zz_239;
+  wire       [3:0]    _zz_240;
+  wire                _zz_241;
+  wire                _zz_242;
+  reg        [31:0]   _zz_243;
+  reg        [31:0]   _zz_244;
+  reg        [31:0]   _zz_245;
+  reg                 _zz_246;
+  reg                 _zz_247;
+  reg                 _zz_248;
+  reg        [9:0]    _zz_249;
+  reg        [9:0]    _zz_250;
+  reg        [9:0]    _zz_251;
+  reg        [9:0]    _zz_252;
+  reg                 _zz_253;
+  reg                 _zz_254;
+  reg                 _zz_255;
+  reg                 _zz_256;
+  reg                 _zz_257;
+  reg                 _zz_258;
+  reg                 _zz_259;
+  reg        [9:0]    _zz_260;
+  reg        [9:0]    _zz_261;
+  reg        [9:0]    _zz_262;
+  reg        [9:0]    _zz_263;
+  reg                 _zz_264;
+  reg                 _zz_265;
+  reg                 _zz_266;
+  reg                 _zz_267;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -1303,550 +161,548 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_250_;
-  wire                _zz_251_;
-  wire                _zz_252_;
-  wire                _zz_253_;
-  wire                _zz_254_;
-  wire                _zz_255_;
-  wire                _zz_256_;
-  wire                _zz_257_;
-  wire                _zz_258_;
-  wire                _zz_259_;
-  wire                _zz_260_;
-  wire                _zz_261_;
-  wire                _zz_262_;
-  wire                _zz_263_;
-  wire                _zz_264_;
-  wire                _zz_265_;
-  wire                _zz_266_;
-  wire       [1:0]    _zz_267_;
-  wire                _zz_268_;
-  wire                _zz_269_;
-  wire                _zz_270_;
-  wire                _zz_271_;
-  wire                _zz_272_;
-  wire                _zz_273_;
-  wire                _zz_274_;
-  wire                _zz_275_;
-  wire                _zz_276_;
-  wire                _zz_277_;
-  wire                _zz_278_;
-  wire                _zz_279_;
-  wire                _zz_280_;
-  wire                _zz_281_;
-  wire                _zz_282_;
-  wire       [1:0]    _zz_283_;
-  wire                _zz_284_;
-  wire                _zz_285_;
-  wire       [5:0]    _zz_286_;
-  wire                _zz_287_;
-  wire                _zz_288_;
-  wire                _zz_289_;
-  wire                _zz_290_;
-  wire                _zz_291_;
-  wire                _zz_292_;
-  wire                _zz_293_;
-  wire                _zz_294_;
-  wire                _zz_295_;
-  wire                _zz_296_;
-  wire                _zz_297_;
-  wire                _zz_298_;
-  wire                _zz_299_;
-  wire                _zz_300_;
-  wire                _zz_301_;
-  wire                _zz_302_;
-  wire                _zz_303_;
-  wire                _zz_304_;
-  wire                _zz_305_;
-  wire                _zz_306_;
-  wire                _zz_307_;
-  wire                _zz_308_;
-  wire                _zz_309_;
-  wire       [1:0]    _zz_310_;
-  wire                _zz_311_;
-  wire       [1:0]    _zz_312_;
-  wire       [0:0]    _zz_313_;
-  wire       [0:0]    _zz_314_;
-  wire       [0:0]    _zz_315_;
-  wire       [51:0]   _zz_316_;
-  wire       [51:0]   _zz_317_;
-  wire       [51:0]   _zz_318_;
-  wire       [32:0]   _zz_319_;
-  wire       [51:0]   _zz_320_;
-  wire       [49:0]   _zz_321_;
-  wire       [51:0]   _zz_322_;
-  wire       [49:0]   _zz_323_;
-  wire       [51:0]   _zz_324_;
-  wire       [0:0]    _zz_325_;
-  wire       [0:0]    _zz_326_;
-  wire       [0:0]    _zz_327_;
-  wire       [32:0]   _zz_328_;
-  wire       [31:0]   _zz_329_;
-  wire       [32:0]   _zz_330_;
-  wire       [0:0]    _zz_331_;
-  wire       [0:0]    _zz_332_;
-  wire       [0:0]    _zz_333_;
-  wire       [0:0]    _zz_334_;
-  wire       [0:0]    _zz_335_;
-  wire       [0:0]    _zz_336_;
-  wire       [0:0]    _zz_337_;
-  wire       [0:0]    _zz_338_;
-  wire       [0:0]    _zz_339_;
-  wire       [0:0]    _zz_340_;
-  wire       [0:0]    _zz_341_;
-  wire       [0:0]    _zz_342_;
-  wire       [0:0]    _zz_343_;
-  wire       [0:0]    _zz_344_;
-  wire       [0:0]    _zz_345_;
-  wire       [4:0]    _zz_346_;
-  wire       [2:0]    _zz_347_;
-  wire       [31:0]   _zz_348_;
-  wire       [11:0]   _zz_349_;
-  wire       [31:0]   _zz_350_;
-  wire       [19:0]   _zz_351_;
-  wire       [11:0]   _zz_352_;
-  wire       [31:0]   _zz_353_;
-  wire       [31:0]   _zz_354_;
-  wire       [19:0]   _zz_355_;
-  wire       [11:0]   _zz_356_;
-  wire       [2:0]    _zz_357_;
-  wire       [2:0]    _zz_358_;
-  wire       [0:0]    _zz_359_;
-  wire       [1:0]    _zz_360_;
-  wire       [0:0]    _zz_361_;
-  wire       [1:0]    _zz_362_;
-  wire       [0:0]    _zz_363_;
-  wire       [0:0]    _zz_364_;
-  wire       [0:0]    _zz_365_;
-  wire       [0:0]    _zz_366_;
-  wire       [0:0]    _zz_367_;
-  wire       [0:0]    _zz_368_;
-  wire       [0:0]    _zz_369_;
-  wire       [0:0]    _zz_370_;
-  wire       [0:0]    _zz_371_;
-  wire       [2:0]    _zz_372_;
-  wire       [4:0]    _zz_373_;
-  wire       [11:0]   _zz_374_;
-  wire       [11:0]   _zz_375_;
-  wire       [31:0]   _zz_376_;
-  wire       [31:0]   _zz_377_;
-  wire       [31:0]   _zz_378_;
-  wire       [31:0]   _zz_379_;
-  wire       [31:0]   _zz_380_;
-  wire       [31:0]   _zz_381_;
-  wire       [31:0]   _zz_382_;
-  wire       [11:0]   _zz_383_;
-  wire       [19:0]   _zz_384_;
-  wire       [11:0]   _zz_385_;
-  wire       [31:0]   _zz_386_;
-  wire       [31:0]   _zz_387_;
-  wire       [31:0]   _zz_388_;
-  wire       [11:0]   _zz_389_;
-  wire       [19:0]   _zz_390_;
-  wire       [11:0]   _zz_391_;
-  wire       [2:0]    _zz_392_;
-  wire       [1:0]    _zz_393_;
-  wire       [1:0]    _zz_394_;
-  wire       [65:0]   _zz_395_;
-  wire       [65:0]   _zz_396_;
-  wire       [31:0]   _zz_397_;
-  wire       [31:0]   _zz_398_;
-  wire       [0:0]    _zz_399_;
-  wire       [5:0]    _zz_400_;
-  wire       [32:0]   _zz_401_;
-  wire       [31:0]   _zz_402_;
-  wire       [31:0]   _zz_403_;
-  wire       [32:0]   _zz_404_;
-  wire       [32:0]   _zz_405_;
-  wire       [32:0]   _zz_406_;
-  wire       [32:0]   _zz_407_;
-  wire       [0:0]    _zz_408_;
-  wire       [32:0]   _zz_409_;
-  wire       [0:0]    _zz_410_;
-  wire       [32:0]   _zz_411_;
-  wire       [0:0]    _zz_412_;
-  wire       [31:0]   _zz_413_;
-  wire       [0:0]    _zz_414_;
-  wire       [0:0]    _zz_415_;
-  wire       [0:0]    _zz_416_;
-  wire       [0:0]    _zz_417_;
-  wire       [0:0]    _zz_418_;
-  wire       [0:0]    _zz_419_;
-  wire       [0:0]    _zz_420_;
-  wire       [0:0]    _zz_421_;
-  wire       [0:0]    _zz_422_;
-  wire       [0:0]    _zz_423_;
-  wire       [0:0]    _zz_424_;
-  wire       [0:0]    _zz_425_;
-  wire       [0:0]    _zz_426_;
-  wire       [0:0]    _zz_427_;
-  wire       [0:0]    _zz_428_;
-  wire       [0:0]    _zz_429_;
-  wire       [0:0]    _zz_430_;
-  wire       [0:0]    _zz_431_;
-  wire       [0:0]    _zz_432_;
-  wire       [0:0]    _zz_433_;
-  wire       [0:0]    _zz_434_;
-  wire       [0:0]    _zz_435_;
-  wire       [0:0]    _zz_436_;
-  wire       [0:0]    _zz_437_;
-  wire       [0:0]    _zz_438_;
-  wire       [0:0]    _zz_439_;
-  wire       [0:0]    _zz_440_;
-  wire       [0:0]    _zz_441_;
-  wire       [0:0]    _zz_442_;
-  wire       [0:0]    _zz_443_;
-  wire       [0:0]    _zz_444_;
-  wire       [0:0]    _zz_445_;
-  wire       [0:0]    _zz_446_;
-  wire       [0:0]    _zz_447_;
-  wire       [0:0]    _zz_448_;
-  wire       [0:0]    _zz_449_;
-  wire       [0:0]    _zz_450_;
-  wire       [0:0]    _zz_451_;
-  wire       [0:0]    _zz_452_;
-  wire       [0:0]    _zz_453_;
-  wire       [0:0]    _zz_454_;
-  wire       [0:0]    _zz_455_;
-  wire       [0:0]    _zz_456_;
-  wire       [0:0]    _zz_457_;
-  wire       [0:0]    _zz_458_;
-  wire       [26:0]   _zz_459_;
-  wire                _zz_460_;
-  wire                _zz_461_;
-  wire       [2:0]    _zz_462_;
-  wire       [31:0]   _zz_463_;
-  wire       [31:0]   _zz_464_;
-  wire       [31:0]   _zz_465_;
-  wire                _zz_466_;
-  wire       [0:0]    _zz_467_;
-  wire       [17:0]   _zz_468_;
-  wire       [31:0]   _zz_469_;
-  wire       [31:0]   _zz_470_;
-  wire       [31:0]   _zz_471_;
-  wire                _zz_472_;
-  wire       [0:0]    _zz_473_;
-  wire       [11:0]   _zz_474_;
-  wire       [31:0]   _zz_475_;
-  wire       [31:0]   _zz_476_;
-  wire       [31:0]   _zz_477_;
-  wire                _zz_478_;
-  wire       [0:0]    _zz_479_;
-  wire       [5:0]    _zz_480_;
-  wire       [31:0]   _zz_481_;
-  wire       [31:0]   _zz_482_;
-  wire       [31:0]   _zz_483_;
-  wire                _zz_484_;
-  wire                _zz_485_;
-  wire                _zz_486_;
-  wire                _zz_487_;
-  wire                _zz_488_;
-  wire       [31:0]   _zz_489_;
-  wire       [31:0]   _zz_490_;
-  wire       [31:0]   _zz_491_;
-  wire       [6:0]    _zz_492_;
-  wire       [6:0]    _zz_493_;
-  wire                _zz_494_;
-  wire       [0:0]    _zz_495_;
-  wire       [29:0]   _zz_496_;
-  wire       [31:0]   _zz_497_;
-  wire       [31:0]   _zz_498_;
-  wire                _zz_499_;
-  wire       [0:0]    _zz_500_;
-  wire       [2:0]    _zz_501_;
-  wire       [31:0]   _zz_502_;
-  wire       [31:0]   _zz_503_;
-  wire       [31:0]   _zz_504_;
-  wire       [31:0]   _zz_505_;
-  wire       [0:0]    _zz_506_;
-  wire       [1:0]    _zz_507_;
-  wire       [2:0]    _zz_508_;
-  wire       [2:0]    _zz_509_;
-  wire                _zz_510_;
-  wire       [0:0]    _zz_511_;
-  wire       [25:0]   _zz_512_;
-  wire       [31:0]   _zz_513_;
-  wire       [31:0]   _zz_514_;
-  wire       [31:0]   _zz_515_;
-  wire                _zz_516_;
-  wire       [0:0]    _zz_517_;
-  wire       [0:0]    _zz_518_;
-  wire       [31:0]   _zz_519_;
-  wire       [31:0]   _zz_520_;
-  wire                _zz_521_;
-  wire                _zz_522_;
-  wire       [0:0]    _zz_523_;
-  wire       [0:0]    _zz_524_;
-  wire       [0:0]    _zz_525_;
-  wire       [0:0]    _zz_526_;
-  wire       [2:0]    _zz_527_;
-  wire       [2:0]    _zz_528_;
-  wire                _zz_529_;
-  wire       [0:0]    _zz_530_;
-  wire       [23:0]   _zz_531_;
-  wire       [31:0]   _zz_532_;
-  wire       [31:0]   _zz_533_;
-  wire       [31:0]   _zz_534_;
-  wire       [31:0]   _zz_535_;
-  wire       [31:0]   _zz_536_;
-  wire       [31:0]   _zz_537_;
-  wire       [31:0]   _zz_538_;
-  wire       [31:0]   _zz_539_;
-  wire       [31:0]   _zz_540_;
-  wire                _zz_541_;
-  wire       [0:0]    _zz_542_;
-  wire       [0:0]    _zz_543_;
-  wire       [0:0]    _zz_544_;
-  wire       [0:0]    _zz_545_;
-  wire       [3:0]    _zz_546_;
-  wire       [3:0]    _zz_547_;
-  wire                _zz_548_;
-  wire       [0:0]    _zz_549_;
-  wire       [21:0]   _zz_550_;
-  wire       [31:0]   _zz_551_;
-  wire       [31:0]   _zz_552_;
-  wire       [31:0]   _zz_553_;
-  wire       [31:0]   _zz_554_;
-  wire       [31:0]   _zz_555_;
-  wire       [31:0]   _zz_556_;
-  wire       [31:0]   _zz_557_;
-  wire       [31:0]   _zz_558_;
-  wire       [31:0]   _zz_559_;
-  wire                _zz_560_;
-  wire       [0:0]    _zz_561_;
-  wire       [1:0]    _zz_562_;
-  wire       [0:0]    _zz_563_;
-  wire       [3:0]    _zz_564_;
-  wire       [0:0]    _zz_565_;
-  wire       [0:0]    _zz_566_;
-  wire                _zz_567_;
-  wire       [0:0]    _zz_568_;
-  wire       [19:0]   _zz_569_;
-  wire       [31:0]   _zz_570_;
-  wire       [31:0]   _zz_571_;
-  wire       [31:0]   _zz_572_;
-  wire                _zz_573_;
-  wire                _zz_574_;
-  wire       [31:0]   _zz_575_;
-  wire       [31:0]   _zz_576_;
-  wire                _zz_577_;
-  wire       [0:0]    _zz_578_;
-  wire       [1:0]    _zz_579_;
-  wire       [31:0]   _zz_580_;
-  wire       [31:0]   _zz_581_;
-  wire                _zz_582_;
-  wire       [1:0]    _zz_583_;
-  wire       [1:0]    _zz_584_;
-  wire                _zz_585_;
-  wire       [0:0]    _zz_586_;
-  wire       [17:0]   _zz_587_;
-  wire       [31:0]   _zz_588_;
-  wire       [31:0]   _zz_589_;
-  wire       [31:0]   _zz_590_;
-  wire       [31:0]   _zz_591_;
-  wire       [31:0]   _zz_592_;
-  wire                _zz_593_;
-  wire       [31:0]   _zz_594_;
-  wire                _zz_595_;
-  wire                _zz_596_;
-  wire       [0:0]    _zz_597_;
-  wire       [1:0]    _zz_598_;
-  wire       [0:0]    _zz_599_;
-  wire       [0:0]    _zz_600_;
-  wire                _zz_601_;
-  wire       [0:0]    _zz_602_;
-  wire       [15:0]   _zz_603_;
-  wire       [31:0]   _zz_604_;
-  wire       [31:0]   _zz_605_;
-  wire       [31:0]   _zz_606_;
-  wire       [31:0]   _zz_607_;
-  wire       [31:0]   _zz_608_;
-  wire                _zz_609_;
-  wire                _zz_610_;
-  wire                _zz_611_;
-  wire       [0:0]    _zz_612_;
-  wire       [0:0]    _zz_613_;
-  wire                _zz_614_;
-  wire       [0:0]    _zz_615_;
-  wire       [12:0]   _zz_616_;
-  wire       [31:0]   _zz_617_;
-  wire       [31:0]   _zz_618_;
-  wire       [31:0]   _zz_619_;
-  wire                _zz_620_;
-  wire       [1:0]    _zz_621_;
-  wire       [1:0]    _zz_622_;
-  wire                _zz_623_;
-  wire       [0:0]    _zz_624_;
-  wire       [9:0]    _zz_625_;
-  wire       [31:0]   _zz_626_;
-  wire       [31:0]   _zz_627_;
-  wire       [31:0]   _zz_628_;
-  wire       [31:0]   _zz_629_;
-  wire       [31:0]   _zz_630_;
-  wire       [0:0]    _zz_631_;
-  wire       [3:0]    _zz_632_;
-  wire       [0:0]    _zz_633_;
-  wire       [0:0]    _zz_634_;
-  wire                _zz_635_;
-  wire       [0:0]    _zz_636_;
-  wire       [5:0]    _zz_637_;
-  wire       [31:0]   _zz_638_;
-  wire       [31:0]   _zz_639_;
-  wire       [31:0]   _zz_640_;
-  wire                _zz_641_;
-  wire       [0:0]    _zz_642_;
-  wire       [0:0]    _zz_643_;
-  wire       [31:0]   _zz_644_;
-  wire                _zz_645_;
-  wire       [0:0]    _zz_646_;
-  wire       [3:0]    _zz_647_;
-  wire       [0:0]    _zz_648_;
-  wire       [3:0]    _zz_649_;
-  wire       [0:0]    _zz_650_;
-  wire       [0:0]    _zz_651_;
-  wire                _zz_652_;
-  wire       [0:0]    _zz_653_;
-  wire       [2:0]    _zz_654_;
-  wire       [31:0]   _zz_655_;
-  wire       [31:0]   _zz_656_;
-  wire       [31:0]   _zz_657_;
-  wire       [31:0]   _zz_658_;
-  wire       [31:0]   _zz_659_;
-  wire       [31:0]   _zz_660_;
-  wire                _zz_661_;
-  wire       [0:0]    _zz_662_;
-  wire       [1:0]    _zz_663_;
-  wire                _zz_664_;
-  wire       [0:0]    _zz_665_;
-  wire       [1:0]    _zz_666_;
-  wire       [31:0]   _zz_667_;
-  wire       [31:0]   _zz_668_;
-  wire       [0:0]    _zz_669_;
-  wire       [0:0]    _zz_670_;
-  wire       [1:0]    _zz_671_;
-  wire       [1:0]    _zz_672_;
-  wire                _zz_673_;
-  wire       [0:0]    _zz_674_;
-  wire       [0:0]    _zz_675_;
-  wire       [31:0]   _zz_676_;
-  wire       [31:0]   _zz_677_;
-  wire       [31:0]   _zz_678_;
-  wire                _zz_679_;
-  wire                _zz_680_;
-  wire       [31:0]   _zz_681_;
-  wire       [31:0]   _zz_682_;
-  wire       [31:0]   _zz_683_;
-  wire                _zz_684_;
-  wire                _zz_685_;
-  wire       [31:0]   _zz_686_;
-  wire       [31:0]   _zz_687_;
-  wire       [31:0]   _zz_688_;
-  wire       [31:0]   _zz_689_;
-  wire                _zz_690_;
-  wire                _zz_691_;
-  wire       [0:0]    _zz_692_;
-  wire       [0:0]    _zz_693_;
-  wire       [0:0]    _zz_694_;
-  wire       [0:0]    _zz_695_;
-  wire                _zz_696_;
-  wire                _zz_697_;
-  wire                _zz_698_;
-  wire       [31:0]   _zz_699_;
-  wire                memory_MEMORY_WR;
-  wire                decode_MEMORY_WR;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire                decode_DO_EBREAK;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire                decode_IS_DIV;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_268;
+  wire                _zz_269;
+  wire                _zz_270;
+  wire                _zz_271;
+  wire                _zz_272;
+  wire                _zz_273;
+  wire                _zz_274;
+  wire                _zz_275;
+  wire                _zz_276;
+  wire                _zz_277;
+  wire                _zz_278;
+  wire                _zz_279;
+  wire                _zz_280;
+  wire                _zz_281;
+  wire                _zz_282;
+  wire                _zz_283;
+  wire                _zz_284;
+  wire       [1:0]    _zz_285;
+  wire                _zz_286;
+  wire                _zz_287;
+  wire                _zz_288;
+  wire                _zz_289;
+  wire                _zz_290;
+  wire                _zz_291;
+  wire                _zz_292;
+  wire                _zz_293;
+  wire                _zz_294;
+  wire                _zz_295;
+  wire                _zz_296;
+  wire                _zz_297;
+  wire                _zz_298;
+  wire                _zz_299;
+  wire                _zz_300;
+  wire       [1:0]    _zz_301;
+  wire                _zz_302;
+  wire                _zz_303;
+  wire       [5:0]    _zz_304;
+  wire                _zz_305;
+  wire                _zz_306;
+  wire                _zz_307;
+  wire                _zz_308;
+  wire                _zz_309;
+  wire                _zz_310;
+  wire                _zz_311;
+  wire                _zz_312;
+  wire                _zz_313;
+  wire                _zz_314;
+  wire                _zz_315;
+  wire                _zz_316;
+  wire                _zz_317;
+  wire                _zz_318;
+  wire                _zz_319;
+  wire                _zz_320;
+  wire                _zz_321;
+  wire                _zz_322;
+  wire                _zz_323;
+  wire                _zz_324;
+  wire                _zz_325;
+  wire                _zz_326;
+  wire       [1:0]    _zz_327;
+  wire                _zz_328;
+  wire       [1:0]    _zz_329;
+  wire       [51:0]   _zz_330;
+  wire       [51:0]   _zz_331;
+  wire       [51:0]   _zz_332;
+  wire       [32:0]   _zz_333;
+  wire       [51:0]   _zz_334;
+  wire       [49:0]   _zz_335;
+  wire       [51:0]   _zz_336;
+  wire       [49:0]   _zz_337;
+  wire       [51:0]   _zz_338;
+  wire       [32:0]   _zz_339;
+  wire       [31:0]   _zz_340;
+  wire       [32:0]   _zz_341;
+  wire       [0:0]    _zz_342;
+  wire       [0:0]    _zz_343;
+  wire       [0:0]    _zz_344;
+  wire       [0:0]    _zz_345;
+  wire       [0:0]    _zz_346;
+  wire       [0:0]    _zz_347;
+  wire       [0:0]    _zz_348;
+  wire       [0:0]    _zz_349;
+  wire       [0:0]    _zz_350;
+  wire       [0:0]    _zz_351;
+  wire       [0:0]    _zz_352;
+  wire       [0:0]    _zz_353;
+  wire       [0:0]    _zz_354;
+  wire       [0:0]    _zz_355;
+  wire       [0:0]    _zz_356;
+  wire       [0:0]    _zz_357;
+  wire       [0:0]    _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [0:0]    _zz_360;
+  wire       [0:0]    _zz_361;
+  wire       [0:0]    _zz_362;
+  wire       [4:0]    _zz_363;
+  wire       [2:0]    _zz_364;
+  wire       [31:0]   _zz_365;
+  wire       [11:0]   _zz_366;
+  wire       [31:0]   _zz_367;
+  wire       [19:0]   _zz_368;
+  wire       [11:0]   _zz_369;
+  wire       [31:0]   _zz_370;
+  wire       [31:0]   _zz_371;
+  wire       [19:0]   _zz_372;
+  wire       [11:0]   _zz_373;
+  wire       [2:0]    _zz_374;
+  wire       [2:0]    _zz_375;
+  wire       [0:0]    _zz_376;
+  wire       [1:0]    _zz_377;
+  wire       [0:0]    _zz_378;
+  wire       [1:0]    _zz_379;
+  wire       [0:0]    _zz_380;
+  wire       [0:0]    _zz_381;
+  wire       [0:0]    _zz_382;
+  wire       [0:0]    _zz_383;
+  wire       [0:0]    _zz_384;
+  wire       [0:0]    _zz_385;
+  wire       [0:0]    _zz_386;
+  wire       [0:0]    _zz_387;
+  wire       [1:0]    _zz_388;
+  wire       [0:0]    _zz_389;
+  wire       [2:0]    _zz_390;
+  wire       [4:0]    _zz_391;
+  wire       [11:0]   _zz_392;
+  wire       [11:0]   _zz_393;
+  wire       [31:0]   _zz_394;
+  wire       [31:0]   _zz_395;
+  wire       [31:0]   _zz_396;
+  wire       [31:0]   _zz_397;
+  wire       [31:0]   _zz_398;
+  wire       [31:0]   _zz_399;
+  wire       [31:0]   _zz_400;
+  wire       [11:0]   _zz_401;
+  wire       [19:0]   _zz_402;
+  wire       [11:0]   _zz_403;
+  wire       [31:0]   _zz_404;
+  wire       [31:0]   _zz_405;
+  wire       [31:0]   _zz_406;
+  wire       [11:0]   _zz_407;
+  wire       [19:0]   _zz_408;
+  wire       [11:0]   _zz_409;
+  wire       [2:0]    _zz_410;
+  wire       [1:0]    _zz_411;
+  wire       [1:0]    _zz_412;
+  wire       [65:0]   _zz_413;
+  wire       [65:0]   _zz_414;
+  wire       [31:0]   _zz_415;
+  wire       [31:0]   _zz_416;
+  wire       [0:0]    _zz_417;
+  wire       [5:0]    _zz_418;
+  wire       [32:0]   _zz_419;
+  wire       [31:0]   _zz_420;
+  wire       [31:0]   _zz_421;
+  wire       [32:0]   _zz_422;
+  wire       [32:0]   _zz_423;
+  wire       [32:0]   _zz_424;
+  wire       [32:0]   _zz_425;
+  wire       [0:0]    _zz_426;
+  wire       [32:0]   _zz_427;
+  wire       [0:0]    _zz_428;
+  wire       [32:0]   _zz_429;
+  wire       [0:0]    _zz_430;
+  wire       [31:0]   _zz_431;
+  wire       [0:0]    _zz_432;
+  wire       [0:0]    _zz_433;
+  wire       [0:0]    _zz_434;
+  wire       [0:0]    _zz_435;
+  wire       [0:0]    _zz_436;
+  wire       [0:0]    _zz_437;
+  wire       [0:0]    _zz_438;
+  wire       [0:0]    _zz_439;
+  wire       [0:0]    _zz_440;
+  wire       [0:0]    _zz_441;
+  wire       [0:0]    _zz_442;
+  wire       [0:0]    _zz_443;
+  wire       [0:0]    _zz_444;
+  wire       [0:0]    _zz_445;
+  wire       [0:0]    _zz_446;
+  wire       [0:0]    _zz_447;
+  wire       [0:0]    _zz_448;
+  wire       [0:0]    _zz_449;
+  wire       [0:0]    _zz_450;
+  wire       [0:0]    _zz_451;
+  wire       [0:0]    _zz_452;
+  wire       [0:0]    _zz_453;
+  wire       [0:0]    _zz_454;
+  wire       [0:0]    _zz_455;
+  wire       [0:0]    _zz_456;
+  wire       [0:0]    _zz_457;
+  wire       [0:0]    _zz_458;
+  wire       [0:0]    _zz_459;
+  wire       [0:0]    _zz_460;
+  wire       [0:0]    _zz_461;
+  wire       [0:0]    _zz_462;
+  wire       [0:0]    _zz_463;
+  wire       [0:0]    _zz_464;
+  wire       [0:0]    _zz_465;
+  wire       [0:0]    _zz_466;
+  wire       [0:0]    _zz_467;
+  wire       [0:0]    _zz_468;
+  wire       [0:0]    _zz_469;
+  wire       [0:0]    _zz_470;
+  wire       [0:0]    _zz_471;
+  wire       [0:0]    _zz_472;
+  wire       [0:0]    _zz_473;
+  wire       [0:0]    _zz_474;
+  wire       [0:0]    _zz_475;
+  wire       [0:0]    _zz_476;
+  wire       [26:0]   _zz_477;
+  wire                _zz_478;
+  wire                _zz_479;
+  wire       [2:0]    _zz_480;
+  wire       [31:0]   _zz_481;
+  wire       [31:0]   _zz_482;
+  wire       [31:0]   _zz_483;
+  wire                _zz_484;
+  wire       [0:0]    _zz_485;
+  wire       [17:0]   _zz_486;
+  wire       [31:0]   _zz_487;
+  wire       [31:0]   _zz_488;
+  wire       [31:0]   _zz_489;
+  wire                _zz_490;
+  wire       [0:0]    _zz_491;
+  wire       [11:0]   _zz_492;
+  wire       [31:0]   _zz_493;
+  wire       [31:0]   _zz_494;
+  wire       [31:0]   _zz_495;
+  wire                _zz_496;
+  wire       [0:0]    _zz_497;
+  wire       [5:0]    _zz_498;
+  wire       [31:0]   _zz_499;
+  wire       [31:0]   _zz_500;
+  wire       [31:0]   _zz_501;
+  wire                _zz_502;
+  wire                _zz_503;
+  wire                _zz_504;
+  wire                _zz_505;
+  wire                _zz_506;
+  wire       [31:0]   _zz_507;
+  wire       [0:0]    _zz_508;
+  wire       [0:0]    _zz_509;
+  wire                _zz_510;
+  wire       [0:0]    _zz_511;
+  wire       [29:0]   _zz_512;
+  wire       [31:0]   _zz_513;
+  wire                _zz_514;
+  wire                _zz_515;
+  wire                _zz_516;
+  wire       [1:0]    _zz_517;
+  wire       [1:0]    _zz_518;
+  wire                _zz_519;
+  wire       [0:0]    _zz_520;
+  wire       [25:0]   _zz_521;
+  wire       [31:0]   _zz_522;
+  wire       [31:0]   _zz_523;
+  wire       [31:0]   _zz_524;
+  wire       [31:0]   _zz_525;
+  wire                _zz_526;
+  wire                _zz_527;
+  wire       [1:0]    _zz_528;
+  wire       [1:0]    _zz_529;
+  wire                _zz_530;
+  wire       [0:0]    _zz_531;
+  wire       [22:0]   _zz_532;
+  wire       [31:0]   _zz_533;
+  wire       [31:0]   _zz_534;
+  wire       [31:0]   _zz_535;
+  wire       [31:0]   _zz_536;
+  wire                _zz_537;
+  wire       [0:0]    _zz_538;
+  wire       [0:0]    _zz_539;
+  wire                _zz_540;
+  wire       [0:0]    _zz_541;
+  wire       [0:0]    _zz_542;
+  wire                _zz_543;
+  wire       [0:0]    _zz_544;
+  wire       [19:0]   _zz_545;
+  wire       [31:0]   _zz_546;
+  wire       [31:0]   _zz_547;
+  wire       [31:0]   _zz_548;
+  wire                _zz_549;
+  wire                _zz_550;
+  wire                _zz_551;
+  wire       [0:0]    _zz_552;
+  wire       [0:0]    _zz_553;
+  wire                _zz_554;
+  wire       [0:0]    _zz_555;
+  wire       [16:0]   _zz_556;
+  wire       [31:0]   _zz_557;
+  wire       [31:0]   _zz_558;
+  wire       [31:0]   _zz_559;
+  wire       [0:0]    _zz_560;
+  wire       [2:0]    _zz_561;
+  wire       [0:0]    _zz_562;
+  wire       [0:0]    _zz_563;
+  wire                _zz_564;
+  wire       [0:0]    _zz_565;
+  wire       [13:0]   _zz_566;
+  wire       [31:0]   _zz_567;
+  wire       [31:0]   _zz_568;
+  wire       [31:0]   _zz_569;
+  wire                _zz_570;
+  wire                _zz_571;
+  wire       [31:0]   _zz_572;
+  wire       [31:0]   _zz_573;
+  wire       [31:0]   _zz_574;
+  wire       [0:0]    _zz_575;
+  wire       [4:0]    _zz_576;
+  wire       [2:0]    _zz_577;
+  wire       [2:0]    _zz_578;
+  wire                _zz_579;
+  wire       [0:0]    _zz_580;
+  wire       [10:0]   _zz_581;
+  wire       [31:0]   _zz_582;
+  wire       [31:0]   _zz_583;
+  wire       [31:0]   _zz_584;
+  wire       [31:0]   _zz_585;
+  wire                _zz_586;
+  wire       [0:0]    _zz_587;
+  wire       [2:0]    _zz_588;
+  wire                _zz_589;
+  wire       [0:0]    _zz_590;
+  wire       [0:0]    _zz_591;
+  wire       [0:0]    _zz_592;
+  wire       [3:0]    _zz_593;
+  wire       [4:0]    _zz_594;
+  wire       [4:0]    _zz_595;
+  wire                _zz_596;
+  wire       [0:0]    _zz_597;
+  wire       [8:0]    _zz_598;
+  wire       [31:0]   _zz_599;
+  wire       [31:0]   _zz_600;
+  wire       [31:0]   _zz_601;
+  wire                _zz_602;
+  wire       [0:0]    _zz_603;
+  wire       [0:0]    _zz_604;
+  wire       [31:0]   _zz_605;
+  wire       [31:0]   _zz_606;
+  wire       [31:0]   _zz_607;
+  wire       [31:0]   _zz_608;
+  wire       [31:0]   _zz_609;
+  wire       [31:0]   _zz_610;
+  wire       [31:0]   _zz_611;
+  wire                _zz_612;
+  wire       [0:0]    _zz_613;
+  wire       [1:0]    _zz_614;
+  wire       [0:0]    _zz_615;
+  wire       [2:0]    _zz_616;
+  wire       [0:0]    _zz_617;
+  wire       [5:0]    _zz_618;
+  wire       [1:0]    _zz_619;
+  wire       [1:0]    _zz_620;
+  wire                _zz_621;
+  wire       [0:0]    _zz_622;
+  wire       [6:0]    _zz_623;
+  wire       [31:0]   _zz_624;
+  wire       [31:0]   _zz_625;
+  wire       [31:0]   _zz_626;
+  wire       [31:0]   _zz_627;
+  wire       [31:0]   _zz_628;
+  wire       [31:0]   _zz_629;
+  wire       [31:0]   _zz_630;
+  wire       [31:0]   _zz_631;
+  wire                _zz_632;
+  wire       [31:0]   _zz_633;
+  wire       [31:0]   _zz_634;
+  wire                _zz_635;
+  wire       [0:0]    _zz_636;
+  wire       [0:0]    _zz_637;
+  wire                _zz_638;
+  wire       [0:0]    _zz_639;
+  wire       [3:0]    _zz_640;
+  wire                _zz_641;
+  wire       [0:0]    _zz_642;
+  wire       [0:0]    _zz_643;
+  wire       [0:0]    _zz_644;
+  wire       [0:0]    _zz_645;
+  wire                _zz_646;
+  wire       [0:0]    _zz_647;
+  wire       [4:0]    _zz_648;
+  wire       [31:0]   _zz_649;
+  wire       [31:0]   _zz_650;
+  wire       [31:0]   _zz_651;
+  wire       [31:0]   _zz_652;
+  wire       [31:0]   _zz_653;
+  wire       [31:0]   _zz_654;
+  wire       [31:0]   _zz_655;
+  wire       [31:0]   _zz_656;
+  wire       [31:0]   _zz_657;
+  wire                _zz_658;
+  wire       [0:0]    _zz_659;
+  wire       [1:0]    _zz_660;
+  wire       [31:0]   _zz_661;
+  wire       [31:0]   _zz_662;
+  wire       [31:0]   _zz_663;
+  wire       [31:0]   _zz_664;
+  wire       [31:0]   _zz_665;
+  wire                _zz_666;
+  wire       [4:0]    _zz_667;
+  wire       [4:0]    _zz_668;
+  wire                _zz_669;
+  wire       [0:0]    _zz_670;
+  wire       [2:0]    _zz_671;
+  wire       [31:0]   _zz_672;
+  wire       [31:0]   _zz_673;
+  wire       [31:0]   _zz_674;
+  wire                _zz_675;
+  wire       [31:0]   _zz_676;
+  wire                _zz_677;
+  wire       [0:0]    _zz_678;
+  wire       [2:0]    _zz_679;
+  wire       [0:0]    _zz_680;
+  wire       [0:0]    _zz_681;
+  wire       [2:0]    _zz_682;
+  wire       [2:0]    _zz_683;
+  wire                _zz_684;
+  wire       [0:0]    _zz_685;
+  wire       [0:0]    _zz_686;
+  wire       [31:0]   _zz_687;
+  wire       [31:0]   _zz_688;
+  wire       [31:0]   _zz_689;
+  wire       [31:0]   _zz_690;
+  wire                _zz_691;
+  wire       [0:0]    _zz_692;
+  wire       [0:0]    _zz_693;
+  wire       [31:0]   _zz_694;
+  wire       [31:0]   _zz_695;
+  wire                _zz_696;
+  wire       [0:0]    _zz_697;
+  wire       [0:0]    _zz_698;
+  wire       [0:0]    _zz_699;
+  wire       [1:0]    _zz_700;
+  wire       [1:0]    _zz_701;
+  wire       [1:0]    _zz_702;
+  wire       [0:0]    _zz_703;
+  wire       [0:0]    _zz_704;
+  wire       [31:0]   _zz_705;
+  wire       [31:0]   _zz_706;
+  wire       [31:0]   _zz_707;
+  wire       [31:0]   _zz_708;
+  wire       [31:0]   _zz_709;
+  wire       [31:0]   _zz_710;
+  wire       [31:0]   _zz_711;
+  wire       [31:0]   _zz_712;
+  wire                _zz_713;
+  wire                _zz_714;
+  wire                _zz_715;
+  wire       [31:0]   _zz_716;
   wire       [51:0]   memory_MUL_LOW;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire                execute_IS_DBUS_SHARING;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_DO_EBREAK;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
   wire                decode_SRC_LESS_UNSIGNED;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_3_;
   wire                memory_IS_SFENCE_VMA;
   wire                execute_IS_SFENCE_VMA;
   wire                decode_IS_SFENCE_VMA;
-  wire                decode_MEMORY_AMO;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       [31:0]   execute_SHIFT_RIGHT;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire                execute_BRANCH_DO;
-  wire                decode_CSR_READ_OPCODE;
-  wire       [31:0]   execute_MUL_LL;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire                execute_IS_DBUS_SHARING;
-  wire       [33:0]   execute_MUL_HL;
+  wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_8_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
   wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_11_;
-  wire       [31:0]   memory_PC;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       [33:0]   execute_MUL_LH;
-  wire                decode_IS_CSR;
-  wire                decode_MEMORY_LRSC;
-  wire                decode_MEMORY_MANAGMENT;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       [33:0]   memory_MUL_HH;
-  wire       [33:0]   execute_MUL_HH;
-  wire                memory_IS_MUL;
-  wire                execute_IS_MUL;
-  wire                decode_IS_MUL;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26_;
-  wire                decode_IS_RS2_SIGNED;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                decode_IS_RS1_SIGNED;
+  wire       [31:0]   memory_PC;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -1863,11 +719,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -1875,10 +731,10 @@ module VexRiscv (
   (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1888,46 +744,46 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_49_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
   wire                writeBack_IS_SFENCE_VMA;
   wire                writeBack_IS_DBUS_SHARING;
   wire                memory_IS_DBUS_SHARING;
-  reg        [31:0]   _zz_50_;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
@@ -1936,24 +792,28 @@ module VexRiscv (
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_AMO;
   wire                execute_MEMORY_LRSC;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
+  wire                decode_MEMORY_AMO;
+  wire                decode_MEMORY_LRSC;
+  reg                 _zz_51;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_51_;
-  reg                 _zz_51__2;
-  reg                 _zz_51__1;
-  reg                 _zz_51__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_52;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53_;
-  reg        [31:0]   _zz_54_;
-  reg        [31:0]   _zz_55_;
+  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_54;
+  reg        [31:0]   _zz_55;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -2018,28 +878,63 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   reg        [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  reg                 IBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   reg                 IBusCachedPlugin_mmuBus_rsp_exception;
   reg                 IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_0_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_0_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_1_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_1_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_2_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_2_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_3_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_3_physical;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  reg                 DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  reg                 DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   reg        [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  reg                 DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
   reg                 DBusCachedPlugin_mmuBus_rsp_exception;
   reg                 DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_0_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_0_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_1_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_1_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_2_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_2_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_3_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_3_physical;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -2047,7 +942,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_56_;
+  reg                 _zz_56;
   reg                 MmuPlugin_dBusAccess_cmd_valid;
   reg                 MmuPlugin_dBusAccess_cmd_ready;
   reg        [31:0]   MmuPlugin_dBusAccess_cmd_payload_address;
@@ -2093,12 +988,12 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [4:0]    _zz_57_;
-  wire       [4:0]    _zz_58_;
-  wire                _zz_59_;
-  wire                _zz_60_;
-  wire                _zz_61_;
-  wire                _zz_62_;
+  wire       [4:0]    _zz_57;
+  wire       [4:0]    _zz_58;
+  wire                _zz_59;
+  wire                _zz_60;
+  wire                _zz_61;
+  wire                _zz_62;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -2135,16 +1030,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_63_;
-  wire                _zz_64_;
-  wire                _zz_65_;
+  wire                _zz_63;
+  wire                _zz_64;
+  wire                _zz_65;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_66_;
-  wire                _zz_67_;
-  reg                 _zz_68_;
-  wire                _zz_69_;
-  reg                 _zz_70_;
-  reg        [31:0]   _zz_71_;
+  wire                _zz_66;
+  wire                _zz_67;
+  reg                 _zz_68;
+  wire                _zz_69;
+  reg                 _zz_70;
+  reg        [31:0]   _zz_71;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -2157,17 +1052,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_72_;
-  reg        [18:0]   _zz_73_;
-  wire                _zz_74_;
-  reg        [10:0]   _zz_75_;
-  wire                _zz_76_;
-  reg        [18:0]   _zz_77_;
-  reg                 _zz_78_;
-  wire                _zz_79_;
-  reg        [10:0]   _zz_80_;
-  wire                _zz_81_;
-  reg        [18:0]   _zz_82_;
+  wire                _zz_72;
+  reg        [18:0]   _zz_73;
+  wire                _zz_74;
+  reg        [10:0]   _zz_75;
+  wire                _zz_76;
+  reg        [18:0]   _zz_77;
+  reg                 _zz_78;
+  wire                _zz_79;
+  reg        [10:0]   _zz_80;
+  wire                _zz_81;
+  reg        [18:0]   _zz_82;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -2175,7 +1070,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_83_;
+  wire       [31:0]   _zz_83;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -2183,62 +1078,56 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_84_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_84;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_85_;
+  reg        [31:0]   _zz_85;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_86_;
-  reg        [31:0]   _zz_87_;
-  wire                _zz_88_;
-  reg        [31:0]   _zz_89_;
+  wire                _zz_86;
+  reg        [31:0]   _zz_87;
+  wire                _zz_88;
+  reg        [31:0]   _zz_89;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
   reg                 DBusCachedPlugin_forceDatapath;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
   reg                 MmuPlugin_satp_mode;
+  reg        [8:0]    MmuPlugin_satp_asid;
   reg        [19:0]   MmuPlugin_satp_ppn;
   reg                 MmuPlugin_ports_0_cache_0_valid;
   reg                 MmuPlugin_ports_0_cache_0_exception;
@@ -2284,14 +1173,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowWrite;
   reg                 MmuPlugin_ports_0_cache_3_allowExecute;
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
-  wire                MmuPlugin_ports_0_cacheHits_0;
-  wire                MmuPlugin_ports_0_cacheHits_1;
-  wire                MmuPlugin_ports_0_cacheHits_2;
-  wire                MmuPlugin_ports_0_cacheHits_3;
+  wire                MmuPlugin_ports_0_dirty;
+  reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
+  reg        [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
-  wire                _zz_90_;
-  wire                _zz_91_;
-  wire       [1:0]    _zz_92_;
+  wire                _zz_90;
+  wire                _zz_91;
+  wire                _zz_92;
+  wire       [1:0]    _zz_93;
   wire                MmuPlugin_ports_0_cacheLine_valid;
   wire                MmuPlugin_ports_0_cacheLine_exception;
   wire                MmuPlugin_ports_0_cacheLine_superPage;
@@ -2309,7 +1198,6 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_ports_0_entryToReplace_value;
   wire                MmuPlugin_ports_0_entryToReplace_willOverflowIfInc;
   wire                MmuPlugin_ports_0_entryToReplace_willOverflow;
-  reg                 MmuPlugin_ports_0_requireMmuLockup;
   reg                 MmuPlugin_ports_1_cache_0_valid;
   reg                 MmuPlugin_ports_1_cache_0_exception;
   reg                 MmuPlugin_ports_1_cache_0_superPage;
@@ -2354,14 +1242,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowWrite;
   reg                 MmuPlugin_ports_1_cache_3_allowExecute;
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
-  wire                MmuPlugin_ports_1_cacheHits_0;
-  wire                MmuPlugin_ports_1_cacheHits_1;
-  wire                MmuPlugin_ports_1_cacheHits_2;
-  wire                MmuPlugin_ports_1_cacheHits_3;
+  wire                MmuPlugin_ports_1_dirty;
+  reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
+  reg        [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
-  wire                _zz_93_;
-  wire                _zz_94_;
-  wire       [1:0]    _zz_95_;
+  wire                _zz_94;
+  wire                _zz_95;
+  wire                _zz_96;
+  wire       [1:0]    _zz_97;
   wire                MmuPlugin_ports_1_cacheLine_valid;
   wire                MmuPlugin_ports_1_cacheLine_exception;
   wire                MmuPlugin_ports_1_cacheLine_superPage;
@@ -2379,11 +1267,14 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_ports_1_entryToReplace_value;
   wire                MmuPlugin_ports_1_entryToReplace_willOverflowIfInc;
   wire                MmuPlugin_ports_1_entryToReplace_willOverflow;
-  reg                 MmuPlugin_ports_1_requireMmuLockup;
-  reg        `MmuPlugin_shared_State_defaultEncoding_type MmuPlugin_shared_state_1_;
+  reg        `MmuPlugin_shared_State_defaultEncoding_type MmuPlugin_shared_state_1;
   reg        [9:0]    MmuPlugin_shared_vpn_0;
   reg        [9:0]    MmuPlugin_shared_vpn_1;
-  reg        [0:0]    MmuPlugin_shared_portId;
+  reg        [1:0]    MmuPlugin_shared_portSortedOh;
+  reg                 MmuPlugin_shared_dBusRspStaged_valid;
+  reg        [31:0]   MmuPlugin_shared_dBusRspStaged_payload_data;
+  reg                 MmuPlugin_shared_dBusRspStaged_payload_error;
+  reg                 MmuPlugin_shared_dBusRspStaged_payload_redo;
   wire                MmuPlugin_shared_dBusRsp_pte_V;
   wire                MmuPlugin_shared_dBusRsp_pte_R;
   wire                MmuPlugin_shared_dBusRsp_pte_W;
@@ -2408,75 +1299,82 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_shared_pteBuffer_RSW;
   reg        [9:0]    MmuPlugin_shared_pteBuffer_PPN0;
   reg        [11:0]   MmuPlugin_shared_pteBuffer_PPN1;
-  wire       [35:0]   _zz_96_;
-  wire                _zz_97_;
-  wire                _zz_98_;
-  wire                _zz_99_;
-  wire                _zz_100_;
-  wire                _zz_101_;
-  wire                _zz_102_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_103_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_104_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_105_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_106_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_107_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_108_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_109_;
+  reg        [1:0]    _zz_98;
+  wire       [1:0]    _zz_99;
+  reg        [1:0]    _zz_100;
+  wire       [1:0]    MmuPlugin_shared_refills;
+  wire       [1:0]    _zz_101;
+  reg        [1:0]    _zz_102;
+  wire       [31:0]   _zz_103;
+  wire       [35:0]   _zz_104;
+  wire                _zz_105;
+  wire                _zz_106;
+  wire                _zz_107;
+  wire                _zz_108;
+  wire                _zz_109;
+  wire                _zz_110;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_111;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_112;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_113;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_114;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_115;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_116;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_117;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_110_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_118;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_111_;
-  reg        [31:0]   _zz_112_;
-  wire                _zz_113_;
-  reg        [19:0]   _zz_114_;
-  wire                _zz_115_;
-  reg        [19:0]   _zz_116_;
-  reg        [31:0]   _zz_117_;
+  reg        [31:0]   _zz_119;
+  reg        [31:0]   _zz_120;
+  wire                _zz_121;
+  reg        [19:0]   _zz_122;
+  wire                _zz_123;
+  reg        [19:0]   _zz_124;
+  reg        [31:0]   _zz_125;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_118_;
+  reg        [31:0]   _zz_126;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_119_;
-  reg                 _zz_120_;
-  reg                 _zz_121_;
-  reg                 _zz_122_;
-  reg        [4:0]    _zz_123_;
-  reg        [31:0]   _zz_124_;
-  wire                _zz_125_;
-  wire                _zz_126_;
-  wire                _zz_127_;
-  wire                _zz_128_;
-  wire                _zz_129_;
-  wire                _zz_130_;
+  reg        [31:0]   _zz_127;
+  reg                 _zz_128;
+  reg                 _zz_129;
+  reg                 _zz_130;
+  reg        [4:0]    _zz_131;
+  reg        [31:0]   _zz_132;
+  wire                _zz_133;
+  wire                _zz_134;
+  wire                _zz_135;
+  wire                _zz_136;
+  wire                _zz_137;
+  wire                _zz_138;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_131_;
-  reg                 _zz_132_;
-  reg                 _zz_133_;
-  wire                _zz_134_;
-  reg        [19:0]   _zz_135_;
-  wire                _zz_136_;
-  reg        [10:0]   _zz_137_;
-  wire                _zz_138_;
-  reg        [18:0]   _zz_139_;
-  reg                 _zz_140_;
+  wire       [2:0]    _zz_139;
+  reg                 _zz_140;
+  reg                 _zz_141;
+  wire                _zz_142;
+  reg        [19:0]   _zz_143;
+  wire                _zz_144;
+  reg        [10:0]   _zz_145;
+  wire                _zz_146;
+  reg        [18:0]   _zz_147;
+  reg                 _zz_148;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_141_;
-  reg        [19:0]   _zz_142_;
-  wire                _zz_143_;
-  reg        [10:0]   _zz_144_;
-  wire                _zz_145_;
-  reg        [18:0]   _zz_146_;
+  wire                _zz_149;
+  reg        [19:0]   _zz_150;
+  wire                _zz_151;
+  reg        [10:0]   _zz_152;
+  wire                _zz_153;
+  reg        [18:0]   _zz_154;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_147_;
+  reg        [1:0]    _zz_155;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -2533,12 +1431,12 @@ module VexRiscv (
   reg        [21:0]   CsrPlugin_satp_PPN;
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
-  wire                _zz_148_;
-  wire                _zz_149_;
-  wire                _zz_150_;
-  wire                _zz_151_;
-  wire                _zz_152_;
-  wire                _zz_153_;
+  wire                _zz_156;
+  wire                _zz_157;
+  wire                _zz_158;
+  wire                _zz_159;
+  wire                _zz_160;
+  wire                _zz_161;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -2551,8 +1449,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_154_;
-  wire                _zz_155_;
+  wire       [1:0]    _zz_162;
+  wire                _zz_163;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -2564,7 +1462,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2605,20 +1503,20 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_156_;
+  wire       [31:0]   _zz_164;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_157_;
-  wire                _zz_158_;
-  wire                _zz_159_;
-  reg        [32:0]   _zz_160_;
+  wire       [31:0]   _zz_165;
+  wire                _zz_166;
+  wire                _zz_167;
+  reg        [32:0]   _zz_168;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_161_;
-  wire       [31:0]   _zz_162_;
-  reg        [31:0]   _zz_163_;
-  wire       [31:0]   _zz_164_;
+  reg        [31:0]   _zz_169;
+  wire       [31:0]   _zz_170;
+  reg        [31:0]   _zz_171;
+  wire       [31:0]   _zz_172;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -2628,79 +1526,80 @@ module VexRiscv (
   reg                 DebugPlugin_godmode;
   reg                 DebugPlugin_haltedByBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_165_;
+  reg                 _zz_173;
   wire                DebugPlugin_allowEBreak;
   reg                 DebugPlugin_resetIt_regNext;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 memory_to_writeBack_IS_MUL;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
-  reg                 decode_to_execute_MEMORY_LRSC;
-  reg                 decode_to_execute_IS_CSR;
-  reg        [33:0]   execute_to_memory_MUL_LH;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg        [33:0]   execute_to_memory_MUL_HL;
-  reg                 execute_to_memory_IS_DBUS_SHARING;
-  reg                 memory_to_writeBack_IS_DBUS_SHARING;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg        [31:0]   execute_to_memory_MUL_LL;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg                 decode_to_execute_MEMORY_AMO;
-  reg                 decode_to_execute_IS_SFENCE_VMA;
-  reg                 execute_to_memory_IS_SFENCE_VMA;
-  reg                 memory_to_writeBack_IS_SFENCE_VMA;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
   reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg                 decode_to_execute_DO_EBREAK;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   reg                 decode_to_execute_MEMORY_WR;
   reg                 execute_to_memory_MEMORY_WR;
   reg                 memory_to_writeBack_MEMORY_WR;
-  reg        [2:0]    _zz_166_;
+  reg                 decode_to_execute_MEMORY_LRSC;
+  reg                 decode_to_execute_MEMORY_AMO;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_IS_SFENCE_VMA;
+  reg                 execute_to_memory_IS_SFENCE_VMA;
+  reg                 memory_to_writeBack_IS_SFENCE_VMA;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 memory_to_writeBack_IS_MUL;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_DO_EBREAK;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg                 execute_to_memory_IS_DBUS_SHARING;
+  reg                 memory_to_writeBack_IS_DBUS_SHARING;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  reg        [2:0]    _zz_174;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_256;
@@ -2729,1073 +1628,886 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_4032;
   reg                 execute_CsrPlugin_csr_2496;
   reg                 execute_CsrPlugin_csr_3520;
-  reg        [31:0]   _zz_167_;
-  reg        [31:0]   _zz_168_;
-  reg        [31:0]   _zz_169_;
-  reg        [31:0]   _zz_170_;
-  reg        [31:0]   _zz_171_;
-  reg        [31:0]   _zz_172_;
-  reg        [31:0]   _zz_173_;
-  reg        [31:0]   _zz_174_;
-  reg        [31:0]   _zz_175_;
-  reg        [31:0]   _zz_176_;
-  reg        [31:0]   _zz_177_;
-  reg        [31:0]   _zz_178_;
-  reg        [31:0]   _zz_179_;
-  reg        [31:0]   _zz_180_;
-  reg        [31:0]   _zz_181_;
-  reg        [31:0]   _zz_182_;
-  reg        [31:0]   _zz_183_;
-  reg        [31:0]   _zz_184_;
-  reg        [31:0]   _zz_185_;
-  reg        [31:0]   _zz_186_;
-  reg        [31:0]   _zz_187_;
-  reg        [31:0]   _zz_188_;
-  reg        [31:0]   _zz_189_;
-  reg        [31:0]   _zz_190_;
-  reg        [2:0]    _zz_191_;
-  reg                 _zz_192_;
+  reg        [31:0]   _zz_175;
+  reg        [31:0]   _zz_176;
+  reg        [31:0]   _zz_177;
+  reg        [31:0]   _zz_178;
+  reg        [31:0]   _zz_179;
+  reg        [31:0]   _zz_180;
+  reg        [31:0]   _zz_181;
+  reg        [31:0]   _zz_182;
+  reg        [31:0]   _zz_183;
+  reg        [31:0]   _zz_184;
+  reg        [31:0]   _zz_185;
+  reg        [31:0]   _zz_186;
+  reg        [31:0]   _zz_187;
+  reg        [31:0]   _zz_188;
+  reg        [31:0]   _zz_189;
+  reg        [31:0]   _zz_190;
+  reg        [31:0]   _zz_191;
+  reg        [31:0]   _zz_192;
+  reg        [31:0]   _zz_193;
+  reg        [31:0]   _zz_194;
+  reg        [31:0]   _zz_195;
+  reg        [31:0]   _zz_196;
+  reg        [31:0]   _zz_197;
+  reg        [31:0]   _zz_198;
+  reg        [2:0]    _zz_199;
+  reg                 _zz_200;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_193_;
-  wire                _zz_194_;
-  wire                _zz_195_;
-  wire                _zz_196_;
-  wire                _zz_197_;
-  wire                _zz_198_;
-  reg                 _zz_199_;
+  reg        [2:0]    _zz_201;
+  wire                _zz_202;
+  wire                _zz_203;
+  wire                _zz_204;
+  wire                _zz_205;
+  wire                _zz_206;
+  reg                 _zz_207;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_1__string;
-  reg [63:0] _zz_2__string;
-  reg [63:0] _zz_3__string;
-  reg [31:0] _zz_4__string;
-  reg [31:0] _zz_5__string;
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_6__string;
-  reg [23:0] _zz_7__string;
-  reg [23:0] _zz_8__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_9__string;
-  reg [95:0] _zz_10__string;
-  reg [95:0] _zz_11__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_12__string;
-  reg [39:0] _zz_13__string;
-  reg [39:0] _zz_14__string;
-  reg [71:0] _zz_15__string;
-  reg [71:0] _zz_16__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_17__string;
-  reg [71:0] _zz_18__string;
-  reg [71:0] _zz_19__string;
-  reg [39:0] _zz_20__string;
-  reg [39:0] _zz_21__string;
-  reg [39:0] _zz_22__string;
-  reg [39:0] _zz_23__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_24__string;
-  reg [39:0] _zz_25__string;
-  reg [39:0] _zz_26__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [95:0] _zz_43__string;
-  reg [71:0] _zz_44__string;
-  reg [39:0] _zz_45__string;
-  reg [39:0] _zz_46__string;
-  reg [23:0] _zz_47__string;
-  reg [31:0] _zz_48__string;
-  reg [63:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_52__string;
-  reg [47:0] MmuPlugin_shared_state_1__string;
-  reg [63:0] _zz_103__string;
-  reg [31:0] _zz_104__string;
-  reg [23:0] _zz_105__string;
-  reg [39:0] _zz_106__string;
-  reg [39:0] _zz_107__string;
-  reg [71:0] _zz_108__string;
-  reg [95:0] _zz_109__string;
+  reg [31:0] _zz_52_string;
+  reg [47:0] MmuPlugin_shared_state_1_string;
+  reg [95:0] _zz_111_string;
+  reg [63:0] _zz_112_string;
+  reg [23:0] _zz_113_string;
+  reg [39:0] _zz_114_string;
+  reg [71:0] _zz_115_string;
+  reg [31:0] _zz_116_string;
+  reg [39:0] _zz_117_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
+  reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
-  reg [63:0] decode_to_execute_ALU_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_250_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_251_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_252_ = 1'b1;
-  assign _zz_253_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_254_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_255_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_256_ = ((_zz_204_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_51__2));
-  assign _zz_257_ = ((_zz_204_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_51__1));
-  assign _zz_258_ = ((_zz_204_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_51__0));
-  assign _zz_259_ = ((_zz_204_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_260_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_261_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_262_ = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_263_ = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00)) == 1'b0);
-  assign _zz_264_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_265_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_266_ = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_267_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_268_ = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != (3'b000)));
-  assign _zz_269_ = (! dataCache_1__io_cpu_redo);
-  assign _zz_270_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_271_ = ((MmuPlugin_dBusAccess_rsp_valid && (! MmuPlugin_dBusAccess_rsp_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign _zz_272_ = (MmuPlugin_shared_portId == (1'b1));
-  assign _zz_273_ = (MmuPlugin_shared_portId == (1'b0));
-  assign _zz_274_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_275_ = (1'b0 || (! 1'b1));
-  assign _zz_276_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_277_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_278_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_279_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_280_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_281_ = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_282_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_283_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_284_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_285_ = (! memory_arbitration_isStuck);
-  assign _zz_286_ = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_287_ = (iBus_cmd_valid || (_zz_191_ != (3'b000)));
-  assign _zz_288_ = (_zz_224_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_289_ = (IBusCachedPlugin_mmuBus_cmd_isValid && IBusCachedPlugin_mmuBus_rsp_refilling);
-  assign _zz_290_ = (DBusCachedPlugin_mmuBus_cmd_isValid && DBusCachedPlugin_mmuBus_rsp_refilling);
-  assign _zz_291_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b00));
-  assign _zz_292_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b01));
-  assign _zz_293_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b10));
-  assign _zz_294_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b11));
-  assign _zz_295_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b00));
-  assign _zz_296_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b01));
-  assign _zz_297_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b10));
-  assign _zz_298_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b11));
-  assign _zz_299_ = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == (2'b01))) || (CsrPlugin_privilege < (2'b01)));
-  assign _zz_300_ = ((_zz_148_ && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign _zz_301_ = ((_zz_149_ && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign _zz_302_ = ((_zz_150_ && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign _zz_303_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_304_ = ((_zz_148_ && 1'b1) && (! (CsrPlugin_mideleg_ST != (1'b0))));
-  assign _zz_305_ = ((_zz_149_ && 1'b1) && (! (CsrPlugin_mideleg_SS != (1'b0))));
-  assign _zz_306_ = ((_zz_150_ && 1'b1) && (! (CsrPlugin_mideleg_SE != (1'b0))));
-  assign _zz_307_ = ((_zz_151_ && 1'b1) && (! 1'b0));
-  assign _zz_308_ = ((_zz_152_ && 1'b1) && (! 1'b0));
-  assign _zz_309_ = ((_zz_153_ && 1'b1) && (! 1'b0));
-  assign _zz_310_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_311_ = execute_INSTRUCTION[13];
-  assign _zz_312_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_313_ = _zz_96_[26 : 26];
-  assign _zz_314_ = _zz_96_[6 : 6];
-  assign _zz_315_ = _zz_96_[34 : 34];
-  assign _zz_316_ = ($signed(_zz_317_) + $signed(_zz_322_));
-  assign _zz_317_ = ($signed(_zz_318_) + $signed(_zz_320_));
-  assign _zz_318_ = 52'h0;
-  assign _zz_319_ = {1'b0,memory_MUL_LL};
-  assign _zz_320_ = {{19{_zz_319_[32]}}, _zz_319_};
-  assign _zz_321_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_322_ = {{2{_zz_321_[49]}}, _zz_321_};
-  assign _zz_323_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_324_ = {{2{_zz_323_[49]}}, _zz_323_};
-  assign _zz_325_ = _zz_96_[4 : 4];
-  assign _zz_326_ = _zz_96_[22 : 22];
-  assign _zz_327_ = _zz_96_[21 : 21];
-  assign _zz_328_ = ($signed(_zz_330_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_329_ = _zz_328_[31 : 0];
-  assign _zz_330_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_331_ = _zz_96_[25 : 25];
-  assign _zz_332_ = _zz_96_[30 : 30];
-  assign _zz_333_ = _zz_96_[8 : 8];
-  assign _zz_334_ = _zz_96_[5 : 5];
-  assign _zz_335_ = _zz_96_[9 : 9];
-  assign _zz_336_ = _zz_96_[33 : 33];
-  assign _zz_337_ = _zz_96_[18 : 18];
-  assign _zz_338_ = _zz_96_[10 : 10];
-  assign _zz_339_ = _zz_96_[24 : 24];
-  assign _zz_340_ = _zz_96_[23 : 23];
-  assign _zz_341_ = _zz_96_[29 : 29];
-  assign _zz_342_ = _zz_96_[35 : 35];
-  assign _zz_343_ = _zz_96_[32 : 32];
-  assign _zz_344_ = _zz_96_[31 : 31];
-  assign _zz_345_ = _zz_96_[13 : 13];
-  assign _zz_346_ = (_zz_57_ - 5'h01);
-  assign _zz_347_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_348_ = {29'd0, _zz_347_};
-  assign _zz_349_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_350_ = {{_zz_73_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_351_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_352_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_353_ = {{_zz_75_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_354_ = {{_zz_77_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_355_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_356_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_357_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_358_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_359_ = MmuPlugin_ports_0_entryToReplace_willIncrement;
-  assign _zz_360_ = {1'd0, _zz_359_};
-  assign _zz_361_ = MmuPlugin_ports_1_entryToReplace_willIncrement;
-  assign _zz_362_ = {1'd0, _zz_361_};
-  assign _zz_363_ = MmuPlugin_dBusAccess_rsp_payload_data[0 : 0];
-  assign _zz_364_ = MmuPlugin_dBusAccess_rsp_payload_data[1 : 1];
-  assign _zz_365_ = MmuPlugin_dBusAccess_rsp_payload_data[2 : 2];
-  assign _zz_366_ = MmuPlugin_dBusAccess_rsp_payload_data[3 : 3];
-  assign _zz_367_ = MmuPlugin_dBusAccess_rsp_payload_data[4 : 4];
-  assign _zz_368_ = MmuPlugin_dBusAccess_rsp_payload_data[5 : 5];
-  assign _zz_369_ = MmuPlugin_dBusAccess_rsp_payload_data[6 : 6];
-  assign _zz_370_ = MmuPlugin_dBusAccess_rsp_payload_data[7 : 7];
-  assign _zz_371_ = execute_SRC_LESS;
-  assign _zz_372_ = (3'b100);
-  assign _zz_373_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_374_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_375_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_376_ = ($signed(_zz_377_) + $signed(_zz_380_));
-  assign _zz_377_ = ($signed(_zz_378_) + $signed(_zz_379_));
-  assign _zz_378_ = execute_SRC1;
-  assign _zz_379_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_380_ = (execute_SRC_USE_SUB_LESS ? _zz_381_ : _zz_382_);
-  assign _zz_381_ = 32'h00000001;
-  assign _zz_382_ = 32'h0;
-  assign _zz_383_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_384_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_385_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_386_ = {_zz_135_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_387_ = {{_zz_137_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_388_ = {{_zz_139_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_389_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_390_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_391_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_392_ = (3'b100);
-  assign _zz_393_ = (_zz_154_ & (~ _zz_394_));
-  assign _zz_394_ = (_zz_154_ - (2'b01));
-  assign _zz_395_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_396_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_397_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_398_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_399_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_400_ = {5'd0, _zz_399_};
-  assign _zz_401_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_402_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_403_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_404_ = {_zz_156_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_405_ = _zz_406_;
-  assign _zz_406_ = _zz_407_;
-  assign _zz_407_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_157_) : _zz_157_)} + _zz_409_);
-  assign _zz_408_ = memory_DivPlugin_div_needRevert;
-  assign _zz_409_ = {32'd0, _zz_408_};
-  assign _zz_410_ = _zz_159_;
-  assign _zz_411_ = {32'd0, _zz_410_};
-  assign _zz_412_ = _zz_158_;
-  assign _zz_413_ = {31'd0, _zz_412_};
-  assign _zz_414_ = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_415_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_416_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_417_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_418_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_419_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_420_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_421_ = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_422_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_423_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_424_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_425_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_426_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_427_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_428_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_429_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_430_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_431_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_432_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_433_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_434_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_435_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_436_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_437_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_438_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_439_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_440_ = execute_CsrPlugin_writeData[13 : 13];
-  assign _zz_441_ = execute_CsrPlugin_writeData[4 : 4];
-  assign _zz_442_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_443_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_444_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_445_ = execute_CsrPlugin_writeData[12 : 12];
-  assign _zz_446_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_447_ = execute_CsrPlugin_writeData[6 : 6];
-  assign _zz_448_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_449_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_450_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_451_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_452_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_453_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_454_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_455_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_456_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_457_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_458_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_459_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_460_ = 1'b1;
-  assign _zz_461_ = 1'b1;
-  assign _zz_462_ = {_zz_60_,{_zz_62_,_zz_61_}};
-  assign _zz_463_ = 32'h0000107f;
-  assign _zz_464_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_465_ = 32'h00002073;
-  assign _zz_466_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_467_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_468_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_469_) == 32'h00000003),{(_zz_470_ == _zz_471_),{_zz_472_,{_zz_473_,_zz_474_}}}}}};
-  assign _zz_469_ = 32'h0000505f;
-  assign _zz_470_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_471_ = 32'h00000063;
-  assign _zz_472_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_473_ = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
-  assign _zz_474_ = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_475_) == 32'h0000500f),{(_zz_476_ == _zz_477_),{_zz_478_,{_zz_479_,_zz_480_}}}}}};
-  assign _zz_475_ = 32'h01f0707f;
-  assign _zz_476_ = (decode_INSTRUCTION & 32'hbc00707f);
-  assign _zz_477_ = 32'h00005013;
-  assign _zz_478_ = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
-  assign _zz_479_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_480_ = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_481_) == 32'h12000073),{(_zz_482_ == _zz_483_),{_zz_484_,_zz_485_}}}}};
-  assign _zz_481_ = 32'hfe007fff;
-  assign _zz_482_ = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_483_ = 32'h10200073;
-  assign _zz_484_ = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_485_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_486_ = decode_INSTRUCTION[31];
-  assign _zz_487_ = decode_INSTRUCTION[31];
-  assign _zz_488_ = decode_INSTRUCTION[7];
-  assign _zz_489_ = 32'h00000064;
-  assign _zz_490_ = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_491_ = 32'h02004020;
-  assign _zz_492_ = {_zz_97_,{(_zz_497_ == _zz_498_),{_zz_499_,{_zz_500_,_zz_501_}}}};
-  assign _zz_493_ = 7'h0;
-  assign _zz_494_ = ({_zz_101_,(_zz_502_ == _zz_503_)} != (2'b00));
-  assign _zz_495_ = ((_zz_504_ == _zz_505_) != (1'b0));
-  assign _zz_496_ = {({_zz_506_,_zz_507_} != (3'b000)),{(_zz_508_ != _zz_509_),{_zz_510_,{_zz_511_,_zz_512_}}}};
-  assign _zz_497_ = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_498_ = 32'h00001010;
-  assign _zz_499_ = ((decode_INSTRUCTION & _zz_513_) == 32'h00002010);
-  assign _zz_500_ = (_zz_514_ == _zz_515_);
-  assign _zz_501_ = {_zz_516_,{_zz_517_,_zz_518_}};
-  assign _zz_502_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_503_ = 32'h0;
-  assign _zz_504_ = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz_505_ = 32'h10000008;
-  assign _zz_506_ = (_zz_519_ == _zz_520_);
-  assign _zz_507_ = {_zz_521_,_zz_522_};
-  assign _zz_508_ = {_zz_97_,{_zz_523_,_zz_524_}};
-  assign _zz_509_ = (3'b000);
-  assign _zz_510_ = ({_zz_525_,_zz_526_} != (2'b00));
-  assign _zz_511_ = (_zz_527_ != _zz_528_);
-  assign _zz_512_ = {_zz_529_,{_zz_530_,_zz_531_}};
-  assign _zz_513_ = 32'h00002010;
-  assign _zz_514_ = (decode_INSTRUCTION & 32'h00002008);
-  assign _zz_515_ = 32'h00002008;
-  assign _zz_516_ = ((decode_INSTRUCTION & _zz_532_) == 32'h00000010);
-  assign _zz_517_ = _zz_98_;
-  assign _zz_518_ = (_zz_533_ == _zz_534_);
-  assign _zz_519_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_520_ = 32'h00000040;
-  assign _zz_521_ = ((decode_INSTRUCTION & _zz_535_) == 32'h00002010);
-  assign _zz_522_ = ((decode_INSTRUCTION & _zz_536_) == 32'h40000030);
-  assign _zz_523_ = _zz_102_;
-  assign _zz_524_ = (_zz_537_ == _zz_538_);
-  assign _zz_525_ = _zz_102_;
-  assign _zz_526_ = (_zz_539_ == _zz_540_);
-  assign _zz_527_ = {_zz_541_,{_zz_542_,_zz_543_}};
-  assign _zz_528_ = (3'b000);
-  assign _zz_529_ = ({_zz_544_,_zz_545_} != (2'b00));
-  assign _zz_530_ = (_zz_546_ != _zz_547_);
-  assign _zz_531_ = {_zz_548_,{_zz_549_,_zz_550_}};
-  assign _zz_532_ = 32'h00000050;
-  assign _zz_533_ = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_534_ = 32'h0;
-  assign _zz_535_ = 32'h00002014;
-  assign _zz_536_ = 32'h40000034;
-  assign _zz_537_ = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_538_ = 32'h00000004;
-  assign _zz_539_ = (decode_INSTRUCTION & 32'h0000004c);
-  assign _zz_540_ = 32'h00000004;
-  assign _zz_541_ = ((decode_INSTRUCTION & _zz_551_) == 32'h08000020);
-  assign _zz_542_ = (_zz_552_ == _zz_553_);
-  assign _zz_543_ = (_zz_554_ == _zz_555_);
-  assign _zz_544_ = (_zz_556_ == _zz_557_);
-  assign _zz_545_ = (_zz_558_ == _zz_559_);
-  assign _zz_546_ = {_zz_560_,{_zz_561_,_zz_562_}};
-  assign _zz_547_ = (4'b0000);
-  assign _zz_548_ = ({_zz_563_,_zz_564_} != 5'h0);
-  assign _zz_549_ = (_zz_565_ != _zz_566_);
-  assign _zz_550_ = {_zz_567_,{_zz_568_,_zz_569_}};
-  assign _zz_551_ = 32'h08000020;
-  assign _zz_552_ = (decode_INSTRUCTION & 32'h10000020);
-  assign _zz_553_ = 32'h00000020;
-  assign _zz_554_ = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_555_ = 32'h00000020;
-  assign _zz_556_ = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_557_ = 32'h00001050;
-  assign _zz_558_ = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_559_ = 32'h00002050;
-  assign _zz_560_ = ((decode_INSTRUCTION & _zz_570_) == 32'h00000020);
-  assign _zz_561_ = (_zz_571_ == _zz_572_);
-  assign _zz_562_ = {_zz_573_,_zz_574_};
-  assign _zz_563_ = (_zz_575_ == _zz_576_);
-  assign _zz_564_ = {_zz_577_,{_zz_578_,_zz_579_}};
-  assign _zz_565_ = (_zz_580_ == _zz_581_);
-  assign _zz_566_ = (1'b0);
-  assign _zz_567_ = (_zz_582_ != (1'b0));
-  assign _zz_568_ = (_zz_583_ != _zz_584_);
-  assign _zz_569_ = {_zz_585_,{_zz_586_,_zz_587_}};
-  assign _zz_570_ = 32'h00000034;
-  assign _zz_571_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_572_ = 32'h00000020;
-  assign _zz_573_ = ((decode_INSTRUCTION & _zz_588_) == 32'h08000020);
-  assign _zz_574_ = ((decode_INSTRUCTION & _zz_589_) == 32'h00000020);
-  assign _zz_575_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_576_ = 32'h0;
-  assign _zz_577_ = ((decode_INSTRUCTION & _zz_590_) == 32'h0);
-  assign _zz_578_ = (_zz_591_ == _zz_592_);
-  assign _zz_579_ = {_zz_593_,_zz_101_};
-  assign _zz_580_ = (decode_INSTRUCTION & 32'h02003050);
-  assign _zz_581_ = 32'h02000050;
-  assign _zz_582_ = ((decode_INSTRUCTION & _zz_594_) == 32'h00000008);
-  assign _zz_583_ = {_zz_595_,_zz_596_};
-  assign _zz_584_ = (2'b00);
-  assign _zz_585_ = ({_zz_597_,_zz_598_} != (3'b000));
-  assign _zz_586_ = (_zz_599_ != _zz_600_);
-  assign _zz_587_ = {_zz_601_,{_zz_602_,_zz_603_}};
-  assign _zz_588_ = 32'h08000070;
-  assign _zz_589_ = 32'h10000070;
-  assign _zz_590_ = 32'h00000018;
-  assign _zz_591_ = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_592_ = 32'h00002000;
-  assign _zz_593_ = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_594_ = 32'h10000008;
-  assign _zz_595_ = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
-  assign _zz_596_ = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
-  assign _zz_597_ = ((decode_INSTRUCTION & _zz_604_) == 32'h40001010);
-  assign _zz_598_ = {(_zz_605_ == _zz_606_),(_zz_607_ == _zz_608_)};
-  assign _zz_599_ = _zz_100_;
-  assign _zz_600_ = (1'b0);
-  assign _zz_601_ = ({_zz_609_,_zz_610_} != (2'b00));
-  assign _zz_602_ = (_zz_611_ != (1'b0));
-  assign _zz_603_ = {(_zz_612_ != _zz_613_),{_zz_614_,{_zz_615_,_zz_616_}}};
-  assign _zz_604_ = 32'h40003054;
-  assign _zz_605_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_606_ = 32'h00001010;
-  assign _zz_607_ = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_608_ = 32'h00001010;
-  assign _zz_609_ = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_610_ = ((decode_INSTRUCTION & 32'h12203050) == 32'h10000050);
-  assign _zz_611_ = ((decode_INSTRUCTION & 32'h02103050) == 32'h00000050);
-  assign _zz_612_ = ((decode_INSTRUCTION & _zz_617_) == 32'h00001000);
-  assign _zz_613_ = (1'b0);
-  assign _zz_614_ = ((_zz_618_ == _zz_619_) != (1'b0));
-  assign _zz_615_ = (_zz_620_ != (1'b0));
-  assign _zz_616_ = {(_zz_621_ != _zz_622_),{_zz_623_,{_zz_624_,_zz_625_}}};
-  assign _zz_617_ = 32'h00001000;
-  assign _zz_618_ = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_619_ = 32'h00002000;
-  assign _zz_620_ = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
-  assign _zz_621_ = {_zz_99_,((decode_INSTRUCTION & _zz_626_) == 32'h00000020)};
-  assign _zz_622_ = (2'b00);
-  assign _zz_623_ = ({_zz_99_,(_zz_627_ == _zz_628_)} != (2'b00));
-  assign _zz_624_ = ((_zz_629_ == _zz_630_) != (1'b0));
-  assign _zz_625_ = {({_zz_631_,_zz_632_} != 5'h0),{(_zz_633_ != _zz_634_),{_zz_635_,{_zz_636_,_zz_637_}}}};
-  assign _zz_626_ = 32'h00000070;
-  assign _zz_627_ = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_628_ = 32'h0;
-  assign _zz_629_ = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz_630_ = 32'h00100050;
-  assign _zz_631_ = ((decode_INSTRUCTION & _zz_638_) == 32'h00000040);
-  assign _zz_632_ = {(_zz_639_ == _zz_640_),{_zz_641_,{_zz_642_,_zz_643_}}};
-  assign _zz_633_ = ((decode_INSTRUCTION & _zz_644_) == 32'h00004008);
-  assign _zz_634_ = (1'b0);
-  assign _zz_635_ = ({_zz_645_,{_zz_646_,_zz_647_}} != 6'h0);
-  assign _zz_636_ = ({_zz_648_,_zz_649_} != 5'h0);
-  assign _zz_637_ = {(_zz_650_ != _zz_651_),{_zz_652_,{_zz_653_,_zz_654_}}};
-  assign _zz_638_ = 32'h00000040;
-  assign _zz_639_ = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_640_ = 32'h00004020;
-  assign _zz_641_ = ((decode_INSTRUCTION & _zz_655_) == 32'h00000010);
-  assign _zz_642_ = _zz_98_;
-  assign _zz_643_ = (_zz_656_ == _zz_657_);
-  assign _zz_644_ = 32'h00004048;
-  assign _zz_645_ = ((decode_INSTRUCTION & _zz_658_) == 32'h00002040);
-  assign _zz_646_ = (_zz_659_ == _zz_660_);
-  assign _zz_647_ = {_zz_661_,{_zz_662_,_zz_663_}};
-  assign _zz_648_ = _zz_98_;
-  assign _zz_649_ = {_zz_664_,{_zz_665_,_zz_666_}};
-  assign _zz_650_ = (_zz_667_ == _zz_668_);
-  assign _zz_651_ = (1'b0);
-  assign _zz_652_ = ({_zz_669_,_zz_670_} != (2'b00));
-  assign _zz_653_ = (_zz_671_ != _zz_672_);
-  assign _zz_654_ = {_zz_673_,{_zz_674_,_zz_675_}};
-  assign _zz_655_ = 32'h00000030;
-  assign _zz_656_ = (decode_INSTRUCTION & 32'h02000028);
-  assign _zz_657_ = 32'h00000020;
-  assign _zz_658_ = 32'h00002040;
-  assign _zz_659_ = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_660_ = 32'h00001040;
-  assign _zz_661_ = ((decode_INSTRUCTION & _zz_676_) == 32'h00000040);
-  assign _zz_662_ = (_zz_677_ == _zz_678_);
-  assign _zz_663_ = {_zz_679_,_zz_680_};
-  assign _zz_664_ = ((decode_INSTRUCTION & _zz_681_) == 32'h00002010);
-  assign _zz_665_ = (_zz_682_ == _zz_683_);
-  assign _zz_666_ = {_zz_684_,_zz_685_};
-  assign _zz_667_ = (decode_INSTRUCTION & 32'h02004074);
-  assign _zz_668_ = 32'h02000030;
-  assign _zz_669_ = (_zz_686_ == _zz_687_);
-  assign _zz_670_ = (_zz_688_ == _zz_689_);
-  assign _zz_671_ = {_zz_97_,_zz_690_};
-  assign _zz_672_ = (2'b00);
-  assign _zz_673_ = (_zz_691_ != (1'b0));
-  assign _zz_674_ = (_zz_692_ != _zz_693_);
-  assign _zz_675_ = (_zz_694_ != _zz_695_);
-  assign _zz_676_ = 32'h00000050;
-  assign _zz_677_ = (decode_INSTRUCTION & 32'h02100040);
-  assign _zz_678_ = 32'h00000040;
-  assign _zz_679_ = ((decode_INSTRUCTION & 32'h00000038) == 32'h0);
-  assign _zz_680_ = ((decode_INSTRUCTION & 32'h18002008) == 32'h10002008);
-  assign _zz_681_ = 32'h00002030;
-  assign _zz_682_ = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_683_ = 32'h00000010;
-  assign _zz_684_ = ((decode_INSTRUCTION & 32'h02003020) == 32'h00000020);
-  assign _zz_685_ = ((decode_INSTRUCTION & 32'h02002068) == 32'h00002020);
-  assign _zz_686_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_687_ = 32'h00002000;
-  assign _zz_688_ = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_689_ = 32'h00001000;
-  assign _zz_690_ = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_691_ = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_692_ = ((decode_INSTRUCTION & 32'h00004014) == 32'h00004010);
-  assign _zz_693_ = (1'b0);
-  assign _zz_694_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz_695_ = (1'b0);
-  assign _zz_696_ = execute_INSTRUCTION[31];
-  assign _zz_697_ = execute_INSTRUCTION[31];
-  assign _zz_698_ = execute_INSTRUCTION[7];
-  assign _zz_699_ = 32'h0;
+  assign _zz_268 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_269 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_270 = 1'b1;
+  assign _zz_271 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_272 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_273 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_274 = ((_zz_213 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_275 = ((_zz_213 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_276 = ((_zz_213 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_277 = ((_zz_213 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_278 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_279 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_280 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign _zz_281 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign _zz_282 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_283 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_284 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign _zz_285 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_286 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign _zz_287 = (! dataCache_1_io_cpu_execute_refilling);
+  assign _zz_288 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_289 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign _zz_290 = MmuPlugin_shared_portSortedOh[0];
+  assign _zz_291 = MmuPlugin_shared_portSortedOh[1];
+  assign _zz_292 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_293 = (1'b0 || (! 1'b1));
+  assign _zz_294 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_295 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_296 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_297 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_298 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_299 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_300 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_301 = execute_INSTRUCTION[13 : 12];
+  assign _zz_302 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_303 = (! memory_arbitration_isStuck);
+  assign _zz_304 = debug_bus_cmd_payload_address[7 : 2];
+  assign _zz_305 = (iBus_cmd_valid || (_zz_199 != 3'b000));
+  assign _zz_306 = (_zz_242 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_307 = (MmuPlugin_shared_refills != 2'b00);
+  assign _zz_308 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign _zz_309 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign _zz_310 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign _zz_311 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign _zz_312 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign _zz_313 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign _zz_314 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign _zz_315 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign _zz_316 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign _zz_317 = ((_zz_156 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign _zz_318 = ((_zz_157 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign _zz_319 = ((_zz_158 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign _zz_320 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_321 = ((_zz_156 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign _zz_322 = ((_zz_157 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign _zz_323 = ((_zz_158 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign _zz_324 = ((_zz_159 && 1'b1) && (! 1'b0));
+  assign _zz_325 = ((_zz_160 && 1'b1) && (! 1'b0));
+  assign _zz_326 = ((_zz_161 && 1'b1) && (! 1'b0));
+  assign _zz_327 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_328 = execute_INSTRUCTION[13];
+  assign _zz_329 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_330 = ($signed(_zz_331) + $signed(_zz_336));
+  assign _zz_331 = ($signed(_zz_332) + $signed(_zz_334));
+  assign _zz_332 = 52'h0;
+  assign _zz_333 = {1'b0,memory_MUL_LL};
+  assign _zz_334 = {{19{_zz_333[32]}}, _zz_333};
+  assign _zz_335 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_336 = {{2{_zz_335[49]}}, _zz_335};
+  assign _zz_337 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_338 = {{2{_zz_337[49]}}, _zz_337};
+  assign _zz_339 = ($signed(_zz_341) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_340 = _zz_339[31 : 0];
+  assign _zz_341 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_342 = _zz_104[34 : 34];
+  assign _zz_343 = _zz_104[33 : 33];
+  assign _zz_344 = _zz_104[32 : 32];
+  assign _zz_345 = _zz_104[31 : 31];
+  assign _zz_346 = _zz_104[28 : 28];
+  assign _zz_347 = _zz_104[21 : 21];
+  assign _zz_348 = _zz_104[20 : 20];
+  assign _zz_349 = _zz_104[19 : 19];
+  assign _zz_350 = _zz_104[13 : 13];
+  assign _zz_351 = _zz_104[12 : 12];
+  assign _zz_352 = _zz_104[11 : 11];
+  assign _zz_353 = _zz_104[35 : 35];
+  assign _zz_354 = _zz_104[17 : 17];
+  assign _zz_355 = _zz_104[5 : 5];
+  assign _zz_356 = _zz_104[3 : 3];
+  assign _zz_357 = _zz_104[18 : 18];
+  assign _zz_358 = _zz_104[10 : 10];
+  assign _zz_359 = _zz_104[16 : 16];
+  assign _zz_360 = _zz_104[15 : 15];
+  assign _zz_361 = _zz_104[4 : 4];
+  assign _zz_362 = _zz_104[0 : 0];
+  assign _zz_363 = (_zz_57 - 5'h01);
+  assign _zz_364 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_365 = {29'd0, _zz_364};
+  assign _zz_366 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_367 = {{_zz_73,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_368 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_369 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_370 = {{_zz_75,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_371 = {{_zz_77,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_372 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_373 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_374 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_375 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_376 = MmuPlugin_ports_0_entryToReplace_willIncrement;
+  assign _zz_377 = {1'd0, _zz_376};
+  assign _zz_378 = MmuPlugin_ports_1_entryToReplace_willIncrement;
+  assign _zz_379 = {1'd0, _zz_378};
+  assign _zz_380 = MmuPlugin_shared_dBusRspStaged_payload_data[0 : 0];
+  assign _zz_381 = MmuPlugin_shared_dBusRspStaged_payload_data[1 : 1];
+  assign _zz_382 = MmuPlugin_shared_dBusRspStaged_payload_data[2 : 2];
+  assign _zz_383 = MmuPlugin_shared_dBusRspStaged_payload_data[3 : 3];
+  assign _zz_384 = MmuPlugin_shared_dBusRspStaged_payload_data[4 : 4];
+  assign _zz_385 = MmuPlugin_shared_dBusRspStaged_payload_data[5 : 5];
+  assign _zz_386 = MmuPlugin_shared_dBusRspStaged_payload_data[6 : 6];
+  assign _zz_387 = MmuPlugin_shared_dBusRspStaged_payload_data[7 : 7];
+  assign _zz_388 = (_zz_100 - 2'b01);
+  assign _zz_389 = execute_SRC_LESS;
+  assign _zz_390 = 3'b100;
+  assign _zz_391 = execute_INSTRUCTION[19 : 15];
+  assign _zz_392 = execute_INSTRUCTION[31 : 20];
+  assign _zz_393 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_394 = ($signed(_zz_395) + $signed(_zz_398));
+  assign _zz_395 = ($signed(_zz_396) + $signed(_zz_397));
+  assign _zz_396 = execute_SRC1;
+  assign _zz_397 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_398 = (execute_SRC_USE_SUB_LESS ? _zz_399 : _zz_400);
+  assign _zz_399 = 32'h00000001;
+  assign _zz_400 = 32'h0;
+  assign _zz_401 = execute_INSTRUCTION[31 : 20];
+  assign _zz_402 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_403 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_404 = {_zz_143,execute_INSTRUCTION[31 : 20]};
+  assign _zz_405 = {{_zz_145,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_406 = {{_zz_147,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_407 = execute_INSTRUCTION[31 : 20];
+  assign _zz_408 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_409 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_410 = 3'b100;
+  assign _zz_411 = (_zz_162 & (~ _zz_412));
+  assign _zz_412 = (_zz_162 - 2'b01);
+  assign _zz_413 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_414 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_415 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_416 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_417 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_418 = {5'd0, _zz_417};
+  assign _zz_419 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_420 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_421 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_422 = {_zz_164,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_423 = _zz_424;
+  assign _zz_424 = _zz_425;
+  assign _zz_425 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_165) : _zz_165)} + _zz_427);
+  assign _zz_426 = memory_DivPlugin_div_needRevert;
+  assign _zz_427 = {32'd0, _zz_426};
+  assign _zz_428 = _zz_167;
+  assign _zz_429 = {32'd0, _zz_428};
+  assign _zz_430 = _zz_166;
+  assign _zz_431 = {31'd0, _zz_430};
+  assign _zz_432 = execute_CsrPlugin_writeData[19 : 19];
+  assign _zz_433 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_434 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_435 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_436 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_437 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_438 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_439 = execute_CsrPlugin_writeData[19 : 19];
+  assign _zz_440 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_441 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_442 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_443 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_444 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_445 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_446 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_447 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_448 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_449 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_450 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_451 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_452 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_453 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_454 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_455 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_456 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_457 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_458 = execute_CsrPlugin_writeData[4 : 4];
+  assign _zz_459 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_460 = execute_CsrPlugin_writeData[6 : 6];
+  assign _zz_461 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_462 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_463 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_464 = execute_CsrPlugin_writeData[12 : 12];
+  assign _zz_465 = execute_CsrPlugin_writeData[13 : 13];
+  assign _zz_466 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_467 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_468 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_469 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_470 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_471 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_472 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_473 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_474 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_475 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_476 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_477 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_478 = 1'b1;
+  assign _zz_479 = 1'b1;
+  assign _zz_480 = {_zz_60,{_zz_62,_zz_61}};
+  assign _zz_481 = 32'h0000107f;
+  assign _zz_482 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_483 = 32'h00002073;
+  assign _zz_484 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_485 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_486 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_487) == 32'h00000003),{(_zz_488 == _zz_489),{_zz_490,{_zz_491,_zz_492}}}}}};
+  assign _zz_487 = 32'h0000505f;
+  assign _zz_488 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_489 = 32'h00000063;
+  assign _zz_490 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_491 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
+  assign _zz_492 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_493) == 32'h0000500f),{(_zz_494 == _zz_495),{_zz_496,{_zz_497,_zz_498}}}}}};
+  assign _zz_493 = 32'h01f0707f;
+  assign _zz_494 = (decode_INSTRUCTION & 32'hbc00707f);
+  assign _zz_495 = 32'h00005013;
+  assign _zz_496 = ((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013);
+  assign _zz_497 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_498 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_499) == 32'h12000073),{(_zz_500 == _zz_501),{_zz_502,_zz_503}}}}};
+  assign _zz_499 = 32'hfe007fff;
+  assign _zz_500 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_501 = 32'h10200073;
+  assign _zz_502 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_503 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_504 = decode_INSTRUCTION[31];
+  assign _zz_505 = decode_INSTRUCTION[31];
+  assign _zz_506 = decode_INSTRUCTION[7];
+  assign _zz_507 = 32'h10103050;
+  assign _zz_508 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz_509 = 1'b0;
+  assign _zz_510 = (((decode_INSTRUCTION & _zz_513) == 32'h02000030) != 1'b0);
+  assign _zz_511 = ({_zz_514,_zz_515} != 2'b00);
+  assign _zz_512 = {(_zz_516 != 1'b0),{(_zz_517 != _zz_518),{_zz_519,{_zz_520,_zz_521}}}};
+  assign _zz_513 = 32'h02004074;
+  assign _zz_514 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz_515 = ((decode_INSTRUCTION & 32'h12203050) == 32'h10000050);
+  assign _zz_516 = ((decode_INSTRUCTION & 32'h02103050) == 32'h00000050);
+  assign _zz_517 = {(_zz_522 == _zz_523),(_zz_524 == _zz_525)};
+  assign _zz_518 = 2'b00;
+  assign _zz_519 = ({_zz_106,_zz_526} != 2'b00);
+  assign _zz_520 = (_zz_527 != 1'b0);
+  assign _zz_521 = {(_zz_528 != _zz_529),{_zz_530,{_zz_531,_zz_532}}};
+  assign _zz_522 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_523 = 32'h00001050;
+  assign _zz_524 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_525 = 32'h00002050;
+  assign _zz_526 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_527 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_528 = {(_zz_533 == _zz_534),(_zz_535 == _zz_536)};
+  assign _zz_529 = 2'b00;
+  assign _zz_530 = ({_zz_537,{_zz_538,_zz_539}} != 3'b000);
+  assign _zz_531 = (_zz_540 != 1'b0);
+  assign _zz_532 = {(_zz_541 != _zz_542),{_zz_543,{_zz_544,_zz_545}}};
+  assign _zz_533 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_534 = 32'h00005010;
+  assign _zz_535 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz_536 = 32'h00005020;
+  assign _zz_537 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz_538 = ((decode_INSTRUCTION & _zz_546) == 32'h00001010);
+  assign _zz_539 = ((decode_INSTRUCTION & _zz_547) == 32'h00001010);
+  assign _zz_540 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz_541 = ((decode_INSTRUCTION & _zz_548) == 32'h00002000);
+  assign _zz_542 = 1'b0;
+  assign _zz_543 = ({_zz_549,_zz_550} != 2'b00);
+  assign _zz_544 = (_zz_551 != 1'b0);
+  assign _zz_545 = {(_zz_552 != _zz_553),{_zz_554,{_zz_555,_zz_556}}};
+  assign _zz_546 = 32'h00007034;
+  assign _zz_547 = 32'h02007054;
+  assign _zz_548 = 32'h00003000;
+  assign _zz_549 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz_550 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz_551 = ((decode_INSTRUCTION & 32'h02003050) == 32'h02000050);
+  assign _zz_552 = ((decode_INSTRUCTION & _zz_557) == 32'h00004008);
+  assign _zz_553 = 1'b0;
+  assign _zz_554 = ((_zz_558 == _zz_559) != 1'b0);
+  assign _zz_555 = ({_zz_560,_zz_561} != 4'b0000);
+  assign _zz_556 = {(_zz_562 != _zz_563),{_zz_564,{_zz_565,_zz_566}}};
+  assign _zz_557 = 32'h00004048;
+  assign _zz_558 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_559 = 32'h00000024;
+  assign _zz_560 = ((decode_INSTRUCTION & _zz_567) == 32'h00000020);
+  assign _zz_561 = {(_zz_568 == _zz_569),{_zz_570,_zz_571}};
+  assign _zz_562 = ((decode_INSTRUCTION & _zz_572) == 32'h00000008);
+  assign _zz_563 = 1'b0;
+  assign _zz_564 = ((_zz_573 == _zz_574) != 1'b0);
+  assign _zz_565 = ({_zz_575,_zz_576} != 6'h0);
+  assign _zz_566 = {(_zz_577 != _zz_578),{_zz_579,{_zz_580,_zz_581}}};
+  assign _zz_567 = 32'h00000034;
+  assign _zz_568 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_569 = 32'h00000020;
+  assign _zz_570 = ((decode_INSTRUCTION & _zz_582) == 32'h08000020);
+  assign _zz_571 = ((decode_INSTRUCTION & _zz_583) == 32'h00000020);
+  assign _zz_572 = 32'h10000008;
+  assign _zz_573 = (decode_INSTRUCTION & 32'h10000008);
+  assign _zz_574 = 32'h10000008;
+  assign _zz_575 = (_zz_584 == _zz_585);
+  assign _zz_576 = {_zz_586,{_zz_587,_zz_588}};
+  assign _zz_577 = {_zz_589,{_zz_590,_zz_591}};
+  assign _zz_578 = 3'b000;
+  assign _zz_579 = ({_zz_592,_zz_593} != 5'h0);
+  assign _zz_580 = (_zz_594 != _zz_595);
+  assign _zz_581 = {_zz_596,{_zz_597,_zz_598}};
+  assign _zz_582 = 32'h08000070;
+  assign _zz_583 = 32'h10000070;
+  assign _zz_584 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz_585 = 32'h00002040;
+  assign _zz_586 = ((decode_INSTRUCTION & _zz_599) == 32'h00001040);
+  assign _zz_587 = (_zz_600 == _zz_601);
+  assign _zz_588 = {_zz_602,{_zz_603,_zz_604}};
+  assign _zz_589 = ((decode_INSTRUCTION & _zz_605) == 32'h08000020);
+  assign _zz_590 = (_zz_606 == _zz_607);
+  assign _zz_591 = (_zz_608 == _zz_609);
+  assign _zz_592 = (_zz_610 == _zz_611);
+  assign _zz_593 = {_zz_612,{_zz_613,_zz_614}};
+  assign _zz_594 = {_zz_109,{_zz_615,_zz_616}};
+  assign _zz_595 = 5'h0;
+  assign _zz_596 = ({_zz_617,_zz_618} != 7'h0);
+  assign _zz_597 = (_zz_619 != _zz_620);
+  assign _zz_598 = {_zz_621,{_zz_622,_zz_623}};
+  assign _zz_599 = 32'h00001040;
+  assign _zz_600 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_601 = 32'h00000040;
+  assign _zz_602 = ((decode_INSTRUCTION & _zz_624) == 32'h00000040);
+  assign _zz_603 = (_zz_625 == _zz_626);
+  assign _zz_604 = (_zz_627 == _zz_628);
+  assign _zz_605 = 32'h08000020;
+  assign _zz_606 = (decode_INSTRUCTION & 32'h10000020);
+  assign _zz_607 = 32'h00000020;
+  assign _zz_608 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_609 = 32'h00000020;
+  assign _zz_610 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_611 = 32'h00000040;
+  assign _zz_612 = ((decode_INSTRUCTION & _zz_629) == 32'h00004020);
+  assign _zz_613 = (_zz_630 == _zz_631);
+  assign _zz_614 = {_zz_109,_zz_632};
+  assign _zz_615 = (_zz_633 == _zz_634);
+  assign _zz_616 = {_zz_635,{_zz_636,_zz_637}};
+  assign _zz_617 = _zz_106;
+  assign _zz_618 = {_zz_638,{_zz_639,_zz_640}};
+  assign _zz_619 = {_zz_108,_zz_641};
+  assign _zz_620 = 2'b00;
+  assign _zz_621 = ({_zz_642,_zz_643} != 2'b00);
+  assign _zz_622 = (_zz_644 != _zz_645);
+  assign _zz_623 = {_zz_646,{_zz_647,_zz_648}};
+  assign _zz_624 = 32'h02100040;
+  assign _zz_625 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_626 = 32'h0;
+  assign _zz_627 = (decode_INSTRUCTION & 32'h18002008);
+  assign _zz_628 = 32'h10002008;
+  assign _zz_629 = 32'h00004020;
+  assign _zz_630 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_631 = 32'h00000010;
+  assign _zz_632 = ((decode_INSTRUCTION & _zz_649) == 32'h00000020);
+  assign _zz_633 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz_634 = 32'h00002010;
+  assign _zz_635 = ((decode_INSTRUCTION & _zz_650) == 32'h00000010);
+  assign _zz_636 = (_zz_651 == _zz_652);
+  assign _zz_637 = (_zz_653 == _zz_654);
+  assign _zz_638 = ((decode_INSTRUCTION & _zz_655) == 32'h00001010);
+  assign _zz_639 = (_zz_656 == _zz_657);
+  assign _zz_640 = {_zz_658,{_zz_659,_zz_660}};
+  assign _zz_641 = ((decode_INSTRUCTION & _zz_661) == 32'h00000020);
+  assign _zz_642 = _zz_108;
+  assign _zz_643 = (_zz_662 == _zz_663);
+  assign _zz_644 = (_zz_664 == _zz_665);
+  assign _zz_645 = 1'b0;
+  assign _zz_646 = (_zz_666 != 1'b0);
+  assign _zz_647 = (_zz_667 != _zz_668);
+  assign _zz_648 = {_zz_669,{_zz_670,_zz_671}};
+  assign _zz_649 = 32'h02000028;
+  assign _zz_650 = 32'h00001030;
+  assign _zz_651 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz_652 = 32'h00000020;
+  assign _zz_653 = (decode_INSTRUCTION & 32'h02002068);
+  assign _zz_654 = 32'h00002020;
+  assign _zz_655 = 32'h00001010;
+  assign _zz_656 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_657 = 32'h00002010;
+  assign _zz_658 = ((decode_INSTRUCTION & _zz_672) == 32'h00002008);
+  assign _zz_659 = (_zz_673 == _zz_674);
+  assign _zz_660 = {_zz_109,_zz_675};
+  assign _zz_661 = 32'h00000070;
+  assign _zz_662 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_663 = 32'h0;
+  assign _zz_664 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz_665 = 32'h00004010;
+  assign _zz_666 = ((decode_INSTRUCTION & _zz_676) == 32'h00002010);
+  assign _zz_667 = {_zz_677,{_zz_678,_zz_679}};
+  assign _zz_668 = 5'h0;
+  assign _zz_669 = ({_zz_680,_zz_681} != 2'b00);
+  assign _zz_670 = (_zz_682 != _zz_683);
+  assign _zz_671 = {_zz_684,{_zz_685,_zz_686}};
+  assign _zz_672 = 32'h00002008;
+  assign _zz_673 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_674 = 32'h00000010;
+  assign _zz_675 = ((decode_INSTRUCTION & _zz_687) == 32'h0);
+  assign _zz_676 = 32'h00006014;
+  assign _zz_677 = ((decode_INSTRUCTION & _zz_688) == 32'h0);
+  assign _zz_678 = (_zz_689 == _zz_690);
+  assign _zz_679 = {_zz_691,{_zz_692,_zz_693}};
+  assign _zz_680 = _zz_107;
+  assign _zz_681 = (_zz_694 == _zz_695);
+  assign _zz_682 = {_zz_696,{_zz_697,_zz_698}};
+  assign _zz_683 = 3'b000;
+  assign _zz_684 = ({_zz_699,_zz_700} != 3'b000);
+  assign _zz_685 = (_zz_701 != _zz_702);
+  assign _zz_686 = (_zz_703 != _zz_704);
+  assign _zz_687 = 32'h00000028;
+  assign _zz_688 = 32'h00000044;
+  assign _zz_689 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_690 = 32'h0;
+  assign _zz_691 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_692 = ((decode_INSTRUCTION & _zz_705) == 32'h00001000);
+  assign _zz_693 = _zz_107;
+  assign _zz_694 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_695 = 32'h0;
+  assign _zz_696 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_697 = ((decode_INSTRUCTION & _zz_706) == 32'h00002010);
+  assign _zz_698 = ((decode_INSTRUCTION & _zz_707) == 32'h40000030);
+  assign _zz_699 = _zz_106;
+  assign _zz_700 = {_zz_105,(_zz_708 == _zz_709)};
+  assign _zz_701 = {_zz_105,(_zz_710 == _zz_711)};
+  assign _zz_702 = 2'b00;
+  assign _zz_703 = ((decode_INSTRUCTION & _zz_712) == 32'h00001008);
+  assign _zz_704 = 1'b0;
+  assign _zz_705 = 32'h00005004;
+  assign _zz_706 = 32'h00002014;
+  assign _zz_707 = 32'h40000034;
+  assign _zz_708 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz_709 = 32'h00000004;
+  assign _zz_710 = (decode_INSTRUCTION & 32'h0000004c);
+  assign _zz_711 = 32'h00000004;
+  assign _zz_712 = 32'h00005048;
+  assign _zz_713 = execute_INSTRUCTION[31];
+  assign _zz_714 = execute_INSTRUCTION[31];
+  assign _zz_715 = execute_INSTRUCTION[7];
+  assign _zz_716 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_460_) begin
-      _zz_225_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_478) begin
+      _zz_243 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_461_) begin
-      _zz_226_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_479) begin
+      _zz_244 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_200_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_201_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_202_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_203_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_204_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_205_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_206_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_207_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    ._zz_10_                                      (_zz_166_[2:0]                                                        ), //i
-    ._zz_11_                                      (IBusCachedPlugin_injectionPort_payload[31:0]                         ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_208                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_209                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_210                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_211                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_212                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]           ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_213                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_214                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_215                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_216                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    ._zz_9                                    (_zz_174[2:0]                                                ), //i
+    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_208_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_209_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (_zz_210_                                                    ), //i
-    .io_cpu_execute_args_data                      (_zz_211_[31:0]                                              ), //i
-    .io_cpu_execute_args_size                      (_zz_212_[1:0]                                               ), //i
-    .io_cpu_execute_args_isLrsc                    (_zz_213_                                                    ), //i
-    .io_cpu_execute_args_isAmo                     (_zz_214_                                                    ), //i
-    .io_cpu_execute_args_amoCtrl_swap              (_zz_215_                                                    ), //i
-    .io_cpu_execute_args_amoCtrl_alu               (_zz_216_[2:0]                                               ), //i
-    .io_cpu_memory_isValid                         (_zz_217_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_218_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_219_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_220_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_221_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_222_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_writeBack_clearLrsc                    (contextSwitching                                            ), //i
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_223_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_224_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_217                                            ), //i
+    .io_cpu_execute_address                    (_zz_218[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (_zz_219                                            ), //i
+    .io_cpu_execute_args_data                  (_zz_220[31:0]                                      ), //i
+    .io_cpu_execute_args_size                  (_zz_221[1:0]                                       ), //i
+    .io_cpu_execute_args_isLrsc                (_zz_222                                            ), //i
+    .io_cpu_execute_args_isAmo                 (_zz_223                                            ), //i
+    .io_cpu_execute_args_amoCtrl_swap          (_zz_224                                            ), //i
+    .io_cpu_execute_args_amoCtrl_alu           (_zz_225[2:0]                                       ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_226                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_227[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_228                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]  ), //i
+    .io_cpu_writeBack_isValid                  (_zz_229                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_230                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_231[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_232                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_233                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_234                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_235                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_236                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_237                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_238                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_239                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_240[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_241                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_242                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_462_)
+    case(_zz_480)
       3'b000 : begin
-        _zz_227_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_245 = DBusCachedPlugin_redoBranch_payload;
       end
       3'b001 : begin
-        _zz_227_ = CsrPlugin_jumpInterface_payload;
+        _zz_245 = CsrPlugin_jumpInterface_payload;
       end
       3'b010 : begin
-        _zz_227_ = BranchPlugin_jumpInterface_payload;
+        _zz_245 = BranchPlugin_jumpInterface_payload;
       end
       3'b011 : begin
-        _zz_227_ = CsrPlugin_redoInterface_payload;
+        _zz_245 = CsrPlugin_redoInterface_payload;
       end
       default : begin
-        _zz_227_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_245 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_92_)
+    case(_zz_93)
       2'b00 : begin
-        _zz_228_ = MmuPlugin_ports_0_cache_0_valid;
-        _zz_229_ = MmuPlugin_ports_0_cache_0_exception;
-        _zz_230_ = MmuPlugin_ports_0_cache_0_superPage;
-        _zz_231_ = MmuPlugin_ports_0_cache_0_virtualAddress_0;
-        _zz_232_ = MmuPlugin_ports_0_cache_0_virtualAddress_1;
-        _zz_233_ = MmuPlugin_ports_0_cache_0_physicalAddress_0;
-        _zz_234_ = MmuPlugin_ports_0_cache_0_physicalAddress_1;
-        _zz_235_ = MmuPlugin_ports_0_cache_0_allowRead;
-        _zz_236_ = MmuPlugin_ports_0_cache_0_allowWrite;
-        _zz_237_ = MmuPlugin_ports_0_cache_0_allowExecute;
-        _zz_238_ = MmuPlugin_ports_0_cache_0_allowUser;
+        _zz_246 = MmuPlugin_ports_0_cache_0_valid;
+        _zz_247 = MmuPlugin_ports_0_cache_0_exception;
+        _zz_248 = MmuPlugin_ports_0_cache_0_superPage;
+        _zz_249 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
+        _zz_250 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
+        _zz_251 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
+        _zz_252 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
+        _zz_253 = MmuPlugin_ports_0_cache_0_allowRead;
+        _zz_254 = MmuPlugin_ports_0_cache_0_allowWrite;
+        _zz_255 = MmuPlugin_ports_0_cache_0_allowExecute;
+        _zz_256 = MmuPlugin_ports_0_cache_0_allowUser;
       end
       2'b01 : begin
-        _zz_228_ = MmuPlugin_ports_0_cache_1_valid;
-        _zz_229_ = MmuPlugin_ports_0_cache_1_exception;
-        _zz_230_ = MmuPlugin_ports_0_cache_1_superPage;
-        _zz_231_ = MmuPlugin_ports_0_cache_1_virtualAddress_0;
-        _zz_232_ = MmuPlugin_ports_0_cache_1_virtualAddress_1;
-        _zz_233_ = MmuPlugin_ports_0_cache_1_physicalAddress_0;
-        _zz_234_ = MmuPlugin_ports_0_cache_1_physicalAddress_1;
-        _zz_235_ = MmuPlugin_ports_0_cache_1_allowRead;
-        _zz_236_ = MmuPlugin_ports_0_cache_1_allowWrite;
-        _zz_237_ = MmuPlugin_ports_0_cache_1_allowExecute;
-        _zz_238_ = MmuPlugin_ports_0_cache_1_allowUser;
+        _zz_246 = MmuPlugin_ports_0_cache_1_valid;
+        _zz_247 = MmuPlugin_ports_0_cache_1_exception;
+        _zz_248 = MmuPlugin_ports_0_cache_1_superPage;
+        _zz_249 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
+        _zz_250 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
+        _zz_251 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
+        _zz_252 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
+        _zz_253 = MmuPlugin_ports_0_cache_1_allowRead;
+        _zz_254 = MmuPlugin_ports_0_cache_1_allowWrite;
+        _zz_255 = MmuPlugin_ports_0_cache_1_allowExecute;
+        _zz_256 = MmuPlugin_ports_0_cache_1_allowUser;
       end
       2'b10 : begin
-        _zz_228_ = MmuPlugin_ports_0_cache_2_valid;
-        _zz_229_ = MmuPlugin_ports_0_cache_2_exception;
-        _zz_230_ = MmuPlugin_ports_0_cache_2_superPage;
-        _zz_231_ = MmuPlugin_ports_0_cache_2_virtualAddress_0;
-        _zz_232_ = MmuPlugin_ports_0_cache_2_virtualAddress_1;
-        _zz_233_ = MmuPlugin_ports_0_cache_2_physicalAddress_0;
-        _zz_234_ = MmuPlugin_ports_0_cache_2_physicalAddress_1;
-        _zz_235_ = MmuPlugin_ports_0_cache_2_allowRead;
-        _zz_236_ = MmuPlugin_ports_0_cache_2_allowWrite;
-        _zz_237_ = MmuPlugin_ports_0_cache_2_allowExecute;
-        _zz_238_ = MmuPlugin_ports_0_cache_2_allowUser;
+        _zz_246 = MmuPlugin_ports_0_cache_2_valid;
+        _zz_247 = MmuPlugin_ports_0_cache_2_exception;
+        _zz_248 = MmuPlugin_ports_0_cache_2_superPage;
+        _zz_249 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
+        _zz_250 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
+        _zz_251 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
+        _zz_252 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
+        _zz_253 = MmuPlugin_ports_0_cache_2_allowRead;
+        _zz_254 = MmuPlugin_ports_0_cache_2_allowWrite;
+        _zz_255 = MmuPlugin_ports_0_cache_2_allowExecute;
+        _zz_256 = MmuPlugin_ports_0_cache_2_allowUser;
       end
       default : begin
-        _zz_228_ = MmuPlugin_ports_0_cache_3_valid;
-        _zz_229_ = MmuPlugin_ports_0_cache_3_exception;
-        _zz_230_ = MmuPlugin_ports_0_cache_3_superPage;
-        _zz_231_ = MmuPlugin_ports_0_cache_3_virtualAddress_0;
-        _zz_232_ = MmuPlugin_ports_0_cache_3_virtualAddress_1;
-        _zz_233_ = MmuPlugin_ports_0_cache_3_physicalAddress_0;
-        _zz_234_ = MmuPlugin_ports_0_cache_3_physicalAddress_1;
-        _zz_235_ = MmuPlugin_ports_0_cache_3_allowRead;
-        _zz_236_ = MmuPlugin_ports_0_cache_3_allowWrite;
-        _zz_237_ = MmuPlugin_ports_0_cache_3_allowExecute;
-        _zz_238_ = MmuPlugin_ports_0_cache_3_allowUser;
+        _zz_246 = MmuPlugin_ports_0_cache_3_valid;
+        _zz_247 = MmuPlugin_ports_0_cache_3_exception;
+        _zz_248 = MmuPlugin_ports_0_cache_3_superPage;
+        _zz_249 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
+        _zz_250 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
+        _zz_251 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
+        _zz_252 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
+        _zz_253 = MmuPlugin_ports_0_cache_3_allowRead;
+        _zz_254 = MmuPlugin_ports_0_cache_3_allowWrite;
+        _zz_255 = MmuPlugin_ports_0_cache_3_allowExecute;
+        _zz_256 = MmuPlugin_ports_0_cache_3_allowUser;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_95_)
+    case(_zz_97)
       2'b00 : begin
-        _zz_239_ = MmuPlugin_ports_1_cache_0_valid;
-        _zz_240_ = MmuPlugin_ports_1_cache_0_exception;
-        _zz_241_ = MmuPlugin_ports_1_cache_0_superPage;
-        _zz_242_ = MmuPlugin_ports_1_cache_0_virtualAddress_0;
-        _zz_243_ = MmuPlugin_ports_1_cache_0_virtualAddress_1;
-        _zz_244_ = MmuPlugin_ports_1_cache_0_physicalAddress_0;
-        _zz_245_ = MmuPlugin_ports_1_cache_0_physicalAddress_1;
-        _zz_246_ = MmuPlugin_ports_1_cache_0_allowRead;
-        _zz_247_ = MmuPlugin_ports_1_cache_0_allowWrite;
-        _zz_248_ = MmuPlugin_ports_1_cache_0_allowExecute;
-        _zz_249_ = MmuPlugin_ports_1_cache_0_allowUser;
+        _zz_257 = MmuPlugin_ports_1_cache_0_valid;
+        _zz_258 = MmuPlugin_ports_1_cache_0_exception;
+        _zz_259 = MmuPlugin_ports_1_cache_0_superPage;
+        _zz_260 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
+        _zz_261 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
+        _zz_262 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
+        _zz_263 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
+        _zz_264 = MmuPlugin_ports_1_cache_0_allowRead;
+        _zz_265 = MmuPlugin_ports_1_cache_0_allowWrite;
+        _zz_266 = MmuPlugin_ports_1_cache_0_allowExecute;
+        _zz_267 = MmuPlugin_ports_1_cache_0_allowUser;
       end
       2'b01 : begin
-        _zz_239_ = MmuPlugin_ports_1_cache_1_valid;
-        _zz_240_ = MmuPlugin_ports_1_cache_1_exception;
-        _zz_241_ = MmuPlugin_ports_1_cache_1_superPage;
-        _zz_242_ = MmuPlugin_ports_1_cache_1_virtualAddress_0;
-        _zz_243_ = MmuPlugin_ports_1_cache_1_virtualAddress_1;
-        _zz_244_ = MmuPlugin_ports_1_cache_1_physicalAddress_0;
-        _zz_245_ = MmuPlugin_ports_1_cache_1_physicalAddress_1;
-        _zz_246_ = MmuPlugin_ports_1_cache_1_allowRead;
-        _zz_247_ = MmuPlugin_ports_1_cache_1_allowWrite;
-        _zz_248_ = MmuPlugin_ports_1_cache_1_allowExecute;
-        _zz_249_ = MmuPlugin_ports_1_cache_1_allowUser;
+        _zz_257 = MmuPlugin_ports_1_cache_1_valid;
+        _zz_258 = MmuPlugin_ports_1_cache_1_exception;
+        _zz_259 = MmuPlugin_ports_1_cache_1_superPage;
+        _zz_260 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
+        _zz_261 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
+        _zz_262 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
+        _zz_263 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
+        _zz_264 = MmuPlugin_ports_1_cache_1_allowRead;
+        _zz_265 = MmuPlugin_ports_1_cache_1_allowWrite;
+        _zz_266 = MmuPlugin_ports_1_cache_1_allowExecute;
+        _zz_267 = MmuPlugin_ports_1_cache_1_allowUser;
       end
       2'b10 : begin
-        _zz_239_ = MmuPlugin_ports_1_cache_2_valid;
-        _zz_240_ = MmuPlugin_ports_1_cache_2_exception;
-        _zz_241_ = MmuPlugin_ports_1_cache_2_superPage;
-        _zz_242_ = MmuPlugin_ports_1_cache_2_virtualAddress_0;
-        _zz_243_ = MmuPlugin_ports_1_cache_2_virtualAddress_1;
-        _zz_244_ = MmuPlugin_ports_1_cache_2_physicalAddress_0;
-        _zz_245_ = MmuPlugin_ports_1_cache_2_physicalAddress_1;
-        _zz_246_ = MmuPlugin_ports_1_cache_2_allowRead;
-        _zz_247_ = MmuPlugin_ports_1_cache_2_allowWrite;
-        _zz_248_ = MmuPlugin_ports_1_cache_2_allowExecute;
-        _zz_249_ = MmuPlugin_ports_1_cache_2_allowUser;
+        _zz_257 = MmuPlugin_ports_1_cache_2_valid;
+        _zz_258 = MmuPlugin_ports_1_cache_2_exception;
+        _zz_259 = MmuPlugin_ports_1_cache_2_superPage;
+        _zz_260 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
+        _zz_261 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
+        _zz_262 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
+        _zz_263 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
+        _zz_264 = MmuPlugin_ports_1_cache_2_allowRead;
+        _zz_265 = MmuPlugin_ports_1_cache_2_allowWrite;
+        _zz_266 = MmuPlugin_ports_1_cache_2_allowExecute;
+        _zz_267 = MmuPlugin_ports_1_cache_2_allowUser;
       end
       default : begin
-        _zz_239_ = MmuPlugin_ports_1_cache_3_valid;
-        _zz_240_ = MmuPlugin_ports_1_cache_3_exception;
-        _zz_241_ = MmuPlugin_ports_1_cache_3_superPage;
-        _zz_242_ = MmuPlugin_ports_1_cache_3_virtualAddress_0;
-        _zz_243_ = MmuPlugin_ports_1_cache_3_virtualAddress_1;
-        _zz_244_ = MmuPlugin_ports_1_cache_3_physicalAddress_0;
-        _zz_245_ = MmuPlugin_ports_1_cache_3_physicalAddress_1;
-        _zz_246_ = MmuPlugin_ports_1_cache_3_allowRead;
-        _zz_247_ = MmuPlugin_ports_1_cache_3_allowWrite;
-        _zz_248_ = MmuPlugin_ports_1_cache_3_allowExecute;
-        _zz_249_ = MmuPlugin_ports_1_cache_3_allowUser;
+        _zz_257 = MmuPlugin_ports_1_cache_3_valid;
+        _zz_258 = MmuPlugin_ports_1_cache_3_exception;
+        _zz_259 = MmuPlugin_ports_1_cache_3_superPage;
+        _zz_260 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
+        _zz_261 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
+        _zz_262 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
+        _zz_263 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
+        _zz_264 = MmuPlugin_ports_1_cache_3_allowRead;
+        _zz_265 = MmuPlugin_ports_1_cache_3_allowWrite;
+        _zz_266 = MmuPlugin_ports_1_cache_3_allowExecute;
+        _zz_267 = MmuPlugin_ports_1_cache_3_allowUser;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_1_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_1__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_1__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_1__string = "BITWISE ";
-      default : _zz_1__string = "????????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_2__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_2__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_2__string = "BITWISE ";
-      default : _zz_2__string = "????????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_3__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_3__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_3__string = "BITWISE ";
-      default : _zz_3__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_4__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_4__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_4__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_4__string = "JALR";
-      default : _zz_4__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_5__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_5__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_5__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_5__string = "JALR";
-      default : _zz_5__string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_6__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_6__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_6__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_6__string = "PC ";
-      default : _zz_6__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_7__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_7__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_7__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_7__string = "PC ";
-      default : _zz_7__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_8__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_8__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_8__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_8__string = "PC ";
-      default : _zz_8__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_9__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_9__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_9__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_9__string = "URS1        ";
-      default : _zz_9__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_10__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_10__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_10__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_10__string = "URS1        ";
-      default : _zz_10__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_11_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_11__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_11__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_11__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_11__string = "URS1        ";
-      default : _zz_11__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_12__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_12__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_12__string = "AND_1";
-      default : _zz_12__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13__string = "AND_1";
-      default : _zz_13__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14__string = "AND_1";
-      default : _zz_14__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15__string = "SRA_1    ";
-      default : _zz_15__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_16__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_16__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_16__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_16__string = "SRA_1    ";
-      default : _zz_16__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17__string = "SRA_1    ";
-      default : _zz_17__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_18__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_18__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_18__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_18__string = "SRA_1    ";
-      default : _zz_18__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_19__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_19__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_19__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_19__string = "SRA_1    ";
-      default : _zz_19__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_20__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_20__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_20__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_20__string = "ECALL";
-      default : _zz_20__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_21_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_21__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_21__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_21__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_21__string = "ECALL";
-      default : _zz_21__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_22_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_22__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_22__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_22__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_22__string = "ECALL";
-      default : _zz_22__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_23_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_23__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_23__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_23__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_23__string = "ECALL";
-      default : _zz_23__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3808,30 +2520,238 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_24__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_24__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_24__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_24__string = "ECALL";
-      default : _zz_24__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_25__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_25__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_25__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_25__string = "ECALL";
-      default : _zz_25__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_26__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26__string = "ECALL";
-      default : _zz_26__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3844,12 +2764,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3862,12 +2782,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3880,12 +2800,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3898,12 +2818,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -3916,12 +2836,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3934,12 +2854,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3952,12 +2872,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -3970,12 +2890,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3987,11 +2907,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -4003,72 +2923,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_43__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_43__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_43__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_43__string = "URS1        ";
-      default : _zz_43__string = "????????????";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_44__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_44__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_44__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_44__string = "SRA_1    ";
-      default : _zz_44__string = "?????????";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_45__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_45__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_45__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_45__string = "ECALL";
-      default : _zz_45__string = "?????";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46__string = "AND_1";
-      default : _zz_46__string = "?????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_47__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_47__string = "PC ";
-      default : _zz_47__string = "???";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_48__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_48__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_48__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_48__string = "JALR";
-      default : _zz_48__string = "????";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_49__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_49__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_49__string = "BITWISE ";
-      default : _zz_49__string = "????????";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4081,83 +3001,144 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_52_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_52__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_52__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52__string = "JALR";
-      default : _zz_52__string = "????";
+    case(_zz_52)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_52_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_52_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_52_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_52_string = "JALR";
+      default : _zz_52_string = "????";
     endcase
   end
   always @(*) begin
-    case(MmuPlugin_shared_state_1_)
-      `MmuPlugin_shared_State_defaultEncoding_IDLE : MmuPlugin_shared_state_1__string = "IDLE  ";
-      `MmuPlugin_shared_State_defaultEncoding_L1_CMD : MmuPlugin_shared_state_1__string = "L1_CMD";
-      `MmuPlugin_shared_State_defaultEncoding_L1_RSP : MmuPlugin_shared_state_1__string = "L1_RSP";
-      `MmuPlugin_shared_State_defaultEncoding_L0_CMD : MmuPlugin_shared_state_1__string = "L0_CMD";
-      `MmuPlugin_shared_State_defaultEncoding_L0_RSP : MmuPlugin_shared_state_1__string = "L0_RSP";
-      default : MmuPlugin_shared_state_1__string = "??????";
+    case(MmuPlugin_shared_state_1)
+      `MmuPlugin_shared_State_defaultEncoding_IDLE : MmuPlugin_shared_state_1_string = "IDLE  ";
+      `MmuPlugin_shared_State_defaultEncoding_L1_CMD : MmuPlugin_shared_state_1_string = "L1_CMD";
+      `MmuPlugin_shared_State_defaultEncoding_L1_RSP : MmuPlugin_shared_state_1_string = "L1_RSP";
+      `MmuPlugin_shared_State_defaultEncoding_L0_CMD : MmuPlugin_shared_state_1_string = "L0_CMD";
+      `MmuPlugin_shared_State_defaultEncoding_L0_RSP : MmuPlugin_shared_state_1_string = "L0_RSP";
+      default : MmuPlugin_shared_state_1_string = "??????";
     endcase
   end
   always @(*) begin
-    case(_zz_103_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_103__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_103__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_103__string = "BITWISE ";
-      default : _zz_103__string = "????????";
+    case(_zz_111)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_111_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_111_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_111_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_111_string = "URS1        ";
+      default : _zz_111_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_104_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_104__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_104__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_104__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_104__string = "JALR";
-      default : _zz_104__string = "????";
+    case(_zz_112)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_112_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_112_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_112_string = "BITWISE ";
+      default : _zz_112_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_105_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_105__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_105__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_105__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_105__string = "PC ";
-      default : _zz_105__string = "???";
+    case(_zz_113)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_113_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_113_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_113_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_113_string = "PC ";
+      default : _zz_113_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_106_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_106__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_106__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_106__string = "AND_1";
-      default : _zz_106__string = "?????";
+    case(_zz_114)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_114_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_114_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_114_string = "AND_1";
+      default : _zz_114_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_107_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_107__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_107__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_107__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_107__string = "ECALL";
-      default : _zz_107__string = "?????";
+    case(_zz_115)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_115_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_115_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_115_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_115_string = "SRA_1    ";
+      default : _zz_115_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_108_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_108__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_108__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_108__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_108__string = "SRA_1    ";
-      default : _zz_108__string = "?????????";
+    case(_zz_116)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_116_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_116_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_116_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_116_string = "JALR";
+      default : _zz_116_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_109_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_109__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_109__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_109__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_109__string = "URS1        ";
-      default : _zz_109__string = "????????????";
+    case(_zz_117)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_117_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_117_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_117_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_117_string = "ECALL";
+      default : _zz_117_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -4187,129 +3168,67 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
-      default : decode_to_execute_BRANCH_CTRL_string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
-      default : decode_to_execute_ALU_CTRL_string = "????????";
-    endcase
-  end
   `endif
 
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_313_[0];
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign memory_MUL_LOW = ($signed(_zz_330) + $signed(_zz_338));
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_SHIFT_RIGHT = _zz_340;
+  assign execute_REGFILE_WRITE_DATA = _zz_119;
+  assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_218[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_314_[0];
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign decode_IS_DIV = _zz_315_[0];
-  assign memory_MUL_LOW = ($signed(_zz_316_) + $signed(_zz_324_));
-  assign decode_SRC_LESS_UNSIGNED = _zz_325_[0];
-  assign decode_ALU_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_342[0];
+  assign decode_IS_RS1_SIGNED = _zz_343[0];
+  assign decode_IS_DIV = _zz_344[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_345[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_346[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_347[0];
   assign memory_IS_SFENCE_VMA = execute_to_memory_IS_SFENCE_VMA;
   assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
-  assign decode_IS_SFENCE_VMA = _zz_326_[0];
-  assign decode_MEMORY_AMO = _zz_327_[0];
-  assign _zz_4_ = _zz_5_;
-  assign execute_SHIFT_RIGHT = _zz_329_;
-  assign execute_REGFILE_WRITE_DATA = _zz_111_;
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_209_[1 : 0];
-  assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
-  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign decode_SRC2_CTRL = _zz_6_;
-  assign _zz_7_ = _zz_8_;
-  assign decode_SRC1_CTRL = _zz_9_;
-  assign _zz_10_ = _zz_11_;
-  assign memory_PC = execute_to_memory_PC;
+  assign decode_IS_SFENCE_VMA = _zz_348[0];
+  assign decode_MEMORY_MANAGMENT = _zz_349[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_350[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_351[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_352[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_51;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign decode_ALU_BITWISE_CTRL = _zz_12_;
-  assign _zz_13_ = _zz_14_;
-  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign decode_IS_CSR = _zz_331_[0];
-  assign decode_MEMORY_LRSC = _zz_332_[0];
-  assign decode_MEMORY_MANAGMENT = _zz_333_[0];
-  assign _zz_15_ = _zz_16_;
-  assign decode_SHIFT_CTRL = _zz_17_;
-  assign _zz_18_ = _zz_19_;
-  assign memory_MUL_HH = execute_to_memory_MUL_HH;
-  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_334_[0];
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_335_[0];
-  assign _zz_20_ = _zz_21_;
-  assign _zz_22_ = _zz_23_;
-  assign decode_ENV_CTRL = _zz_24_;
-  assign _zz_25_ = _zz_26_;
-  assign decode_IS_RS2_SIGNED = _zz_336_[0];
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_IS_RS1_SIGNED = _zz_337_[0];
+  assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_338_[0];
+  assign decode_IS_EBREAK = _zz_353[0];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -4323,25 +3242,25 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_133_;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_339_[0];
-  assign decode_RS1_USE = _zz_340_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_141;
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_354[0];
+  assign decode_RS1_USE = _zz_355[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_250_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_268)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
     if(DBusCachedPlugin_forceDatapath)begin
-      _zz_31_ = MmuPlugin_dBusAccess_cmd_payload_address;
+      _zz_31 = MmuPlugin_dBusAccess_cmd_payload_address;
     end
   end
 
@@ -4353,29 +3272,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_122_)begin
-      if((_zz_123_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_124_;
+    if(_zz_130)begin
+      if((_zz_131 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_132;
       end
     end
-    if(_zz_251_)begin
-      if(_zz_252_)begin
-        if(_zz_126_)begin
-          decode_RS2 = _zz_50_;
+    if(_zz_269)begin
+      if(_zz_270)begin
+        if(_zz_134)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_253_)begin
+    if(_zz_271)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_128_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_136)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_254_)begin
+    if(_zz_272)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_130_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_138)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -4383,29 +3302,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_122_)begin
-      if((_zz_123_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_124_;
+    if(_zz_130)begin
+      if((_zz_131 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_132;
       end
     end
-    if(_zz_251_)begin
-      if(_zz_252_)begin
-        if(_zz_125_)begin
-          decode_RS1 = _zz_50_;
+    if(_zz_269)begin
+      if(_zz_270)begin
+        if(_zz_133)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_253_)begin
+    if(_zz_271)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_127_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_135)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_254_)begin
+    if(_zz_272)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_129_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_137)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -4413,73 +3332,73 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_119_;
+          _zz_32 = _zz_127;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_255_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_273)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_341_[0];
-  assign decode_SRC_ADD_ZERO = _zz_342_[0];
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_356[0];
+  assign decode_SRC_ADD_ZERO = _zz_357[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_117_;
-  assign execute_SRC1 = _zz_112_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_125;
+  assign execute_SRC1 = _zz_120;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_343_[0];
+    decode_REGFILE_WRITE_VALID = _zz_358[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_463_) == 32'h00001073),{(_zz_464_ == _zz_465_),{_zz_466_,{_zz_467_,_zz_468_}}}}}}} != 25'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_481) == 32'h00001073),{(_zz_482 == _zz_483),{_zz_484,{_zz_485,_zz_486}}}}}}} != 25'h0);
   assign writeBack_IS_SFENCE_VMA = memory_to_writeBack_IS_SFENCE_VMA;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
   always @ (*) begin
-    _zz_50_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_50_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_312_)
+      case(_zz_329)
         2'b00 : begin
-          _zz_50_ = _zz_397_;
+          _zz_50 = _zz_415;
         end
         default : begin
-          _zz_50_ = _zz_398_;
+          _zz_50 = _zz_416;
         end
       endcase
     end
@@ -4493,62 +3412,65 @@ module VexRiscv (
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
   assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_344_[0];
-  assign decode_FLUSH_ALL = _zz_345_[0];
+  assign decode_MEMORY_AMO = _zz_359[0];
+  assign decode_MEMORY_LRSC = _zz_360[0];
+  assign decode_MEMORY_ENABLE = _zz_361[0];
+  assign decode_FLUSH_ALL = _zz_362[0];
   always @ (*) begin
-    _zz_51_ = _zz_51__2;
-    if(_zz_256_)begin
-      _zz_51_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_274)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(_zz_257_)begin
-      _zz_51__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_275)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(_zz_258_)begin
-      _zz_51__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_276)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_51__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_259_)begin
-      _zz_51__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_277)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_52_;
+  assign decode_BRANCH_CTRL = _zz_52;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_53_ = execute_FORMAL_PC_NEXT;
+    _zz_53 = execute_FORMAL_PC_NEXT;
     if(CsrPlugin_redoInterface_valid)begin
-      _zz_53_ = CsrPlugin_redoInterface_payload;
+      _zz_53 = CsrPlugin_redoInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_54_ = memory_FORMAL_PC_NEXT;
+    _zz_54 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_54_ = BranchPlugin_jumpInterface_payload;
+      _zz_54 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_55_ = decode_FORMAL_PC_NEXT;
+    _zz_55 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_55_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_55 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -4560,17 +3482,9 @@ module VexRiscv (
     if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_166_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_174)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
-      end
-      3'b011 : begin
-      end
-      3'b100 : begin
       end
       default : begin
       end
@@ -4582,20 +3496,20 @@ module VexRiscv (
     if(MmuPlugin_dBusAccess_cmd_valid)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if((decode_arbitration_isValid && (_zz_120_ || _zz_121_)))begin
+    if((decode_arbitration_isValid && (_zz_128 || _zz_129)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_260_)begin
+    if(_zz_278)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -4609,25 +3523,22 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_260_)begin
+    if(_zz_278)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_223_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_241 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_261_)begin
+    if(_zz_279)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_250_)begin
+    if(_zz_268)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -4636,7 +3547,10 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(_zz_262_)begin
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+    if(_zz_280)begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -4653,8 +3567,8 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_262_)begin
-      if(_zz_263_)begin
+    if(_zz_280)begin
+      if(_zz_281)begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -4665,13 +3579,13 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_262_)begin
-      if(_zz_263_)begin
+    if(_zz_280)begin
+      if(_zz_281)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
     if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
+      if(execute_CsrPlugin_writeInstruction)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -4679,7 +3593,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_255_)begin
+    if(_zz_273)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -4710,7 +3624,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -4741,10 +3655,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_264_)begin
+    if(_zz_282)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_265_)begin
+    if(_zz_283)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -4755,24 +3669,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_264_)begin
+    if(_zz_282)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_265_)begin
+    if(_zz_283)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_262_)begin
-      if(_zz_263_)begin
+    if(_zz_280)begin
+      if(_zz_281)begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_266_)begin
+    if(_zz_284)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -4785,15 +3699,15 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_56_ = 1'b0;
+    _zz_56 = 1'b0;
     if(DebugPlugin_godmode)begin
-      _zz_56_ = 1'b1;
+      _zz_56 = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_261_)begin
+    if(_zz_279)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -4807,21 +3721,21 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_264_)begin
+    if(_zz_282)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_265_)begin
+    if(_zz_283)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_264_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_282)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_265_)begin
-      case(_zz_267_)
+    if(_zz_283)begin
+      case(_zz_285)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4855,15 +3769,15 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
   assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}}} != 5'h0);
-  assign _zz_57_ = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
-  assign _zz_58_ = (_zz_57_ & (~ _zz_346_));
-  assign _zz_59_ = _zz_58_[3];
-  assign _zz_60_ = _zz_58_[4];
-  assign _zz_61_ = (_zz_58_[1] || _zz_59_);
-  assign _zz_62_ = (_zz_58_[2] || _zz_59_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_227_;
+  assign _zz_57 = {IBusCachedPlugin_predictionJumpInterface_valid,{CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}}};
+  assign _zz_58 = (_zz_57 & (~ _zz_363));
+  assign _zz_59 = _zz_58[3];
+  assign _zz_60 = _zz_58[4];
+  assign _zz_61 = (_zz_58[1] || _zz_59);
+  assign _zz_62 = (_zz_58[2] || _zz_59);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_245;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -4883,7 +3797,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_348_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_365);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -4923,44 +3837,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_63_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_63_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_63_);
+  assign _zz_63 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_63);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_63);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_64_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_64_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_64_);
+  assign _zz_64 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_64);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_64);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_51_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_65_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_65_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_65_);
+  assign _zz_65 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_65);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_65);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_66_;
-  assign _zz_66_ = ((1'b0 && (! _zz_67_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_67_ = _zz_68_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_67_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_66;
+  assign _zz_66 = ((1'b0 && (! _zz_67)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_67 = _zz_68;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_67;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_69_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_69_ = _zz_70_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_69_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_71_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_69)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_69 = _zz_70;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_69;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_71;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -4975,143 +3889,137 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @ (*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_166_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_174)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
       3'b011 : begin
         decode_arbitration_isValid = 1'b1;
       end
-      3'b100 : begin
-      end
       default : begin
       end
     endcase
   end
 
-  assign _zz_72_ = _zz_349_[11];
+  assign _zz_72 = _zz_366[11];
   always @ (*) begin
-    _zz_73_[18] = _zz_72_;
-    _zz_73_[17] = _zz_72_;
-    _zz_73_[16] = _zz_72_;
-    _zz_73_[15] = _zz_72_;
-    _zz_73_[14] = _zz_72_;
-    _zz_73_[13] = _zz_72_;
-    _zz_73_[12] = _zz_72_;
-    _zz_73_[11] = _zz_72_;
-    _zz_73_[10] = _zz_72_;
-    _zz_73_[9] = _zz_72_;
-    _zz_73_[8] = _zz_72_;
-    _zz_73_[7] = _zz_72_;
-    _zz_73_[6] = _zz_72_;
-    _zz_73_[5] = _zz_72_;
-    _zz_73_[4] = _zz_72_;
-    _zz_73_[3] = _zz_72_;
-    _zz_73_[2] = _zz_72_;
-    _zz_73_[1] = _zz_72_;
-    _zz_73_[0] = _zz_72_;
+    _zz_73[18] = _zz_72;
+    _zz_73[17] = _zz_72;
+    _zz_73[16] = _zz_72;
+    _zz_73[15] = _zz_72;
+    _zz_73[14] = _zz_72;
+    _zz_73[13] = _zz_72;
+    _zz_73[12] = _zz_72;
+    _zz_73[11] = _zz_72;
+    _zz_73[10] = _zz_72;
+    _zz_73[9] = _zz_72;
+    _zz_73[8] = _zz_72;
+    _zz_73[7] = _zz_72;
+    _zz_73[6] = _zz_72;
+    _zz_73[5] = _zz_72;
+    _zz_73[4] = _zz_72;
+    _zz_73[3] = _zz_72;
+    _zz_73[2] = _zz_72;
+    _zz_73[1] = _zz_72;
+    _zz_73[0] = _zz_72;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_350_[31]));
-    if(_zz_78_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_367[31]));
+    if(_zz_78)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_74_ = _zz_351_[19];
+  assign _zz_74 = _zz_368[19];
   always @ (*) begin
-    _zz_75_[10] = _zz_74_;
-    _zz_75_[9] = _zz_74_;
-    _zz_75_[8] = _zz_74_;
-    _zz_75_[7] = _zz_74_;
-    _zz_75_[6] = _zz_74_;
-    _zz_75_[5] = _zz_74_;
-    _zz_75_[4] = _zz_74_;
-    _zz_75_[3] = _zz_74_;
-    _zz_75_[2] = _zz_74_;
-    _zz_75_[1] = _zz_74_;
-    _zz_75_[0] = _zz_74_;
+    _zz_75[10] = _zz_74;
+    _zz_75[9] = _zz_74;
+    _zz_75[8] = _zz_74;
+    _zz_75[7] = _zz_74;
+    _zz_75[6] = _zz_74;
+    _zz_75[5] = _zz_74;
+    _zz_75[4] = _zz_74;
+    _zz_75[3] = _zz_74;
+    _zz_75[2] = _zz_74;
+    _zz_75[1] = _zz_74;
+    _zz_75[0] = _zz_74;
   end
 
-  assign _zz_76_ = _zz_352_[11];
+  assign _zz_76 = _zz_369[11];
   always @ (*) begin
-    _zz_77_[18] = _zz_76_;
-    _zz_77_[17] = _zz_76_;
-    _zz_77_[16] = _zz_76_;
-    _zz_77_[15] = _zz_76_;
-    _zz_77_[14] = _zz_76_;
-    _zz_77_[13] = _zz_76_;
-    _zz_77_[12] = _zz_76_;
-    _zz_77_[11] = _zz_76_;
-    _zz_77_[10] = _zz_76_;
-    _zz_77_[9] = _zz_76_;
-    _zz_77_[8] = _zz_76_;
-    _zz_77_[7] = _zz_76_;
-    _zz_77_[6] = _zz_76_;
-    _zz_77_[5] = _zz_76_;
-    _zz_77_[4] = _zz_76_;
-    _zz_77_[3] = _zz_76_;
-    _zz_77_[2] = _zz_76_;
-    _zz_77_[1] = _zz_76_;
-    _zz_77_[0] = _zz_76_;
+    _zz_77[18] = _zz_76;
+    _zz_77[17] = _zz_76;
+    _zz_77[16] = _zz_76;
+    _zz_77[15] = _zz_76;
+    _zz_77[14] = _zz_76;
+    _zz_77[13] = _zz_76;
+    _zz_77[12] = _zz_76;
+    _zz_77[11] = _zz_76;
+    _zz_77[10] = _zz_76;
+    _zz_77[9] = _zz_76;
+    _zz_77[8] = _zz_76;
+    _zz_77[7] = _zz_76;
+    _zz_77[6] = _zz_76;
+    _zz_77[5] = _zz_76;
+    _zz_77[4] = _zz_76;
+    _zz_77[3] = _zz_76;
+    _zz_77[2] = _zz_76;
+    _zz_77[1] = _zz_76;
+    _zz_77[0] = _zz_76;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_78_ = _zz_353_[1];
+        _zz_78 = _zz_370[1];
       end
       default : begin
-        _zz_78_ = _zz_354_[1];
+        _zz_78 = _zz_371[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_79_ = _zz_355_[19];
+  assign _zz_79 = _zz_372[19];
   always @ (*) begin
-    _zz_80_[10] = _zz_79_;
-    _zz_80_[9] = _zz_79_;
-    _zz_80_[8] = _zz_79_;
-    _zz_80_[7] = _zz_79_;
-    _zz_80_[6] = _zz_79_;
-    _zz_80_[5] = _zz_79_;
-    _zz_80_[4] = _zz_79_;
-    _zz_80_[3] = _zz_79_;
-    _zz_80_[2] = _zz_79_;
-    _zz_80_[1] = _zz_79_;
-    _zz_80_[0] = _zz_79_;
+    _zz_80[10] = _zz_79;
+    _zz_80[9] = _zz_79;
+    _zz_80[8] = _zz_79;
+    _zz_80[7] = _zz_79;
+    _zz_80[6] = _zz_79;
+    _zz_80[5] = _zz_79;
+    _zz_80[4] = _zz_79;
+    _zz_80[3] = _zz_79;
+    _zz_80[2] = _zz_79;
+    _zz_80[1] = _zz_79;
+    _zz_80[0] = _zz_79;
   end
 
-  assign _zz_81_ = _zz_356_[11];
+  assign _zz_81 = _zz_373[11];
   always @ (*) begin
-    _zz_82_[18] = _zz_81_;
-    _zz_82_[17] = _zz_81_;
-    _zz_82_[16] = _zz_81_;
-    _zz_82_[15] = _zz_81_;
-    _zz_82_[14] = _zz_81_;
-    _zz_82_[13] = _zz_81_;
-    _zz_82_[12] = _zz_81_;
-    _zz_82_[11] = _zz_81_;
-    _zz_82_[10] = _zz_81_;
-    _zz_82_[9] = _zz_81_;
-    _zz_82_[8] = _zz_81_;
-    _zz_82_[7] = _zz_81_;
-    _zz_82_[6] = _zz_81_;
-    _zz_82_[5] = _zz_81_;
-    _zz_82_[4] = _zz_81_;
-    _zz_82_[3] = _zz_81_;
-    _zz_82_[2] = _zz_81_;
-    _zz_82_[1] = _zz_81_;
-    _zz_82_[0] = _zz_81_;
+    _zz_82[18] = _zz_81;
+    _zz_82[17] = _zz_81;
+    _zz_82[16] = _zz_81;
+    _zz_82[15] = _zz_81;
+    _zz_82[14] = _zz_81;
+    _zz_82[13] = _zz_81;
+    _zz_82[12] = _zz_81;
+    _zz_82[11] = _zz_81;
+    _zz_82[10] = _zz_81;
+    _zz_82[9] = _zz_81;
+    _zz_82[8] = _zz_81;
+    _zz_82[7] = _zz_81;
+    _zz_82[6] = _zz_81;
+    _zz_82[5] = _zz_81;
+    _zz_82[4] = _zz_81;
+    _zz_82[3] = _zz_81;
+    _zz_82[2] = _zz_81;
+    _zz_82[1] = _zz_81;
+    _zz_82[0] = _zz_81;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_80_,{{{_zz_486_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_82_,{{{_zz_487_,_zz_488_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_80,{{{_zz_504,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_82,{{{_zz_505,_zz_506},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -5120,111 +4028,127 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_201_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_202_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_203_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_204_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_205_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_206_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_209 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_210 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_211 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_210;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_213 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_214 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_215 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_259_)begin
+    if(_zz_277)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_257_)begin
+    if(_zz_275)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_207_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_257_)begin
-      _zz_207_ = 1'b1;
+    _zz_216 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_275)begin
+      _zz_216 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_258_)begin
+    if(_zz_276)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_256_)begin
+    if(_zz_274)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_258_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_276)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_256_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_274)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_200_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_224_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_208 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_242 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  always @ (*) begin
+    _zz_51 = 1'b0;
+    if(decode_INSTRUCTION[25])begin
+      if(decode_MEMORY_LRSC)begin
+        _zz_51 = 1'b1;
+      end
+      if(decode_MEMORY_AMO)begin
+        _zz_51 = 1'b1;
+      end
+    end
+  end
+
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
-    _zz_208_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+    _zz_217 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
-        if(_zz_269_)begin
-          _zz_208_ = 1'b1;
+      if(_zz_286)begin
+        if(_zz_287)begin
+          _zz_217 = 1'b1;
         end
       end
     end
   end
 
   always @ (*) begin
-    _zz_209_ = execute_SRC_ADD;
+    _zz_218 = execute_SRC_ADD;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
-        _zz_209_ = MmuPlugin_dBusAccess_cmd_payload_address;
+      if(_zz_286)begin
+        _zz_218 = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
   end
 
   always @ (*) begin
-    _zz_210_ = execute_MEMORY_WR;
+    _zz_219 = execute_MEMORY_WR;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
-        _zz_210_ = MmuPlugin_dBusAccess_cmd_payload_write;
+      if(_zz_286)begin
+        _zz_219 = MmuPlugin_dBusAccess_cmd_payload_write;
       end
     end
   end
@@ -5232,97 +4156,98 @@ module VexRiscv (
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_85_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_85 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_85_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_85 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_85_ = execute_RS2[31 : 0];
+        _zz_85 = execute_RS2[31 : 0];
       end
     endcase
   end
 
   always @ (*) begin
-    _zz_211_ = _zz_85_;
+    _zz_220 = _zz_85;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
-        _zz_211_ = MmuPlugin_dBusAccess_cmd_payload_data;
+      if(_zz_286)begin
+        _zz_220 = MmuPlugin_dBusAccess_cmd_payload_data;
       end
     end
   end
 
   always @ (*) begin
-    _zz_212_ = execute_DBusCachedPlugin_size;
+    _zz_221 = execute_DBusCachedPlugin_size;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
-        _zz_212_ = MmuPlugin_dBusAccess_cmd_payload_size;
+      if(_zz_286)begin
+        _zz_221 = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
-  assign _zz_223_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_241 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
   always @ (*) begin
-    _zz_213_ = 1'b0;
+    _zz_222 = 1'b0;
     if(execute_MEMORY_LRSC)begin
-      _zz_213_ = 1'b1;
+      _zz_222 = 1'b1;
     end
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
-        _zz_213_ = 1'b0;
+      if(_zz_286)begin
+        _zz_222 = 1'b0;
       end
     end
   end
 
   always @ (*) begin
-    _zz_214_ = execute_MEMORY_AMO;
+    _zz_223 = execute_MEMORY_AMO;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
-        _zz_214_ = 1'b0;
+      if(_zz_286)begin
+        _zz_223 = 1'b0;
       end
     end
   end
 
-  assign _zz_216_ = execute_INSTRUCTION[31 : 29];
-  assign _zz_215_ = execute_INSTRUCTION[27];
+  assign _zz_225 = execute_INSTRUCTION[31 : 29];
+  assign _zz_224 = execute_INSTRUCTION[27];
   always @ (*) begin
-    _zz_217_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+    _zz_226 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
     if(memory_IS_DBUS_SHARING)begin
-      _zz_217_ = 1'b1;
+      _zz_226 = 1'b1;
     end
   end
 
-  assign _zz_218_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
+  assign _zz_227 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_226;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_227;
   always @ (*) begin
-    DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+    DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
     if(memory_IS_DBUS_SHARING)begin
-      DBusCachedPlugin_mmuBus_cmd_bypassTranslation = 1'b1;
+      DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b1;
+    end
+  end
+
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  always @ (*) begin
+    _zz_228 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((_zz_56 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_228 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_219_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_56_ && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_219_ = 1'b1;
-    end
-  end
-
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  always @ (*) begin
-    _zz_220_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    _zz_229 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_IS_DBUS_SHARING)begin
-      _zz_220_ = 1'b1;
+      _zz_229 = 1'b1;
     end
   end
 
-  assign _zz_221_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_222_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_230 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_231 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_270_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_288)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -5331,17 +4256,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_270_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_288)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -5349,94 +4274,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_270_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_357_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_288)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_374};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_358_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_375};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_86_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_86 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_87_[31] = _zz_86_;
-    _zz_87_[30] = _zz_86_;
-    _zz_87_[29] = _zz_86_;
-    _zz_87_[28] = _zz_86_;
-    _zz_87_[27] = _zz_86_;
-    _zz_87_[26] = _zz_86_;
-    _zz_87_[25] = _zz_86_;
-    _zz_87_[24] = _zz_86_;
-    _zz_87_[23] = _zz_86_;
-    _zz_87_[22] = _zz_86_;
-    _zz_87_[21] = _zz_86_;
-    _zz_87_[20] = _zz_86_;
-    _zz_87_[19] = _zz_86_;
-    _zz_87_[18] = _zz_86_;
-    _zz_87_[17] = _zz_86_;
-    _zz_87_[16] = _zz_86_;
-    _zz_87_[15] = _zz_86_;
-    _zz_87_[14] = _zz_86_;
-    _zz_87_[13] = _zz_86_;
-    _zz_87_[12] = _zz_86_;
-    _zz_87_[11] = _zz_86_;
-    _zz_87_[10] = _zz_86_;
-    _zz_87_[9] = _zz_86_;
-    _zz_87_[8] = _zz_86_;
-    _zz_87_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_87[31] = _zz_86;
+    _zz_87[30] = _zz_86;
+    _zz_87[29] = _zz_86;
+    _zz_87[28] = _zz_86;
+    _zz_87[27] = _zz_86;
+    _zz_87[26] = _zz_86;
+    _zz_87[25] = _zz_86;
+    _zz_87[24] = _zz_86;
+    _zz_87[23] = _zz_86;
+    _zz_87[22] = _zz_86;
+    _zz_87[21] = _zz_86;
+    _zz_87[20] = _zz_86;
+    _zz_87[19] = _zz_86;
+    _zz_87[18] = _zz_86;
+    _zz_87[17] = _zz_86;
+    _zz_87[16] = _zz_86;
+    _zz_87[15] = _zz_86;
+    _zz_87[14] = _zz_86;
+    _zz_87[13] = _zz_86;
+    _zz_87[12] = _zz_86;
+    _zz_87[11] = _zz_86;
+    _zz_87[10] = _zz_86;
+    _zz_87[9] = _zz_86;
+    _zz_87[8] = _zz_86;
+    _zz_87[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_88_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_88 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_89_[31] = _zz_88_;
-    _zz_89_[30] = _zz_88_;
-    _zz_89_[29] = _zz_88_;
-    _zz_89_[28] = _zz_88_;
-    _zz_89_[27] = _zz_88_;
-    _zz_89_[26] = _zz_88_;
-    _zz_89_[25] = _zz_88_;
-    _zz_89_[24] = _zz_88_;
-    _zz_89_[23] = _zz_88_;
-    _zz_89_[22] = _zz_88_;
-    _zz_89_[21] = _zz_88_;
-    _zz_89_[20] = _zz_88_;
-    _zz_89_[19] = _zz_88_;
-    _zz_89_[18] = _zz_88_;
-    _zz_89_[17] = _zz_88_;
-    _zz_89_[16] = _zz_88_;
-    _zz_89_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_89[31] = _zz_88;
+    _zz_89[30] = _zz_88;
+    _zz_89[29] = _zz_88;
+    _zz_89[28] = _zz_88;
+    _zz_89[27] = _zz_88;
+    _zz_89[26] = _zz_88;
+    _zz_89[25] = _zz_88;
+    _zz_89[24] = _zz_88;
+    _zz_89[23] = _zz_88;
+    _zz_89[22] = _zz_88;
+    _zz_89[21] = _zz_88;
+    _zz_89[20] = _zz_88;
+    _zz_89[19] = _zz_88;
+    _zz_89[18] = _zz_88;
+    _zz_89[17] = _zz_88;
+    _zz_89[16] = _zz_88;
+    _zz_89[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_310_)
+    case(_zz_327)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_87_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_87;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_89_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_89;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -5447,8 +4372,8 @@ module VexRiscv (
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
-        if(_zz_269_)begin
+      if(_zz_286)begin
+        if(_zz_287)begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
@@ -5458,228 +4383,272 @@ module VexRiscv (
   always @ (*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_268_)begin
+      if(_zz_286)begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
-  assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1__io_cpu_writeBack_isWrite)) && (dataCache_1__io_cpu_redo || (! dataCache_1__io_cpu_writeBack_haltIt)));
-  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1__io_cpu_writeBack_data;
-  assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1__io_cpu_writeBack_unalignedAccess || dataCache_1__io_cpu_writeBack_accessError);
-  assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1__io_cpu_redo;
-  assign MmuPlugin_ports_0_cacheHits_0 = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_1 = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_2 = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_3 = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHit = ({MmuPlugin_ports_0_cacheHits_3,{MmuPlugin_ports_0_cacheHits_2,{MmuPlugin_ports_0_cacheHits_1,MmuPlugin_ports_0_cacheHits_0}}} != (4'b0000));
-  assign _zz_90_ = (MmuPlugin_ports_0_cacheHits_1 || MmuPlugin_ports_0_cacheHits_3);
-  assign _zz_91_ = (MmuPlugin_ports_0_cacheHits_2 || MmuPlugin_ports_0_cacheHits_3);
-  assign _zz_92_ = {_zz_91_,_zz_90_};
-  assign MmuPlugin_ports_0_cacheLine_valid = _zz_228_;
-  assign MmuPlugin_ports_0_cacheLine_exception = _zz_229_;
-  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_230_;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_231_;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_232_;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_233_;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_234_;
-  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_235_;
-  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_236_;
-  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_237_;
-  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_238_;
+  assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
+  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1_io_cpu_writeBack_data;
+  assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1_io_cpu_writeBack_unalignedAccess || dataCache_1_io_cpu_writeBack_accessError);
+  assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1_io_cpu_redo;
+  assign MmuPlugin_ports_0_dirty = 1'b0;
+  always @ (*) begin
+    MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
+    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+      MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
+    end
+    if((CsrPlugin_privilege == 2'b11))begin
+      MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    MmuPlugin_ports_0_cacheHitsCalc[0] = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[1] = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[2] = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[3] = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+  end
+
+  assign MmuPlugin_ports_0_cacheHit = (MmuPlugin_ports_0_cacheHitsCalc != 4'b0000);
+  assign _zz_90 = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign _zz_91 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_90);
+  assign _zz_92 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_90);
+  assign _zz_93 = {_zz_92,_zz_91};
+  assign MmuPlugin_ports_0_cacheLine_valid = _zz_246;
+  assign MmuPlugin_ports_0_cacheLine_exception = _zz_247;
+  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_248;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_249;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_250;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_251;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_252;
+  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_253;
+  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_254;
+  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_255;
+  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_256;
   always @ (*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(_zz_271_)begin
-      if(_zz_272_)begin
+    if(_zz_289)begin
+      if(_zz_290)begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
   end
 
   assign MmuPlugin_ports_0_entryToReplace_willClear = 1'b0;
-  assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == (2'b11));
+  assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_0_entryToReplace_willOverflow = (MmuPlugin_ports_0_entryToReplace_willOverflowIfInc && MmuPlugin_ports_0_entryToReplace_willIncrement);
   always @ (*) begin
-    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_360_);
+    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_377);
     if(MmuPlugin_ports_0_entryToReplace_willClear)begin
-      MmuPlugin_ports_0_entryToReplace_valueNext = (2'b00);
+      MmuPlugin_ports_0_entryToReplace_valueNext = 2'b00;
     end
   end
 
   always @ (*) begin
-    MmuPlugin_ports_0_requireMmuLockup = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == (2'b11))))begin
-      MmuPlugin_ports_0_requireMmuLockup = 1'b0;
-    end
-    if((CsrPlugin_privilege == (2'b11)))begin
-      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == (2'b11))))begin
-        MmuPlugin_ports_0_requireMmuLockup = 1'b0;
-      end
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_virtualAddress[11 : 0]};
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+      IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_exception = (MmuPlugin_ports_0_cacheHit && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == (2'b01))) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == (2'b00)))));
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_refilling = (! MmuPlugin_ports_0_cacheHit);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-    end
-  end
-
-  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = (((DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1011)) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1110))) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1111)));
-  assign MmuPlugin_ports_1_cacheHits_0 = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_1 = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_2 = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_3 = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHit = ({MmuPlugin_ports_1_cacheHits_3,{MmuPlugin_ports_1_cacheHits_2,{MmuPlugin_ports_1_cacheHits_1,MmuPlugin_ports_1_cacheHits_0}}} != (4'b0000));
-  assign _zz_93_ = (MmuPlugin_ports_1_cacheHits_1 || MmuPlugin_ports_1_cacheHits_3);
-  assign _zz_94_ = (MmuPlugin_ports_1_cacheHits_2 || MmuPlugin_ports_1_cacheHits_3);
-  assign _zz_95_ = {_zz_94_,_zz_93_};
-  assign MmuPlugin_ports_1_cacheLine_valid = _zz_239_;
-  assign MmuPlugin_ports_1_cacheLine_exception = _zz_240_;
-  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_241_;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_242_;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_243_;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_244_;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_245_;
-  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_246_;
-  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_247_;
-  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_248_;
-  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_249_;
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(_zz_271_)begin
-      if(_zz_273_)begin
-        MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
-      end
-    end
-  end
-
-  assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
-  assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == (2'b11));
-  assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_362_);
-    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
-      MmuPlugin_ports_1_entryToReplace_valueNext = (2'b00);
-    end
-  end
-
-  always @ (*) begin
-    MmuPlugin_ports_1_requireMmuLockup = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == (2'b11))))begin
-      MmuPlugin_ports_1_requireMmuLockup = 1'b0;
-    end
-    if((CsrPlugin_privilege == (2'b11)))begin
-      MmuPlugin_ports_1_requireMmuLockup = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_virtualAddress[11 : 0]};
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_exception = (MmuPlugin_ports_1_cacheHit && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == (2'b01))) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == (2'b00)))));
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_0_dirty) && MmuPlugin_ports_0_cacheHit) && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_refilling = (! MmuPlugin_ports_1_cacheHit);
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_0_dirty || (! MmuPlugin_ports_0_cacheHit));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = (((IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1011)) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1110))) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1111)));
-  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_363_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_364_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_365_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_366_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_367_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_368_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_369_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_370_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_dBusAccess_rsp_payload_data[9 : 8];
-  assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_dBusAccess_rsp_payload_data[19 : 10];
-  assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_dBusAccess_rsp_payload_data[31 : 20];
-  assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_dBusAccess_rsp_payload_error);
+  always @ (*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+    end
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = (((IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1011) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1110)) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1111));
+  assign IBusCachedPlugin_mmuBus_rsp_bypassTranslation = (! MmuPlugin_ports_0_requireMmuLockupCalc);
+  assign IBusCachedPlugin_mmuBus_rsp_ways_0_sel = MmuPlugin_ports_0_cacheHitsCalc[0];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_0_physical = {{MmuPlugin_ports_0_cache_0_physicalAddress_1,(MmuPlugin_ports_0_cache_0_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_0_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_1_sel = MmuPlugin_ports_0_cacheHitsCalc[1];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_1_physical = {{MmuPlugin_ports_0_cache_1_physicalAddress_1,(MmuPlugin_ports_0_cache_1_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_1_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_2_sel = MmuPlugin_ports_0_cacheHitsCalc[2];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_0_cache_2_physicalAddress_1,(MmuPlugin_ports_0_cache_2_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_2_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_0_cache_3_physicalAddress_1,(MmuPlugin_ports_0_cache_3_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_3_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign MmuPlugin_ports_1_dirty = 1'b0;
+  always @ (*) begin
+    MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
+    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+      MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
+    end
+    if((CsrPlugin_privilege == 2'b11))begin
+      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11)))begin
+        MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
+      end
+    end
+  end
+
+  always @ (*) begin
+    MmuPlugin_ports_1_cacheHitsCalc[0] = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[1] = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[2] = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[3] = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+  end
+
+  assign MmuPlugin_ports_1_cacheHit = (MmuPlugin_ports_1_cacheHitsCalc != 4'b0000);
+  assign _zz_94 = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign _zz_95 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_94);
+  assign _zz_96 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_94);
+  assign _zz_97 = {_zz_96,_zz_95};
+  assign MmuPlugin_ports_1_cacheLine_valid = _zz_257;
+  assign MmuPlugin_ports_1_cacheLine_exception = _zz_258;
+  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_259;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_260;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_261;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_262;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_263;
+  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_264;
+  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_265;
+  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_266;
+  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_267;
+  always @ (*) begin
+    MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
+    if(_zz_289)begin
+      if(_zz_291)begin
+        MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
+      end
+    end
+  end
+
+  assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
+  assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
+  always @ (*) begin
+    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_379);
+    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
+      MmuPlugin_ports_1_entryToReplace_valueNext = 2'b00;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_1_dirty) && MmuPlugin_ports_1_cacheHit) && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_1_dirty || (! MmuPlugin_ports_1_cacheHit));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+    end
+  end
+
+  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = (((DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1011) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1110)) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1111));
+  assign DBusCachedPlugin_mmuBus_rsp_bypassTranslation = (! MmuPlugin_ports_1_requireMmuLockupCalc);
+  assign DBusCachedPlugin_mmuBus_rsp_ways_0_sel = MmuPlugin_ports_1_cacheHitsCalc[0];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_0_physical = {{MmuPlugin_ports_1_cache_0_physicalAddress_1,(MmuPlugin_ports_1_cache_0_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_0_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_1_sel = MmuPlugin_ports_1_cacheHitsCalc[1];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_1_physical = {{MmuPlugin_ports_1_cache_1_physicalAddress_1,(MmuPlugin_ports_1_cache_1_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_1_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_2_sel = MmuPlugin_ports_1_cacheHitsCalc[2];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_1_cache_2_physicalAddress_1,(MmuPlugin_ports_1_cache_2_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_2_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_1_cache_3_physicalAddress_1,(MmuPlugin_ports_1_cache_3_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_3_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_380[0];
+  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_381[0];
+  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_382[0];
+  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_383[0];
+  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_384[0];
+  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_385[0];
+  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_386[0];
+  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_387[0];
+  assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_shared_dBusRspStaged_payload_data[9 : 8];
+  assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_shared_dBusRspStaged_payload_data[19 : 10];
+  assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
+  assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -5696,19 +4665,19 @@ module VexRiscv (
   end
 
   assign MmuPlugin_dBusAccess_cmd_payload_write = 1'b0;
-  assign MmuPlugin_dBusAccess_cmd_payload_size = (2'b10);
+  assign MmuPlugin_dBusAccess_cmd_payload_size = 2'b10;
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_payload_address = 32'h0;
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},(2'b00)};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},2'b00};
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{{MmuPlugin_shared_pteBuffer_PPN1[9 : 0],MmuPlugin_shared_pteBuffer_PPN0},MmuPlugin_shared_vpn_0},(2'b00)};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{{MmuPlugin_shared_pteBuffer_PPN1[9 : 0],MmuPlugin_shared_pteBuffer_PPN0},MmuPlugin_shared_vpn_0},2'b00};
       end
       default : begin
       end
@@ -5716,46 +4685,77 @@ module VexRiscv (
   end
 
   assign MmuPlugin_dBusAccess_cmd_payload_data = 32'h0;
-  assign MmuPlugin_dBusAccess_cmd_payload_writeMask = (4'bxxxx);
-  assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1_ != `MmuPlugin_shared_State_defaultEncoding_IDLE) && (MmuPlugin_shared_portId == (1'b1)));
-  assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1_ != `MmuPlugin_shared_State_defaultEncoding_IDLE) && (MmuPlugin_shared_portId == (1'b0)));
-  assign _zz_97_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_98_ = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_99_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_100_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_101_ = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_102_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_96_ = {(((decode_INSTRUCTION & _zz_489_) == 32'h00000024) != (1'b0)),{((_zz_490_ == _zz_491_) != (1'b0)),{(_zz_100_ != (1'b0)),{(_zz_492_ != _zz_493_),{_zz_494_,{_zz_495_,_zz_496_}}}}}};
-  assign _zz_103_ = _zz_96_[1 : 0];
-  assign _zz_49_ = _zz_103_;
-  assign _zz_104_ = _zz_96_[3 : 2];
-  assign _zz_48_ = _zz_104_;
-  assign _zz_105_ = _zz_96_[12 : 11];
-  assign _zz_47_ = _zz_105_;
-  assign _zz_106_ = _zz_96_[15 : 14];
-  assign _zz_46_ = _zz_106_;
-  assign _zz_107_ = _zz_96_[17 : 16];
-  assign _zz_45_ = _zz_107_;
-  assign _zz_108_ = _zz_96_[20 : 19];
-  assign _zz_44_ = _zz_108_;
-  assign _zz_109_ = _zz_96_[28 : 27];
-  assign _zz_43_ = _zz_109_;
+  assign MmuPlugin_dBusAccess_cmd_payload_writeMask = 4'bxxxx;
+  always @ (*) begin
+    _zz_98[0] = (((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit));
+    _zz_98[1] = (((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit));
+  end
+
+  assign _zz_99 = _zz_98;
+  always @ (*) begin
+    _zz_100[0] = _zz_99[1];
+    _zz_100[1] = _zz_99[0];
+  end
+
+  assign _zz_101 = (_zz_100 & (~ _zz_388));
+  always @ (*) begin
+    _zz_102[0] = _zz_101[1];
+    _zz_102[1] = _zz_101[0];
+  end
+
+  assign MmuPlugin_shared_refills = _zz_102;
+  assign _zz_103 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[0]);
+  assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[1]);
+  assign _zz_105 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_106 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_107 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_108 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_109 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_110 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_104 = {(((decode_INSTRUCTION & _zz_507) == 32'h00100050) != 1'b0),{(_zz_110 != 1'b0),{(_zz_110 != 1'b0),{(_zz_508 != _zz_509),{_zz_510,{_zz_511,_zz_512}}}}}};
+  assign _zz_111 = _zz_104[2 : 1];
+  assign _zz_49 = _zz_111;
+  assign _zz_112 = _zz_104[7 : 6];
+  assign _zz_48 = _zz_112;
+  assign _zz_113 = _zz_104[9 : 8];
+  assign _zz_47 = _zz_113;
+  assign _zz_114 = _zz_104[23 : 22];
+  assign _zz_46 = _zz_114;
+  assign _zz_115 = _zz_104[25 : 24];
+  assign _zz_45 = _zz_115;
+  assign _zz_116 = _zz_104[27 : 26];
+  assign _zz_44 = _zz_116;
+  assign _zz_117 = _zz_104[30 : 29];
+  assign _zz_43 = _zz_117;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_225_;
-  assign decode_RegFilePlugin_rs2Data = _zz_226_;
+  assign decode_RegFilePlugin_rs1Data = _zz_243;
+  assign decode_RegFilePlugin_rs2Data = _zz_244;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_110_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_118)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_50_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_118)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_118)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -5773,13 +4773,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_111_ = execute_IntAluPlugin_bitwise;
+        _zz_119 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_111_ = {31'd0, _zz_371_};
+        _zz_119 = {31'd0, _zz_389};
       end
       default : begin
-        _zz_111_ = execute_SRC_ADD_SUB;
+        _zz_119 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -5787,87 +4787,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_112_ = execute_RS1;
+        _zz_120 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_112_ = {29'd0, _zz_372_};
+        _zz_120 = {29'd0, _zz_390};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_112_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_120 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_112_ = {27'd0, _zz_373_};
+        _zz_120 = {27'd0, _zz_391};
       end
     endcase
   end
 
-  assign _zz_113_ = _zz_374_[11];
+  assign _zz_121 = _zz_392[11];
   always @ (*) begin
-    _zz_114_[19] = _zz_113_;
-    _zz_114_[18] = _zz_113_;
-    _zz_114_[17] = _zz_113_;
-    _zz_114_[16] = _zz_113_;
-    _zz_114_[15] = _zz_113_;
-    _zz_114_[14] = _zz_113_;
-    _zz_114_[13] = _zz_113_;
-    _zz_114_[12] = _zz_113_;
-    _zz_114_[11] = _zz_113_;
-    _zz_114_[10] = _zz_113_;
-    _zz_114_[9] = _zz_113_;
-    _zz_114_[8] = _zz_113_;
-    _zz_114_[7] = _zz_113_;
-    _zz_114_[6] = _zz_113_;
-    _zz_114_[5] = _zz_113_;
-    _zz_114_[4] = _zz_113_;
-    _zz_114_[3] = _zz_113_;
-    _zz_114_[2] = _zz_113_;
-    _zz_114_[1] = _zz_113_;
-    _zz_114_[0] = _zz_113_;
+    _zz_122[19] = _zz_121;
+    _zz_122[18] = _zz_121;
+    _zz_122[17] = _zz_121;
+    _zz_122[16] = _zz_121;
+    _zz_122[15] = _zz_121;
+    _zz_122[14] = _zz_121;
+    _zz_122[13] = _zz_121;
+    _zz_122[12] = _zz_121;
+    _zz_122[11] = _zz_121;
+    _zz_122[10] = _zz_121;
+    _zz_122[9] = _zz_121;
+    _zz_122[8] = _zz_121;
+    _zz_122[7] = _zz_121;
+    _zz_122[6] = _zz_121;
+    _zz_122[5] = _zz_121;
+    _zz_122[4] = _zz_121;
+    _zz_122[3] = _zz_121;
+    _zz_122[2] = _zz_121;
+    _zz_122[1] = _zz_121;
+    _zz_122[0] = _zz_121;
   end
 
-  assign _zz_115_ = _zz_375_[11];
+  assign _zz_123 = _zz_393[11];
   always @ (*) begin
-    _zz_116_[19] = _zz_115_;
-    _zz_116_[18] = _zz_115_;
-    _zz_116_[17] = _zz_115_;
-    _zz_116_[16] = _zz_115_;
-    _zz_116_[15] = _zz_115_;
-    _zz_116_[14] = _zz_115_;
-    _zz_116_[13] = _zz_115_;
-    _zz_116_[12] = _zz_115_;
-    _zz_116_[11] = _zz_115_;
-    _zz_116_[10] = _zz_115_;
-    _zz_116_[9] = _zz_115_;
-    _zz_116_[8] = _zz_115_;
-    _zz_116_[7] = _zz_115_;
-    _zz_116_[6] = _zz_115_;
-    _zz_116_[5] = _zz_115_;
-    _zz_116_[4] = _zz_115_;
-    _zz_116_[3] = _zz_115_;
-    _zz_116_[2] = _zz_115_;
-    _zz_116_[1] = _zz_115_;
-    _zz_116_[0] = _zz_115_;
+    _zz_124[19] = _zz_123;
+    _zz_124[18] = _zz_123;
+    _zz_124[17] = _zz_123;
+    _zz_124[16] = _zz_123;
+    _zz_124[15] = _zz_123;
+    _zz_124[14] = _zz_123;
+    _zz_124[13] = _zz_123;
+    _zz_124[12] = _zz_123;
+    _zz_124[11] = _zz_123;
+    _zz_124[10] = _zz_123;
+    _zz_124[9] = _zz_123;
+    _zz_124[8] = _zz_123;
+    _zz_124[7] = _zz_123;
+    _zz_124[6] = _zz_123;
+    _zz_124[5] = _zz_123;
+    _zz_124[4] = _zz_123;
+    _zz_124[3] = _zz_123;
+    _zz_124[2] = _zz_123;
+    _zz_124[1] = _zz_123;
+    _zz_124[0] = _zz_123;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_117_ = execute_RS2;
+        _zz_125 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_117_ = {_zz_114_,execute_INSTRUCTION[31 : 20]};
+        _zz_125 = {_zz_122,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_117_ = {_zz_116_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_125 = {_zz_124,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_117_ = _zz_35_;
+        _zz_125 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_376_;
+    execute_SrcPlugin_addSub = _zz_394;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -5876,246 +4876,246 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_118_[0] = execute_SRC1[31];
-    _zz_118_[1] = execute_SRC1[30];
-    _zz_118_[2] = execute_SRC1[29];
-    _zz_118_[3] = execute_SRC1[28];
-    _zz_118_[4] = execute_SRC1[27];
-    _zz_118_[5] = execute_SRC1[26];
-    _zz_118_[6] = execute_SRC1[25];
-    _zz_118_[7] = execute_SRC1[24];
-    _zz_118_[8] = execute_SRC1[23];
-    _zz_118_[9] = execute_SRC1[22];
-    _zz_118_[10] = execute_SRC1[21];
-    _zz_118_[11] = execute_SRC1[20];
-    _zz_118_[12] = execute_SRC1[19];
-    _zz_118_[13] = execute_SRC1[18];
-    _zz_118_[14] = execute_SRC1[17];
-    _zz_118_[15] = execute_SRC1[16];
-    _zz_118_[16] = execute_SRC1[15];
-    _zz_118_[17] = execute_SRC1[14];
-    _zz_118_[18] = execute_SRC1[13];
-    _zz_118_[19] = execute_SRC1[12];
-    _zz_118_[20] = execute_SRC1[11];
-    _zz_118_[21] = execute_SRC1[10];
-    _zz_118_[22] = execute_SRC1[9];
-    _zz_118_[23] = execute_SRC1[8];
-    _zz_118_[24] = execute_SRC1[7];
-    _zz_118_[25] = execute_SRC1[6];
-    _zz_118_[26] = execute_SRC1[5];
-    _zz_118_[27] = execute_SRC1[4];
-    _zz_118_[28] = execute_SRC1[3];
-    _zz_118_[29] = execute_SRC1[2];
-    _zz_118_[30] = execute_SRC1[1];
-    _zz_118_[31] = execute_SRC1[0];
+    _zz_126[0] = execute_SRC1[31];
+    _zz_126[1] = execute_SRC1[30];
+    _zz_126[2] = execute_SRC1[29];
+    _zz_126[3] = execute_SRC1[28];
+    _zz_126[4] = execute_SRC1[27];
+    _zz_126[5] = execute_SRC1[26];
+    _zz_126[6] = execute_SRC1[25];
+    _zz_126[7] = execute_SRC1[24];
+    _zz_126[8] = execute_SRC1[23];
+    _zz_126[9] = execute_SRC1[22];
+    _zz_126[10] = execute_SRC1[21];
+    _zz_126[11] = execute_SRC1[20];
+    _zz_126[12] = execute_SRC1[19];
+    _zz_126[13] = execute_SRC1[18];
+    _zz_126[14] = execute_SRC1[17];
+    _zz_126[15] = execute_SRC1[16];
+    _zz_126[16] = execute_SRC1[15];
+    _zz_126[17] = execute_SRC1[14];
+    _zz_126[18] = execute_SRC1[13];
+    _zz_126[19] = execute_SRC1[12];
+    _zz_126[20] = execute_SRC1[11];
+    _zz_126[21] = execute_SRC1[10];
+    _zz_126[22] = execute_SRC1[9];
+    _zz_126[23] = execute_SRC1[8];
+    _zz_126[24] = execute_SRC1[7];
+    _zz_126[25] = execute_SRC1[6];
+    _zz_126[26] = execute_SRC1[5];
+    _zz_126[27] = execute_SRC1[4];
+    _zz_126[28] = execute_SRC1[3];
+    _zz_126[29] = execute_SRC1[2];
+    _zz_126[30] = execute_SRC1[1];
+    _zz_126[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_118_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_126 : execute_SRC1);
   always @ (*) begin
-    _zz_119_[0] = memory_SHIFT_RIGHT[31];
-    _zz_119_[1] = memory_SHIFT_RIGHT[30];
-    _zz_119_[2] = memory_SHIFT_RIGHT[29];
-    _zz_119_[3] = memory_SHIFT_RIGHT[28];
-    _zz_119_[4] = memory_SHIFT_RIGHT[27];
-    _zz_119_[5] = memory_SHIFT_RIGHT[26];
-    _zz_119_[6] = memory_SHIFT_RIGHT[25];
-    _zz_119_[7] = memory_SHIFT_RIGHT[24];
-    _zz_119_[8] = memory_SHIFT_RIGHT[23];
-    _zz_119_[9] = memory_SHIFT_RIGHT[22];
-    _zz_119_[10] = memory_SHIFT_RIGHT[21];
-    _zz_119_[11] = memory_SHIFT_RIGHT[20];
-    _zz_119_[12] = memory_SHIFT_RIGHT[19];
-    _zz_119_[13] = memory_SHIFT_RIGHT[18];
-    _zz_119_[14] = memory_SHIFT_RIGHT[17];
-    _zz_119_[15] = memory_SHIFT_RIGHT[16];
-    _zz_119_[16] = memory_SHIFT_RIGHT[15];
-    _zz_119_[17] = memory_SHIFT_RIGHT[14];
-    _zz_119_[18] = memory_SHIFT_RIGHT[13];
-    _zz_119_[19] = memory_SHIFT_RIGHT[12];
-    _zz_119_[20] = memory_SHIFT_RIGHT[11];
-    _zz_119_[21] = memory_SHIFT_RIGHT[10];
-    _zz_119_[22] = memory_SHIFT_RIGHT[9];
-    _zz_119_[23] = memory_SHIFT_RIGHT[8];
-    _zz_119_[24] = memory_SHIFT_RIGHT[7];
-    _zz_119_[25] = memory_SHIFT_RIGHT[6];
-    _zz_119_[26] = memory_SHIFT_RIGHT[5];
-    _zz_119_[27] = memory_SHIFT_RIGHT[4];
-    _zz_119_[28] = memory_SHIFT_RIGHT[3];
-    _zz_119_[29] = memory_SHIFT_RIGHT[2];
-    _zz_119_[30] = memory_SHIFT_RIGHT[1];
-    _zz_119_[31] = memory_SHIFT_RIGHT[0];
+    _zz_127[0] = memory_SHIFT_RIGHT[31];
+    _zz_127[1] = memory_SHIFT_RIGHT[30];
+    _zz_127[2] = memory_SHIFT_RIGHT[29];
+    _zz_127[3] = memory_SHIFT_RIGHT[28];
+    _zz_127[4] = memory_SHIFT_RIGHT[27];
+    _zz_127[5] = memory_SHIFT_RIGHT[26];
+    _zz_127[6] = memory_SHIFT_RIGHT[25];
+    _zz_127[7] = memory_SHIFT_RIGHT[24];
+    _zz_127[8] = memory_SHIFT_RIGHT[23];
+    _zz_127[9] = memory_SHIFT_RIGHT[22];
+    _zz_127[10] = memory_SHIFT_RIGHT[21];
+    _zz_127[11] = memory_SHIFT_RIGHT[20];
+    _zz_127[12] = memory_SHIFT_RIGHT[19];
+    _zz_127[13] = memory_SHIFT_RIGHT[18];
+    _zz_127[14] = memory_SHIFT_RIGHT[17];
+    _zz_127[15] = memory_SHIFT_RIGHT[16];
+    _zz_127[16] = memory_SHIFT_RIGHT[15];
+    _zz_127[17] = memory_SHIFT_RIGHT[14];
+    _zz_127[18] = memory_SHIFT_RIGHT[13];
+    _zz_127[19] = memory_SHIFT_RIGHT[12];
+    _zz_127[20] = memory_SHIFT_RIGHT[11];
+    _zz_127[21] = memory_SHIFT_RIGHT[10];
+    _zz_127[22] = memory_SHIFT_RIGHT[9];
+    _zz_127[23] = memory_SHIFT_RIGHT[8];
+    _zz_127[24] = memory_SHIFT_RIGHT[7];
+    _zz_127[25] = memory_SHIFT_RIGHT[6];
+    _zz_127[26] = memory_SHIFT_RIGHT[5];
+    _zz_127[27] = memory_SHIFT_RIGHT[4];
+    _zz_127[28] = memory_SHIFT_RIGHT[3];
+    _zz_127[29] = memory_SHIFT_RIGHT[2];
+    _zz_127[30] = memory_SHIFT_RIGHT[1];
+    _zz_127[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_120_ = 1'b0;
-    if(_zz_274_)begin
-      if(_zz_275_)begin
-        if(_zz_125_)begin
-          _zz_120_ = 1'b1;
+    _zz_128 = 1'b0;
+    if(_zz_292)begin
+      if(_zz_293)begin
+        if(_zz_133)begin
+          _zz_128 = 1'b1;
         end
       end
     end
-    if(_zz_276_)begin
-      if(_zz_277_)begin
-        if(_zz_127_)begin
-          _zz_120_ = 1'b1;
+    if(_zz_294)begin
+      if(_zz_295)begin
+        if(_zz_135)begin
+          _zz_128 = 1'b1;
         end
       end
     end
-    if(_zz_278_)begin
-      if(_zz_279_)begin
-        if(_zz_129_)begin
-          _zz_120_ = 1'b1;
+    if(_zz_296)begin
+      if(_zz_297)begin
+        if(_zz_137)begin
+          _zz_128 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_120_ = 1'b0;
+      _zz_128 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_121_ = 1'b0;
-    if(_zz_274_)begin
-      if(_zz_275_)begin
-        if(_zz_126_)begin
-          _zz_121_ = 1'b1;
+    _zz_129 = 1'b0;
+    if(_zz_292)begin
+      if(_zz_293)begin
+        if(_zz_134)begin
+          _zz_129 = 1'b1;
         end
       end
     end
-    if(_zz_276_)begin
-      if(_zz_277_)begin
-        if(_zz_128_)begin
-          _zz_121_ = 1'b1;
+    if(_zz_294)begin
+      if(_zz_295)begin
+        if(_zz_136)begin
+          _zz_129 = 1'b1;
         end
       end
     end
-    if(_zz_278_)begin
-      if(_zz_279_)begin
-        if(_zz_130_)begin
-          _zz_121_ = 1'b1;
+    if(_zz_296)begin
+      if(_zz_297)begin
+        if(_zz_138)begin
+          _zz_129 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_121_ = 1'b0;
+      _zz_129 = 1'b0;
     end
   end
 
-  assign _zz_125_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_126_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_127_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_128_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_129_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_130_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_133 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_134 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_135 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_136 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_137 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_138 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_131_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_139 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_131_ == (3'b000))) begin
-        _zz_132_ = execute_BranchPlugin_eq;
-    end else if((_zz_131_ == (3'b001))) begin
-        _zz_132_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_131_ & (3'b101)) == (3'b101)))) begin
-        _zz_132_ = (! execute_SRC_LESS);
+    if((_zz_139 == 3'b000)) begin
+        _zz_140 = execute_BranchPlugin_eq;
+    end else if((_zz_139 == 3'b001)) begin
+        _zz_140 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_139 & 3'b101) == 3'b101))) begin
+        _zz_140 = (! execute_SRC_LESS);
     end else begin
-        _zz_132_ = execute_SRC_LESS;
+        _zz_140 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_133_ = 1'b0;
+        _zz_141 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_133_ = 1'b1;
+        _zz_141 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_133_ = 1'b1;
+        _zz_141 = 1'b1;
       end
       default : begin
-        _zz_133_ = _zz_132_;
+        _zz_141 = _zz_140;
       end
     endcase
   end
 
-  assign _zz_134_ = _zz_383_[11];
+  assign _zz_142 = _zz_401[11];
   always @ (*) begin
-    _zz_135_[19] = _zz_134_;
-    _zz_135_[18] = _zz_134_;
-    _zz_135_[17] = _zz_134_;
-    _zz_135_[16] = _zz_134_;
-    _zz_135_[15] = _zz_134_;
-    _zz_135_[14] = _zz_134_;
-    _zz_135_[13] = _zz_134_;
-    _zz_135_[12] = _zz_134_;
-    _zz_135_[11] = _zz_134_;
-    _zz_135_[10] = _zz_134_;
-    _zz_135_[9] = _zz_134_;
-    _zz_135_[8] = _zz_134_;
-    _zz_135_[7] = _zz_134_;
-    _zz_135_[6] = _zz_134_;
-    _zz_135_[5] = _zz_134_;
-    _zz_135_[4] = _zz_134_;
-    _zz_135_[3] = _zz_134_;
-    _zz_135_[2] = _zz_134_;
-    _zz_135_[1] = _zz_134_;
-    _zz_135_[0] = _zz_134_;
+    _zz_143[19] = _zz_142;
+    _zz_143[18] = _zz_142;
+    _zz_143[17] = _zz_142;
+    _zz_143[16] = _zz_142;
+    _zz_143[15] = _zz_142;
+    _zz_143[14] = _zz_142;
+    _zz_143[13] = _zz_142;
+    _zz_143[12] = _zz_142;
+    _zz_143[11] = _zz_142;
+    _zz_143[10] = _zz_142;
+    _zz_143[9] = _zz_142;
+    _zz_143[8] = _zz_142;
+    _zz_143[7] = _zz_142;
+    _zz_143[6] = _zz_142;
+    _zz_143[5] = _zz_142;
+    _zz_143[4] = _zz_142;
+    _zz_143[3] = _zz_142;
+    _zz_143[2] = _zz_142;
+    _zz_143[1] = _zz_142;
+    _zz_143[0] = _zz_142;
   end
 
-  assign _zz_136_ = _zz_384_[19];
+  assign _zz_144 = _zz_402[19];
   always @ (*) begin
-    _zz_137_[10] = _zz_136_;
-    _zz_137_[9] = _zz_136_;
-    _zz_137_[8] = _zz_136_;
-    _zz_137_[7] = _zz_136_;
-    _zz_137_[6] = _zz_136_;
-    _zz_137_[5] = _zz_136_;
-    _zz_137_[4] = _zz_136_;
-    _zz_137_[3] = _zz_136_;
-    _zz_137_[2] = _zz_136_;
-    _zz_137_[1] = _zz_136_;
-    _zz_137_[0] = _zz_136_;
+    _zz_145[10] = _zz_144;
+    _zz_145[9] = _zz_144;
+    _zz_145[8] = _zz_144;
+    _zz_145[7] = _zz_144;
+    _zz_145[6] = _zz_144;
+    _zz_145[5] = _zz_144;
+    _zz_145[4] = _zz_144;
+    _zz_145[3] = _zz_144;
+    _zz_145[2] = _zz_144;
+    _zz_145[1] = _zz_144;
+    _zz_145[0] = _zz_144;
   end
 
-  assign _zz_138_ = _zz_385_[11];
+  assign _zz_146 = _zz_403[11];
   always @ (*) begin
-    _zz_139_[18] = _zz_138_;
-    _zz_139_[17] = _zz_138_;
-    _zz_139_[16] = _zz_138_;
-    _zz_139_[15] = _zz_138_;
-    _zz_139_[14] = _zz_138_;
-    _zz_139_[13] = _zz_138_;
-    _zz_139_[12] = _zz_138_;
-    _zz_139_[11] = _zz_138_;
-    _zz_139_[10] = _zz_138_;
-    _zz_139_[9] = _zz_138_;
-    _zz_139_[8] = _zz_138_;
-    _zz_139_[7] = _zz_138_;
-    _zz_139_[6] = _zz_138_;
-    _zz_139_[5] = _zz_138_;
-    _zz_139_[4] = _zz_138_;
-    _zz_139_[3] = _zz_138_;
-    _zz_139_[2] = _zz_138_;
-    _zz_139_[1] = _zz_138_;
-    _zz_139_[0] = _zz_138_;
+    _zz_147[18] = _zz_146;
+    _zz_147[17] = _zz_146;
+    _zz_147[16] = _zz_146;
+    _zz_147[15] = _zz_146;
+    _zz_147[14] = _zz_146;
+    _zz_147[13] = _zz_146;
+    _zz_147[12] = _zz_146;
+    _zz_147[11] = _zz_146;
+    _zz_147[10] = _zz_146;
+    _zz_147[9] = _zz_146;
+    _zz_147[8] = _zz_146;
+    _zz_147[7] = _zz_146;
+    _zz_147[6] = _zz_146;
+    _zz_147[5] = _zz_146;
+    _zz_147[4] = _zz_146;
+    _zz_147[3] = _zz_146;
+    _zz_147[2] = _zz_146;
+    _zz_147[1] = _zz_146;
+    _zz_147[0] = _zz_146;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_140_ = (_zz_386_[1] ^ execute_RS1[1]);
+        _zz_148 = (_zz_404[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_140_ = _zz_387_[1];
+        _zz_148 = _zz_405[1];
       end
       default : begin
-        _zz_140_ = _zz_388_[1];
+        _zz_148 = _zz_406[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_140_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_148);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -6127,176 +5127,176 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_141_ = _zz_389_[11];
+  assign _zz_149 = _zz_407[11];
   always @ (*) begin
-    _zz_142_[19] = _zz_141_;
-    _zz_142_[18] = _zz_141_;
-    _zz_142_[17] = _zz_141_;
-    _zz_142_[16] = _zz_141_;
-    _zz_142_[15] = _zz_141_;
-    _zz_142_[14] = _zz_141_;
-    _zz_142_[13] = _zz_141_;
-    _zz_142_[12] = _zz_141_;
-    _zz_142_[11] = _zz_141_;
-    _zz_142_[10] = _zz_141_;
-    _zz_142_[9] = _zz_141_;
-    _zz_142_[8] = _zz_141_;
-    _zz_142_[7] = _zz_141_;
-    _zz_142_[6] = _zz_141_;
-    _zz_142_[5] = _zz_141_;
-    _zz_142_[4] = _zz_141_;
-    _zz_142_[3] = _zz_141_;
-    _zz_142_[2] = _zz_141_;
-    _zz_142_[1] = _zz_141_;
-    _zz_142_[0] = _zz_141_;
+    _zz_150[19] = _zz_149;
+    _zz_150[18] = _zz_149;
+    _zz_150[17] = _zz_149;
+    _zz_150[16] = _zz_149;
+    _zz_150[15] = _zz_149;
+    _zz_150[14] = _zz_149;
+    _zz_150[13] = _zz_149;
+    _zz_150[12] = _zz_149;
+    _zz_150[11] = _zz_149;
+    _zz_150[10] = _zz_149;
+    _zz_150[9] = _zz_149;
+    _zz_150[8] = _zz_149;
+    _zz_150[7] = _zz_149;
+    _zz_150[6] = _zz_149;
+    _zz_150[5] = _zz_149;
+    _zz_150[4] = _zz_149;
+    _zz_150[3] = _zz_149;
+    _zz_150[2] = _zz_149;
+    _zz_150[1] = _zz_149;
+    _zz_150[0] = _zz_149;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_142_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_150,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_144_,{{{_zz_696_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_146_,{{{_zz_697_,_zz_698_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_152,{{{_zz_713,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_154,{{{_zz_714,_zz_715},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_392_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_410};
         end
       end
     endcase
   end
 
-  assign _zz_143_ = _zz_390_[19];
+  assign _zz_151 = _zz_408[19];
   always @ (*) begin
-    _zz_144_[10] = _zz_143_;
-    _zz_144_[9] = _zz_143_;
-    _zz_144_[8] = _zz_143_;
-    _zz_144_[7] = _zz_143_;
-    _zz_144_[6] = _zz_143_;
-    _zz_144_[5] = _zz_143_;
-    _zz_144_[4] = _zz_143_;
-    _zz_144_[3] = _zz_143_;
-    _zz_144_[2] = _zz_143_;
-    _zz_144_[1] = _zz_143_;
-    _zz_144_[0] = _zz_143_;
+    _zz_152[10] = _zz_151;
+    _zz_152[9] = _zz_151;
+    _zz_152[8] = _zz_151;
+    _zz_152[7] = _zz_151;
+    _zz_152[6] = _zz_151;
+    _zz_152[5] = _zz_151;
+    _zz_152[4] = _zz_151;
+    _zz_152[3] = _zz_151;
+    _zz_152[2] = _zz_151;
+    _zz_152[1] = _zz_151;
+    _zz_152[0] = _zz_151;
   end
 
-  assign _zz_145_ = _zz_391_[11];
+  assign _zz_153 = _zz_409[11];
   always @ (*) begin
-    _zz_146_[18] = _zz_145_;
-    _zz_146_[17] = _zz_145_;
-    _zz_146_[16] = _zz_145_;
-    _zz_146_[15] = _zz_145_;
-    _zz_146_[14] = _zz_145_;
-    _zz_146_[13] = _zz_145_;
-    _zz_146_[12] = _zz_145_;
-    _zz_146_[11] = _zz_145_;
-    _zz_146_[10] = _zz_145_;
-    _zz_146_[9] = _zz_145_;
-    _zz_146_[8] = _zz_145_;
-    _zz_146_[7] = _zz_145_;
-    _zz_146_[6] = _zz_145_;
-    _zz_146_[5] = _zz_145_;
-    _zz_146_[4] = _zz_145_;
-    _zz_146_[3] = _zz_145_;
-    _zz_146_[2] = _zz_145_;
-    _zz_146_[1] = _zz_145_;
-    _zz_146_[0] = _zz_145_;
+    _zz_154[18] = _zz_153;
+    _zz_154[17] = _zz_153;
+    _zz_154[16] = _zz_153;
+    _zz_154[15] = _zz_153;
+    _zz_154[14] = _zz_153;
+    _zz_154[13] = _zz_153;
+    _zz_154[12] = _zz_153;
+    _zz_154[11] = _zz_153;
+    _zz_154[10] = _zz_153;
+    _zz_154[9] = _zz_153;
+    _zz_154[8] = _zz_153;
+    _zz_154[7] = _zz_153;
+    _zz_154[6] = _zz_153;
+    _zz_154[5] = _zz_153;
+    _zz_154[4] = _zz_153;
+    _zz_154[3] = _zz_153;
+    _zz_154[2] = _zz_153;
+    _zz_154[1] = _zz_153;
+    _zz_154[0] = _zz_153;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = _zz_147_;
+    CsrPlugin_privilege = _zz_155;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
   always @ (*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
     if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
+      if(execute_CsrPlugin_writeInstruction)begin
         CsrPlugin_redoInterface_valid = 1'b1;
       end
     end
   end
 
   assign CsrPlugin_redoInterface_payload = decode_PC;
-  assign _zz_148_ = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_149_ = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_150_ = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_151_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_152_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_153_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_156 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_157 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_158 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_159 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_160 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_161 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   always @ (*) begin
-    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
-      4'b1000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0010 : begin
-        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b1101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0000 : begin
+        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
         if(((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0010 : begin
+        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0100 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0101 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
         if(((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b0000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0111 : begin
+        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1000 : begin
+        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1001 : begin
+        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1100 : begin
+        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1101 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1111 : begin
+        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       default : begin
@@ -6305,11 +5305,11 @@ module VexRiscv (
   end
 
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_154_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_155_ = _zz_393_[0];
+  assign _zz_162 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_163 = _zz_411[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_260_)begin
+    if(_zz_278)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -6355,7 +5355,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -6379,7 +5379,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_stvec_mode;
@@ -6407,7 +5407,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -6518,7 +5518,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_280_)begin
+    if(_zz_298)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -6537,29 +5537,29 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_281_)begin
+    if(_zz_299)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_282_)begin
+    if(_zz_300)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_281_)begin
-      CsrPlugin_selfException_payload_code = (4'b0010);
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_299)begin
+      CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_282_)begin
+    if(_zz_300)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         2'b01 : begin
-          CsrPlugin_selfException_payload_code = (4'b1001);
+          CsrPlugin_selfException_payload_code = 4'b1001;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -6568,14 +5568,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_280_)begin
+    if(_zz_298)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_280_)begin
+    if(_zz_298)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -6593,7 +5593,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_311_)
+    case(_zz_328)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -6607,7 +5607,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_283_)
+    case(_zz_301)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -6621,7 +5621,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_283_)
+    case(_zz_301)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -6640,12 +5640,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_395_) + $signed(_zz_396_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_413) + $signed(_zz_414));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_255_)begin
-      if(_zz_284_)begin
+    if(_zz_273)begin
+      if(_zz_302)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -6653,7 +5653,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_285_)begin
+    if(_zz_303)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -6664,37 +5664,35 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_400_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_418);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_156_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_156_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_401_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_402_ : _zz_403_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_404_[31:0];
-  assign _zz_157_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_158_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_159_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_164 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_164[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_419);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_420 : _zz_421);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_422[31:0];
+  assign _zz_165 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_166 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_167 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_160_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_160_[31 : 0] = execute_RS1;
+    _zz_168[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_168[31 : 0] = execute_RS1;
   end
 
-  assign _zz_162_ = (_zz_161_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_162_ != 32'h0);
-  assign _zz_164_ = (_zz_163_ & externalInterruptArray_regNext);
-  assign externalInterruptS = (_zz_164_ != 32'h0);
+  assign _zz_170 = (_zz_169 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_170 != 32'h0);
+  assign _zz_172 = (_zz_171 & externalInterruptArray_regNext);
+  assign externalInterruptS = (_zz_172 != 32'h0);
   always @ (*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid)begin
-      case(_zz_286_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_304)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
@@ -6707,7 +5705,7 @@ module VexRiscv (
 
   always @ (*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_165_))begin
+    if((! _zz_173))begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -6719,10 +5717,8 @@ module VexRiscv (
   always @ (*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid)begin
-      case(_zz_286_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_304)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
@@ -6734,39 +5730,39 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == (2'b11));
+  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26_ = decode_ENV_CTRL;
-  assign _zz_23_ = execute_ENV_CTRL;
-  assign _zz_21_ = memory_ENV_CTRL;
-  assign _zz_24_ = _zz_45_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_19_ = decode_SHIFT_CTRL;
-  assign _zz_16_ = execute_SHIFT_CTRL;
-  assign _zz_17_ = _zz_44_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_14_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_12_ = _zz_46_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_11_ = decode_SRC1_CTRL;
-  assign _zz_9_ = _zz_43_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_8_ = decode_SRC2_CTRL;
-  assign _zz_6_ = _zz_47_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_5_ = decode_BRANCH_CTRL;
-  assign _zz_52_ = _zz_48_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_3_ = decode_ALU_CTRL;
-  assign _zz_1_ = _zz_49_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_52 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -6785,15 +5781,7 @@ module VexRiscv (
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_166_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
-      3'b010 : begin
-      end
-      3'b011 : begin
-      end
+    case(_zz_174)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -6803,245 +5791,246 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_167_ = 32'h0;
+    _zz_175 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_167_[12 : 0] = 13'h1000;
-      _zz_167_[25 : 20] = 6'h20;
+      _zz_175[12 : 0] = 13'h1000;
+      _zz_175[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_168_ = 32'h0;
+    _zz_176 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_168_[19 : 19] = MmuPlugin_status_mxr;
-      _zz_168_[18 : 18] = MmuPlugin_status_sum;
-      _zz_168_[17 : 17] = MmuPlugin_status_mprv;
-      _zz_168_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_168_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_168_[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_168_[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_168_[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_168_[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_176[19 : 19] = MmuPlugin_status_mxr;
+      _zz_176[18 : 18] = MmuPlugin_status_sum;
+      _zz_176[17 : 17] = MmuPlugin_status_mprv;
+      _zz_176[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_176[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_176[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_176[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_176[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_176[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @ (*) begin
-    _zz_169_ = 32'h0;
+    _zz_177 = 32'h0;
     if(execute_CsrPlugin_csr_256)begin
-      _zz_169_[19 : 19] = MmuPlugin_status_mxr;
-      _zz_169_[18 : 18] = MmuPlugin_status_sum;
-      _zz_169_[17 : 17] = MmuPlugin_status_mprv;
-      _zz_169_[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_169_[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_169_[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_177[19 : 19] = MmuPlugin_status_mxr;
+      _zz_177[18 : 18] = MmuPlugin_status_sum;
+      _zz_177[17 : 17] = MmuPlugin_status_mprv;
+      _zz_177[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_177[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_177[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @ (*) begin
-    _zz_170_ = 32'h0;
+    _zz_178 = 32'h0;
     if(execute_CsrPlugin_csr_384)begin
-      _zz_170_[31 : 31] = MmuPlugin_satp_mode;
-      _zz_170_[19 : 0] = MmuPlugin_satp_ppn;
+      _zz_178[31 : 31] = MmuPlugin_satp_mode;
+      _zz_178[30 : 22] = MmuPlugin_satp_asid;
+      _zz_178[19 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
   always @ (*) begin
-    _zz_171_ = 32'h0;
+    _zz_179 = 32'h0;
     if(execute_CsrPlugin_csr_3857)begin
-      _zz_171_[0 : 0] = (1'b1);
+      _zz_179[0 : 0] = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_172_ = 32'h0;
+    _zz_180 = 32'h0;
     if(execute_CsrPlugin_csr_3858)begin
-      _zz_172_[1 : 0] = (2'b10);
+      _zz_180[1 : 0] = 2'b10;
     end
   end
 
   always @ (*) begin
-    _zz_173_ = 32'h0;
+    _zz_181 = 32'h0;
     if(execute_CsrPlugin_csr_3859)begin
-      _zz_173_[1 : 0] = (2'b11);
+      _zz_181[1 : 0] = 2'b11;
     end
   end
 
   always @ (*) begin
-    _zz_174_ = 32'h0;
+    _zz_182 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_174_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_174_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_174_[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_174_[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_174_[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_174_[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_182[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_182[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_182[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_182[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_182[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_182[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @ (*) begin
-    _zz_175_ = 32'h0;
+    _zz_183 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_175_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_175_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_175_[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_175_[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_175_[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_175_[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_183[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_183[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_183[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_183[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_183[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_183[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @ (*) begin
-    _zz_176_ = 32'h0;
+    _zz_184 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_176_[31 : 0] = CsrPlugin_mepc;
+      _zz_184[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_177_ = 32'h0;
+    _zz_185 = 32'h0;
     if(execute_CsrPlugin_csr_832)begin
-      _zz_177_[31 : 0] = CsrPlugin_mscratch;
+      _zz_185[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
-    _zz_178_ = 32'h0;
+    _zz_186 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_178_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_178_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_186[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_186[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_179_ = 32'h0;
+    _zz_187 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_179_[31 : 0] = CsrPlugin_mtval;
+      _zz_187[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_180_ = 32'h0;
+    _zz_188 = 32'h0;
     if(execute_CsrPlugin_csr_324)begin
-      _zz_180_[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_180_[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_180_[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_188[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_188[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_188[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @ (*) begin
-    _zz_181_ = 32'h0;
+    _zz_189 = 32'h0;
     if(execute_CsrPlugin_csr_260)begin
-      _zz_181_[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_181_[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_181_[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_189[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_189[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_189[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @ (*) begin
-    _zz_182_ = 32'h0;
+    _zz_190 = 32'h0;
     if(execute_CsrPlugin_csr_261)begin
-      _zz_182_[31 : 2] = CsrPlugin_stvec_base;
-      _zz_182_[1 : 0] = CsrPlugin_stvec_mode;
+      _zz_190[31 : 2] = CsrPlugin_stvec_base;
+      _zz_190[1 : 0] = CsrPlugin_stvec_mode;
     end
   end
 
   always @ (*) begin
-    _zz_183_ = 32'h0;
+    _zz_191 = 32'h0;
     if(execute_CsrPlugin_csr_321)begin
-      _zz_183_[31 : 0] = CsrPlugin_sepc;
+      _zz_191[31 : 0] = CsrPlugin_sepc;
     end
   end
 
   always @ (*) begin
-    _zz_184_ = 32'h0;
+    _zz_192 = 32'h0;
     if(execute_CsrPlugin_csr_320)begin
-      _zz_184_[31 : 0] = CsrPlugin_sscratch;
+      _zz_192[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
   always @ (*) begin
-    _zz_185_ = 32'h0;
+    _zz_193 = 32'h0;
     if(execute_CsrPlugin_csr_322)begin
-      _zz_185_[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_185_[3 : 0] = CsrPlugin_scause_exceptionCode;
+      _zz_193[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_193[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_186_ = 32'h0;
+    _zz_194 = 32'h0;
     if(execute_CsrPlugin_csr_323)begin
-      _zz_186_[31 : 0] = CsrPlugin_stval;
+      _zz_194[31 : 0] = CsrPlugin_stval;
     end
   end
 
   always @ (*) begin
-    _zz_187_ = 32'h0;
+    _zz_195 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_187_[31 : 0] = _zz_161_;
+      _zz_195[31 : 0] = _zz_169;
     end
   end
 
   always @ (*) begin
-    _zz_188_ = 32'h0;
+    _zz_196 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_188_[31 : 0] = _zz_162_;
+      _zz_196[31 : 0] = _zz_170;
     end
   end
 
   always @ (*) begin
-    _zz_189_ = 32'h0;
+    _zz_197 = 32'h0;
     if(execute_CsrPlugin_csr_2496)begin
-      _zz_189_[31 : 0] = _zz_163_;
+      _zz_197[31 : 0] = _zz_171;
     end
   end
 
   always @ (*) begin
-    _zz_190_ = 32'h0;
+    _zz_198 = 32'h0;
     if(execute_CsrPlugin_csr_3520)begin
-      _zz_190_[31 : 0] = _zz_164_;
+      _zz_198[31 : 0] = _zz_172;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_167_ | _zz_168_) | (_zz_169_ | _zz_170_)) | ((_zz_171_ | _zz_172_) | (_zz_173_ | _zz_699_))) | (((_zz_174_ | _zz_175_) | (_zz_176_ | _zz_177_)) | ((_zz_178_ | _zz_179_) | (_zz_180_ | _zz_181_)))) | ((((_zz_182_ | _zz_183_) | (_zz_184_ | _zz_185_)) | ((_zz_186_ | _zz_187_) | (_zz_188_ | _zz_189_))) | _zz_190_));
-  assign iBusWishbone_ADR = {_zz_459_,_zz_191_};
-  assign iBusWishbone_CTI = ((_zz_191_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((((_zz_175 | _zz_176) | (_zz_177 | _zz_178)) | ((_zz_179 | _zz_180) | (_zz_181 | _zz_716))) | (((_zz_182 | _zz_183) | (_zz_184 | _zz_185)) | ((_zz_186 | _zz_187) | (_zz_188 | _zz_189)))) | ((((_zz_190 | _zz_191) | (_zz_192 | _zz_193)) | ((_zz_194 | _zz_195) | (_zz_196 | _zz_197))) | _zz_198));
+  assign iBusWishbone_ADR = {_zz_477,_zz_199};
+  assign iBusWishbone_CTI = ((_zz_199 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_287_)begin
+    if(_zz_305)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_287_)begin
+    if(_zz_305)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_192_;
+  assign iBus_rsp_valid = _zz_200;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_198_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_194_ = dBus_cmd_valid;
-  assign _zz_196_ = dBus_cmd_payload_wr;
-  assign _zz_197_ = (_zz_193_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_195_ && (_zz_196_ || _zz_197_));
-  assign dBusWishbone_ADR = ((_zz_198_ ? {{dBus_cmd_payload_address[31 : 5],_zz_193_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_198_ ? (_zz_197_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_196_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_196_;
+  assign _zz_206 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_202 = dBus_cmd_valid;
+  assign _zz_204 = dBus_cmd_payload_wr;
+  assign _zz_205 = (_zz_201 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_203 && (_zz_204 || _zz_205));
+  assign dBusWishbone_ADR = ((_zz_206 ? {{dBus_cmd_payload_address[31 : 5],_zz_201},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_206 ? (_zz_205 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_204 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_204;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_195_ = (_zz_194_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_194_;
-  assign dBusWishbone_STB = _zz_194_;
-  assign dBus_rsp_valid = _zz_199_;
+  assign _zz_203 = (_zz_202 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_202;
+  assign dBusWishbone_STB = _zz_202;
+  assign dBus_rsp_valid = _zz_207;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -7050,18 +6039,18 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_68_ <= 1'b0;
-      _zz_70_ <= 1'b0;
+      _zz_68 <= 1'b0;
+      _zz_70 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_83_;
+      IBusCachedPlugin_rspCounter <= _zz_83;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_84_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_84;
       DBusCachedPlugin_rspCounter <= 32'h0;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
@@ -7071,19 +6060,20 @@ module VexRiscv (
       MmuPlugin_ports_0_cache_1_valid <= 1'b0;
       MmuPlugin_ports_0_cache_2_valid <= 1'b0;
       MmuPlugin_ports_0_cache_3_valid <= 1'b0;
-      MmuPlugin_ports_0_entryToReplace_value <= (2'b00);
+      MmuPlugin_ports_0_entryToReplace_value <= 2'b00;
       MmuPlugin_ports_1_cache_0_valid <= 1'b0;
       MmuPlugin_ports_1_cache_1_valid <= 1'b0;
       MmuPlugin_ports_1_cache_2_valid <= 1'b0;
       MmuPlugin_ports_1_cache_3_valid <= 1'b0;
-      MmuPlugin_ports_1_entryToReplace_value <= (2'b00);
-      MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-      _zz_110_ <= 1'b1;
-      _zz_122_ <= 1'b0;
-      _zz_147_ <= (2'b11);
+      MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
+      MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+      MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
+      _zz_118 <= 1'b1;
+      _zz_130 <= 1'b0;
+      _zz_155 <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -7104,7 +6094,7 @@ module VexRiscv (
       CsrPlugin_mideleg_SS <= 1'b0;
       CsrPlugin_sstatus_SIE <= 1'b0;
       CsrPlugin_sstatus_SPIE <= 1'b0;
-      CsrPlugin_sstatus_SPP <= (1'b1);
+      CsrPlugin_sstatus_SPP <= 1'b1;
       CsrPlugin_sip_SEIP_SOFT <= 1'b0;
       CsrPlugin_sip_STIP <= 1'b0;
       CsrPlugin_sip_SSIP <= 1'b0;
@@ -7123,20 +6113,18 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_161_ <= 32'h0;
-      _zz_163_ <= 32'h0;
+      _zz_169 <= 32'h0;
+      _zz_171 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_166_ <= (3'b000);
+      _zz_174 <= 3'b000;
       execute_to_memory_IS_DBUS_SHARING <= 1'b0;
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_191_ <= (3'b000);
-      _zz_192_ <= 1'b0;
-      _zz_193_ <= (3'b000);
-      _zz_199_ <= 1'b0;
+      _zz_199 <= 3'b000;
+      _zz_200 <= 1'b0;
+      _zz_201 <= 3'b000;
+      _zz_207 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -7158,16 +6146,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_68_ <= 1'b0;
+        _zz_68 <= 1'b0;
       end
-      if(_zz_66_)begin
-        _zz_68_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_66)begin
+        _zz_68 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_70_ <= 1'b0;
+        _zz_70 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_70_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_70 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -7214,14 +6202,14 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_288_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_306)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
@@ -7256,71 +6244,69 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
       end
-      case(MmuPlugin_shared_state_1_)
+      MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
+      case(MmuPlugin_shared_state_1)
         `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-          if(_zz_289_)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
-          end
-          if(_zz_290_)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
+          if(_zz_307)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
           if(MmuPlugin_dBusAccess_cmd_ready)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
-          if(MmuPlugin_dBusAccess_rsp_valid)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
+          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             if((MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception))begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
             end
-            if(MmuPlugin_dBusAccess_rsp_payload_redo)begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
             end
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
           if(MmuPlugin_dBusAccess_cmd_ready)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
           end
         end
         default : begin
-          if(MmuPlugin_dBusAccess_rsp_valid)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-            if(MmuPlugin_dBusAccess_rsp_payload_redo)begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
+          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             end
           end
         end
       endcase
-      if(_zz_271_)begin
-        if(_zz_272_)begin
-          if(_zz_291_)begin
+      if(_zz_289)begin
+        if(_zz_290)begin
+          if(_zz_308)begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(_zz_292_)begin
+          if(_zz_309)begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(_zz_293_)begin
+          if(_zz_310)begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(_zz_294_)begin
+          if(_zz_311)begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(_zz_273_)begin
-          if(_zz_295_)begin
+        if(_zz_291)begin
+          if(_zz_312)begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(_zz_296_)begin
+          if(_zz_313)begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(_zz_297_)begin
+          if(_zz_314)begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(_zz_298_)begin
+          if(_zz_315)begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
@@ -7335,8 +6321,8 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_110_ <= 1'b0;
-      _zz_122_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_118 <= 1'b0;
+      _zz_130 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -7358,34 +6344,34 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_299_)begin
-        if(_zz_300_)begin
+      if(_zz_316)begin
+        if(_zz_317)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_301_)begin
+        if(_zz_318)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_302_)begin
+        if(_zz_319)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(_zz_303_)begin
-        if(_zz_304_)begin
+      if(_zz_320)begin
+        if(_zz_321)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_305_)begin
+        if(_zz_322)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_306_)begin
+        if(_zz_323)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_307_)begin
+        if(_zz_324)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_308_)begin
+        if(_zz_325)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_309_)begin
+        if(_zz_326)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -7410,8 +6396,8 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_264_)begin
-        _zz_147_ <= CsrPlugin_targetPrivilege;
+      if(_zz_282)begin
+        _zz_155 <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b01 : begin
             CsrPlugin_sstatus_SIE <= 1'b0;
@@ -7427,37 +6413,31 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_265_)begin
-        case(_zz_267_)
+      if(_zz_283)begin
+        case(_zz_285)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_147_ <= CsrPlugin_mstatus_MPP;
+            _zz_155 <= CsrPlugin_mstatus_MPP;
           end
           2'b01 : begin
-            CsrPlugin_sstatus_SPP <= (1'b0);
+            CsrPlugin_sstatus_SPP <= 1'b0;
             CsrPlugin_sstatus_SIE <= CsrPlugin_sstatus_SPIE;
             CsrPlugin_sstatus_SPIE <= 1'b1;
-            _zz_147_ <= {(1'b0),CsrPlugin_sstatus_SPP};
+            _zz_155 <= {1'b0,CsrPlugin_sstatus_SPP};
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_153_,{_zz_152_,{_zz_151_,{_zz_150_,{_zz_149_,_zz_148_}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_161,{_zz_160,{_zz_159,{_zz_158,{_zz_157,_zz_156}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
       if((! memory_arbitration_isStuck))begin
         execute_to_memory_IS_DBUS_SHARING <= execute_IS_DBUS_SHARING;
       end
       if((! writeBack_arbitration_isStuck))begin
         memory_to_writeBack_IS_DBUS_SHARING <= memory_IS_DBUS_SHARING;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
       end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
@@ -7477,25 +6457,25 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_166_)
+      case(_zz_174)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_166_ <= (3'b001);
+            _zz_174 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_166_ <= (3'b010);
+          _zz_174 <= 3'b010;
         end
         3'b010 : begin
-          _zz_166_ <= (3'b011);
+          _zz_174 <= 3'b011;
         end
         3'b011 : begin
           if((! decode_arbitration_isStuck))begin
-            _zz_166_ <= (3'b100);
+            _zz_174 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_166_ <= (3'b000);
+          _zz_174 <= 3'b000;
         end
         default : begin
         end
@@ -7505,115 +6485,125 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_414_[0];
-          MmuPlugin_status_sum <= _zz_415_[0];
-          MmuPlugin_status_mprv <= _zz_416_[0];
+          MmuPlugin_status_mxr <= _zz_432[0];
+          MmuPlugin_status_sum <= _zz_433[0];
+          MmuPlugin_status_mprv <= _zz_434[0];
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_417_[0];
-          CsrPlugin_mstatus_MIE <= _zz_418_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_435[0];
+          CsrPlugin_mstatus_MIE <= _zz_436[0];
           CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_419_[0];
-          CsrPlugin_sstatus_SIE <= _zz_420_[0];
+          CsrPlugin_sstatus_SPIE <= _zz_437[0];
+          CsrPlugin_sstatus_SIE <= _zz_438[0];
         end
       end
       if(execute_CsrPlugin_csr_256)begin
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_421_[0];
-          MmuPlugin_status_sum <= _zz_422_[0];
-          MmuPlugin_status_mprv <= _zz_423_[0];
+          MmuPlugin_status_mxr <= _zz_439[0];
+          MmuPlugin_status_sum <= _zz_440[0];
+          MmuPlugin_status_mprv <= _zz_441[0];
           CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_424_[0];
-          CsrPlugin_sstatus_SIE <= _zz_425_[0];
+          CsrPlugin_sstatus_SPIE <= _zz_442[0];
+          CsrPlugin_sstatus_SIE <= _zz_443[0];
         end
       end
       if(execute_CsrPlugin_csr_384)begin
+        if(execute_CsrPlugin_writeInstruction)begin
+          MmuPlugin_ports_0_cache_0_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_1_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_2_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_3_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_0_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_1_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_2_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_3_valid <= 1'b0;
+        end
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_satp_mode <= _zz_426_[0];
+          MmuPlugin_satp_mode <= _zz_444[0];
         end
       end
       if(execute_CsrPlugin_csr_836)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_428_[0];
-          CsrPlugin_sip_SSIP <= _zz_429_[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_430_[0];
+          CsrPlugin_sip_STIP <= _zz_446[0];
+          CsrPlugin_sip_SSIP <= _zz_447[0];
+          CsrPlugin_sip_SEIP_SOFT <= _zz_448[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_431_[0];
-          CsrPlugin_mie_MTIE <= _zz_432_[0];
-          CsrPlugin_mie_MSIE <= _zz_433_[0];
-          CsrPlugin_sie_SEIE <= _zz_434_[0];
-          CsrPlugin_sie_STIE <= _zz_435_[0];
-          CsrPlugin_sie_SSIE <= _zz_436_[0];
+          CsrPlugin_mie_MEIE <= _zz_449[0];
+          CsrPlugin_mie_MTIE <= _zz_450[0];
+          CsrPlugin_mie_MSIE <= _zz_451[0];
+          CsrPlugin_sie_SEIE <= _zz_452[0];
+          CsrPlugin_sie_STIE <= _zz_453[0];
+          CsrPlugin_sie_SSIE <= _zz_454[0];
         end
       end
       if(execute_CsrPlugin_csr_770)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_medeleg_EU <= _zz_437_[0];
-          CsrPlugin_medeleg_II <= _zz_438_[0];
-          CsrPlugin_medeleg_LAF <= _zz_439_[0];
-          CsrPlugin_medeleg_LPF <= _zz_440_[0];
-          CsrPlugin_medeleg_LAM <= _zz_441_[0];
-          CsrPlugin_medeleg_SAF <= _zz_442_[0];
-          CsrPlugin_medeleg_IAF <= _zz_443_[0];
-          CsrPlugin_medeleg_ES <= _zz_444_[0];
-          CsrPlugin_medeleg_IPF <= _zz_445_[0];
-          CsrPlugin_medeleg_SPF <= _zz_446_[0];
-          CsrPlugin_medeleg_SAM <= _zz_447_[0];
-          CsrPlugin_medeleg_IAM <= _zz_448_[0];
+          CsrPlugin_medeleg_IAM <= _zz_455[0];
+          CsrPlugin_medeleg_IAF <= _zz_456[0];
+          CsrPlugin_medeleg_II <= _zz_457[0];
+          CsrPlugin_medeleg_LAM <= _zz_458[0];
+          CsrPlugin_medeleg_LAF <= _zz_459[0];
+          CsrPlugin_medeleg_SAM <= _zz_460[0];
+          CsrPlugin_medeleg_SAF <= _zz_461[0];
+          CsrPlugin_medeleg_EU <= _zz_462[0];
+          CsrPlugin_medeleg_ES <= _zz_463[0];
+          CsrPlugin_medeleg_IPF <= _zz_464[0];
+          CsrPlugin_medeleg_LPF <= _zz_465[0];
+          CsrPlugin_medeleg_SPF <= _zz_466[0];
         end
       end
       if(execute_CsrPlugin_csr_771)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mideleg_SE <= _zz_449_[0];
-          CsrPlugin_mideleg_ST <= _zz_450_[0];
-          CsrPlugin_mideleg_SS <= _zz_451_[0];
+          CsrPlugin_mideleg_SE <= _zz_467[0];
+          CsrPlugin_mideleg_ST <= _zz_468[0];
+          CsrPlugin_mideleg_SS <= _zz_469[0];
         end
       end
       if(execute_CsrPlugin_csr_324)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_452_[0];
-          CsrPlugin_sip_SSIP <= _zz_453_[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_454_[0];
+          CsrPlugin_sip_STIP <= _zz_470[0];
+          CsrPlugin_sip_SSIP <= _zz_471[0];
+          CsrPlugin_sip_SEIP_SOFT <= _zz_472[0];
         end
       end
       if(execute_CsrPlugin_csr_260)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sie_SEIE <= _zz_455_[0];
-          CsrPlugin_sie_STIE <= _zz_456_[0];
-          CsrPlugin_sie_SSIE <= _zz_457_[0];
+          CsrPlugin_sie_SEIE <= _zz_473[0];
+          CsrPlugin_sie_STIE <= _zz_474[0];
+          CsrPlugin_sie_SSIE <= _zz_475[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_161_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_169 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_2496)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_163_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_171 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_287_)begin
+      if(_zz_305)begin
         if(iBusWishbone_ACK)begin
-          _zz_191_ <= (_zz_191_ + (3'b001));
+          _zz_199 <= (_zz_199 + 3'b001);
         end
       end
-      _zz_192_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_194_ && _zz_195_))begin
-        _zz_193_ <= (_zz_193_ + (3'b001));
-        if(_zz_197_)begin
-          _zz_193_ <= (3'b000);
+      _zz_200 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_202 && _zz_203))begin
+        _zz_201 <= (_zz_201 + 3'b001);
+        if(_zz_205)begin
+          _zz_201 <= 3'b000;
         end
       end
-      _zz_199_ <= ((_zz_194_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_207 <= ((_zz_202 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_71_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_71 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -7621,23 +6611,28 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_288_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_306)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if((MmuPlugin_dBusAccess_rsp_valid && (! MmuPlugin_dBusAccess_rsp_payload_redo)))begin
+    MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
+    MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
+    MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
+    if((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)))begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -7650,17 +6645,12 @@ module VexRiscv (
       MmuPlugin_shared_pteBuffer_PPN0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
       MmuPlugin_shared_pteBuffer_PPN1 <= MmuPlugin_shared_dBusRsp_pte_PPN1;
     end
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-        if(_zz_289_)begin
-          MmuPlugin_shared_vpn_1 <= IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22];
-          MmuPlugin_shared_vpn_0 <= IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12];
-          MmuPlugin_shared_portId <= (1'b0);
-        end
-        if(_zz_290_)begin
-          MmuPlugin_shared_vpn_1 <= DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22];
-          MmuPlugin_shared_vpn_0 <= DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12];
-          MmuPlugin_shared_portId <= (1'b1);
+        if(_zz_307)begin
+          MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
+          MmuPlugin_shared_vpn_1 <= _zz_103[31 : 22];
+          MmuPlugin_shared_vpn_0 <= _zz_103[21 : 12];
         end
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -7672,10 +6662,10 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(_zz_271_)begin
-      if(_zz_272_)begin
-        if(_zz_291_)begin
-          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+    if(_zz_289)begin
+      if(_zz_290)begin
+        if(_zz_308)begin
+          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7684,10 +6674,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_292_)begin
-          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_309)begin
+          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7696,10 +6686,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_293_)begin
-          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_310)begin
+          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7708,10 +6698,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_294_)begin
-          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_311)begin
+          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7720,12 +6710,12 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
-      if(_zz_273_)begin
-        if(_zz_295_)begin
-          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+      if(_zz_291)begin
+        if(_zz_312)begin
+          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7734,10 +6724,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_296_)begin
-          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_313)begin
+          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7746,10 +6736,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_297_)begin
-          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_314)begin
+          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7758,10 +6748,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_298_)begin
-          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_315)begin
+          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7770,12 +6760,12 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
     end
-    _zz_123_ <= _zz_40_[11 : 7];
-    _zz_124_ <= _zz_50_;
+    _zz_131 <= _zz_40[11 : 7];
+    _zz_132 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -7784,9 +6774,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_260_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_155_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_155_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_278)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_163 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_163 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -7800,47 +6790,47 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_299_)begin
-      if(_zz_300_)begin
-        CsrPlugin_interrupt_code <= (4'b0101);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
+    if(_zz_316)begin
+      if(_zz_317)begin
+        CsrPlugin_interrupt_code <= 4'b0101;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_301_)begin
-        CsrPlugin_interrupt_code <= (4'b0001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
+      if(_zz_318)begin
+        CsrPlugin_interrupt_code <= 4'b0001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_302_)begin
-        CsrPlugin_interrupt_code <= (4'b1001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
-      end
-    end
-    if(_zz_303_)begin
-      if(_zz_304_)begin
-        CsrPlugin_interrupt_code <= (4'b0101);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_305_)begin
-        CsrPlugin_interrupt_code <= (4'b0001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_306_)begin
-        CsrPlugin_interrupt_code <= (4'b1001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_307_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_308_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_309_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_319)begin
+        CsrPlugin_interrupt_code <= 4'b1001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(_zz_264_)begin
+    if(_zz_320)begin
+      if(_zz_321)begin
+        CsrPlugin_interrupt_code <= 4'b0101;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_322)begin
+        CsrPlugin_interrupt_code <= 4'b0001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_323)begin
+        CsrPlugin_interrupt_code <= 4'b1001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_324)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_325)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_326)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+    end
+    if(_zz_282)begin
       case(CsrPlugin_targetPrivilege)
         2'b01 : begin
           CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
@@ -7868,165 +6858,57 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_255_)begin
-      if(_zz_284_)begin
+    if(_zz_273)begin
+      if(_zz_302)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_405_[31:0];
+          memory_DivPlugin_div_result <= _zz_423[31:0];
         end
       end
     end
-    if(_zz_285_)begin
+    if(_zz_303)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_159_ ? (~ _zz_160_) : _zz_160_) + _zz_411_);
-      memory_DivPlugin_rs2 <= ((_zz_158_ ? (~ execute_RS2) : execute_RS2) + _zz_413_);
-      memory_DivPlugin_div_needRevert <= ((_zz_159_ ^ (_zz_158_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_167 ? (~ _zz_168) : _zz_168) + _zz_429);
+      memory_DivPlugin_rs2 <= ((_zz_166 ? (~ execute_RS2) : execute_RS2) + _zz_431);
+      memory_DivPlugin_div_needRevert <= ((_zz_167 ^ (_zz_166 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_25_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_22_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_20_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_18_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_15_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_13_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_55_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_53_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54_;
-    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
+      execute_to_memory_PC <= _zz_35;
     end
     if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
       memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_10_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_7_;
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_55;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_4_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_SFENCE_VMA <= execute_IS_SFENCE_VMA;
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_53;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_SFENCE_VMA <= memory_IS_SFENCE_VMA;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_2_;
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_25;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -8038,37 +6920,28 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      decode_to_execute_ALU_CTRL <= _zz_22;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_19;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
@@ -8078,6 +6951,132 @@ module VexRiscv (
     end
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_SFENCE_VMA <= execute_IS_SFENCE_VMA;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_SFENCE_VMA <= memory_IS_SFENCE_VMA;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -8165,12 +7164,13 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_384)begin
       if(execute_CsrPlugin_writeEnable)begin
+        MmuPlugin_satp_asid <= execute_CsrPlugin_writeData[30 : 22];
         MmuPlugin_satp_ppn <= execute_CsrPlugin_writeData[19 : 0];
       end
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_427_[0];
+        CsrPlugin_mip_MSIP <= _zz_445[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -8207,7 +7207,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_322)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_scause_interrupt <= _zz_458_[0];
+        CsrPlugin_scause_interrupt <= _zz_476[0];
         CsrPlugin_scause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -8226,12 +7226,12 @@ module VexRiscv (
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
-    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != (4'b0000)) || IBusCachedPlugin_incomingInstruction);
+    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
     if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_50_;
+      DebugPlugin_busReadDataReg <= _zz_50;
     end
-    _zz_165_ <= debug_bus_cmd_payload_address[2];
-    if(_zz_262_)begin
+    _zz_173 <= debug_bus_cmd_payload_address[2];
+    if(_zz_280)begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -8249,8 +7249,8 @@ module VexRiscv (
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid)begin
-        case(_zz_286_)
-          6'b000000 : begin
+        case(_zz_304)
+          6'h0 : begin
             if(debug_bus_cmd_payload_wr)begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
               if(debug_bus_cmd_payload_data[16])begin
@@ -8273,23 +7273,1291 @@ module VexRiscv (
               end
             end
           end
-          6'b000001 : begin
-          end
           default : begin
           end
         endcase
       end
-      if(_zz_262_)begin
-        if(_zz_263_)begin
+      if(_zz_280)begin
+        if(_zz_281)begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_266_)begin
+      if(_zz_284)begin
         if(decode_arbitration_isValid)begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
+    end
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_isLrsc,
+  input               io_cpu_execute_args_isAmo,
+  input               io_cpu_execute_args_amoCtrl_swap,
+  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_memory_mmuRsp_ways_0_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
+  input               io_cpu_memory_mmuRsp_ways_1_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
+  input               io_cpu_memory_mmuRsp_ways_2_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
+  input               io_cpu_memory_mmuRsp_ways_3_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire                _zz_19;
+  wire                _zz_20;
+  wire                _zz_21;
+  wire                _zz_22;
+  wire       [2:0]    _zz_23;
+  wire       [0:0]    _zz_24;
+  wire       [0:0]    _zz_25;
+  wire       [9:0]    _zz_26;
+  wire       [9:0]    _zz_27;
+  wire       [31:0]   _zz_28;
+  wire       [31:0]   _zz_29;
+  wire       [31:0]   _zz_30;
+  wire       [31:0]   _zz_31;
+  wire       [1:0]    _zz_32;
+  wire       [31:0]   _zz_33;
+  wire       [1:0]    _zz_34;
+  wire       [1:0]    _zz_35;
+  wire       [0:0]    _zz_36;
+  wire       [0:0]    _zz_37;
+  wire       [0:0]    _zz_38;
+  wire       [2:0]    _zz_39;
+  wire       [1:0]    _zz_40;
+  wire       [21:0]   _zz_41;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_isLrsc;
+  reg                 stageA_request_isAmo;
+  reg                 stageA_request_amoCtrl_swap;
+  reg        [2:0]    stageA_request_amoCtrl_alu;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_isLrsc;
+  reg                 stageB_request_isAmo;
+  reg                 stageB_request_amoCtrl_swap;
+  reg        [2:0]    stageB_request_amoCtrl_alu;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_mmuRsp_ways_0_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_0_physical;
+  reg                 stageB_mmuRsp_ways_1_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_1_physical;
+  reg                 stageB_mmuRsp_ways_2_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_2_physical;
+  reg                 stageB_mmuRsp_ways_3_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_3_physical;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  reg                 stageB_lrSc_reserved;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  reg        [31:0]   stageB_requestDataBypass;
+  wire                stageB_amo_compare;
+  wire                stageB_amo_unsigned;
+  wire       [31:0]   stageB_amo_addSub;
+  wire                stageB_amo_less;
+  wire                stageB_amo_selectRf;
+  reg        [31:0]   stageB_amo_result;
+  reg        [31:0]   stageB_amo_resultReg;
+  reg                 stageB_amo_internal_resultRegValid;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_42;
+  reg [7:0] _zz_43;
+  reg [7:0] _zz_44;
+  reg [7:0] _zz_45;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign _zz_16 = (! stageB_amo_internal_resultRegValid);
+  assign _zz_17 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_18 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_19 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_20 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign _zz_21 = (! stageB_flusher_hold);
+  assign _zz_22 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_23 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  assign _zz_24 = _zz_4[0 : 0];
+  assign _zz_25 = _zz_4[1 : 1];
+  assign _zz_26 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_27 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_28 = ($signed(_zz_29) + $signed(_zz_33));
+  assign _zz_29 = ($signed(_zz_30) + $signed(_zz_31));
+  assign _zz_30 = stageB_request_data;
+  assign _zz_31 = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
+  assign _zz_32 = (stageB_amo_compare ? _zz_34 : _zz_35);
+  assign _zz_33 = {{30{_zz_32[1]}}, _zz_32};
+  assign _zz_34 = 2'b01;
+  assign _zz_35 = 2'b00;
+  assign _zz_36 = 1'b1;
+  assign _zz_37 = (! stageB_lrSc_reserved);
+  assign _zz_38 = loader_counter_willIncrement;
+  assign _zz_39 = {2'd0, _zz_38};
+  assign _zz_40 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_41 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_41;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_45, _zz_44, _zz_43, _zz_42};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_42 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_43 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_44 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_45 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_24[0];
+  assign ways_0_tagsReadRsp_error = _zz_25[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                dataWriteCmd_valid = 1'b0;
+              end
+            end
+            if(_zz_17)begin
+              dataWriteCmd_valid = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_36[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_26)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_27)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+          if(_zz_19)begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                io_cpu_writeBack_haltIt = 1'b1;
+              end
+            end
+            if(_zz_17)begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  always @ (*) begin
+    stageB_requestDataBypass = stageB_request_data;
+    if(stageB_request_isAmo)begin
+      stageB_requestDataBypass = stageB_amo_resultReg;
+    end
+  end
+
+  assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
+  assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == 2'b11);
+  assign stageB_amo_addSub = _zz_28;
+  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
+  assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
+  always @ (*) begin
+    case(_zz_23)
+      3'b000 : begin
+        stageB_amo_result = stageB_amo_addSub;
+      end
+      3'b001 : begin
+        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
+      end
+      3'b010 : begin
+        stageB_amo_result = (stageB_request_data | stageB_dataMux);
+      end
+      3'b011 : begin
+        stageB_amo_result = (stageB_request_data & stageB_dataMux);
+      end
+      default : begin
+        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if(_zz_20)begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          io_mem_cmd_valid = (! memCmdSent);
+          if(_zz_19)begin
+            io_mem_cmd_valid = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                io_mem_cmd_valid = 1'b0;
+              end
+            end
+            if(_zz_20)begin
+              io_mem_cmd_valid = 1'b0;
+            end
+            if(_zz_17)begin
+              io_mem_cmd_valid = 1'b0;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+    if((stageB_request_isLrsc && stageB_request_wr))begin
+      io_cpu_writeBack_data = {31'd0, _zz_37};
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_18)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_39);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
+      stageA_request_isAmo <= io_cpu_execute_args_isAmo;
+      stageA_request_amoCtrl_swap <= io_cpu_execute_args_amoCtrl_swap;
+      stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_isLrsc <= stageA_request_isLrsc;
+      stageB_request_isAmo <= stageA_request_isAmo;
+      stageB_request_amoCtrl_swap <= stageA_request_amoCtrl_swap;
+      stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+      stageB_mmuRsp_ways_0_sel <= io_cpu_memory_mmuRsp_ways_0_sel;
+      stageB_mmuRsp_ways_0_physical <= io_cpu_memory_mmuRsp_ways_0_physical;
+      stageB_mmuRsp_ways_1_sel <= io_cpu_memory_mmuRsp_ways_1_sel;
+      stageB_mmuRsp_ways_1_physical <= io_cpu_memory_mmuRsp_ways_1_physical;
+      stageB_mmuRsp_ways_2_sel <= io_cpu_memory_mmuRsp_ways_2_sel;
+      stageB_mmuRsp_ways_2_physical <= io_cpu_memory_mmuRsp_ways_2_physical;
+      stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
+      stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_21)begin
+        if(_zz_22)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
+    stageB_amo_resultReg <= stageB_amo_result;
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      stageB_lrSc_reserved <= 1'b0;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_21)begin
+          if(! _zz_22) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+        stageB_lrSc_reserved <= (! stageB_request_wr);
+      end
+      if(_zz_13)begin
+        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_18)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_40[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  input               io_cpu_fetch_mmuRsp_ways_0_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
+  input               io_cpu_fetch_mmuRsp_ways_1_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
+  input               io_cpu_fetch_mmuRsp_ways_2_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
+  input               io_cpu_fetch_mmuRsp_ways_3_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input      [2:0]    _zz_9,
+  input      [31:0]   _zz_10,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_11;
+  reg        [21:0]   _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire       [0:0]    _zz_15;
+  wire       [0:0]    _zz_16;
+  wire       [21:0]   _zz_17;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_mmuRsp_ways_0_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_0_physical;
+  reg                 decodeStage_mmuRsp_ways_1_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_1_physical;
+  reg                 decodeStage_mmuRsp_ways_2_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_2_physical;
+  reg                 decodeStage_mmuRsp_ways_3_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_3_physical;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_13 = (! lineLoader_flushCounter[7]);
+  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_15 = _zz_8[0 : 0];
+  assign _zz_16 = _zz_8[1 : 1];
+  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_11 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_12 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_13)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_12;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_14)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_13)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_14)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+      decodeStage_mmuRsp_ways_0_sel <= io_cpu_fetch_mmuRsp_ways_0_sel;
+      decodeStage_mmuRsp_ways_0_physical <= io_cpu_fetch_mmuRsp_ways_0_physical;
+      decodeStage_mmuRsp_ways_1_sel <= io_cpu_fetch_mmuRsp_ways_1_sel;
+      decodeStage_mmuRsp_ways_1_physical <= io_cpu_fetch_mmuRsp_ways_1_physical;
+      decodeStage_mmuRsp_ways_2_sel <= io_cpu_fetch_mmuRsp_ways_2_sel;
+      decodeStage_mmuRsp_ways_2_physical <= io_cpu_fetch_mmuRsp_ways_2_physical;
+      decodeStage_mmuRsp_ways_3_sel <= io_cpu_fetch_mmuRsp_ways_3_sel;
+      decodeStage_mmuRsp_ways_3_physical <= io_cpu_fetch_mmuRsp_ways_3_physical;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
+    if((_zz_9 != 3'b000))begin
+      io_cpu_fetch_data_regNextWhen <= _zz_10;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxNoDspFmax.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LinuxNoDspFmax.v
@@ -1,6 +1,6 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:39:12
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
@@ -15,15 +15,16 @@
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
+`define ShiftCtrlEnum_defaultEncoding_type [1:0]
+`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
 `define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
 `define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
 `define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
-
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -31,11 +32,10 @@
 `define Src2CtrlEnum_defaultEncoding_IMS 2'b10
 `define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
-`define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
 `define Src1CtrlEnum_defaultEncoding_type [1:0]
 `define Src1CtrlEnum_defaultEncoding_RS 2'b00
@@ -51,1148 +51,6 @@
 `define MmuPlugin_shared_State_defaultEncoding_L0_RSP 3'b100
 
 
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire       [0:0]    _zz_14_;
-  wire       [0:0]    _zz_15_;
-  wire       [21:0]   _zz_16_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* syn_keep , keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* syn_keep , keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-
-  assign _zz_12_ = (! lineLoader_flushCounter[7]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_execute_args_isLrsc,
-  input               io_cpu_execute_args_isAmo,
-  input               io_cpu_execute_args_amoCtrl_swap,
-  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  input               io_cpu_writeBack_clearLrsc,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire                _zz_17_;
-  wire                _zz_18_;
-  wire                _zz_19_;
-  wire                _zz_20_;
-  wire       [2:0]    _zz_21_;
-  wire       [0:0]    _zz_22_;
-  wire       [0:0]    _zz_23_;
-  wire       [31:0]   _zz_24_;
-  wire       [31:0]   _zz_25_;
-  wire       [31:0]   _zz_26_;
-  wire       [31:0]   _zz_27_;
-  wire       [1:0]    _zz_28_;
-  wire       [31:0]   _zz_29_;
-  wire       [1:0]    _zz_30_;
-  wire       [1:0]    _zz_31_;
-  wire       [0:0]    _zz_32_;
-  wire       [0:0]    _zz_33_;
-  wire       [2:0]    _zz_34_;
-  wire       [1:0]    _zz_35_;
-  wire       [21:0]   _zz_36_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg                 stageA_request_isLrsc;
-  reg                 stageA_request_isAmo;
-  reg                 stageA_request_amoCtrl_swap;
-  reg        [2:0]    stageA_request_amoCtrl_alu;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_request_isLrsc;
-  reg                 stageB_request_isAmo;
-  reg                 stageB_request_amoCtrl_swap;
-  reg        [2:0]    stageB_request_amoCtrl_alu;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  reg                 stageB_lrsc_reserved;
-  reg        [31:0]   stageB_requestDataBypass;
-  wire                stageB_amo_compare;
-  wire                stageB_amo_unsigned;
-  wire       [31:0]   stageB_amo_addSub;
-  wire                stageB_amo_less;
-  wire                stageB_amo_selectRf;
-  reg        [31:0]   stageB_amo_result;
-  reg                 stageB_amo_resultRegValid;
-  reg        [31:0]   stageB_amo_resultReg;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_37_;
-  reg [7:0] _zz_38_;
-  reg [7:0] _zz_39_;
-  reg [7:0] _zz_40_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
-  assign _zz_15_ = (! stageB_amo_resultRegValid);
-  assign _zz_16_ = (stageB_request_isLrsc && (! stageB_lrsc_reserved));
-  assign _zz_17_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_18_ = (stageB_request_isLrsc && (! stageB_lrsc_reserved));
-  assign _zz_19_ = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0)));
-  assign _zz_20_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_21_ = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,(2'b00)});
-  assign _zz_22_ = _zz_4_[0 : 0];
-  assign _zz_23_ = _zz_4_[1 : 1];
-  assign _zz_24_ = ($signed(_zz_25_) + $signed(_zz_29_));
-  assign _zz_25_ = ($signed(_zz_26_) + $signed(_zz_27_));
-  assign _zz_26_ = stageB_request_data;
-  assign _zz_27_ = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
-  assign _zz_28_ = (stageB_amo_compare ? _zz_30_ : _zz_31_);
-  assign _zz_29_ = {{30{_zz_28_[1]}}, _zz_28_};
-  assign _zz_30_ = (2'b01);
-  assign _zz_31_ = (2'b00);
-  assign _zz_32_ = (! stageB_lrsc_reserved);
-  assign _zz_33_ = loader_counter_willIncrement;
-  assign _zz_34_ = {2'd0, _zz_33_};
-  assign _zz_35_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_36_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_36_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_40_, _zz_39_, _zz_38_, _zz_37_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_37_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_38_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_39_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_40_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_22_[0];
-  assign ways_0_tagsReadRsp_error = _zz_23_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              dataWriteCmd_valid = 1'b0;
-            end
-          end
-          if(_zz_16_)begin
-            dataWriteCmd_valid = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_17_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-        if(_zz_18_)begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              io_cpu_writeBack_haltIt = 1'b1;
-            end
-          end
-          if(_zz_16_)begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    stageB_requestDataBypass = stageB_request_data;
-    if(stageB_request_isAmo)begin
-      stageB_requestDataBypass = stageB_amo_resultReg;
-    end
-  end
-
-  assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
-  assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == (2'b11));
-  assign stageB_amo_addSub = _zz_24_;
-  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
-  assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
-  always @ (*) begin
-    case(_zz_21_)
-      3'b000 : begin
-        stageB_amo_result = stageB_amo_addSub;
-      end
-      3'b001 : begin
-        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
-      end
-      3'b010 : begin
-        stageB_amo_result = (stageB_request_data | stageB_dataMux);
-      end
-      3'b011 : begin
-        stageB_amo_result = (stageB_request_data & stageB_dataMux);
-      end
-      default : begin
-        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
-      end
-    endcase
-  end
-
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if(_zz_19_)begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-        if(_zz_18_)begin
-          io_mem_cmd_valid = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-          if(stageB_request_isAmo)begin
-            if(_zz_15_)begin
-              io_mem_cmd_valid = 1'b0;
-            end
-          end
-          if(_zz_19_)begin
-            io_mem_cmd_valid = 1'b0;
-          end
-          if(_zz_16_)begin
-            io_mem_cmd_valid = 1'b0;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-    if((stageB_request_isLrsc && stageB_request_wr))begin
-      io_cpu_writeBack_data = {31'd0, _zz_32_};
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_17_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_34_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
-      stageA_request_isAmo <= io_cpu_execute_args_isAmo;
-      stageA_request_amoCtrl_swap <= io_cpu_execute_args_amoCtrl_swap;
-      stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-      stageB_request_isLrsc <= stageA_request_isLrsc;
-      stageB_request_isAmo <= stageA_request_isAmo;
-      stageB_request_amoCtrl_swap <= stageA_request_amoCtrl_swap;
-      stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_20_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    stageB_amo_resultRegValid <= 1'b1;
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_amo_resultRegValid <= 1'b0;
-    end
-    stageB_amo_resultReg <= stageB_amo_result;
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_lrsc_reserved <= 1'b0;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_20_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(((((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && (! io_cpu_redo)) && stageB_request_isLrsc) && (! stageB_request_wr)))begin
-        stageB_lrsc_reserved <= 1'b1;
-      end
-      if(io_cpu_writeBack_clearLrsc)begin
-        stageB_lrsc_reserved <= 1'b0;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_17_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_35_[0:0];
-      end
-    end
-  end
-
-
-endmodule
-
 module VexRiscv (
   input      [31:0]   externalResetVector,
   input               timerInterrupt,
@@ -1207,8 +65,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1218,69 +76,74 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset 
+  input               reset
 );
-  wire                _zz_184_;
-  wire                _zz_185_;
-  wire                _zz_186_;
-  wire                _zz_187_;
-  wire                _zz_188_;
-  wire                _zz_189_;
-  wire                _zz_190_;
-  reg                 _zz_191_;
-  reg                 _zz_192_;
-  reg        [31:0]   _zz_193_;
-  reg                 _zz_194_;
-  reg        [31:0]   _zz_195_;
-  reg        [1:0]    _zz_196_;
-  reg                 _zz_197_;
-  reg                 _zz_198_;
-  wire                _zz_199_;
-  wire       [2:0]    _zz_200_;
-  reg                 _zz_201_;
-  wire       [31:0]   _zz_202_;
-  reg                 _zz_203_;
-  reg                 _zz_204_;
-  wire                _zz_205_;
-  wire       [31:0]   _zz_206_;
-  wire                _zz_207_;
-  wire                _zz_208_;
-  reg        [31:0]   _zz_209_;
-  reg        [31:0]   _zz_210_;
-  reg        [31:0]   _zz_211_;
-  reg                 _zz_212_;
-  reg                 _zz_213_;
-  reg                 _zz_214_;
-  reg        [9:0]    _zz_215_;
-  reg        [9:0]    _zz_216_;
-  reg        [9:0]    _zz_217_;
-  reg        [9:0]    _zz_218_;
-  reg                 _zz_219_;
-  reg                 _zz_220_;
-  reg                 _zz_221_;
-  reg                 _zz_222_;
-  reg                 _zz_223_;
-  reg                 _zz_224_;
-  reg                 _zz_225_;
-  reg        [9:0]    _zz_226_;
-  reg        [9:0]    _zz_227_;
-  reg        [9:0]    _zz_228_;
-  reg        [9:0]    _zz_229_;
-  reg                 _zz_230_;
-  reg                 _zz_231_;
-  reg                 _zz_232_;
-  reg                 _zz_233_;
+  wire                _zz_192;
+  wire                _zz_193;
+  wire                _zz_194;
+  wire                _zz_195;
+  wire                _zz_196;
+  wire                _zz_197;
+  wire                _zz_198;
+  wire                _zz_199;
+  reg                 _zz_200;
+  reg                 _zz_201;
+  reg        [31:0]   _zz_202;
+  reg                 _zz_203;
+  reg        [31:0]   _zz_204;
+  reg        [1:0]    _zz_205;
+  reg                 _zz_206;
+  reg                 _zz_207;
+  wire                _zz_208;
+  wire       [2:0]    _zz_209;
+  reg                 _zz_210;
+  wire       [31:0]   _zz_211;
+  reg                 _zz_212;
+  reg                 _zz_213;
+  wire                _zz_214;
+  wire       [31:0]   _zz_215;
+  wire                _zz_216;
+  wire                _zz_217;
+  wire                _zz_218;
+  wire                _zz_219;
+  wire                _zz_220;
+  wire                _zz_221;
+  wire                _zz_222;
+  wire                _zz_223;
+  wire       [3:0]    _zz_224;
+  wire                _zz_225;
+  wire                _zz_226;
+  reg        [31:0]   _zz_227;
+  reg        [31:0]   _zz_228;
+  reg        [31:0]   _zz_229;
+  reg                 _zz_230;
+  reg                 _zz_231;
+  reg                 _zz_232;
+  reg        [9:0]    _zz_233;
+  reg        [9:0]    _zz_234;
+  reg        [9:0]    _zz_235;
+  reg        [9:0]    _zz_236;
+  reg                 _zz_237;
+  reg                 _zz_238;
+  reg                 _zz_239;
+  reg                 _zz_240;
+  reg                 _zz_241;
+  reg                 _zz_242;
+  reg                 _zz_243;
+  reg        [9:0]    _zz_244;
+  reg        [9:0]    _zz_245;
+  reg        [9:0]    _zz_246;
+  reg        [9:0]    _zz_247;
+  reg                 _zz_248;
+  reg                 _zz_249;
+  reg                 _zz_250;
+  reg                 _zz_251;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -1290,479 +153,493 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_234_;
-  wire                _zz_235_;
-  wire                _zz_236_;
-  wire                _zz_237_;
-  wire                _zz_238_;
-  wire                _zz_239_;
-  wire                _zz_240_;
-  wire                _zz_241_;
-  wire                _zz_242_;
-  wire                _zz_243_;
-  wire                _zz_244_;
-  wire                _zz_245_;
-  wire                _zz_246_;
-  wire                _zz_247_;
-  wire                _zz_248_;
-  wire                _zz_249_;
-  wire       [1:0]    _zz_250_;
-  wire                _zz_251_;
-  wire                _zz_252_;
-  wire                _zz_253_;
-  wire                _zz_254_;
-  wire                _zz_255_;
-  wire                _zz_256_;
-  wire                _zz_257_;
-  wire                _zz_258_;
-  wire                _zz_259_;
-  wire                _zz_260_;
-  wire                _zz_261_;
-  wire                _zz_262_;
-  wire                _zz_263_;
-  wire                _zz_264_;
-  wire                _zz_265_;
-  wire                _zz_266_;
-  wire                _zz_267_;
-  wire                _zz_268_;
-  wire                _zz_269_;
-  wire                _zz_270_;
-  wire                _zz_271_;
-  wire                _zz_272_;
-  wire                _zz_273_;
-  wire                _zz_274_;
-  wire                _zz_275_;
-  wire                _zz_276_;
-  wire                _zz_277_;
-  wire                _zz_278_;
-  wire                _zz_279_;
-  wire                _zz_280_;
-  wire                _zz_281_;
-  wire                _zz_282_;
-  wire                _zz_283_;
-  wire                _zz_284_;
-  wire                _zz_285_;
-  wire                _zz_286_;
-  wire                _zz_287_;
-  wire                _zz_288_;
-  wire                _zz_289_;
-  wire                _zz_290_;
-  wire       [1:0]    _zz_291_;
-  wire                _zz_292_;
-  wire       [0:0]    _zz_293_;
-  wire       [0:0]    _zz_294_;
-  wire       [0:0]    _zz_295_;
-  wire       [0:0]    _zz_296_;
-  wire       [0:0]    _zz_297_;
-  wire       [0:0]    _zz_298_;
-  wire       [0:0]    _zz_299_;
-  wire       [0:0]    _zz_300_;
-  wire       [0:0]    _zz_301_;
-  wire       [0:0]    _zz_302_;
-  wire       [0:0]    _zz_303_;
-  wire       [0:0]    _zz_304_;
-  wire       [0:0]    _zz_305_;
-  wire       [32:0]   _zz_306_;
-  wire       [31:0]   _zz_307_;
-  wire       [32:0]   _zz_308_;
-  wire       [0:0]    _zz_309_;
-  wire       [0:0]    _zz_310_;
-  wire       [0:0]    _zz_311_;
-  wire       [0:0]    _zz_312_;
-  wire       [0:0]    _zz_313_;
-  wire       [0:0]    _zz_314_;
-  wire       [0:0]    _zz_315_;
-  wire       [3:0]    _zz_316_;
-  wire       [2:0]    _zz_317_;
-  wire       [31:0]   _zz_318_;
-  wire       [2:0]    _zz_319_;
-  wire       [2:0]    _zz_320_;
-  wire       [0:0]    _zz_321_;
-  wire       [1:0]    _zz_322_;
-  wire       [0:0]    _zz_323_;
-  wire       [1:0]    _zz_324_;
-  wire       [0:0]    _zz_325_;
-  wire       [0:0]    _zz_326_;
-  wire       [0:0]    _zz_327_;
-  wire       [0:0]    _zz_328_;
-  wire       [0:0]    _zz_329_;
-  wire       [0:0]    _zz_330_;
-  wire       [0:0]    _zz_331_;
-  wire       [0:0]    _zz_332_;
-  wire       [0:0]    _zz_333_;
-  wire       [2:0]    _zz_334_;
-  wire       [4:0]    _zz_335_;
-  wire       [11:0]   _zz_336_;
-  wire       [11:0]   _zz_337_;
-  wire       [31:0]   _zz_338_;
-  wire       [31:0]   _zz_339_;
-  wire       [31:0]   _zz_340_;
-  wire       [31:0]   _zz_341_;
-  wire       [31:0]   _zz_342_;
-  wire       [31:0]   _zz_343_;
-  wire       [31:0]   _zz_344_;
-  wire       [19:0]   _zz_345_;
-  wire       [11:0]   _zz_346_;
-  wire       [11:0]   _zz_347_;
-  wire       [1:0]    _zz_348_;
-  wire       [1:0]    _zz_349_;
-  wire       [0:0]    _zz_350_;
-  wire       [5:0]    _zz_351_;
-  wire       [33:0]   _zz_352_;
-  wire       [32:0]   _zz_353_;
-  wire       [33:0]   _zz_354_;
-  wire       [32:0]   _zz_355_;
-  wire       [33:0]   _zz_356_;
-  wire       [32:0]   _zz_357_;
-  wire       [0:0]    _zz_358_;
-  wire       [5:0]    _zz_359_;
-  wire       [32:0]   _zz_360_;
-  wire       [31:0]   _zz_361_;
-  wire       [31:0]   _zz_362_;
-  wire       [32:0]   _zz_363_;
-  wire       [32:0]   _zz_364_;
-  wire       [32:0]   _zz_365_;
-  wire       [32:0]   _zz_366_;
-  wire       [0:0]    _zz_367_;
-  wire       [32:0]   _zz_368_;
-  wire       [0:0]    _zz_369_;
-  wire       [32:0]   _zz_370_;
-  wire       [0:0]    _zz_371_;
-  wire       [31:0]   _zz_372_;
-  wire       [0:0]    _zz_373_;
-  wire       [0:0]    _zz_374_;
-  wire       [0:0]    _zz_375_;
-  wire       [0:0]    _zz_376_;
-  wire       [0:0]    _zz_377_;
-  wire       [0:0]    _zz_378_;
-  wire       [0:0]    _zz_379_;
-  wire       [0:0]    _zz_380_;
-  wire       [0:0]    _zz_381_;
-  wire       [0:0]    _zz_382_;
-  wire       [0:0]    _zz_383_;
-  wire       [0:0]    _zz_384_;
-  wire       [0:0]    _zz_385_;
-  wire       [0:0]    _zz_386_;
-  wire       [0:0]    _zz_387_;
-  wire       [0:0]    _zz_388_;
-  wire       [0:0]    _zz_389_;
-  wire       [0:0]    _zz_390_;
-  wire       [0:0]    _zz_391_;
-  wire       [0:0]    _zz_392_;
-  wire       [0:0]    _zz_393_;
-  wire       [0:0]    _zz_394_;
-  wire       [0:0]    _zz_395_;
-  wire       [0:0]    _zz_396_;
-  wire       [0:0]    _zz_397_;
-  wire       [0:0]    _zz_398_;
-  wire       [0:0]    _zz_399_;
-  wire       [0:0]    _zz_400_;
-  wire       [0:0]    _zz_401_;
-  wire       [0:0]    _zz_402_;
-  wire       [0:0]    _zz_403_;
-  wire       [0:0]    _zz_404_;
-  wire       [0:0]    _zz_405_;
-  wire       [0:0]    _zz_406_;
-  wire       [0:0]    _zz_407_;
-  wire       [0:0]    _zz_408_;
-  wire       [0:0]    _zz_409_;
-  wire       [0:0]    _zz_410_;
-  wire       [0:0]    _zz_411_;
-  wire       [0:0]    _zz_412_;
-  wire       [0:0]    _zz_413_;
-  wire       [0:0]    _zz_414_;
-  wire       [0:0]    _zz_415_;
-  wire       [0:0]    _zz_416_;
-  wire       [0:0]    _zz_417_;
-  wire       [26:0]   _zz_418_;
-  wire                _zz_419_;
-  wire                _zz_420_;
-  wire       [1:0]    _zz_421_;
-  wire       [31:0]   _zz_422_;
-  wire       [31:0]   _zz_423_;
-  wire       [31:0]   _zz_424_;
-  wire                _zz_425_;
-  wire       [0:0]    _zz_426_;
-  wire       [17:0]   _zz_427_;
-  wire       [31:0]   _zz_428_;
-  wire       [31:0]   _zz_429_;
-  wire       [31:0]   _zz_430_;
-  wire                _zz_431_;
-  wire       [0:0]    _zz_432_;
-  wire       [11:0]   _zz_433_;
-  wire       [31:0]   _zz_434_;
-  wire       [31:0]   _zz_435_;
-  wire       [31:0]   _zz_436_;
-  wire                _zz_437_;
-  wire       [0:0]    _zz_438_;
-  wire       [5:0]    _zz_439_;
-  wire       [31:0]   _zz_440_;
-  wire       [31:0]   _zz_441_;
-  wire       [31:0]   _zz_442_;
-  wire                _zz_443_;
-  wire                _zz_444_;
-  wire       [31:0]   _zz_445_;
-  wire       [31:0]   _zz_446_;
-  wire                _zz_447_;
-  wire                _zz_448_;
-  wire       [31:0]   _zz_449_;
-  wire       [31:0]   _zz_450_;
-  wire       [0:0]    _zz_451_;
-  wire       [0:0]    _zz_452_;
-  wire                _zz_453_;
-  wire       [0:0]    _zz_454_;
-  wire       [28:0]   _zz_455_;
-  wire       [31:0]   _zz_456_;
-  wire                _zz_457_;
-  wire       [0:0]    _zz_458_;
-  wire       [2:0]    _zz_459_;
-  wire                _zz_460_;
-  wire       [0:0]    _zz_461_;
-  wire       [0:0]    _zz_462_;
-  wire                _zz_463_;
-  wire       [0:0]    _zz_464_;
-  wire       [25:0]   _zz_465_;
-  wire       [31:0]   _zz_466_;
-  wire       [31:0]   _zz_467_;
-  wire       [31:0]   _zz_468_;
-  wire                _zz_469_;
-  wire       [31:0]   _zz_470_;
-  wire                _zz_471_;
-  wire       [0:0]    _zz_472_;
-  wire       [1:0]    _zz_473_;
-  wire       [0:0]    _zz_474_;
-  wire       [0:0]    _zz_475_;
-  wire       [2:0]    _zz_476_;
-  wire       [2:0]    _zz_477_;
-  wire                _zz_478_;
-  wire       [0:0]    _zz_479_;
-  wire       [22:0]   _zz_480_;
-  wire       [31:0]   _zz_481_;
-  wire       [31:0]   _zz_482_;
-  wire       [31:0]   _zz_483_;
-  wire       [31:0]   _zz_484_;
-  wire                _zz_485_;
-  wire                _zz_486_;
-  wire       [31:0]   _zz_487_;
-  wire       [31:0]   _zz_488_;
-  wire       [31:0]   _zz_489_;
-  wire       [31:0]   _zz_490_;
-  wire                _zz_491_;
-  wire       [0:0]    _zz_492_;
-  wire       [0:0]    _zz_493_;
-  wire       [0:0]    _zz_494_;
-  wire       [1:0]    _zz_495_;
-  wire       [1:0]    _zz_496_;
-  wire       [1:0]    _zz_497_;
-  wire                _zz_498_;
-  wire       [0:0]    _zz_499_;
-  wire       [20:0]   _zz_500_;
-  wire       [31:0]   _zz_501_;
-  wire       [31:0]   _zz_502_;
-  wire       [31:0]   _zz_503_;
-  wire       [31:0]   _zz_504_;
-  wire       [31:0]   _zz_505_;
-  wire       [31:0]   _zz_506_;
-  wire       [31:0]   _zz_507_;
-  wire                _zz_508_;
-  wire                _zz_509_;
-  wire                _zz_510_;
-  wire       [1:0]    _zz_511_;
-  wire       [1:0]    _zz_512_;
-  wire                _zz_513_;
-  wire       [0:0]    _zz_514_;
-  wire       [18:0]   _zz_515_;
-  wire       [31:0]   _zz_516_;
-  wire       [31:0]   _zz_517_;
-  wire       [31:0]   _zz_518_;
-  wire       [31:0]   _zz_519_;
-  wire       [31:0]   _zz_520_;
-  wire       [31:0]   _zz_521_;
-  wire       [0:0]    _zz_522_;
-  wire       [0:0]    _zz_523_;
-  wire       [0:0]    _zz_524_;
-  wire       [0:0]    _zz_525_;
-  wire                _zz_526_;
-  wire       [0:0]    _zz_527_;
-  wire       [15:0]   _zz_528_;
-  wire       [31:0]   _zz_529_;
-  wire       [31:0]   _zz_530_;
-  wire       [0:0]    _zz_531_;
-  wire       [0:0]    _zz_532_;
-  wire       [1:0]    _zz_533_;
-  wire       [1:0]    _zz_534_;
-  wire                _zz_535_;
-  wire       [0:0]    _zz_536_;
-  wire       [12:0]   _zz_537_;
-  wire       [31:0]   _zz_538_;
-  wire       [31:0]   _zz_539_;
-  wire       [31:0]   _zz_540_;
-  wire       [31:0]   _zz_541_;
-  wire       [31:0]   _zz_542_;
-  wire       [0:0]    _zz_543_;
-  wire       [4:0]    _zz_544_;
-  wire                _zz_545_;
-  wire       [4:0]    _zz_546_;
-  wire       [4:0]    _zz_547_;
-  wire                _zz_548_;
-  wire       [0:0]    _zz_549_;
-  wire       [9:0]    _zz_550_;
-  wire       [31:0]   _zz_551_;
-  wire       [31:0]   _zz_552_;
-  wire       [31:0]   _zz_553_;
-  wire                _zz_554_;
-  wire       [0:0]    _zz_555_;
-  wire       [1:0]    _zz_556_;
-  wire                _zz_557_;
-  wire       [0:0]    _zz_558_;
-  wire       [1:0]    _zz_559_;
-  wire       [31:0]   _zz_560_;
-  wire       [31:0]   _zz_561_;
-  wire       [0:0]    _zz_562_;
-  wire       [0:0]    _zz_563_;
-  wire       [1:0]    _zz_564_;
-  wire       [1:0]    _zz_565_;
-  wire                _zz_566_;
-  wire       [0:0]    _zz_567_;
-  wire       [6:0]    _zz_568_;
-  wire       [31:0]   _zz_569_;
-  wire       [31:0]   _zz_570_;
-  wire       [31:0]   _zz_571_;
-  wire                _zz_572_;
-  wire       [31:0]   _zz_573_;
-  wire       [31:0]   _zz_574_;
-  wire       [31:0]   _zz_575_;
-  wire                _zz_576_;
-  wire                _zz_577_;
-  wire       [31:0]   _zz_578_;
-  wire       [31:0]   _zz_579_;
-  wire                _zz_580_;
-  wire                _zz_581_;
-  wire       [0:0]    _zz_582_;
-  wire       [0:0]    _zz_583_;
-  wire                _zz_584_;
-  wire       [0:0]    _zz_585_;
-  wire       [4:0]    _zz_586_;
-  wire       [31:0]   _zz_587_;
-  wire       [31:0]   _zz_588_;
-  wire       [31:0]   _zz_589_;
-  wire       [31:0]   _zz_590_;
-  wire       [31:0]   _zz_591_;
-  wire       [31:0]   _zz_592_;
-  wire       [31:0]   _zz_593_;
-  wire                _zz_594_;
-  wire       [2:0]    _zz_595_;
-  wire       [2:0]    _zz_596_;
-  wire                _zz_597_;
-  wire       [0:0]    _zz_598_;
-  wire       [2:0]    _zz_599_;
-  wire       [31:0]   _zz_600_;
-  wire                _zz_601_;
-  wire       [0:0]    _zz_602_;
-  wire       [0:0]    _zz_603_;
-  wire       [0:0]    _zz_604_;
-  wire       [4:0]    _zz_605_;
-  wire       [0:0]    _zz_606_;
-  wire       [0:0]    _zz_607_;
-  wire       [0:0]    _zz_608_;
-  wire       [0:0]    _zz_609_;
-  wire       [31:0]   _zz_610_;
-  wire       [31:0]   _zz_611_;
-  wire       [31:0]   _zz_612_;
-  wire       [31:0]   _zz_613_;
-  wire       [31:0]   _zz_614_;
-  wire                _zz_615_;
-  wire       [0:0]    _zz_616_;
-  wire       [1:0]    _zz_617_;
-  wire       [31:0]   _zz_618_;
-  wire       [31:0]   _zz_619_;
-  wire       [31:0]   _zz_620_;
-  wire                decode_IS_RS2_SIGNED;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7_;
-  wire                decode_MEMORY_MANAGMENT;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       [31:0]   memory_PC;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_252;
+  wire                _zz_253;
+  wire                _zz_254;
+  wire                _zz_255;
+  wire                _zz_256;
+  wire                _zz_257;
+  wire                _zz_258;
+  wire                _zz_259;
+  wire                _zz_260;
+  wire                _zz_261;
+  wire                _zz_262;
+  wire                _zz_263;
+  wire                _zz_264;
+  wire                _zz_265;
+  wire                _zz_266;
+  wire                _zz_267;
+  wire       [1:0]    _zz_268;
+  wire                _zz_269;
+  wire                _zz_270;
+  wire                _zz_271;
+  wire                _zz_272;
+  wire                _zz_273;
+  wire                _zz_274;
+  wire                _zz_275;
+  wire                _zz_276;
+  wire                _zz_277;
+  wire                _zz_278;
+  wire                _zz_279;
+  wire                _zz_280;
+  wire                _zz_281;
+  wire                _zz_282;
+  wire                _zz_283;
+  wire                _zz_284;
+  wire                _zz_285;
+  wire                _zz_286;
+  wire                _zz_287;
+  wire                _zz_288;
+  wire                _zz_289;
+  wire                _zz_290;
+  wire                _zz_291;
+  wire                _zz_292;
+  wire                _zz_293;
+  wire                _zz_294;
+  wire                _zz_295;
+  wire                _zz_296;
+  wire                _zz_297;
+  wire                _zz_298;
+  wire                _zz_299;
+  wire                _zz_300;
+  wire                _zz_301;
+  wire                _zz_302;
+  wire                _zz_303;
+  wire                _zz_304;
+  wire                _zz_305;
+  wire                _zz_306;
+  wire                _zz_307;
+  wire       [1:0]    _zz_308;
+  wire                _zz_309;
+  wire       [32:0]   _zz_310;
+  wire       [31:0]   _zz_311;
+  wire       [32:0]   _zz_312;
+  wire       [0:0]    _zz_313;
+  wire       [0:0]    _zz_314;
+  wire       [0:0]    _zz_315;
+  wire       [0:0]    _zz_316;
+  wire       [0:0]    _zz_317;
+  wire       [0:0]    _zz_318;
+  wire       [0:0]    _zz_319;
+  wire       [0:0]    _zz_320;
+  wire       [0:0]    _zz_321;
+  wire       [0:0]    _zz_322;
+  wire       [0:0]    _zz_323;
+  wire       [0:0]    _zz_324;
+  wire       [0:0]    _zz_325;
+  wire       [0:0]    _zz_326;
+  wire       [0:0]    _zz_327;
+  wire       [0:0]    _zz_328;
+  wire       [0:0]    _zz_329;
+  wire       [0:0]    _zz_330;
+  wire       [0:0]    _zz_331;
+  wire       [0:0]    _zz_332;
+  wire       [3:0]    _zz_333;
+  wire       [2:0]    _zz_334;
+  wire       [31:0]   _zz_335;
+  wire       [2:0]    _zz_336;
+  wire       [2:0]    _zz_337;
+  wire       [0:0]    _zz_338;
+  wire       [1:0]    _zz_339;
+  wire       [0:0]    _zz_340;
+  wire       [1:0]    _zz_341;
+  wire       [0:0]    _zz_342;
+  wire       [0:0]    _zz_343;
+  wire       [0:0]    _zz_344;
+  wire       [0:0]    _zz_345;
+  wire       [0:0]    _zz_346;
+  wire       [0:0]    _zz_347;
+  wire       [0:0]    _zz_348;
+  wire       [0:0]    _zz_349;
+  wire       [1:0]    _zz_350;
+  wire       [0:0]    _zz_351;
+  wire       [2:0]    _zz_352;
+  wire       [4:0]    _zz_353;
+  wire       [11:0]   _zz_354;
+  wire       [11:0]   _zz_355;
+  wire       [31:0]   _zz_356;
+  wire       [31:0]   _zz_357;
+  wire       [31:0]   _zz_358;
+  wire       [31:0]   _zz_359;
+  wire       [31:0]   _zz_360;
+  wire       [31:0]   _zz_361;
+  wire       [31:0]   _zz_362;
+  wire       [19:0]   _zz_363;
+  wire       [11:0]   _zz_364;
+  wire       [11:0]   _zz_365;
+  wire       [1:0]    _zz_366;
+  wire       [1:0]    _zz_367;
+  wire       [0:0]    _zz_368;
+  wire       [5:0]    _zz_369;
+  wire       [33:0]   _zz_370;
+  wire       [32:0]   _zz_371;
+  wire       [33:0]   _zz_372;
+  wire       [32:0]   _zz_373;
+  wire       [33:0]   _zz_374;
+  wire       [32:0]   _zz_375;
+  wire       [0:0]    _zz_376;
+  wire       [5:0]    _zz_377;
+  wire       [32:0]   _zz_378;
+  wire       [31:0]   _zz_379;
+  wire       [31:0]   _zz_380;
+  wire       [32:0]   _zz_381;
+  wire       [32:0]   _zz_382;
+  wire       [32:0]   _zz_383;
+  wire       [32:0]   _zz_384;
+  wire       [0:0]    _zz_385;
+  wire       [32:0]   _zz_386;
+  wire       [0:0]    _zz_387;
+  wire       [32:0]   _zz_388;
+  wire       [0:0]    _zz_389;
+  wire       [31:0]   _zz_390;
+  wire       [0:0]    _zz_391;
+  wire       [0:0]    _zz_392;
+  wire       [0:0]    _zz_393;
+  wire       [0:0]    _zz_394;
+  wire       [0:0]    _zz_395;
+  wire       [0:0]    _zz_396;
+  wire       [0:0]    _zz_397;
+  wire       [0:0]    _zz_398;
+  wire       [0:0]    _zz_399;
+  wire       [0:0]    _zz_400;
+  wire       [0:0]    _zz_401;
+  wire       [0:0]    _zz_402;
+  wire       [0:0]    _zz_403;
+  wire       [0:0]    _zz_404;
+  wire       [0:0]    _zz_405;
+  wire       [0:0]    _zz_406;
+  wire       [0:0]    _zz_407;
+  wire       [0:0]    _zz_408;
+  wire       [0:0]    _zz_409;
+  wire       [0:0]    _zz_410;
+  wire       [0:0]    _zz_411;
+  wire       [0:0]    _zz_412;
+  wire       [0:0]    _zz_413;
+  wire       [0:0]    _zz_414;
+  wire       [0:0]    _zz_415;
+  wire       [0:0]    _zz_416;
+  wire       [0:0]    _zz_417;
+  wire       [0:0]    _zz_418;
+  wire       [0:0]    _zz_419;
+  wire       [0:0]    _zz_420;
+  wire       [0:0]    _zz_421;
+  wire       [0:0]    _zz_422;
+  wire       [0:0]    _zz_423;
+  wire       [0:0]    _zz_424;
+  wire       [0:0]    _zz_425;
+  wire       [0:0]    _zz_426;
+  wire       [0:0]    _zz_427;
+  wire       [0:0]    _zz_428;
+  wire       [0:0]    _zz_429;
+  wire       [0:0]    _zz_430;
+  wire       [0:0]    _zz_431;
+  wire       [0:0]    _zz_432;
+  wire       [0:0]    _zz_433;
+  wire       [0:0]    _zz_434;
+  wire       [0:0]    _zz_435;
+  wire       [26:0]   _zz_436;
+  wire                _zz_437;
+  wire                _zz_438;
+  wire       [1:0]    _zz_439;
+  wire       [31:0]   _zz_440;
+  wire       [31:0]   _zz_441;
+  wire       [31:0]   _zz_442;
+  wire                _zz_443;
+  wire       [0:0]    _zz_444;
+  wire       [17:0]   _zz_445;
+  wire       [31:0]   _zz_446;
+  wire       [31:0]   _zz_447;
+  wire       [31:0]   _zz_448;
+  wire                _zz_449;
+  wire       [0:0]    _zz_450;
+  wire       [11:0]   _zz_451;
+  wire       [31:0]   _zz_452;
+  wire       [31:0]   _zz_453;
+  wire       [31:0]   _zz_454;
+  wire                _zz_455;
+  wire       [0:0]    _zz_456;
+  wire       [5:0]    _zz_457;
+  wire       [31:0]   _zz_458;
+  wire       [31:0]   _zz_459;
+  wire       [31:0]   _zz_460;
+  wire                _zz_461;
+  wire                _zz_462;
+  wire       [31:0]   _zz_463;
+  wire       [0:0]    _zz_464;
+  wire       [1:0]    _zz_465;
+  wire       [0:0]    _zz_466;
+  wire       [0:0]    _zz_467;
+  wire                _zz_468;
+  wire       [0:0]    _zz_469;
+  wire       [28:0]   _zz_470;
+  wire       [31:0]   _zz_471;
+  wire       [31:0]   _zz_472;
+  wire       [31:0]   _zz_473;
+  wire       [0:0]    _zz_474;
+  wire       [0:0]    _zz_475;
+  wire       [1:0]    _zz_476;
+  wire       [1:0]    _zz_477;
+  wire                _zz_478;
+  wire       [0:0]    _zz_479;
+  wire       [24:0]   _zz_480;
+  wire       [31:0]   _zz_481;
+  wire       [31:0]   _zz_482;
+  wire       [31:0]   _zz_483;
+  wire       [31:0]   _zz_484;
+  wire       [31:0]   _zz_485;
+  wire       [31:0]   _zz_486;
+  wire       [0:0]    _zz_487;
+  wire       [0:0]    _zz_488;
+  wire       [2:0]    _zz_489;
+  wire       [2:0]    _zz_490;
+  wire                _zz_491;
+  wire       [0:0]    _zz_492;
+  wire       [21:0]   _zz_493;
+  wire       [31:0]   _zz_494;
+  wire       [31:0]   _zz_495;
+  wire       [31:0]   _zz_496;
+  wire       [31:0]   _zz_497;
+  wire                _zz_498;
+  wire                _zz_499;
+  wire       [31:0]   _zz_500;
+  wire       [31:0]   _zz_501;
+  wire       [1:0]    _zz_502;
+  wire       [1:0]    _zz_503;
+  wire                _zz_504;
+  wire       [0:0]    _zz_505;
+  wire       [18:0]   _zz_506;
+  wire       [31:0]   _zz_507;
+  wire       [31:0]   _zz_508;
+  wire       [31:0]   _zz_509;
+  wire       [31:0]   _zz_510;
+  wire       [31:0]   _zz_511;
+  wire       [31:0]   _zz_512;
+  wire                _zz_513;
+  wire       [0:0]    _zz_514;
+  wire       [0:0]    _zz_515;
+  wire                _zz_516;
+  wire       [0:0]    _zz_517;
+  wire       [15:0]   _zz_518;
+  wire       [31:0]   _zz_519;
+  wire       [31:0]   _zz_520;
+  wire                _zz_521;
+  wire       [0:0]    _zz_522;
+  wire       [0:0]    _zz_523;
+  wire       [31:0]   _zz_524;
+  wire       [31:0]   _zz_525;
+  wire                _zz_526;
+  wire       [5:0]    _zz_527;
+  wire       [5:0]    _zz_528;
+  wire                _zz_529;
+  wire       [0:0]    _zz_530;
+  wire       [11:0]   _zz_531;
+  wire       [31:0]   _zz_532;
+  wire       [31:0]   _zz_533;
+  wire       [31:0]   _zz_534;
+  wire       [31:0]   _zz_535;
+  wire                _zz_536;
+  wire       [0:0]    _zz_537;
+  wire       [2:0]    _zz_538;
+  wire                _zz_539;
+  wire       [0:0]    _zz_540;
+  wire       [0:0]    _zz_541;
+  wire                _zz_542;
+  wire       [4:0]    _zz_543;
+  wire       [4:0]    _zz_544;
+  wire                _zz_545;
+  wire       [0:0]    _zz_546;
+  wire       [8:0]    _zz_547;
+  wire       [31:0]   _zz_548;
+  wire       [31:0]   _zz_549;
+  wire       [31:0]   _zz_550;
+  wire                _zz_551;
+  wire       [0:0]    _zz_552;
+  wire       [0:0]    _zz_553;
+  wire       [31:0]   _zz_554;
+  wire       [31:0]   _zz_555;
+  wire       [31:0]   _zz_556;
+  wire       [31:0]   _zz_557;
+  wire       [31:0]   _zz_558;
+  wire       [31:0]   _zz_559;
+  wire       [0:0]    _zz_560;
+  wire       [2:0]    _zz_561;
+  wire       [0:0]    _zz_562;
+  wire       [5:0]    _zz_563;
+  wire       [1:0]    _zz_564;
+  wire       [1:0]    _zz_565;
+  wire                _zz_566;
+  wire       [0:0]    _zz_567;
+  wire       [6:0]    _zz_568;
+  wire       [31:0]   _zz_569;
+  wire       [31:0]   _zz_570;
+  wire       [31:0]   _zz_571;
+  wire       [31:0]   _zz_572;
+  wire       [31:0]   _zz_573;
+  wire       [31:0]   _zz_574;
+  wire       [31:0]   _zz_575;
+  wire                _zz_576;
+  wire       [0:0]    _zz_577;
+  wire       [0:0]    _zz_578;
+  wire                _zz_579;
+  wire       [0:0]    _zz_580;
+  wire       [3:0]    _zz_581;
+  wire                _zz_582;
+  wire       [0:0]    _zz_583;
+  wire       [0:0]    _zz_584;
+  wire       [0:0]    _zz_585;
+  wire       [0:0]    _zz_586;
+  wire                _zz_587;
+  wire       [0:0]    _zz_588;
+  wire       [4:0]    _zz_589;
+  wire       [31:0]   _zz_590;
+  wire       [31:0]   _zz_591;
+  wire       [31:0]   _zz_592;
+  wire       [31:0]   _zz_593;
+  wire       [31:0]   _zz_594;
+  wire       [31:0]   _zz_595;
+  wire       [31:0]   _zz_596;
+  wire       [31:0]   _zz_597;
+  wire                _zz_598;
+  wire       [0:0]    _zz_599;
+  wire       [1:0]    _zz_600;
+  wire       [31:0]   _zz_601;
+  wire       [31:0]   _zz_602;
+  wire       [31:0]   _zz_603;
+  wire       [31:0]   _zz_604;
+  wire       [31:0]   _zz_605;
+  wire                _zz_606;
+  wire       [4:0]    _zz_607;
+  wire       [4:0]    _zz_608;
+  wire                _zz_609;
+  wire       [0:0]    _zz_610;
+  wire       [2:0]    _zz_611;
+  wire       [31:0]   _zz_612;
+  wire       [31:0]   _zz_613;
+  wire       [31:0]   _zz_614;
+  wire                _zz_615;
+  wire       [31:0]   _zz_616;
+  wire                _zz_617;
+  wire       [0:0]    _zz_618;
+  wire       [2:0]    _zz_619;
+  wire       [0:0]    _zz_620;
+  wire       [0:0]    _zz_621;
+  wire       [2:0]    _zz_622;
+  wire       [2:0]    _zz_623;
+  wire                _zz_624;
+  wire       [0:0]    _zz_625;
+  wire       [0:0]    _zz_626;
+  wire       [31:0]   _zz_627;
+  wire       [31:0]   _zz_628;
+  wire       [31:0]   _zz_629;
+  wire       [31:0]   _zz_630;
+  wire                _zz_631;
+  wire       [0:0]    _zz_632;
+  wire       [0:0]    _zz_633;
+  wire       [31:0]   _zz_634;
+  wire       [31:0]   _zz_635;
+  wire                _zz_636;
+  wire       [0:0]    _zz_637;
+  wire       [0:0]    _zz_638;
+  wire       [0:0]    _zz_639;
+  wire       [1:0]    _zz_640;
+  wire       [1:0]    _zz_641;
+  wire       [1:0]    _zz_642;
+  wire       [0:0]    _zz_643;
+  wire       [0:0]    _zz_644;
+  wire       [31:0]   _zz_645;
+  wire       [31:0]   _zz_646;
+  wire       [31:0]   _zz_647;
+  wire       [31:0]   _zz_648;
+  wire       [31:0]   _zz_649;
+  wire       [31:0]   _zz_650;
+  wire       [31:0]   _zz_651;
+  wire       [31:0]   _zz_652;
+  wire       [31:0]   _zz_653;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire                execute_IS_DBUS_SHARING;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
   wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_DIV;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_10_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                memory_IS_SFENCE_VMA;
+  wire                execute_IS_SFENCE_VMA;
+  wire                decode_IS_SFENCE_VMA;
+  wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire                memory_IS_SFENCE_VMA;
-  wire                execute_IS_SFENCE_VMA;
-  wire                decode_IS_SFENCE_VMA;
-  wire                decode_IS_RS1_SIGNED;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire                decode_IS_DIV;
-  wire                execute_BRANCH_DO;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_16_;
-  wire                decode_IS_MUL;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire                memory_MEMORY_WR;
-  wire                decode_MEMORY_WR;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19_;
-  wire                decode_IS_CSR;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_24_;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire                execute_IS_DBUS_SHARING;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                decode_MEMORY_LRSC;
-  wire                decode_MEMORY_AMO;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire       [31:0]   execute_SHIFT_RIGHT;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_27_;
+  wire       [31:0]   memory_PC;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_MUL;
@@ -1773,20 +650,20 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_30;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_31_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_31;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1796,46 +673,46 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_33_;
+  reg        [31:0]   _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_35_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_35;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_36_;
+  wire       [31:0]   _zz_36;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_37;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_38;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_39_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_39;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_40_;
-  wire       [31:0]   _zz_41_;
-  wire                _zz_42_;
-  reg                 _zz_43_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_40;
+  wire       [31:0]   _zz_41;
+  wire                _zz_42;
+  reg                 _zz_43;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_49_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_50_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_47;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_48;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_49;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_50;
   wire                writeBack_IS_SFENCE_VMA;
   wire                writeBack_IS_DBUS_SHARING;
   wire                memory_IS_DBUS_SHARING;
-  reg        [31:0]   _zz_51_;
+  reg        [31:0]   _zz_51;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
@@ -1844,21 +721,25 @@ module VexRiscv (
   wire                memory_MEMORY_ENABLE;
   wire                execute_MEMORY_AMO;
   wire                execute_MEMORY_LRSC;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
   wire       [31:0]   execute_RS2;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
+  wire                decode_MEMORY_AMO;
+  wire                decode_MEMORY_LRSC;
+  reg                 _zz_52;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_52_;
-  reg                 _zz_52__2;
-  reg                 _zz_52__1;
-  reg                 _zz_52__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_53_;
-  reg        [31:0]   _zz_54_;
+  reg        [31:0]   _zz_53;
+  reg        [31:0]   _zz_54;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -1874,7 +755,7 @@ module VexRiscv (
   wire                decode_arbitration_isMoving;
   wire                decode_arbitration_isFiring;
   reg                 execute_arbitration_haltItself;
-  wire                execute_arbitration_haltByOther;
+  reg                 execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
   wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
@@ -1919,28 +800,63 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   reg        [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  reg                 IBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   reg                 IBusCachedPlugin_mmuBus_rsp_exception;
   reg                 IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_0_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_0_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_1_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_1_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_2_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_2_physical;
+  wire                IBusCachedPlugin_mmuBus_rsp_ways_3_sel;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_ways_3_physical;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  reg                 DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  reg                 DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   reg        [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  reg                 DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
   reg                 DBusCachedPlugin_mmuBus_rsp_exception;
   reg                 DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_0_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_0_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_1_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_1_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_2_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_2_physical;
+  wire                DBusCachedPlugin_mmuBus_rsp_ways_3_sel;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_ways_3_physical;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -1990,11 +906,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_55_;
-  wire       [3:0]    _zz_56_;
-  wire                _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
+  wire       [3:0]    _zz_55;
+  wire       [3:0]    _zz_56;
+  wire                _zz_57;
+  wire                _zz_58;
+  wire                _zz_59;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -2038,20 +954,20 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_3_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_3_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_3_halt;
-  wire                _zz_60_;
-  wire                _zz_61_;
-  wire                _zz_62_;
-  wire                _zz_63_;
+  wire                _zz_60;
+  wire                _zz_61;
+  wire                _zz_62;
+  wire                _zz_63;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_64_;
-  wire                _zz_65_;
-  reg                 _zz_66_;
-  wire                _zz_67_;
-  reg                 _zz_68_;
-  reg        [31:0]   _zz_69_;
-  wire                _zz_70_;
-  reg                 _zz_71_;
-  reg        [31:0]   _zz_72_;
+  wire                _zz_64;
+  wire                _zz_65;
+  reg                 _zz_66;
+  wire                _zz_67;
+  reg                 _zz_68;
+  reg        [31:0]   _zz_69;
+  wire                _zz_70;
+  reg                 _zz_71;
+  reg        [31:0]   _zz_72;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -2072,7 +988,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_73_;
+  wire       [31:0]   _zz_73;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -2080,62 +996,56 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_74_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_74;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_75_;
+  reg        [31:0]   _zz_75;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_76_;
-  reg        [31:0]   _zz_77_;
-  wire                _zz_78_;
-  reg        [31:0]   _zz_79_;
+  wire                _zz_76;
+  reg        [31:0]   _zz_77;
+  wire                _zz_78;
+  reg        [31:0]   _zz_79;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
   reg                 DBusCachedPlugin_forceDatapath;
   reg                 MmuPlugin_status_sum;
   reg                 MmuPlugin_status_mxr;
   reg                 MmuPlugin_status_mprv;
   reg                 MmuPlugin_satp_mode;
+  reg        [8:0]    MmuPlugin_satp_asid;
   reg        [19:0]   MmuPlugin_satp_ppn;
   reg                 MmuPlugin_ports_0_cache_0_valid;
   reg                 MmuPlugin_ports_0_cache_0_exception;
@@ -2181,14 +1091,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_0_cache_3_allowWrite;
   reg                 MmuPlugin_ports_0_cache_3_allowExecute;
   reg                 MmuPlugin_ports_0_cache_3_allowUser;
-  wire                MmuPlugin_ports_0_cacheHits_0;
-  wire                MmuPlugin_ports_0_cacheHits_1;
-  wire                MmuPlugin_ports_0_cacheHits_2;
-  wire                MmuPlugin_ports_0_cacheHits_3;
+  wire                MmuPlugin_ports_0_dirty;
+  reg                 MmuPlugin_ports_0_requireMmuLockupCalc;
+  reg        [3:0]    MmuPlugin_ports_0_cacheHitsCalc;
   wire                MmuPlugin_ports_0_cacheHit;
-  wire                _zz_80_;
-  wire                _zz_81_;
-  wire       [1:0]    _zz_82_;
+  wire                _zz_80;
+  wire                _zz_81;
+  wire                _zz_82;
+  wire       [1:0]    _zz_83;
   wire                MmuPlugin_ports_0_cacheLine_valid;
   wire                MmuPlugin_ports_0_cacheLine_exception;
   wire                MmuPlugin_ports_0_cacheLine_superPage;
@@ -2206,7 +1116,6 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_ports_0_entryToReplace_value;
   wire                MmuPlugin_ports_0_entryToReplace_willOverflowIfInc;
   wire                MmuPlugin_ports_0_entryToReplace_willOverflow;
-  reg                 MmuPlugin_ports_0_requireMmuLockup;
   reg                 MmuPlugin_ports_1_cache_0_valid;
   reg                 MmuPlugin_ports_1_cache_0_exception;
   reg                 MmuPlugin_ports_1_cache_0_superPage;
@@ -2251,14 +1160,14 @@ module VexRiscv (
   reg                 MmuPlugin_ports_1_cache_3_allowWrite;
   reg                 MmuPlugin_ports_1_cache_3_allowExecute;
   reg                 MmuPlugin_ports_1_cache_3_allowUser;
-  wire                MmuPlugin_ports_1_cacheHits_0;
-  wire                MmuPlugin_ports_1_cacheHits_1;
-  wire                MmuPlugin_ports_1_cacheHits_2;
-  wire                MmuPlugin_ports_1_cacheHits_3;
+  wire                MmuPlugin_ports_1_dirty;
+  reg                 MmuPlugin_ports_1_requireMmuLockupCalc;
+  reg        [3:0]    MmuPlugin_ports_1_cacheHitsCalc;
   wire                MmuPlugin_ports_1_cacheHit;
-  wire                _zz_83_;
-  wire                _zz_84_;
-  wire       [1:0]    _zz_85_;
+  wire                _zz_84;
+  wire                _zz_85;
+  wire                _zz_86;
+  wire       [1:0]    _zz_87;
   wire                MmuPlugin_ports_1_cacheLine_valid;
   wire                MmuPlugin_ports_1_cacheLine_exception;
   wire                MmuPlugin_ports_1_cacheLine_superPage;
@@ -2276,11 +1185,14 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_ports_1_entryToReplace_value;
   wire                MmuPlugin_ports_1_entryToReplace_willOverflowIfInc;
   wire                MmuPlugin_ports_1_entryToReplace_willOverflow;
-  reg                 MmuPlugin_ports_1_requireMmuLockup;
-  reg        `MmuPlugin_shared_State_defaultEncoding_type MmuPlugin_shared_state_1_;
+  reg        `MmuPlugin_shared_State_defaultEncoding_type MmuPlugin_shared_state_1;
   reg        [9:0]    MmuPlugin_shared_vpn_0;
   reg        [9:0]    MmuPlugin_shared_vpn_1;
-  reg        [0:0]    MmuPlugin_shared_portId;
+  reg        [1:0]    MmuPlugin_shared_portSortedOh;
+  reg                 MmuPlugin_shared_dBusRspStaged_valid;
+  reg        [31:0]   MmuPlugin_shared_dBusRspStaged_payload_data;
+  reg                 MmuPlugin_shared_dBusRspStaged_payload_error;
+  reg                 MmuPlugin_shared_dBusRspStaged_payload_redo;
   wire                MmuPlugin_shared_dBusRsp_pte_V;
   wire                MmuPlugin_shared_dBusRsp_pte_R;
   wire                MmuPlugin_shared_dBusRsp_pte_W;
@@ -2305,70 +1217,77 @@ module VexRiscv (
   reg        [1:0]    MmuPlugin_shared_pteBuffer_RSW;
   reg        [9:0]    MmuPlugin_shared_pteBuffer_PPN0;
   reg        [11:0]   MmuPlugin_shared_pteBuffer_PPN1;
-  wire       [34:0]   _zz_86_;
-  wire                _zz_87_;
-  wire                _zz_88_;
-  wire                _zz_89_;
-  wire                _zz_90_;
-  wire                _zz_91_;
-  wire                _zz_92_;
-  wire                _zz_93_;
-  wire                _zz_94_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_95_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_96_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_97_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_98_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_99_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_100_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_101_;
+  reg        [1:0]    _zz_88;
+  wire       [1:0]    _zz_89;
+  reg        [1:0]    _zz_90;
+  wire       [1:0]    MmuPlugin_shared_refills;
+  wire       [1:0]    _zz_91;
+  reg        [1:0]    _zz_92;
+  wire       [31:0]   _zz_93;
+  wire       [34:0]   _zz_94;
+  wire                _zz_95;
+  wire                _zz_96;
+  wire                _zz_97;
+  wire                _zz_98;
+  wire                _zz_99;
+  wire                _zz_100;
+  wire                _zz_101;
+  wire                _zz_102;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_103;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_104;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_105;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_106;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_107;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_108;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_109;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_102_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_110;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_103_;
-  reg        [31:0]   _zz_104_;
-  wire                _zz_105_;
-  reg        [19:0]   _zz_106_;
-  wire                _zz_107_;
-  reg        [19:0]   _zz_108_;
-  reg        [31:0]   _zz_109_;
+  reg        [31:0]   _zz_111;
+  reg        [31:0]   _zz_112;
+  wire                _zz_113;
+  reg        [19:0]   _zz_114;
+  wire                _zz_115;
+  reg        [19:0]   _zz_116;
+  reg        [31:0]   _zz_117;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_110_;
+  reg        [31:0]   _zz_118;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_111_;
-  reg                 _zz_112_;
-  reg                 _zz_113_;
-  reg                 _zz_114_;
-  reg        [4:0]    _zz_115_;
-  reg        [31:0]   _zz_116_;
-  wire                _zz_117_;
-  wire                _zz_118_;
-  wire                _zz_119_;
-  wire                _zz_120_;
-  wire                _zz_121_;
-  wire                _zz_122_;
+  reg        [31:0]   _zz_119;
+  reg                 _zz_120;
+  reg                 _zz_121;
+  reg                 _zz_122;
+  reg        [4:0]    _zz_123;
+  reg        [31:0]   _zz_124;
+  wire                _zz_125;
+  wire                _zz_126;
+  wire                _zz_127;
+  wire                _zz_128;
+  wire                _zz_129;
+  wire                _zz_130;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_123_;
-  reg                 _zz_124_;
-  reg                 _zz_125_;
+  wire       [2:0]    _zz_131;
+  reg                 _zz_132;
+  reg                 _zz_133;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_126_;
-  reg        [10:0]   _zz_127_;
-  wire                _zz_128_;
-  reg        [19:0]   _zz_129_;
-  wire                _zz_130_;
-  reg        [18:0]   _zz_131_;
-  reg        [31:0]   _zz_132_;
+  wire                _zz_134;
+  reg        [10:0]   _zz_135;
+  wire                _zz_136;
+  reg        [19:0]   _zz_137;
+  wire                _zz_138;
+  reg        [18:0]   _zz_139;
+  reg        [31:0]   _zz_140;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_133_;
+  reg        [1:0]    _zz_141;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -2425,12 +1344,12 @@ module VexRiscv (
   reg        [21:0]   CsrPlugin_satp_PPN;
   reg        [8:0]    CsrPlugin_satp_ASID;
   reg        [0:0]    CsrPlugin_satp_MODE;
-  wire                _zz_134_;
-  wire                _zz_135_;
-  wire                _zz_136_;
-  wire                _zz_137_;
-  wire                _zz_138_;
-  wire                _zz_139_;
+  wire                _zz_142;
+  wire                _zz_143;
+  wire                _zz_144;
+  wire                _zz_145;
+  wire                _zz_146;
+  wire                _zz_147;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -2443,8 +1362,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   reg        [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_140_;
-  wire                _zz_141_;
+  wire       [1:0]    _zz_148;
+  wire                _zz_149;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -2456,7 +1375,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2492,80 +1411,81 @@ module VexRiscv (
   wire                memory_MulDivIterativePlugin_div_counter_willOverflow;
   reg                 memory_MulDivIterativePlugin_div_done;
   reg        [31:0]   memory_MulDivIterativePlugin_div_result;
-  wire       [31:0]   _zz_142_;
+  wire       [31:0]   _zz_150;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_143_;
-  wire                _zz_144_;
-  wire                _zz_145_;
-  reg        [32:0]   _zz_146_;
+  wire       [31:0]   _zz_151;
+  wire                _zz_152;
+  wire                _zz_153;
+  reg        [32:0]   _zz_154;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_147_;
-  wire       [31:0]   _zz_148_;
-  reg        [31:0]   _zz_149_;
-  wire       [31:0]   _zz_150_;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg                 decode_to_execute_MEMORY_AMO;
-  reg                 decode_to_execute_MEMORY_LRSC;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 execute_to_memory_IS_DBUS_SHARING;
-  reg                 memory_to_writeBack_IS_DBUS_SHARING;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg                 decode_to_execute_IS_CSR;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg                 decode_to_execute_MEMORY_WR;
-  reg                 execute_to_memory_MEMORY_WR;
-  reg                 memory_to_writeBack_MEMORY_WR;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg        [31:0]   decode_to_execute_INSTRUCTION;
-  reg        [31:0]   execute_to_memory_INSTRUCTION;
-  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg                 decode_to_execute_IS_SFENCE_VMA;
-  reg                 execute_to_memory_IS_SFENCE_VMA;
-  reg                 memory_to_writeBack_IS_SFENCE_VMA;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [31:0]   _zz_155;
+  wire       [31:0]   _zz_156;
+  reg        [31:0]   _zz_157;
+  wire       [31:0]   _zz_158;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
+  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_LRSC;
+  reg                 decode_to_execute_MEMORY_AMO;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_IS_SFENCE_VMA;
+  reg                 execute_to_memory_IS_SFENCE_VMA;
+  reg                 memory_to_writeBack_IS_SFENCE_VMA;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
   reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg                 execute_to_memory_IS_DBUS_SHARING;
+  reg                 memory_to_writeBack_IS_DBUS_SHARING;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_256;
@@ -2594,117 +1514,117 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_4032;
   reg                 execute_CsrPlugin_csr_2496;
   reg                 execute_CsrPlugin_csr_3520;
-  reg        [31:0]   _zz_151_;
-  reg        [31:0]   _zz_152_;
-  reg        [31:0]   _zz_153_;
-  reg        [31:0]   _zz_154_;
-  reg        [31:0]   _zz_155_;
-  reg        [31:0]   _zz_156_;
-  reg        [31:0]   _zz_157_;
-  reg        [31:0]   _zz_158_;
-  reg        [31:0]   _zz_159_;
-  reg        [31:0]   _zz_160_;
-  reg        [31:0]   _zz_161_;
-  reg        [31:0]   _zz_162_;
-  reg        [31:0]   _zz_163_;
-  reg        [31:0]   _zz_164_;
-  reg        [31:0]   _zz_165_;
-  reg        [31:0]   _zz_166_;
-  reg        [31:0]   _zz_167_;
-  reg        [31:0]   _zz_168_;
-  reg        [31:0]   _zz_169_;
-  reg        [31:0]   _zz_170_;
-  reg        [31:0]   _zz_171_;
-  reg        [31:0]   _zz_172_;
-  reg        [31:0]   _zz_173_;
-  reg        [31:0]   _zz_174_;
-  reg        [2:0]    _zz_175_;
-  reg                 _zz_176_;
+  reg        [31:0]   _zz_159;
+  reg        [31:0]   _zz_160;
+  reg        [31:0]   _zz_161;
+  reg        [31:0]   _zz_162;
+  reg        [31:0]   _zz_163;
+  reg        [31:0]   _zz_164;
+  reg        [31:0]   _zz_165;
+  reg        [31:0]   _zz_166;
+  reg        [31:0]   _zz_167;
+  reg        [31:0]   _zz_168;
+  reg        [31:0]   _zz_169;
+  reg        [31:0]   _zz_170;
+  reg        [31:0]   _zz_171;
+  reg        [31:0]   _zz_172;
+  reg        [31:0]   _zz_173;
+  reg        [31:0]   _zz_174;
+  reg        [31:0]   _zz_175;
+  reg        [31:0]   _zz_176;
+  reg        [31:0]   _zz_177;
+  reg        [31:0]   _zz_178;
+  reg        [31:0]   _zz_179;
+  reg        [31:0]   _zz_180;
+  reg        [31:0]   _zz_181;
+  reg        [31:0]   _zz_182;
+  reg        [2:0]    _zz_183;
+  reg                 _zz_184;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_177_;
-  wire                _zz_178_;
-  wire                _zz_179_;
-  wire                _zz_180_;
-  wire                _zz_181_;
-  wire                _zz_182_;
-  reg                 _zz_183_;
+  reg        [2:0]    _zz_185;
+  wire                _zz_186;
+  wire                _zz_187;
+  wire                _zz_188;
+  wire                _zz_189;
+  wire                _zz_190;
+  reg                 _zz_191;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [39:0] _zz_1__string;
-  reg [39:0] _zz_2__string;
-  reg [39:0] _zz_3__string;
-  reg [39:0] _zz_4__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_5__string;
-  reg [39:0] _zz_6__string;
-  reg [39:0] _zz_7__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_8__string;
-  reg [31:0] _zz_9__string;
-  reg [31:0] _zz_10__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_11__string;
-  reg [39:0] _zz_12__string;
-  reg [39:0] _zz_13__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_14__string;
-  reg [63:0] _zz_15__string;
-  reg [63:0] _zz_16__string;
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_17__string;
-  reg [23:0] _zz_18__string;
-  reg [23:0] _zz_19__string;
-  reg [71:0] _zz_20__string;
-  reg [71:0] _zz_21__string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [31:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] _zz_12_string;
   reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_22__string;
-  reg [71:0] _zz_23__string;
-  reg [71:0] _zz_24__string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [71:0] _zz_15_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
+  reg [39:0] _zz_18_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
+  reg [23:0] _zz_21_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [63:0] _zz_24_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_25__string;
-  reg [95:0] _zz_26__string;
-  reg [95:0] _zz_27__string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
+  reg [95:0] _zz_27_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_30__string;
+  reg [39:0] _zz_30_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_31__string;
+  reg [31:0] _zz_31_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_35__string;
+  reg [71:0] _zz_35_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_37__string;
+  reg [23:0] _zz_37_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_38__string;
+  reg [95:0] _zz_38_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_39__string;
+  reg [63:0] _zz_39_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_40__string;
-  reg [39:0] _zz_44__string;
-  reg [39:0] _zz_45__string;
-  reg [71:0] _zz_46__string;
-  reg [95:0] _zz_47__string;
-  reg [31:0] _zz_48__string;
-  reg [23:0] _zz_49__string;
-  reg [63:0] _zz_50__string;
-  reg [47:0] MmuPlugin_shared_state_1__string;
-  reg [63:0] _zz_95__string;
-  reg [23:0] _zz_96__string;
-  reg [31:0] _zz_97__string;
-  reg [95:0] _zz_98__string;
-  reg [71:0] _zz_99__string;
-  reg [39:0] _zz_100__string;
-  reg [39:0] _zz_101__string;
+  reg [39:0] _zz_40_string;
+  reg [39:0] _zz_44_string;
+  reg [31:0] _zz_45_string;
+  reg [71:0] _zz_46_string;
+  reg [39:0] _zz_47_string;
+  reg [23:0] _zz_48_string;
+  reg [63:0] _zz_49_string;
+  reg [95:0] _zz_50_string;
+  reg [47:0] MmuPlugin_shared_state_1_string;
+  reg [95:0] _zz_103_string;
+  reg [63:0] _zz_104_string;
+  reg [23:0] _zz_105_string;
+  reg [39:0] _zz_106_string;
+  reg [71:0] _zz_107_string;
+  reg [31:0] _zz_108_string;
+  reg [39:0] _zz_109_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
+  reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
   reg [71:0] execute_to_memory_SHIFT_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [63:0] decode_to_execute_ALU_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
@@ -2713,678 +1633,715 @@ module VexRiscv (
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_234_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_235_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_236_ = 1'b1;
-  assign _zz_237_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_238_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_239_ = (memory_arbitration_isValid && memory_IS_MUL);
-  assign _zz_240_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_241_ = ((_zz_188_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_52__2));
-  assign _zz_242_ = ((_zz_188_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_52__1));
-  assign _zz_243_ = ((_zz_188_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_52__0));
-  assign _zz_244_ = ((_zz_188_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_245_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_246_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_247_ = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_248_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_249_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_250_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_251_ = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != (3'b000)));
-  assign _zz_252_ = (! dataCache_1__io_cpu_redo);
-  assign _zz_253_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_254_ = ((MmuPlugin_dBusAccess_rsp_valid && (! MmuPlugin_dBusAccess_rsp_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
-  assign _zz_255_ = (MmuPlugin_shared_portId == (1'b1));
-  assign _zz_256_ = (MmuPlugin_shared_portId == (1'b0));
-  assign _zz_257_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_258_ = (1'b0 || (! 1'b1));
-  assign _zz_259_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_260_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_261_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_262_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_263_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_264_ = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_265_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_266_ = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
-  assign _zz_267_ = (! memory_arbitration_isStuck);
-  assign _zz_268_ = (iBus_cmd_valid || (_zz_175_ != (3'b000)));
-  assign _zz_269_ = (_zz_208_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_270_ = (IBusCachedPlugin_mmuBus_cmd_isValid && IBusCachedPlugin_mmuBus_rsp_refilling);
-  assign _zz_271_ = (DBusCachedPlugin_mmuBus_cmd_isValid && DBusCachedPlugin_mmuBus_rsp_refilling);
-  assign _zz_272_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b00));
-  assign _zz_273_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b01));
-  assign _zz_274_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b10));
-  assign _zz_275_ = (MmuPlugin_ports_0_entryToReplace_value == (2'b11));
-  assign _zz_276_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b00));
-  assign _zz_277_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b01));
-  assign _zz_278_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b10));
-  assign _zz_279_ = (MmuPlugin_ports_1_entryToReplace_value == (2'b11));
-  assign _zz_280_ = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == (2'b01))) || (CsrPlugin_privilege < (2'b01)));
-  assign _zz_281_ = ((_zz_134_ && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
-  assign _zz_282_ = ((_zz_135_ && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
-  assign _zz_283_ = ((_zz_136_ && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
-  assign _zz_284_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_285_ = ((_zz_134_ && 1'b1) && (! (CsrPlugin_mideleg_ST != (1'b0))));
-  assign _zz_286_ = ((_zz_135_ && 1'b1) && (! (CsrPlugin_mideleg_SS != (1'b0))));
-  assign _zz_287_ = ((_zz_136_ && 1'b1) && (! (CsrPlugin_mideleg_SE != (1'b0))));
-  assign _zz_288_ = ((_zz_137_ && 1'b1) && (! 1'b0));
-  assign _zz_289_ = ((_zz_138_ && 1'b1) && (! 1'b0));
-  assign _zz_290_ = ((_zz_139_ && 1'b1) && (! 1'b0));
-  assign _zz_291_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_292_ = execute_INSTRUCTION[13];
-  assign _zz_293_ = _zz_86_[17 : 17];
-  assign _zz_294_ = _zz_86_[15 : 15];
-  assign _zz_295_ = _zz_86_[1 : 1];
-  assign _zz_296_ = _zz_86_[12 : 12];
-  assign _zz_297_ = _zz_86_[0 : 0];
-  assign _zz_298_ = _zz_86_[5 : 5];
-  assign _zz_299_ = _zz_86_[31 : 31];
-  assign _zz_300_ = _zz_86_[4 : 4];
-  assign _zz_301_ = _zz_86_[34 : 34];
-  assign _zz_302_ = _zz_86_[21 : 21];
-  assign _zz_303_ = _zz_86_[11 : 11];
-  assign _zz_304_ = _zz_86_[20 : 20];
-  assign _zz_305_ = _zz_86_[13 : 13];
-  assign _zz_306_ = ($signed(_zz_308_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_307_ = _zz_306_[31 : 0];
-  assign _zz_308_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_309_ = _zz_86_[27 : 27];
-  assign _zz_310_ = _zz_86_[30 : 30];
-  assign _zz_311_ = _zz_86_[3 : 3];
-  assign _zz_312_ = _zz_86_[8 : 8];
-  assign _zz_313_ = _zz_86_[14 : 14];
-  assign _zz_314_ = _zz_86_[16 : 16];
-  assign _zz_315_ = _zz_86_[22 : 22];
-  assign _zz_316_ = (_zz_55_ - (4'b0001));
-  assign _zz_317_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_318_ = {29'd0, _zz_317_};
-  assign _zz_319_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_320_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_321_ = MmuPlugin_ports_0_entryToReplace_willIncrement;
-  assign _zz_322_ = {1'd0, _zz_321_};
-  assign _zz_323_ = MmuPlugin_ports_1_entryToReplace_willIncrement;
-  assign _zz_324_ = {1'd0, _zz_323_};
-  assign _zz_325_ = MmuPlugin_dBusAccess_rsp_payload_data[0 : 0];
-  assign _zz_326_ = MmuPlugin_dBusAccess_rsp_payload_data[1 : 1];
-  assign _zz_327_ = MmuPlugin_dBusAccess_rsp_payload_data[2 : 2];
-  assign _zz_328_ = MmuPlugin_dBusAccess_rsp_payload_data[3 : 3];
-  assign _zz_329_ = MmuPlugin_dBusAccess_rsp_payload_data[4 : 4];
-  assign _zz_330_ = MmuPlugin_dBusAccess_rsp_payload_data[5 : 5];
-  assign _zz_331_ = MmuPlugin_dBusAccess_rsp_payload_data[6 : 6];
-  assign _zz_332_ = MmuPlugin_dBusAccess_rsp_payload_data[7 : 7];
-  assign _zz_333_ = execute_SRC_LESS;
-  assign _zz_334_ = (3'b100);
-  assign _zz_335_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_336_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_337_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_338_ = ($signed(_zz_339_) + $signed(_zz_342_));
-  assign _zz_339_ = ($signed(_zz_340_) + $signed(_zz_341_));
-  assign _zz_340_ = execute_SRC1;
-  assign _zz_341_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_342_ = (execute_SRC_USE_SUB_LESS ? _zz_343_ : _zz_344_);
-  assign _zz_343_ = 32'h00000001;
-  assign _zz_344_ = 32'h0;
-  assign _zz_345_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_346_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_347_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_348_ = (_zz_140_ & (~ _zz_349_));
-  assign _zz_349_ = (_zz_140_ - (2'b01));
-  assign _zz_350_ = memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_351_ = {5'd0, _zz_350_};
-  assign _zz_352_ = (_zz_354_ + _zz_356_);
-  assign _zz_353_ = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_354_ = {{1{_zz_353_[32]}}, _zz_353_};
-  assign _zz_355_ = _zz_357_;
-  assign _zz_356_ = {{1{_zz_355_[32]}}, _zz_355_};
-  assign _zz_357_ = (memory_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_358_ = memory_MulDivIterativePlugin_div_counter_willIncrement;
-  assign _zz_359_ = {5'd0, _zz_358_};
-  assign _zz_360_ = {1'd0, memory_MulDivIterativePlugin_rs2};
-  assign _zz_361_ = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_362_ = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_363_ = {_zz_142_,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_364_ = _zz_365_;
-  assign _zz_365_ = _zz_366_;
-  assign _zz_366_ = ({1'b0,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_143_) : _zz_143_)} + _zz_368_);
-  assign _zz_367_ = memory_MulDivIterativePlugin_div_needRevert;
-  assign _zz_368_ = {32'd0, _zz_367_};
-  assign _zz_369_ = _zz_145_;
-  assign _zz_370_ = {32'd0, _zz_369_};
-  assign _zz_371_ = _zz_144_;
-  assign _zz_372_ = {31'd0, _zz_371_};
-  assign _zz_373_ = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_374_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_375_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_376_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_377_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_378_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_379_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_380_ = execute_CsrPlugin_writeData[19 : 19];
-  assign _zz_381_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_382_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_383_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_384_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_385_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_386_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_387_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_388_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_389_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_390_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_391_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_392_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_393_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_394_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_395_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_396_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_397_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_398_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_399_ = execute_CsrPlugin_writeData[13 : 13];
-  assign _zz_400_ = execute_CsrPlugin_writeData[4 : 4];
-  assign _zz_401_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_402_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_403_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_404_ = execute_CsrPlugin_writeData[12 : 12];
-  assign _zz_405_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_406_ = execute_CsrPlugin_writeData[6 : 6];
-  assign _zz_407_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_408_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_409_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_410_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_411_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_412_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_413_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_414_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_415_ = execute_CsrPlugin_writeData[5 : 5];
-  assign _zz_416_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_417_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_418_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_419_ = 1'b1;
-  assign _zz_420_ = 1'b1;
-  assign _zz_421_ = {_zz_59_,_zz_58_};
-  assign _zz_422_ = 32'h0000107f;
-  assign _zz_423_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_424_ = 32'h00002073;
-  assign _zz_425_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_426_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_427_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_428_) == 32'h00000003),{(_zz_429_ == _zz_430_),{_zz_431_,{_zz_432_,_zz_433_}}}}}};
-  assign _zz_428_ = 32'h0000505f;
-  assign _zz_429_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_430_ = 32'h00000063;
-  assign _zz_431_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_432_ = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
-  assign _zz_433_ = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_434_) == 32'h00001013),{(_zz_435_ == _zz_436_),{_zz_437_,{_zz_438_,_zz_439_}}}}}};
-  assign _zz_434_ = 32'hfc00305f;
-  assign _zz_435_ = (decode_INSTRUCTION & 32'h01f0707f);
-  assign _zz_436_ = 32'h0000500f;
-  assign _zz_437_ = ((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013);
-  assign _zz_438_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
-  assign _zz_439_ = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_440_) == 32'h12000073),{(_zz_441_ == _zz_442_),{_zz_443_,_zz_444_}}}}};
-  assign _zz_440_ = 32'hfe007fff;
-  assign _zz_441_ = (decode_INSTRUCTION & 32'hdfffffff);
-  assign _zz_442_ = 32'h10200073;
-  assign _zz_443_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_444_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz_445_ = (decode_INSTRUCTION & 32'h08000020);
-  assign _zz_446_ = 32'h08000020;
-  assign _zz_447_ = ((decode_INSTRUCTION & 32'h10000020) == 32'h00000020);
-  assign _zz_448_ = ((decode_INSTRUCTION & 32'h00000028) == 32'h00000020);
-  assign _zz_449_ = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_450_ = 32'h00001000;
-  assign _zz_451_ = ((decode_INSTRUCTION & _zz_456_) == 32'h02004020);
-  assign _zz_452_ = (1'b0);
-  assign _zz_453_ = ({_zz_457_,{_zz_458_,_zz_459_}} != 5'h0);
-  assign _zz_454_ = (_zz_460_ != (1'b0));
-  assign _zz_455_ = {(_zz_461_ != _zz_462_),{_zz_463_,{_zz_464_,_zz_465_}}};
-  assign _zz_456_ = 32'h02004064;
-  assign _zz_457_ = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
-  assign _zz_458_ = ((decode_INSTRUCTION & _zz_466_) == 32'h0);
-  assign _zz_459_ = {(_zz_467_ == _zz_468_),{_zz_469_,_zz_93_}};
-  assign _zz_460_ = ((decode_INSTRUCTION & 32'h02203050) == 32'h00000050);
-  assign _zz_461_ = ((decode_INSTRUCTION & _zz_470_) == 32'h00000050);
-  assign _zz_462_ = (1'b0);
-  assign _zz_463_ = ({_zz_471_,{_zz_472_,_zz_473_}} != (4'b0000));
-  assign _zz_464_ = ({_zz_474_,_zz_475_} != (2'b00));
-  assign _zz_465_ = {(_zz_476_ != _zz_477_),{_zz_478_,{_zz_479_,_zz_480_}}};
-  assign _zz_466_ = 32'h00000018;
-  assign _zz_467_ = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_468_ = 32'h00002000;
-  assign _zz_469_ = ((decode_INSTRUCTION & _zz_481_) == 32'h00001000);
-  assign _zz_470_ = 32'h02403050;
-  assign _zz_471_ = ((decode_INSTRUCTION & _zz_482_) == 32'h00000020);
-  assign _zz_472_ = (_zz_483_ == _zz_484_);
-  assign _zz_473_ = {_zz_485_,_zz_486_};
-  assign _zz_474_ = (_zz_487_ == _zz_488_);
-  assign _zz_475_ = (_zz_489_ == _zz_490_);
-  assign _zz_476_ = {_zz_491_,{_zz_492_,_zz_493_}};
-  assign _zz_477_ = (3'b000);
-  assign _zz_478_ = ({_zz_494_,_zz_495_} != (3'b000));
-  assign _zz_479_ = (_zz_496_ != _zz_497_);
-  assign _zz_480_ = {_zz_498_,{_zz_499_,_zz_500_}};
-  assign _zz_481_ = 32'h00005004;
-  assign _zz_482_ = 32'h00000034;
-  assign _zz_483_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_484_ = 32'h00000020;
-  assign _zz_485_ = ((decode_INSTRUCTION & _zz_501_) == 32'h08000020);
-  assign _zz_486_ = ((decode_INSTRUCTION & _zz_502_) == 32'h00000020);
-  assign _zz_487_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_488_ = 32'h00005010;
-  assign _zz_489_ = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_490_ = 32'h00005020;
-  assign _zz_491_ = ((decode_INSTRUCTION & _zz_503_) == 32'h40001010);
-  assign _zz_492_ = (_zz_504_ == _zz_505_);
-  assign _zz_493_ = (_zz_506_ == _zz_507_);
-  assign _zz_494_ = _zz_92_;
-  assign _zz_495_ = {_zz_94_,_zz_508_};
-  assign _zz_496_ = {_zz_94_,_zz_509_};
-  assign _zz_497_ = (2'b00);
-  assign _zz_498_ = (_zz_510_ != (1'b0));
-  assign _zz_499_ = (_zz_511_ != _zz_512_);
-  assign _zz_500_ = {_zz_513_,{_zz_514_,_zz_515_}};
-  assign _zz_501_ = 32'h08000070;
-  assign _zz_502_ = 32'h10000070;
-  assign _zz_503_ = 32'h40003054;
-  assign _zz_504_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_505_ = 32'h00001010;
-  assign _zz_506_ = (decode_INSTRUCTION & 32'h02007054);
-  assign _zz_507_ = 32'h00001010;
-  assign _zz_508_ = ((decode_INSTRUCTION & 32'h00002014) == 32'h00000004);
-  assign _zz_509_ = ((decode_INSTRUCTION & 32'h0000004c) == 32'h00000004);
-  assign _zz_510_ = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
-  assign _zz_511_ = {(_zz_516_ == _zz_517_),(_zz_518_ == _zz_519_)};
-  assign _zz_512_ = (2'b00);
-  assign _zz_513_ = ((_zz_520_ == _zz_521_) != (1'b0));
-  assign _zz_514_ = ({_zz_522_,_zz_523_} != (2'b00));
-  assign _zz_515_ = {(_zz_524_ != _zz_525_),{_zz_526_,{_zz_527_,_zz_528_}}};
-  assign _zz_516_ = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_517_ = 32'h00001050;
-  assign _zz_518_ = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_519_ = 32'h00002050;
-  assign _zz_520_ = (decode_INSTRUCTION & 32'h10000008);
-  assign _zz_521_ = 32'h10000008;
-  assign _zz_522_ = _zz_92_;
-  assign _zz_523_ = ((decode_INSTRUCTION & _zz_529_) == 32'h00000004);
-  assign _zz_524_ = ((decode_INSTRUCTION & _zz_530_) == 32'h00000040);
-  assign _zz_525_ = (1'b0);
-  assign _zz_526_ = ({_zz_89_,_zz_87_} != (2'b00));
-  assign _zz_527_ = ({_zz_531_,_zz_532_} != (2'b00));
-  assign _zz_528_ = {(_zz_533_ != _zz_534_),{_zz_535_,{_zz_536_,_zz_537_}}};
-  assign _zz_529_ = 32'h0000001c;
-  assign _zz_530_ = 32'h00000058;
-  assign _zz_531_ = _zz_93_;
-  assign _zz_532_ = ((decode_INSTRUCTION & _zz_538_) == 32'h0);
-  assign _zz_533_ = {(_zz_539_ == _zz_540_),(_zz_541_ == _zz_542_)};
-  assign _zz_534_ = (2'b00);
-  assign _zz_535_ = ({_zz_92_,{_zz_543_,_zz_544_}} != 7'h0);
-  assign _zz_536_ = (_zz_545_ != (1'b0));
-  assign _zz_537_ = {(_zz_546_ != _zz_547_),{_zz_548_,{_zz_549_,_zz_550_}}};
-  assign _zz_538_ = 32'h00000058;
-  assign _zz_539_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_540_ = 32'h00002000;
-  assign _zz_541_ = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_542_ = 32'h00001000;
-  assign _zz_543_ = ((decode_INSTRUCTION & _zz_551_) == 32'h00001010);
-  assign _zz_544_ = {(_zz_552_ == _zz_553_),{_zz_554_,{_zz_555_,_zz_556_}}};
-  assign _zz_545_ = ((decode_INSTRUCTION & 32'h10000008) == 32'h00000008);
-  assign _zz_546_ = {_zz_91_,{_zz_557_,{_zz_558_,_zz_559_}}};
-  assign _zz_547_ = 5'h0;
-  assign _zz_548_ = ((_zz_560_ == _zz_561_) != (1'b0));
-  assign _zz_549_ = ({_zz_562_,_zz_563_} != (2'b00));
-  assign _zz_550_ = {(_zz_564_ != _zz_565_),{_zz_566_,{_zz_567_,_zz_568_}}};
-  assign _zz_551_ = 32'h00001010;
-  assign _zz_552_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_553_ = 32'h00002010;
-  assign _zz_554_ = ((decode_INSTRUCTION & _zz_569_) == 32'h00002008);
-  assign _zz_555_ = (_zz_570_ == _zz_571_);
-  assign _zz_556_ = {_zz_91_,_zz_572_};
-  assign _zz_557_ = ((decode_INSTRUCTION & _zz_573_) == 32'h00002010);
-  assign _zz_558_ = (_zz_574_ == _zz_575_);
-  assign _zz_559_ = {_zz_576_,_zz_577_};
-  assign _zz_560_ = (decode_INSTRUCTION & 32'h00000010);
-  assign _zz_561_ = 32'h00000010;
-  assign _zz_562_ = _zz_90_;
-  assign _zz_563_ = (_zz_578_ == _zz_579_);
-  assign _zz_564_ = {_zz_90_,_zz_580_};
-  assign _zz_565_ = (2'b00);
-  assign _zz_566_ = (_zz_581_ != (1'b0));
-  assign _zz_567_ = (_zz_582_ != _zz_583_);
-  assign _zz_568_ = {_zz_584_,{_zz_585_,_zz_586_}};
-  assign _zz_569_ = 32'h00002008;
-  assign _zz_570_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_571_ = 32'h00000010;
-  assign _zz_572_ = ((decode_INSTRUCTION & _zz_587_) == 32'h0);
-  assign _zz_573_ = 32'h00002030;
-  assign _zz_574_ = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_575_ = 32'h00000010;
-  assign _zz_576_ = ((decode_INSTRUCTION & _zz_588_) == 32'h00000020);
-  assign _zz_577_ = ((decode_INSTRUCTION & _zz_589_) == 32'h00002020);
-  assign _zz_578_ = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_579_ = 32'h00000020;
-  assign _zz_580_ = ((decode_INSTRUCTION & _zz_590_) == 32'h0);
-  assign _zz_581_ = ((decode_INSTRUCTION & _zz_591_) == 32'h00000024);
-  assign _zz_582_ = (_zz_592_ == _zz_593_);
-  assign _zz_583_ = (1'b0);
-  assign _zz_584_ = (_zz_594_ != (1'b0));
-  assign _zz_585_ = (_zz_595_ != _zz_596_);
-  assign _zz_586_ = {_zz_597_,{_zz_598_,_zz_599_}};
-  assign _zz_587_ = 32'h00000028;
-  assign _zz_588_ = 32'h02003020;
-  assign _zz_589_ = 32'h02002068;
-  assign _zz_590_ = 32'h00000020;
-  assign _zz_591_ = 32'h00000064;
-  assign _zz_592_ = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_593_ = 32'h00004010;
-  assign _zz_594_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz_595_ = {_zz_89_,{_zz_88_,_zz_87_}};
-  assign _zz_596_ = (3'b000);
-  assign _zz_597_ = (((decode_INSTRUCTION & _zz_600_) == 32'h02000030) != (1'b0));
-  assign _zz_598_ = ({_zz_601_,{_zz_602_,_zz_603_}} != (3'b000));
-  assign _zz_599_ = {({_zz_604_,_zz_605_} != 6'h0),{(_zz_606_ != _zz_607_),(_zz_608_ != _zz_609_)}};
-  assign _zz_600_ = 32'h02004074;
-  assign _zz_601_ = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_602_ = ((decode_INSTRUCTION & _zz_610_) == 32'h00002010);
-  assign _zz_603_ = ((decode_INSTRUCTION & _zz_611_) == 32'h40000030);
-  assign _zz_604_ = ((decode_INSTRUCTION & _zz_612_) == 32'h00002040);
-  assign _zz_605_ = {(_zz_613_ == _zz_614_),{_zz_615_,{_zz_616_,_zz_617_}}};
-  assign _zz_606_ = ((decode_INSTRUCTION & _zz_618_) == 32'h00004008);
-  assign _zz_607_ = (1'b0);
-  assign _zz_608_ = ((decode_INSTRUCTION & _zz_619_) == 32'h02000050);
-  assign _zz_609_ = (1'b0);
-  assign _zz_610_ = 32'h00002014;
-  assign _zz_611_ = 32'h40000034;
-  assign _zz_612_ = 32'h00002040;
-  assign _zz_613_ = (decode_INSTRUCTION & 32'h00001040);
-  assign _zz_614_ = 32'h00001040;
-  assign _zz_615_ = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_616_ = ((decode_INSTRUCTION & 32'h02400040) == 32'h00000040);
-  assign _zz_617_ = {((decode_INSTRUCTION & 32'h00000038) == 32'h0),((decode_INSTRUCTION & 32'h18002008) == 32'h10002008)};
-  assign _zz_618_ = 32'h00004048;
-  assign _zz_619_ = 32'h02003050;
-  assign _zz_620_ = 32'h0;
+  assign _zz_252 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_253 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_254 = 1'b1;
+  assign _zz_255 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_256 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_257 = (memory_arbitration_isValid && memory_IS_MUL);
+  assign _zz_258 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_259 = ((_zz_197 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_260 = ((_zz_197 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_261 = ((_zz_197 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_262 = ((_zz_197 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_263 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_264 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_265 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign _zz_266 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_267 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_268 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_269 = (! ({(writeBack_arbitration_isValid || CsrPlugin_exceptionPendings_3),{(memory_arbitration_isValid || CsrPlugin_exceptionPendings_2),(execute_arbitration_isValid || CsrPlugin_exceptionPendings_1)}} != 3'b000));
+  assign _zz_270 = (! dataCache_1_io_cpu_execute_refilling);
+  assign _zz_271 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_272 = ((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)) && (MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception));
+  assign _zz_273 = MmuPlugin_shared_portSortedOh[0];
+  assign _zz_274 = MmuPlugin_shared_portSortedOh[1];
+  assign _zz_275 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_276 = (1'b0 || (! 1'b1));
+  assign _zz_277 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_278 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_279 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_280 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_281 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_282 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_283 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_284 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
+  assign _zz_285 = (! memory_arbitration_isStuck);
+  assign _zz_286 = (iBus_cmd_valid || (_zz_183 != 3'b000));
+  assign _zz_287 = (_zz_226 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_288 = (MmuPlugin_shared_refills != 2'b00);
+  assign _zz_289 = (MmuPlugin_ports_0_entryToReplace_value == 2'b00);
+  assign _zz_290 = (MmuPlugin_ports_0_entryToReplace_value == 2'b01);
+  assign _zz_291 = (MmuPlugin_ports_0_entryToReplace_value == 2'b10);
+  assign _zz_292 = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
+  assign _zz_293 = (MmuPlugin_ports_1_entryToReplace_value == 2'b00);
+  assign _zz_294 = (MmuPlugin_ports_1_entryToReplace_value == 2'b01);
+  assign _zz_295 = (MmuPlugin_ports_1_entryToReplace_value == 2'b10);
+  assign _zz_296 = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign _zz_297 = ((CsrPlugin_sstatus_SIE && (CsrPlugin_privilege == 2'b01)) || (CsrPlugin_privilege < 2'b01));
+  assign _zz_298 = ((_zz_142 && (1'b1 && CsrPlugin_mideleg_ST)) && (! 1'b0));
+  assign _zz_299 = ((_zz_143 && (1'b1 && CsrPlugin_mideleg_SS)) && (! 1'b0));
+  assign _zz_300 = ((_zz_144 && (1'b1 && CsrPlugin_mideleg_SE)) && (! 1'b0));
+  assign _zz_301 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_302 = ((_zz_142 && 1'b1) && (! (CsrPlugin_mideleg_ST != 1'b0)));
+  assign _zz_303 = ((_zz_143 && 1'b1) && (! (CsrPlugin_mideleg_SS != 1'b0)));
+  assign _zz_304 = ((_zz_144 && 1'b1) && (! (CsrPlugin_mideleg_SE != 1'b0)));
+  assign _zz_305 = ((_zz_145 && 1'b1) && (! 1'b0));
+  assign _zz_306 = ((_zz_146 && 1'b1) && (! 1'b0));
+  assign _zz_307 = ((_zz_147 && 1'b1) && (! 1'b0));
+  assign _zz_308 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_309 = execute_INSTRUCTION[13];
+  assign _zz_310 = ($signed(_zz_312) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_311 = _zz_310[31 : 0];
+  assign _zz_312 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_313 = _zz_94[34 : 34];
+  assign _zz_314 = _zz_94[33 : 33];
+  assign _zz_315 = _zz_94[32 : 32];
+  assign _zz_316 = _zz_94[31 : 31];
+  assign _zz_317 = _zz_94[28 : 28];
+  assign _zz_318 = _zz_94[21 : 21];
+  assign _zz_319 = _zz_94[20 : 20];
+  assign _zz_320 = _zz_94[19 : 19];
+  assign _zz_321 = _zz_94[13 : 13];
+  assign _zz_322 = _zz_94[12 : 12];
+  assign _zz_323 = _zz_94[11 : 11];
+  assign _zz_324 = _zz_94[17 : 17];
+  assign _zz_325 = _zz_94[5 : 5];
+  assign _zz_326 = _zz_94[3 : 3];
+  assign _zz_327 = _zz_94[18 : 18];
+  assign _zz_328 = _zz_94[10 : 10];
+  assign _zz_329 = _zz_94[16 : 16];
+  assign _zz_330 = _zz_94[15 : 15];
+  assign _zz_331 = _zz_94[4 : 4];
+  assign _zz_332 = _zz_94[0 : 0];
+  assign _zz_333 = (_zz_55 - 4'b0001);
+  assign _zz_334 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_335 = {29'd0, _zz_334};
+  assign _zz_336 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_337 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_338 = MmuPlugin_ports_0_entryToReplace_willIncrement;
+  assign _zz_339 = {1'd0, _zz_338};
+  assign _zz_340 = MmuPlugin_ports_1_entryToReplace_willIncrement;
+  assign _zz_341 = {1'd0, _zz_340};
+  assign _zz_342 = MmuPlugin_shared_dBusRspStaged_payload_data[0 : 0];
+  assign _zz_343 = MmuPlugin_shared_dBusRspStaged_payload_data[1 : 1];
+  assign _zz_344 = MmuPlugin_shared_dBusRspStaged_payload_data[2 : 2];
+  assign _zz_345 = MmuPlugin_shared_dBusRspStaged_payload_data[3 : 3];
+  assign _zz_346 = MmuPlugin_shared_dBusRspStaged_payload_data[4 : 4];
+  assign _zz_347 = MmuPlugin_shared_dBusRspStaged_payload_data[5 : 5];
+  assign _zz_348 = MmuPlugin_shared_dBusRspStaged_payload_data[6 : 6];
+  assign _zz_349 = MmuPlugin_shared_dBusRspStaged_payload_data[7 : 7];
+  assign _zz_350 = (_zz_90 - 2'b01);
+  assign _zz_351 = execute_SRC_LESS;
+  assign _zz_352 = 3'b100;
+  assign _zz_353 = execute_INSTRUCTION[19 : 15];
+  assign _zz_354 = execute_INSTRUCTION[31 : 20];
+  assign _zz_355 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_356 = ($signed(_zz_357) + $signed(_zz_360));
+  assign _zz_357 = ($signed(_zz_358) + $signed(_zz_359));
+  assign _zz_358 = execute_SRC1;
+  assign _zz_359 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_360 = (execute_SRC_USE_SUB_LESS ? _zz_361 : _zz_362);
+  assign _zz_361 = 32'h00000001;
+  assign _zz_362 = 32'h0;
+  assign _zz_363 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_364 = execute_INSTRUCTION[31 : 20];
+  assign _zz_365 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_366 = (_zz_148 & (~ _zz_367));
+  assign _zz_367 = (_zz_148 - 2'b01);
+  assign _zz_368 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  assign _zz_369 = {5'd0, _zz_368};
+  assign _zz_370 = (_zz_372 + _zz_374);
+  assign _zz_371 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_372 = {{1{_zz_371[32]}}, _zz_371};
+  assign _zz_373 = _zz_375;
+  assign _zz_374 = {{1{_zz_373[32]}}, _zz_373};
+  assign _zz_375 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_376 = memory_MulDivIterativePlugin_div_counter_willIncrement;
+  assign _zz_377 = {5'd0, _zz_376};
+  assign _zz_378 = {1'd0, memory_MulDivIterativePlugin_rs2};
+  assign _zz_379 = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_380 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_381 = {_zz_150,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_382 = _zz_383;
+  assign _zz_383 = _zz_384;
+  assign _zz_384 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_151) : _zz_151)} + _zz_386);
+  assign _zz_385 = memory_MulDivIterativePlugin_div_needRevert;
+  assign _zz_386 = {32'd0, _zz_385};
+  assign _zz_387 = _zz_153;
+  assign _zz_388 = {32'd0, _zz_387};
+  assign _zz_389 = _zz_152;
+  assign _zz_390 = {31'd0, _zz_389};
+  assign _zz_391 = execute_CsrPlugin_writeData[19 : 19];
+  assign _zz_392 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_393 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_394 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_395 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_396 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_397 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_398 = execute_CsrPlugin_writeData[19 : 19];
+  assign _zz_399 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_400 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_401 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_402 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_403 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_404 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_405 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_406 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_407 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_408 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_409 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_410 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_411 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_412 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_413 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_414 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_415 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_416 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_417 = execute_CsrPlugin_writeData[4 : 4];
+  assign _zz_418 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_419 = execute_CsrPlugin_writeData[6 : 6];
+  assign _zz_420 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_421 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_422 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_423 = execute_CsrPlugin_writeData[12 : 12];
+  assign _zz_424 = execute_CsrPlugin_writeData[13 : 13];
+  assign _zz_425 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_426 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_427 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_428 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_429 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_430 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_431 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_432 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_433 = execute_CsrPlugin_writeData[5 : 5];
+  assign _zz_434 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_435 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_436 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_437 = 1'b1;
+  assign _zz_438 = 1'b1;
+  assign _zz_439 = {_zz_59,_zz_58};
+  assign _zz_440 = 32'h0000107f;
+  assign _zz_441 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_442 = 32'h00002073;
+  assign _zz_443 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_444 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_445 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_446) == 32'h00000003),{(_zz_447 == _zz_448),{_zz_449,{_zz_450,_zz_451}}}}}};
+  assign _zz_446 = 32'h0000505f;
+  assign _zz_447 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_448 = 32'h00000063;
+  assign _zz_449 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_450 = ((decode_INSTRUCTION & 32'h1800707f) == 32'h0000202f);
+  assign _zz_451 = {((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033),{((decode_INSTRUCTION & 32'he800707f) == 32'h0800202f),{((decode_INSTRUCTION & _zz_452) == 32'h00001013),{(_zz_453 == _zz_454),{_zz_455,{_zz_456,_zz_457}}}}}};
+  assign _zz_452 = 32'hfc00305f;
+  assign _zz_453 = (decode_INSTRUCTION & 32'h01f0707f);
+  assign _zz_454 = 32'h0000500f;
+  assign _zz_455 = ((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013);
+  assign _zz_456 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00005033);
+  assign _zz_457 = {((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033),{((decode_INSTRUCTION & 32'hf9f0707f) == 32'h1000202f),{((decode_INSTRUCTION & _zz_458) == 32'h12000073),{(_zz_459 == _zz_460),{_zz_461,_zz_462}}}}};
+  assign _zz_458 = 32'hfe007fff;
+  assign _zz_459 = (decode_INSTRUCTION & 32'hdfffffff);
+  assign _zz_460 = 32'h10200073;
+  assign _zz_461 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_462 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_463 = 32'h02004064;
+  assign _zz_464 = _zz_102;
+  assign _zz_465 = {_zz_100,_zz_101};
+  assign _zz_466 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz_467 = 1'b0;
+  assign _zz_468 = (((decode_INSTRUCTION & _zz_471) == 32'h00000050) != 1'b0);
+  assign _zz_469 = ((_zz_472 == _zz_473) != 1'b0);
+  assign _zz_470 = {({_zz_474,_zz_475} != 2'b00),{(_zz_476 != _zz_477),{_zz_478,{_zz_479,_zz_480}}}};
+  assign _zz_471 = 32'h02203050;
+  assign _zz_472 = (decode_INSTRUCTION & 32'h02403050);
+  assign _zz_473 = 32'h00000050;
+  assign _zz_474 = ((decode_INSTRUCTION & _zz_481) == 32'h00001050);
+  assign _zz_475 = ((decode_INSTRUCTION & _zz_482) == 32'h00002050);
+  assign _zz_476 = {_zz_96,(_zz_483 == _zz_484)};
+  assign _zz_477 = 2'b00;
+  assign _zz_478 = ((_zz_485 == _zz_486) != 1'b0);
+  assign _zz_479 = ({_zz_487,_zz_488} != 2'b00);
+  assign _zz_480 = {(_zz_489 != _zz_490),{_zz_491,{_zz_492,_zz_493}}};
+  assign _zz_481 = 32'h00001050;
+  assign _zz_482 = 32'h00002050;
+  assign _zz_483 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz_484 = 32'h00000004;
+  assign _zz_485 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_486 = 32'h00000040;
+  assign _zz_487 = ((decode_INSTRUCTION & _zz_494) == 32'h00005010);
+  assign _zz_488 = ((decode_INSTRUCTION & _zz_495) == 32'h00005020);
+  assign _zz_489 = {(_zz_496 == _zz_497),{_zz_498,_zz_499}};
+  assign _zz_490 = 3'b000;
+  assign _zz_491 = ((_zz_500 == _zz_501) != 1'b0);
+  assign _zz_492 = (_zz_100 != 1'b0);
+  assign _zz_493 = {(_zz_502 != _zz_503),{_zz_504,{_zz_505,_zz_506}}};
+  assign _zz_494 = 32'h00007034;
+  assign _zz_495 = 32'h02007064;
+  assign _zz_496 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz_497 = 32'h40001010;
+  assign _zz_498 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00001010);
+  assign _zz_499 = ((decode_INSTRUCTION & 32'h02007054) == 32'h00001010);
+  assign _zz_500 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz_501 = 32'h00001000;
+  assign _zz_502 = {(_zz_507 == _zz_508),(_zz_509 == _zz_510)};
+  assign _zz_503 = 2'b00;
+  assign _zz_504 = ((_zz_511 == _zz_512) != 1'b0);
+  assign _zz_505 = (_zz_513 != 1'b0);
+  assign _zz_506 = {(_zz_514 != _zz_515),{_zz_516,{_zz_517,_zz_518}}};
+  assign _zz_507 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_508 = 32'h00002000;
+  assign _zz_509 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz_510 = 32'h00001000;
+  assign _zz_511 = (decode_INSTRUCTION & 32'h02003050);
+  assign _zz_512 = 32'h02000050;
+  assign _zz_513 = ((decode_INSTRUCTION & 32'h00004048) == 32'h00004008);
+  assign _zz_514 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz_515 = 1'b0;
+  assign _zz_516 = ({(_zz_519 == _zz_520),{_zz_521,{_zz_522,_zz_523}}} != 4'b0000);
+  assign _zz_517 = ((_zz_524 == _zz_525) != 1'b0);
+  assign _zz_518 = {(_zz_526 != 1'b0),{(_zz_527 != _zz_528),{_zz_529,{_zz_530,_zz_531}}}};
+  assign _zz_519 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz_520 = 32'h00000020;
+  assign _zz_521 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz_522 = ((decode_INSTRUCTION & _zz_532) == 32'h08000020);
+  assign _zz_523 = ((decode_INSTRUCTION & _zz_533) == 32'h00000020);
+  assign _zz_524 = (decode_INSTRUCTION & 32'h10000008);
+  assign _zz_525 = 32'h00000008;
+  assign _zz_526 = ((decode_INSTRUCTION & 32'h10000008) == 32'h10000008);
+  assign _zz_527 = {(_zz_534 == _zz_535),{_zz_536,{_zz_537,_zz_538}}};
+  assign _zz_528 = 6'h0;
+  assign _zz_529 = ({_zz_539,{_zz_540,_zz_541}} != 3'b000);
+  assign _zz_530 = (_zz_542 != 1'b0);
+  assign _zz_531 = {(_zz_543 != _zz_544),{_zz_545,{_zz_546,_zz_547}}};
+  assign _zz_532 = 32'h08000070;
+  assign _zz_533 = 32'h10000070;
+  assign _zz_534 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz_535 = 32'h00002040;
+  assign _zz_536 = ((decode_INSTRUCTION & _zz_548) == 32'h00001040);
+  assign _zz_537 = (_zz_549 == _zz_550);
+  assign _zz_538 = {_zz_551,{_zz_552,_zz_553}};
+  assign _zz_539 = ((decode_INSTRUCTION & _zz_554) == 32'h08000020);
+  assign _zz_540 = (_zz_555 == _zz_556);
+  assign _zz_541 = (_zz_557 == _zz_558);
+  assign _zz_542 = ((decode_INSTRUCTION & _zz_559) == 32'h00000010);
+  assign _zz_543 = {_zz_99,{_zz_560,_zz_561}};
+  assign _zz_544 = 5'h0;
+  assign _zz_545 = ({_zz_562,_zz_563} != 7'h0);
+  assign _zz_546 = (_zz_564 != _zz_565);
+  assign _zz_547 = {_zz_566,{_zz_567,_zz_568}};
+  assign _zz_548 = 32'h00001040;
+  assign _zz_549 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_550 = 32'h00000040;
+  assign _zz_551 = ((decode_INSTRUCTION & _zz_569) == 32'h00000040);
+  assign _zz_552 = (_zz_570 == _zz_571);
+  assign _zz_553 = (_zz_572 == _zz_573);
+  assign _zz_554 = 32'h08000020;
+  assign _zz_555 = (decode_INSTRUCTION & 32'h10000020);
+  assign _zz_556 = 32'h00000020;
+  assign _zz_557 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_558 = 32'h00000020;
+  assign _zz_559 = 32'h00000010;
+  assign _zz_560 = (_zz_574 == _zz_575);
+  assign _zz_561 = {_zz_576,{_zz_577,_zz_578}};
+  assign _zz_562 = _zz_96;
+  assign _zz_563 = {_zz_579,{_zz_580,_zz_581}};
+  assign _zz_564 = {_zz_98,_zz_582};
+  assign _zz_565 = 2'b00;
+  assign _zz_566 = ({_zz_583,_zz_584} != 2'b00);
+  assign _zz_567 = (_zz_585 != _zz_586);
+  assign _zz_568 = {_zz_587,{_zz_588,_zz_589}};
+  assign _zz_569 = 32'h02400040;
+  assign _zz_570 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_571 = 32'h0;
+  assign _zz_572 = (decode_INSTRUCTION & 32'h18002008);
+  assign _zz_573 = 32'h10002008;
+  assign _zz_574 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz_575 = 32'h00002010;
+  assign _zz_576 = ((decode_INSTRUCTION & _zz_590) == 32'h00000010);
+  assign _zz_577 = (_zz_591 == _zz_592);
+  assign _zz_578 = (_zz_593 == _zz_594);
+  assign _zz_579 = ((decode_INSTRUCTION & _zz_595) == 32'h00001010);
+  assign _zz_580 = (_zz_596 == _zz_597);
+  assign _zz_581 = {_zz_598,{_zz_599,_zz_600}};
+  assign _zz_582 = ((decode_INSTRUCTION & _zz_601) == 32'h00000020);
+  assign _zz_583 = _zz_98;
+  assign _zz_584 = (_zz_602 == _zz_603);
+  assign _zz_585 = (_zz_604 == _zz_605);
+  assign _zz_586 = 1'b0;
+  assign _zz_587 = (_zz_606 != 1'b0);
+  assign _zz_588 = (_zz_607 != _zz_608);
+  assign _zz_589 = {_zz_609,{_zz_610,_zz_611}};
+  assign _zz_590 = 32'h00001030;
+  assign _zz_591 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz_592 = 32'h00000020;
+  assign _zz_593 = (decode_INSTRUCTION & 32'h02002068);
+  assign _zz_594 = 32'h00002020;
+  assign _zz_595 = 32'h00001010;
+  assign _zz_596 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_597 = 32'h00002010;
+  assign _zz_598 = ((decode_INSTRUCTION & _zz_612) == 32'h00002008);
+  assign _zz_599 = (_zz_613 == _zz_614);
+  assign _zz_600 = {_zz_99,_zz_615};
+  assign _zz_601 = 32'h00000070;
+  assign _zz_602 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_603 = 32'h0;
+  assign _zz_604 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz_605 = 32'h00004010;
+  assign _zz_606 = ((decode_INSTRUCTION & _zz_616) == 32'h00002010);
+  assign _zz_607 = {_zz_617,{_zz_618,_zz_619}};
+  assign _zz_608 = 5'h0;
+  assign _zz_609 = ({_zz_620,_zz_621} != 2'b00);
+  assign _zz_610 = (_zz_622 != _zz_623);
+  assign _zz_611 = {_zz_624,{_zz_625,_zz_626}};
+  assign _zz_612 = 32'h00002008;
+  assign _zz_613 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_614 = 32'h00000010;
+  assign _zz_615 = ((decode_INSTRUCTION & _zz_627) == 32'h0);
+  assign _zz_616 = 32'h00006014;
+  assign _zz_617 = ((decode_INSTRUCTION & _zz_628) == 32'h0);
+  assign _zz_618 = (_zz_629 == _zz_630);
+  assign _zz_619 = {_zz_631,{_zz_632,_zz_633}};
+  assign _zz_620 = _zz_97;
+  assign _zz_621 = (_zz_634 == _zz_635);
+  assign _zz_622 = {_zz_636,{_zz_637,_zz_638}};
+  assign _zz_623 = 3'b000;
+  assign _zz_624 = ({_zz_639,_zz_640} != 3'b000);
+  assign _zz_625 = (_zz_641 != _zz_642);
+  assign _zz_626 = (_zz_643 != _zz_644);
+  assign _zz_627 = 32'h00000028;
+  assign _zz_628 = 32'h00000044;
+  assign _zz_629 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_630 = 32'h0;
+  assign _zz_631 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_632 = ((decode_INSTRUCTION & _zz_645) == 32'h00001000);
+  assign _zz_633 = _zz_97;
+  assign _zz_634 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_635 = 32'h0;
+  assign _zz_636 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_637 = ((decode_INSTRUCTION & _zz_646) == 32'h00002010);
+  assign _zz_638 = ((decode_INSTRUCTION & _zz_647) == 32'h40000030);
+  assign _zz_639 = _zz_96;
+  assign _zz_640 = {_zz_95,(_zz_648 == _zz_649)};
+  assign _zz_641 = {_zz_95,(_zz_650 == _zz_651)};
+  assign _zz_642 = 2'b00;
+  assign _zz_643 = ((decode_INSTRUCTION & _zz_652) == 32'h00001008);
+  assign _zz_644 = 1'b0;
+  assign _zz_645 = 32'h00005004;
+  assign _zz_646 = 32'h00002014;
+  assign _zz_647 = 32'h40000034;
+  assign _zz_648 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz_649 = 32'h00000004;
+  assign _zz_650 = (decode_INSTRUCTION & 32'h0000004c);
+  assign _zz_651 = 32'h00000004;
+  assign _zz_652 = 32'h00005048;
+  assign _zz_653 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_419_) begin
-      _zz_209_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_437) begin
+      _zz_227 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_420_) begin
-      _zz_210_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_438) begin
+      _zz_228 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_43_) begin
+    if(_zz_43) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_184_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_185_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_186_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_187_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_188_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_189_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_3_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_190_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_191_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_192                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_193                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_194                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_195                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_196                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_sel           (IBusCachedPlugin_mmuBus_rsp_ways_0_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_0_physical      (IBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_sel           (IBusCachedPlugin_mmuBus_rsp_ways_1_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_1_physical      (IBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_sel           (IBusCachedPlugin_mmuBus_rsp_ways_2_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_2_physical      (IBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_sel           (IBusCachedPlugin_mmuBus_rsp_ways_3_sel                      ), //i
+    .io_cpu_fetch_mmuRsp_ways_3_physical      (IBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]           ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_197                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_198                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_3_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_199                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_200                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_192_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_193_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (_zz_194_                                                    ), //i
-    .io_cpu_execute_args_data                      (_zz_195_[31:0]                                              ), //i
-    .io_cpu_execute_args_size                      (_zz_196_[1:0]                                               ), //i
-    .io_cpu_execute_args_isLrsc                    (_zz_197_                                                    ), //i
-    .io_cpu_execute_args_isAmo                     (_zz_198_                                                    ), //i
-    .io_cpu_execute_args_amoCtrl_swap              (_zz_199_                                                    ), //i
-    .io_cpu_execute_args_amoCtrl_alu               (_zz_200_[2:0]                                               ), //i
-    .io_cpu_memory_isValid                         (_zz_201_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_202_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_203_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_204_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_205_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_206_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_writeBack_clearLrsc                    (contextSwitching                                            ), //i
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_207_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_208_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_201                                            ), //i
+    .io_cpu_execute_address                    (_zz_202[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (_zz_203                                            ), //i
+    .io_cpu_execute_args_data                  (_zz_204[31:0]                                      ), //i
+    .io_cpu_execute_args_size                  (_zz_205[1:0]                                       ), //i
+    .io_cpu_execute_args_isLrsc                (_zz_206                                            ), //i
+    .io_cpu_execute_args_isAmo                 (_zz_207                                            ), //i
+    .io_cpu_execute_args_amoCtrl_swap          (_zz_208                                            ), //i
+    .io_cpu_execute_args_amoCtrl_alu           (_zz_209[2:0]                                       ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_210                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_211[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_212                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_memory_mmuRsp_ways_0_sel           (DBusCachedPlugin_mmuBus_rsp_ways_0_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_0_physical      (DBusCachedPlugin_mmuBus_rsp_ways_0_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_1_sel           (DBusCachedPlugin_mmuBus_rsp_ways_1_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_1_physical      (DBusCachedPlugin_mmuBus_rsp_ways_1_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_2_sel           (DBusCachedPlugin_mmuBus_rsp_ways_2_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_2_physical      (DBusCachedPlugin_mmuBus_rsp_ways_2_physical[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_ways_3_sel           (DBusCachedPlugin_mmuBus_rsp_ways_3_sel             ), //i
+    .io_cpu_memory_mmuRsp_ways_3_physical      (DBusCachedPlugin_mmuBus_rsp_ways_3_physical[31:0]  ), //i
+    .io_cpu_writeBack_isValid                  (_zz_213                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_214                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_215[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_216                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_217                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_218                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_219                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_220                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_221                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_222                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_223                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_224[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_225                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_226                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_421_)
+    case(_zz_439)
       2'b00 : begin
-        _zz_211_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_229 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_211_ = CsrPlugin_jumpInterface_payload;
+        _zz_229 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_211_ = BranchPlugin_jumpInterface_payload;
+        _zz_229 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_211_ = CsrPlugin_redoInterface_payload;
+        _zz_229 = CsrPlugin_redoInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_82_)
+    case(_zz_83)
       2'b00 : begin
-        _zz_212_ = MmuPlugin_ports_0_cache_0_valid;
-        _zz_213_ = MmuPlugin_ports_0_cache_0_exception;
-        _zz_214_ = MmuPlugin_ports_0_cache_0_superPage;
-        _zz_215_ = MmuPlugin_ports_0_cache_0_virtualAddress_0;
-        _zz_216_ = MmuPlugin_ports_0_cache_0_virtualAddress_1;
-        _zz_217_ = MmuPlugin_ports_0_cache_0_physicalAddress_0;
-        _zz_218_ = MmuPlugin_ports_0_cache_0_physicalAddress_1;
-        _zz_219_ = MmuPlugin_ports_0_cache_0_allowRead;
-        _zz_220_ = MmuPlugin_ports_0_cache_0_allowWrite;
-        _zz_221_ = MmuPlugin_ports_0_cache_0_allowExecute;
-        _zz_222_ = MmuPlugin_ports_0_cache_0_allowUser;
+        _zz_230 = MmuPlugin_ports_0_cache_0_valid;
+        _zz_231 = MmuPlugin_ports_0_cache_0_exception;
+        _zz_232 = MmuPlugin_ports_0_cache_0_superPage;
+        _zz_233 = MmuPlugin_ports_0_cache_0_virtualAddress_0;
+        _zz_234 = MmuPlugin_ports_0_cache_0_virtualAddress_1;
+        _zz_235 = MmuPlugin_ports_0_cache_0_physicalAddress_0;
+        _zz_236 = MmuPlugin_ports_0_cache_0_physicalAddress_1;
+        _zz_237 = MmuPlugin_ports_0_cache_0_allowRead;
+        _zz_238 = MmuPlugin_ports_0_cache_0_allowWrite;
+        _zz_239 = MmuPlugin_ports_0_cache_0_allowExecute;
+        _zz_240 = MmuPlugin_ports_0_cache_0_allowUser;
       end
       2'b01 : begin
-        _zz_212_ = MmuPlugin_ports_0_cache_1_valid;
-        _zz_213_ = MmuPlugin_ports_0_cache_1_exception;
-        _zz_214_ = MmuPlugin_ports_0_cache_1_superPage;
-        _zz_215_ = MmuPlugin_ports_0_cache_1_virtualAddress_0;
-        _zz_216_ = MmuPlugin_ports_0_cache_1_virtualAddress_1;
-        _zz_217_ = MmuPlugin_ports_0_cache_1_physicalAddress_0;
-        _zz_218_ = MmuPlugin_ports_0_cache_1_physicalAddress_1;
-        _zz_219_ = MmuPlugin_ports_0_cache_1_allowRead;
-        _zz_220_ = MmuPlugin_ports_0_cache_1_allowWrite;
-        _zz_221_ = MmuPlugin_ports_0_cache_1_allowExecute;
-        _zz_222_ = MmuPlugin_ports_0_cache_1_allowUser;
+        _zz_230 = MmuPlugin_ports_0_cache_1_valid;
+        _zz_231 = MmuPlugin_ports_0_cache_1_exception;
+        _zz_232 = MmuPlugin_ports_0_cache_1_superPage;
+        _zz_233 = MmuPlugin_ports_0_cache_1_virtualAddress_0;
+        _zz_234 = MmuPlugin_ports_0_cache_1_virtualAddress_1;
+        _zz_235 = MmuPlugin_ports_0_cache_1_physicalAddress_0;
+        _zz_236 = MmuPlugin_ports_0_cache_1_physicalAddress_1;
+        _zz_237 = MmuPlugin_ports_0_cache_1_allowRead;
+        _zz_238 = MmuPlugin_ports_0_cache_1_allowWrite;
+        _zz_239 = MmuPlugin_ports_0_cache_1_allowExecute;
+        _zz_240 = MmuPlugin_ports_0_cache_1_allowUser;
       end
       2'b10 : begin
-        _zz_212_ = MmuPlugin_ports_0_cache_2_valid;
-        _zz_213_ = MmuPlugin_ports_0_cache_2_exception;
-        _zz_214_ = MmuPlugin_ports_0_cache_2_superPage;
-        _zz_215_ = MmuPlugin_ports_0_cache_2_virtualAddress_0;
-        _zz_216_ = MmuPlugin_ports_0_cache_2_virtualAddress_1;
-        _zz_217_ = MmuPlugin_ports_0_cache_2_physicalAddress_0;
-        _zz_218_ = MmuPlugin_ports_0_cache_2_physicalAddress_1;
-        _zz_219_ = MmuPlugin_ports_0_cache_2_allowRead;
-        _zz_220_ = MmuPlugin_ports_0_cache_2_allowWrite;
-        _zz_221_ = MmuPlugin_ports_0_cache_2_allowExecute;
-        _zz_222_ = MmuPlugin_ports_0_cache_2_allowUser;
+        _zz_230 = MmuPlugin_ports_0_cache_2_valid;
+        _zz_231 = MmuPlugin_ports_0_cache_2_exception;
+        _zz_232 = MmuPlugin_ports_0_cache_2_superPage;
+        _zz_233 = MmuPlugin_ports_0_cache_2_virtualAddress_0;
+        _zz_234 = MmuPlugin_ports_0_cache_2_virtualAddress_1;
+        _zz_235 = MmuPlugin_ports_0_cache_2_physicalAddress_0;
+        _zz_236 = MmuPlugin_ports_0_cache_2_physicalAddress_1;
+        _zz_237 = MmuPlugin_ports_0_cache_2_allowRead;
+        _zz_238 = MmuPlugin_ports_0_cache_2_allowWrite;
+        _zz_239 = MmuPlugin_ports_0_cache_2_allowExecute;
+        _zz_240 = MmuPlugin_ports_0_cache_2_allowUser;
       end
       default : begin
-        _zz_212_ = MmuPlugin_ports_0_cache_3_valid;
-        _zz_213_ = MmuPlugin_ports_0_cache_3_exception;
-        _zz_214_ = MmuPlugin_ports_0_cache_3_superPage;
-        _zz_215_ = MmuPlugin_ports_0_cache_3_virtualAddress_0;
-        _zz_216_ = MmuPlugin_ports_0_cache_3_virtualAddress_1;
-        _zz_217_ = MmuPlugin_ports_0_cache_3_physicalAddress_0;
-        _zz_218_ = MmuPlugin_ports_0_cache_3_physicalAddress_1;
-        _zz_219_ = MmuPlugin_ports_0_cache_3_allowRead;
-        _zz_220_ = MmuPlugin_ports_0_cache_3_allowWrite;
-        _zz_221_ = MmuPlugin_ports_0_cache_3_allowExecute;
-        _zz_222_ = MmuPlugin_ports_0_cache_3_allowUser;
+        _zz_230 = MmuPlugin_ports_0_cache_3_valid;
+        _zz_231 = MmuPlugin_ports_0_cache_3_exception;
+        _zz_232 = MmuPlugin_ports_0_cache_3_superPage;
+        _zz_233 = MmuPlugin_ports_0_cache_3_virtualAddress_0;
+        _zz_234 = MmuPlugin_ports_0_cache_3_virtualAddress_1;
+        _zz_235 = MmuPlugin_ports_0_cache_3_physicalAddress_0;
+        _zz_236 = MmuPlugin_ports_0_cache_3_physicalAddress_1;
+        _zz_237 = MmuPlugin_ports_0_cache_3_allowRead;
+        _zz_238 = MmuPlugin_ports_0_cache_3_allowWrite;
+        _zz_239 = MmuPlugin_ports_0_cache_3_allowExecute;
+        _zz_240 = MmuPlugin_ports_0_cache_3_allowUser;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_85_)
+    case(_zz_87)
       2'b00 : begin
-        _zz_223_ = MmuPlugin_ports_1_cache_0_valid;
-        _zz_224_ = MmuPlugin_ports_1_cache_0_exception;
-        _zz_225_ = MmuPlugin_ports_1_cache_0_superPage;
-        _zz_226_ = MmuPlugin_ports_1_cache_0_virtualAddress_0;
-        _zz_227_ = MmuPlugin_ports_1_cache_0_virtualAddress_1;
-        _zz_228_ = MmuPlugin_ports_1_cache_0_physicalAddress_0;
-        _zz_229_ = MmuPlugin_ports_1_cache_0_physicalAddress_1;
-        _zz_230_ = MmuPlugin_ports_1_cache_0_allowRead;
-        _zz_231_ = MmuPlugin_ports_1_cache_0_allowWrite;
-        _zz_232_ = MmuPlugin_ports_1_cache_0_allowExecute;
-        _zz_233_ = MmuPlugin_ports_1_cache_0_allowUser;
+        _zz_241 = MmuPlugin_ports_1_cache_0_valid;
+        _zz_242 = MmuPlugin_ports_1_cache_0_exception;
+        _zz_243 = MmuPlugin_ports_1_cache_0_superPage;
+        _zz_244 = MmuPlugin_ports_1_cache_0_virtualAddress_0;
+        _zz_245 = MmuPlugin_ports_1_cache_0_virtualAddress_1;
+        _zz_246 = MmuPlugin_ports_1_cache_0_physicalAddress_0;
+        _zz_247 = MmuPlugin_ports_1_cache_0_physicalAddress_1;
+        _zz_248 = MmuPlugin_ports_1_cache_0_allowRead;
+        _zz_249 = MmuPlugin_ports_1_cache_0_allowWrite;
+        _zz_250 = MmuPlugin_ports_1_cache_0_allowExecute;
+        _zz_251 = MmuPlugin_ports_1_cache_0_allowUser;
       end
       2'b01 : begin
-        _zz_223_ = MmuPlugin_ports_1_cache_1_valid;
-        _zz_224_ = MmuPlugin_ports_1_cache_1_exception;
-        _zz_225_ = MmuPlugin_ports_1_cache_1_superPage;
-        _zz_226_ = MmuPlugin_ports_1_cache_1_virtualAddress_0;
-        _zz_227_ = MmuPlugin_ports_1_cache_1_virtualAddress_1;
-        _zz_228_ = MmuPlugin_ports_1_cache_1_physicalAddress_0;
-        _zz_229_ = MmuPlugin_ports_1_cache_1_physicalAddress_1;
-        _zz_230_ = MmuPlugin_ports_1_cache_1_allowRead;
-        _zz_231_ = MmuPlugin_ports_1_cache_1_allowWrite;
-        _zz_232_ = MmuPlugin_ports_1_cache_1_allowExecute;
-        _zz_233_ = MmuPlugin_ports_1_cache_1_allowUser;
+        _zz_241 = MmuPlugin_ports_1_cache_1_valid;
+        _zz_242 = MmuPlugin_ports_1_cache_1_exception;
+        _zz_243 = MmuPlugin_ports_1_cache_1_superPage;
+        _zz_244 = MmuPlugin_ports_1_cache_1_virtualAddress_0;
+        _zz_245 = MmuPlugin_ports_1_cache_1_virtualAddress_1;
+        _zz_246 = MmuPlugin_ports_1_cache_1_physicalAddress_0;
+        _zz_247 = MmuPlugin_ports_1_cache_1_physicalAddress_1;
+        _zz_248 = MmuPlugin_ports_1_cache_1_allowRead;
+        _zz_249 = MmuPlugin_ports_1_cache_1_allowWrite;
+        _zz_250 = MmuPlugin_ports_1_cache_1_allowExecute;
+        _zz_251 = MmuPlugin_ports_1_cache_1_allowUser;
       end
       2'b10 : begin
-        _zz_223_ = MmuPlugin_ports_1_cache_2_valid;
-        _zz_224_ = MmuPlugin_ports_1_cache_2_exception;
-        _zz_225_ = MmuPlugin_ports_1_cache_2_superPage;
-        _zz_226_ = MmuPlugin_ports_1_cache_2_virtualAddress_0;
-        _zz_227_ = MmuPlugin_ports_1_cache_2_virtualAddress_1;
-        _zz_228_ = MmuPlugin_ports_1_cache_2_physicalAddress_0;
-        _zz_229_ = MmuPlugin_ports_1_cache_2_physicalAddress_1;
-        _zz_230_ = MmuPlugin_ports_1_cache_2_allowRead;
-        _zz_231_ = MmuPlugin_ports_1_cache_2_allowWrite;
-        _zz_232_ = MmuPlugin_ports_1_cache_2_allowExecute;
-        _zz_233_ = MmuPlugin_ports_1_cache_2_allowUser;
+        _zz_241 = MmuPlugin_ports_1_cache_2_valid;
+        _zz_242 = MmuPlugin_ports_1_cache_2_exception;
+        _zz_243 = MmuPlugin_ports_1_cache_2_superPage;
+        _zz_244 = MmuPlugin_ports_1_cache_2_virtualAddress_0;
+        _zz_245 = MmuPlugin_ports_1_cache_2_virtualAddress_1;
+        _zz_246 = MmuPlugin_ports_1_cache_2_physicalAddress_0;
+        _zz_247 = MmuPlugin_ports_1_cache_2_physicalAddress_1;
+        _zz_248 = MmuPlugin_ports_1_cache_2_allowRead;
+        _zz_249 = MmuPlugin_ports_1_cache_2_allowWrite;
+        _zz_250 = MmuPlugin_ports_1_cache_2_allowExecute;
+        _zz_251 = MmuPlugin_ports_1_cache_2_allowUser;
       end
       default : begin
-        _zz_223_ = MmuPlugin_ports_1_cache_3_valid;
-        _zz_224_ = MmuPlugin_ports_1_cache_3_exception;
-        _zz_225_ = MmuPlugin_ports_1_cache_3_superPage;
-        _zz_226_ = MmuPlugin_ports_1_cache_3_virtualAddress_0;
-        _zz_227_ = MmuPlugin_ports_1_cache_3_virtualAddress_1;
-        _zz_228_ = MmuPlugin_ports_1_cache_3_physicalAddress_0;
-        _zz_229_ = MmuPlugin_ports_1_cache_3_physicalAddress_1;
-        _zz_230_ = MmuPlugin_ports_1_cache_3_allowRead;
-        _zz_231_ = MmuPlugin_ports_1_cache_3_allowWrite;
-        _zz_232_ = MmuPlugin_ports_1_cache_3_allowExecute;
-        _zz_233_ = MmuPlugin_ports_1_cache_3_allowUser;
+        _zz_241 = MmuPlugin_ports_1_cache_3_valid;
+        _zz_242 = MmuPlugin_ports_1_cache_3_exception;
+        _zz_243 = MmuPlugin_ports_1_cache_3_superPage;
+        _zz_244 = MmuPlugin_ports_1_cache_3_virtualAddress_0;
+        _zz_245 = MmuPlugin_ports_1_cache_3_virtualAddress_1;
+        _zz_246 = MmuPlugin_ports_1_cache_3_physicalAddress_0;
+        _zz_247 = MmuPlugin_ports_1_cache_3_physicalAddress_1;
+        _zz_248 = MmuPlugin_ports_1_cache_3_allowRead;
+        _zz_249 = MmuPlugin_ports_1_cache_3_allowWrite;
+        _zz_250 = MmuPlugin_ports_1_cache_3_allowExecute;
+        _zz_251 = MmuPlugin_ports_1_cache_3_allowUser;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1__string = "ECALL";
-      default : _zz_1__string = "?????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2__string = "ECALL";
-      default : _zz_2__string = "?????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3__string = "ECALL";
-      default : _zz_3__string = "?????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4__string = "ECALL";
-      default : _zz_4__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3397,30 +2354,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_5_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5__string = "ECALL";
-      default : _zz_5__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_6_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6__string = "ECALL";
-      default : _zz_6__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_7_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7__string = "ECALL";
-      default : _zz_7__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3433,148 +2390,48 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_8__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_8__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8__string = "JALR";
-      default : _zz_8__string = "????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_9_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_9__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_9__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9__string = "JALR";
-      default : _zz_9__string = "????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_10_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_10__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_10__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_10__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_10__string = "JALR";
-      default : _zz_10__string = "????";
+    case(_zz_10)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_10_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_10_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_10_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_10_string = "JALR";
+      default : _zz_10_string = "????";
     endcase
   end
   always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_11_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_11__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_11__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_11__string = "AND_1";
-      default : _zz_11__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_12__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_12__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_12__string = "AND_1";
-      default : _zz_12__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13__string = "AND_1";
-      default : _zz_13__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_14__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_14__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_14__string = "BITWISE ";
-      default : _zz_14__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_15__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_15__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_15__string = "BITWISE ";
-      default : _zz_15__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_16__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_16__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_16__string = "BITWISE ";
-      default : _zz_16__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_17__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_17__string = "PC ";
-      default : _zz_17__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_18__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_18__string = "PC ";
-      default : _zz_18__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_19__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_19__string = "PC ";
-      default : _zz_19__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_20__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_20__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_20__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_20__string = "SRA_1    ";
-      default : _zz_20__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_21_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_21__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_21__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_21__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_21__string = "SRA_1    ";
-      default : _zz_21__string = "?????????";
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3587,30 +2444,130 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_22__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_22__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_22__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_22__string = "SRA_1    ";
-      default : _zz_22__string = "?????????";
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_23__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_23__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_23__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_23__string = "SRA_1    ";
-      default : _zz_23__string = "?????????";
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_24__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_24__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_24__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_24__string = "SRA_1    ";
-      default : _zz_24__string = "?????????";
+    case(_zz_15)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_15_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_15_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_15_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_15_string = "SRA_1    ";
+      default : _zz_15_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18_string = "AND_1";
+      default : _zz_18_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_21_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_21_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_21_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_21_string = "PC ";
+      default : _zz_21_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_24_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_24_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_24_string = "BITWISE ";
+      default : _zz_24_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3623,30 +2580,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25__string = "URS1        ";
-      default : _zz_25__string = "????????????";
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_26__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26__string = "URS1        ";
-      default : _zz_26__string = "????????????";
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_27__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27__string = "URS1        ";
-      default : _zz_27__string = "????????????";
+    case(_zz_27)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_27_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_27_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_27_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_27_string = "URS1        ";
+      default : _zz_27_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3659,12 +2616,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3677,12 +2634,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3695,12 +2652,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_30__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_30__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_30__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_30__string = "ECALL";
-      default : _zz_30__string = "?????";
+    case(_zz_30)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_30_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_30_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_30_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_30_string = "ECALL";
+      default : _zz_30_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3713,12 +2670,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_31_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_31__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_31__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_31__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_31__string = "JALR";
-      default : _zz_31__string = "????";
+    case(_zz_31)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_31_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_31_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_31_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_31_string = "JALR";
+      default : _zz_31_string = "????";
     endcase
   end
   always @(*) begin
@@ -3731,12 +2688,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3749,12 +2706,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_35__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_35__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_35__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_35__string = "SRA_1    ";
-      default : _zz_35__string = "?????????";
+    case(_zz_35)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_35_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_35_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_35_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_35_string = "SRA_1    ";
+      default : _zz_35_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -3767,12 +2724,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_37__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_37__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_37__string = "PC ";
-      default : _zz_37__string = "???";
+    case(_zz_37)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_37_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_37_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_37_string = "PC ";
+      default : _zz_37_string = "???";
     endcase
   end
   always @(*) begin
@@ -3785,12 +2742,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_38__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_38__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_38__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_38__string = "URS1        ";
-      default : _zz_38__string = "????????????";
+    case(_zz_38)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_38_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_38_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_38_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_38_string = "URS1        ";
+      default : _zz_38_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -3802,11 +2759,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_39__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_39__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_39__string = "BITWISE ";
-      default : _zz_39__string = "????????";
+    case(_zz_39)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_39_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_39_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_39_string = "BITWISE ";
+      default : _zz_39_string = "????????";
     endcase
   end
   always @(*) begin
@@ -3818,143 +2775,143 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_40_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_40__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_40__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_40__string = "AND_1";
-      default : _zz_40__string = "?????";
+    case(_zz_40)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_40_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_40_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_40_string = "AND_1";
+      default : _zz_40_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_44__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_44__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_44__string = "AND_1";
-      default : _zz_44__string = "?????";
+    case(_zz_44)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_44_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_44_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_44_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_44_string = "ECALL";
+      default : _zz_44_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_45__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_45__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_45__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_45__string = "ECALL";
-      default : _zz_45__string = "?????";
+    case(_zz_45)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_45_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_45_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_45_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_45_string = "JALR";
+      default : _zz_45_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46__string = "SRA_1    ";
-      default : _zz_46__string = "?????????";
+    case(_zz_46)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46_string = "SRA_1    ";
+      default : _zz_46_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_47__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_47__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_47__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_47__string = "URS1        ";
-      default : _zz_47__string = "????????????";
+    case(_zz_47)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_47_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_47_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_47_string = "AND_1";
+      default : _zz_47_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_48__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_48__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_48__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_48__string = "JALR";
-      default : _zz_48__string = "????";
+    case(_zz_48)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_48_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_48_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_48_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_48_string = "PC ";
+      default : _zz_48_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_49__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_49__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_49__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_49__string = "PC ";
-      default : _zz_49__string = "???";
+    case(_zz_49)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_49_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_49_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_49_string = "BITWISE ";
+      default : _zz_49_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_50_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_50__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_50__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_50__string = "BITWISE ";
-      default : _zz_50__string = "????????";
+    case(_zz_50)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_50_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_50_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_50_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_50_string = "URS1        ";
+      default : _zz_50_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(MmuPlugin_shared_state_1_)
-      `MmuPlugin_shared_State_defaultEncoding_IDLE : MmuPlugin_shared_state_1__string = "IDLE  ";
-      `MmuPlugin_shared_State_defaultEncoding_L1_CMD : MmuPlugin_shared_state_1__string = "L1_CMD";
-      `MmuPlugin_shared_State_defaultEncoding_L1_RSP : MmuPlugin_shared_state_1__string = "L1_RSP";
-      `MmuPlugin_shared_State_defaultEncoding_L0_CMD : MmuPlugin_shared_state_1__string = "L0_CMD";
-      `MmuPlugin_shared_State_defaultEncoding_L0_RSP : MmuPlugin_shared_state_1__string = "L0_RSP";
-      default : MmuPlugin_shared_state_1__string = "??????";
+    case(MmuPlugin_shared_state_1)
+      `MmuPlugin_shared_State_defaultEncoding_IDLE : MmuPlugin_shared_state_1_string = "IDLE  ";
+      `MmuPlugin_shared_State_defaultEncoding_L1_CMD : MmuPlugin_shared_state_1_string = "L1_CMD";
+      `MmuPlugin_shared_State_defaultEncoding_L1_RSP : MmuPlugin_shared_state_1_string = "L1_RSP";
+      `MmuPlugin_shared_State_defaultEncoding_L0_CMD : MmuPlugin_shared_state_1_string = "L0_CMD";
+      `MmuPlugin_shared_State_defaultEncoding_L0_RSP : MmuPlugin_shared_state_1_string = "L0_RSP";
+      default : MmuPlugin_shared_state_1_string = "??????";
     endcase
   end
   always @(*) begin
-    case(_zz_95_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_95__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_95__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_95__string = "BITWISE ";
-      default : _zz_95__string = "????????";
+    case(_zz_103)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_103_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_103_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_103_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_103_string = "URS1        ";
+      default : _zz_103_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_96_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_96__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_96__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_96__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_96__string = "PC ";
-      default : _zz_96__string = "???";
+    case(_zz_104)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_104_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_104_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_104_string = "BITWISE ";
+      default : _zz_104_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_97_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_97__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_97__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_97__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_97__string = "JALR";
-      default : _zz_97__string = "????";
+    case(_zz_105)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_105_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_105_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_105_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_105_string = "PC ";
+      default : _zz_105_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_98_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_98__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_98__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_98__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_98__string = "URS1        ";
-      default : _zz_98__string = "????????????";
+    case(_zz_106)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_106_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_106_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_106_string = "AND_1";
+      default : _zz_106_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_99_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_99__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_99__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_99__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_99__string = "SRA_1    ";
-      default : _zz_99__string = "?????????";
+    case(_zz_107)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_107_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_107_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_107_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_107_string = "SRA_1    ";
+      default : _zz_107_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_100_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_100__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_100__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_100__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_100__string = "ECALL";
-      default : _zz_100__string = "?????";
+    case(_zz_108)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_108_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_108_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_108_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_108_string = "JALR";
+      default : _zz_108_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_101_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_101__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_101__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_101__string = "AND_1";
-      default : _zz_101__string = "?????";
+    case(_zz_109)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_109_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_109_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_109_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_109_string = "ECALL";
+      default : _zz_109_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3964,6 +2921,31 @@ module VexRiscv (
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
       `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
       default : decode_to_execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -3982,31 +2964,6 @@ module VexRiscv (
       `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
       `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
       default : execute_to_memory_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
-      default : decode_to_execute_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4047,55 +3004,54 @@ module VexRiscv (
   end
   `endif
 
-  assign decode_IS_RS2_SIGNED = _zz_293_[0];
-  assign decode_SRC_LESS_UNSIGNED = _zz_294_[0];
-  assign _zz_1_ = _zz_2_;
-  assign _zz_3_ = _zz_4_;
-  assign decode_ENV_CTRL = _zz_5_;
-  assign _zz_6_ = _zz_7_;
-  assign decode_MEMORY_MANAGMENT = _zz_295_[0];
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_296_[0];
-  assign memory_PC = execute_to_memory_PC;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = _zz_133;
+  assign execute_SHIFT_RIGHT = _zz_311;
+  assign execute_REGFILE_WRITE_DATA = _zz_111;
+  assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_202[1 : 0];
   assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_BRANCH_CTRL = _zz_8_;
-  assign _zz_9_ = _zz_10_;
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_DIV = _zz_313[0];
+  assign decode_IS_RS2_SIGNED = _zz_314[0];
+  assign decode_IS_RS1_SIGNED = _zz_315[0];
+  assign decode_IS_MUL = _zz_316[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_317[0];
+  assign decode_BRANCH_CTRL = _zz_8;
+  assign _zz_9 = _zz_10;
+  assign _zz_11 = _zz_12;
+  assign decode_SHIFT_CTRL = _zz_13;
+  assign _zz_14 = _zz_15;
+  assign decode_ALU_BITWISE_CTRL = _zz_16;
+  assign _zz_17 = _zz_18;
+  assign decode_SRC_LESS_UNSIGNED = _zz_318[0];
+  assign memory_IS_SFENCE_VMA = execute_to_memory_IS_SFENCE_VMA;
+  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
+  assign decode_IS_SFENCE_VMA = _zz_319[0];
+  assign decode_MEMORY_MANAGMENT = _zz_320[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_321[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_322[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_323[0];
+  assign decode_SRC2_CTRL = _zz_19;
+  assign _zz_20 = _zz_21;
+  assign decode_ALU_CTRL = _zz_22;
+  assign _zz_23 = _zz_24;
+  assign decode_SRC1_CTRL = _zz_25;
+  assign _zz_26 = _zz_27;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = _zz_52;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign memory_IS_SFENCE_VMA = execute_to_memory_IS_SFENCE_VMA;
-  assign execute_IS_SFENCE_VMA = decode_to_execute_IS_SFENCE_VMA;
-  assign decode_IS_SFENCE_VMA = _zz_297_[0];
-  assign decode_IS_RS1_SIGNED = _zz_298_[0];
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_193_[1 : 0];
-  assign decode_IS_DIV = _zz_299_[0];
-  assign execute_BRANCH_DO = _zz_125_;
-  assign decode_ALU_BITWISE_CTRL = _zz_11_;
-  assign _zz_12_ = _zz_13_;
-  assign decode_ALU_CTRL = _zz_14_;
-  assign _zz_15_ = _zz_16_;
-  assign decode_IS_MUL = _zz_300_[0];
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_301_[0];
-  assign decode_SRC2_CTRL = _zz_17_;
-  assign _zz_18_ = _zz_19_;
-  assign decode_IS_CSR = _zz_302_[0];
-  assign execute_REGFILE_WRITE_DATA = _zz_103_;
-  assign _zz_20_ = _zz_21_;
-  assign decode_SHIFT_CTRL = _zz_22_;
-  assign _zz_23_ = _zz_24_;
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_303_[0];
-  assign execute_IS_DBUS_SHARING = (MmuPlugin_dBusAccess_cmd_valid && MmuPlugin_dBusAccess_cmd_ready);
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_MEMORY_LRSC = _zz_304_[0];
-  assign decode_MEMORY_AMO = _zz_305_[0];
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign execute_SHIFT_RIGHT = _zz_307_;
-  assign decode_SRC1_CTRL = _zz_25_;
-  assign _zz_26_ = _zz_27_;
+  assign memory_PC = execute_to_memory_PC;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
@@ -4105,23 +3061,23 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_28_;
-  assign execute_ENV_CTRL = _zz_29_;
-  assign writeBack_ENV_CTRL = _zz_30_;
+  assign memory_ENV_CTRL = _zz_28;
+  assign execute_ENV_CTRL = _zz_29;
+  assign writeBack_ENV_CTRL = _zz_30;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_31_;
-  assign decode_RS2_USE = _zz_309_[0];
-  assign decode_RS1_USE = _zz_310_[0];
+  assign execute_BRANCH_CTRL = _zz_31;
+  assign decode_RS2_USE = _zz_324[0];
+  assign decode_RS1_USE = _zz_325[0];
   always @ (*) begin
-    _zz_32_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_234_)begin
-      _zz_32_ = execute_CsrPlugin_readData;
+    _zz_32 = execute_REGFILE_WRITE_DATA;
+    if(_zz_252)begin
+      _zz_32 = execute_CsrPlugin_readData;
     end
     if(DBusCachedPlugin_forceDatapath)begin
-      _zz_32_ = MmuPlugin_dBusAccess_cmd_payload_address;
+      _zz_32 = MmuPlugin_dBusAccess_cmd_payload_address;
     end
   end
 
@@ -4133,29 +3089,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_114_)begin
-      if((_zz_115_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_116_;
+    if(_zz_122)begin
+      if((_zz_123 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_124;
       end
     end
-    if(_zz_235_)begin
-      if(_zz_236_)begin
-        if(_zz_118_)begin
-          decode_RS2 = _zz_51_;
+    if(_zz_253)begin
+      if(_zz_254)begin
+        if(_zz_126)begin
+          decode_RS2 = _zz_51;
         end
       end
     end
-    if(_zz_237_)begin
+    if(_zz_255)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_120_)begin
-          decode_RS2 = _zz_33_;
+        if(_zz_128)begin
+          decode_RS2 = _zz_33;
         end
       end
     end
-    if(_zz_238_)begin
+    if(_zz_256)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_122_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_130)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
@@ -4163,29 +3119,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_114_)begin
-      if((_zz_115_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_116_;
+    if(_zz_122)begin
+      if((_zz_123 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_124;
       end
     end
-    if(_zz_235_)begin
-      if(_zz_236_)begin
-        if(_zz_117_)begin
-          decode_RS1 = _zz_51_;
+    if(_zz_253)begin
+      if(_zz_254)begin
+        if(_zz_125)begin
+          decode_RS1 = _zz_51;
         end
       end
     end
-    if(_zz_237_)begin
+    if(_zz_255)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_119_)begin
-          decode_RS1 = _zz_33_;
+        if(_zz_127)begin
+          decode_RS1 = _zz_33;
         end
       end
     end
-    if(_zz_238_)begin
+    if(_zz_256)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_121_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_129)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
@@ -4193,68 +3149,68 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_33_ = memory_REGFILE_WRITE_DATA;
+    _zz_33 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_33_ = _zz_111_;
+          _zz_33 = _zz_119;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_33_ = memory_SHIFT_RIGHT;
+          _zz_33 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_239_)begin
-      _zz_33_ = ((memory_INSTRUCTION[13 : 12] == (2'b00)) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+    if(_zz_257)begin
+      _zz_33 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
     end
-    if(_zz_240_)begin
-      _zz_33_ = memory_MulDivIterativePlugin_div_result;
+    if(_zz_258)begin
+      _zz_33 = memory_MulDivIterativePlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_34_;
-  assign execute_SHIFT_CTRL = _zz_35_;
+  assign memory_SHIFT_CTRL = _zz_34;
+  assign execute_SHIFT_CTRL = _zz_35;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_36_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_37_;
-  assign execute_SRC1_CTRL = _zz_38_;
-  assign decode_SRC_USE_SUB_LESS = _zz_311_[0];
-  assign decode_SRC_ADD_ZERO = _zz_312_[0];
+  assign _zz_36 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_37;
+  assign execute_SRC1_CTRL = _zz_38;
+  assign decode_SRC_USE_SUB_LESS = _zz_326[0];
+  assign decode_SRC_ADD_ZERO = _zz_327[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_39_;
-  assign execute_SRC2 = _zz_109_;
-  assign execute_SRC1 = _zz_104_;
-  assign execute_ALU_BITWISE_CTRL = _zz_40_;
-  assign _zz_41_ = writeBack_INSTRUCTION;
-  assign _zz_42_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_39;
+  assign execute_SRC2 = _zz_117;
+  assign execute_SRC1 = _zz_112;
+  assign execute_ALU_BITWISE_CTRL = _zz_40;
+  assign _zz_41 = writeBack_INSTRUCTION;
+  assign _zz_42 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_43_ = 1'b0;
+    _zz_43 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_43_ = 1'b1;
+      _zz_43 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_313_[0];
+    decode_REGFILE_WRITE_VALID = _zz_328[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_422_) == 32'h00001073),{(_zz_423_ == _zz_424_),{_zz_425_,{_zz_426_,_zz_427_}}}}}}} != 25'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_440) == 32'h00001073),{(_zz_441 == _zz_442),{_zz_443,{_zz_444,_zz_445}}}}}}} != 25'h0);
   assign writeBack_IS_SFENCE_VMA = memory_to_writeBack_IS_SFENCE_VMA;
   assign writeBack_IS_DBUS_SHARING = memory_to_writeBack_IS_DBUS_SHARING;
   assign memory_IS_DBUS_SHARING = execute_to_memory_IS_DBUS_SHARING;
   always @ (*) begin
-    _zz_51_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_51 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_51_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_51 = writeBack_DBusCachedPlugin_rspFormated;
     end
   end
 
@@ -4266,54 +3222,57 @@ module VexRiscv (
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
   assign execute_MEMORY_AMO = decode_to_execute_MEMORY_AMO;
   assign execute_MEMORY_LRSC = decode_to_execute_MEMORY_LRSC;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_314_[0];
-  assign decode_FLUSH_ALL = _zz_315_[0];
+  assign decode_MEMORY_AMO = _zz_329[0];
+  assign decode_MEMORY_LRSC = _zz_330[0];
+  assign decode_MEMORY_ENABLE = _zz_331[0];
+  assign decode_FLUSH_ALL = _zz_332[0];
   always @ (*) begin
-    _zz_52_ = _zz_52__2;
-    if(_zz_241_)begin
-      _zz_52_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_259)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_52__2 = _zz_52__1;
-    if(_zz_242_)begin
-      _zz_52__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_260)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_52__1 = _zz_52__0;
-    if(_zz_243_)begin
-      _zz_52__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_261)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_52__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_244_)begin
-      _zz_52__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_262)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_53_ = execute_FORMAL_PC_NEXT;
+    _zz_53 = execute_FORMAL_PC_NEXT;
     if(CsrPlugin_redoInterface_valid)begin
-      _zz_53_ = CsrPlugin_redoInterface_payload;
+      _zz_53 = CsrPlugin_redoInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_54_ = memory_FORMAL_PC_NEXT;
+    _zz_54 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_54_ = BranchPlugin_jumpInterface_payload;
+      _zz_54 = BranchPlugin_jumpInterface_payload;
     end
   end
 
@@ -4332,20 +3291,20 @@ module VexRiscv (
     if(MmuPlugin_dBusAccess_cmd_valid)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if((decode_arbitration_isValid && (_zz_112_ || _zz_113_)))begin
+    if((decode_arbitration_isValid && (_zz_120 || _zz_121)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_245_)begin
+    if(_zz_263)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -4356,32 +3315,35 @@ module VexRiscv (
   assign decode_arbitration_flushIt = 1'b0;
   always @ (*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(_zz_245_)begin
+    if(_zz_263)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_207_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_225 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_246_)begin
+    if(_zz_264)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_234_)begin
+    if(_zz_252)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  assign execute_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    execute_arbitration_haltByOther = 1'b0;
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+  end
+
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
     if(CsrPlugin_selfException_valid)begin
@@ -4399,7 +3361,7 @@ module VexRiscv (
       execute_arbitration_flushNext = 1'b1;
     end
     if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
+      if(execute_CsrPlugin_writeInstruction)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -4407,15 +3369,15 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_239_)begin
+    if(_zz_257)begin
       if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
         memory_arbitration_haltItself = 1'b1;
       end
-      if(_zz_247_)begin
+      if(_zz_265)begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_240_)begin
+    if(_zz_258)begin
       if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -4446,7 +3408,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -4477,10 +3439,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_248_)begin
+    if(_zz_266)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_249_)begin
+    if(_zz_267)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -4491,13 +3453,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_248_)begin
+    if(_zz_266)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_249_)begin
+    if(_zz_267)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -4511,7 +3473,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_246_)begin
+    if(_zz_264)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -4519,21 +3481,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_248_)begin
+    if(_zz_266)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_249_)begin
+    if(_zz_267)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_248_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_266)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_249_)begin
-      case(_zz_250_)
+    if(_zz_267)begin
+      case(_zz_268)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -4549,14 +3511,14 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}} != (4'b0000));
-  assign _zz_55_ = {CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_56_ = (_zz_55_ & (~ _zz_316_));
-  assign _zz_57_ = _zz_56_[3];
-  assign _zz_58_ = (_zz_56_[1] || _zz_57_);
-  assign _zz_59_ = (_zz_56_[2] || _zz_57_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_211_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_redoInterface_valid,{CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}} != 4'b0000);
+  assign _zz_55 = {CsrPlugin_redoInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_56 = (_zz_55 & (~ _zz_333));
+  assign _zz_57 = _zz_56[3];
+  assign _zz_58 = (_zz_56[1] || _zz_57);
+  assign _zz_59 = (_zz_56[2] || _zz_57);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_229;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -4576,7 +3538,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_318_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_335);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -4610,9 +3572,9 @@ module VexRiscv (
   assign IBusCachedPlugin_fetchPc_output_ready = IBusCachedPlugin_iBusRsp_stages_0_input_ready;
   assign IBusCachedPlugin_iBusRsp_stages_0_input_payload = IBusCachedPlugin_fetchPc_output_payload;
   assign IBusCachedPlugin_iBusRsp_stages_0_halt = 1'b0;
-  assign _zz_60_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60_);
+  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
@@ -4621,48 +3583,48 @@ module VexRiscv (
     end
   end
 
-  assign _zz_61_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61_);
+  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_62_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62_);
+  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_3_halt = 1'b0;
-    if((_zz_52_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_3_halt = 1'b1;
     end
   end
 
-  assign _zz_63_ = (! IBusCachedPlugin_iBusRsp_stages_3_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_3_input_ready = (IBusCachedPlugin_iBusRsp_stages_3_output_ready && _zz_63_);
-  assign IBusCachedPlugin_iBusRsp_stages_3_output_valid = (IBusCachedPlugin_iBusRsp_stages_3_input_valid && _zz_63_);
+  assign _zz_63 = (! IBusCachedPlugin_iBusRsp_stages_3_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_3_input_ready = (IBusCachedPlugin_iBusRsp_stages_3_output_ready && _zz_63);
+  assign IBusCachedPlugin_iBusRsp_stages_3_output_valid = (IBusCachedPlugin_iBusRsp_stages_3_input_valid && _zz_63);
   assign IBusCachedPlugin_iBusRsp_stages_3_output_payload = IBusCachedPlugin_iBusRsp_stages_3_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_3_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_64_;
-  assign _zz_64_ = ((1'b0 && (! _zz_65_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_65_ = _zz_66_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_65_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_64;
+  assign _zz_64 = ((1'b0 && (! _zz_65)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_65 = _zz_66;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_65;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_67_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_67_ = _zz_68_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_67_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_69_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = ((1'b0 && (! _zz_70_)) || IBusCachedPlugin_iBusRsp_stages_3_input_ready);
-  assign _zz_70_ = _zz_71_;
-  assign IBusCachedPlugin_iBusRsp_stages_3_input_valid = _zz_70_;
-  assign IBusCachedPlugin_iBusRsp_stages_3_input_payload = _zz_72_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_67)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_67 = _zz_68;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_67;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_69;
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = ((1'b0 && (! _zz_70)) || IBusCachedPlugin_iBusRsp_stages_3_input_ready);
+  assign _zz_70 = _zz_71;
+  assign IBusCachedPlugin_iBusRsp_stages_3_input_valid = _zz_70;
+  assign IBusCachedPlugin_iBusRsp_stages_3_input_payload = _zz_72;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -4684,111 +3646,127 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_185_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_186_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_187_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_188_ = (IBusCachedPlugin_iBusRsp_stages_3_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_189_ = (! IBusCachedPlugin_iBusRsp_stages_3_input_ready);
-  assign _zz_190_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_193 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_194 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_195 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_194;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_2_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_197 = (IBusCachedPlugin_iBusRsp_stages_3_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_198 = (! IBusCachedPlugin_iBusRsp_stages_3_input_ready);
+  assign _zz_199 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_244_)begin
+    if(_zz_262)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_242_)begin
+    if(_zz_260)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_191_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_242_)begin
-      _zz_191_ = 1'b1;
+    _zz_200 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_260)begin
+      _zz_200 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_243_)begin
+    if(_zz_261)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_241_)begin
+    if(_zz_259)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_243_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_261)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_241_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_259)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_3_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_3_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_3_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_3_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_3_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_184_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_208_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_192 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_226 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  always @ (*) begin
+    _zz_52 = 1'b0;
+    if(decode_INSTRUCTION[25])begin
+      if(decode_MEMORY_LRSC)begin
+        _zz_52 = 1'b1;
+      end
+      if(decode_MEMORY_AMO)begin
+        _zz_52 = 1'b1;
+      end
+    end
+  end
+
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
-    _zz_192_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+    _zz_201 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
-        if(_zz_252_)begin
-          _zz_192_ = 1'b1;
+      if(_zz_269)begin
+        if(_zz_270)begin
+          _zz_201 = 1'b1;
         end
       end
     end
   end
 
   always @ (*) begin
-    _zz_193_ = execute_SRC_ADD;
+    _zz_202 = execute_SRC_ADD;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
-        _zz_193_ = MmuPlugin_dBusAccess_cmd_payload_address;
+      if(_zz_269)begin
+        _zz_202 = MmuPlugin_dBusAccess_cmd_payload_address;
       end
     end
   end
 
   always @ (*) begin
-    _zz_194_ = execute_MEMORY_WR;
+    _zz_203 = execute_MEMORY_WR;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
-        _zz_194_ = MmuPlugin_dBusAccess_cmd_payload_write;
+      if(_zz_269)begin
+        _zz_203 = MmuPlugin_dBusAccess_cmd_payload_write;
       end
     end
   end
@@ -4796,97 +3774,98 @@ module VexRiscv (
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_75_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_75 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_75_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_75 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_75_ = execute_RS2[31 : 0];
+        _zz_75 = execute_RS2[31 : 0];
       end
     endcase
   end
 
   always @ (*) begin
-    _zz_195_ = _zz_75_;
+    _zz_204 = _zz_75;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
-        _zz_195_ = MmuPlugin_dBusAccess_cmd_payload_data;
+      if(_zz_269)begin
+        _zz_204 = MmuPlugin_dBusAccess_cmd_payload_data;
       end
     end
   end
 
   always @ (*) begin
-    _zz_196_ = execute_DBusCachedPlugin_size;
+    _zz_205 = execute_DBusCachedPlugin_size;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
-        _zz_196_ = MmuPlugin_dBusAccess_cmd_payload_size;
+      if(_zz_269)begin
+        _zz_205 = MmuPlugin_dBusAccess_cmd_payload_size;
       end
     end
   end
 
-  assign _zz_207_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_225 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
   always @ (*) begin
-    _zz_197_ = 1'b0;
+    _zz_206 = 1'b0;
     if(execute_MEMORY_LRSC)begin
-      _zz_197_ = 1'b1;
+      _zz_206 = 1'b1;
     end
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
-        _zz_197_ = 1'b0;
+      if(_zz_269)begin
+        _zz_206 = 1'b0;
       end
     end
   end
 
   always @ (*) begin
-    _zz_198_ = execute_MEMORY_AMO;
+    _zz_207 = execute_MEMORY_AMO;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
-        _zz_198_ = 1'b0;
+      if(_zz_269)begin
+        _zz_207 = 1'b0;
       end
     end
   end
 
-  assign _zz_200_ = execute_INSTRUCTION[31 : 29];
-  assign _zz_199_ = execute_INSTRUCTION[27];
+  assign _zz_209 = execute_INSTRUCTION[31 : 29];
+  assign _zz_208 = execute_INSTRUCTION[27];
   always @ (*) begin
-    _zz_201_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+    _zz_210 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
     if(memory_IS_DBUS_SHARING)begin
-      _zz_201_ = 1'b1;
+      _zz_210 = 1'b1;
     end
   end
 
-  assign _zz_202_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
+  assign _zz_211 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_210;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_211;
   always @ (*) begin
-    DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+    DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
     if(memory_IS_DBUS_SHARING)begin
-      DBusCachedPlugin_mmuBus_cmd_bypassTranslation = 1'b1;
+      DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b1;
+    end
+  end
+
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
+  always @ (*) begin
+    _zz_212 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_212 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_203_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_203_ = 1'b1;
-    end
-  end
-
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  always @ (*) begin
-    _zz_204_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+    _zz_213 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
     if(writeBack_IS_DBUS_SHARING)begin
-      _zz_204_ = 1'b1;
+      _zz_213 = 1'b1;
     end
   end
 
-  assign _zz_205_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_206_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_214 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_215 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_253_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_271)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -4895,17 +3874,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_253_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_271)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -4913,94 +3892,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_253_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_319_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_271)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_336};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_320_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_337};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_76_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_76 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_77_[31] = _zz_76_;
-    _zz_77_[30] = _zz_76_;
-    _zz_77_[29] = _zz_76_;
-    _zz_77_[28] = _zz_76_;
-    _zz_77_[27] = _zz_76_;
-    _zz_77_[26] = _zz_76_;
-    _zz_77_[25] = _zz_76_;
-    _zz_77_[24] = _zz_76_;
-    _zz_77_[23] = _zz_76_;
-    _zz_77_[22] = _zz_76_;
-    _zz_77_[21] = _zz_76_;
-    _zz_77_[20] = _zz_76_;
-    _zz_77_[19] = _zz_76_;
-    _zz_77_[18] = _zz_76_;
-    _zz_77_[17] = _zz_76_;
-    _zz_77_[16] = _zz_76_;
-    _zz_77_[15] = _zz_76_;
-    _zz_77_[14] = _zz_76_;
-    _zz_77_[13] = _zz_76_;
-    _zz_77_[12] = _zz_76_;
-    _zz_77_[11] = _zz_76_;
-    _zz_77_[10] = _zz_76_;
-    _zz_77_[9] = _zz_76_;
-    _zz_77_[8] = _zz_76_;
-    _zz_77_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_77[31] = _zz_76;
+    _zz_77[30] = _zz_76;
+    _zz_77[29] = _zz_76;
+    _zz_77[28] = _zz_76;
+    _zz_77[27] = _zz_76;
+    _zz_77[26] = _zz_76;
+    _zz_77[25] = _zz_76;
+    _zz_77[24] = _zz_76;
+    _zz_77[23] = _zz_76;
+    _zz_77[22] = _zz_76;
+    _zz_77[21] = _zz_76;
+    _zz_77[20] = _zz_76;
+    _zz_77[19] = _zz_76;
+    _zz_77[18] = _zz_76;
+    _zz_77[17] = _zz_76;
+    _zz_77[16] = _zz_76;
+    _zz_77[15] = _zz_76;
+    _zz_77[14] = _zz_76;
+    _zz_77[13] = _zz_76;
+    _zz_77[12] = _zz_76;
+    _zz_77[11] = _zz_76;
+    _zz_77[10] = _zz_76;
+    _zz_77[9] = _zz_76;
+    _zz_77[8] = _zz_76;
+    _zz_77[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_78_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_78 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_79_[31] = _zz_78_;
-    _zz_79_[30] = _zz_78_;
-    _zz_79_[29] = _zz_78_;
-    _zz_79_[28] = _zz_78_;
-    _zz_79_[27] = _zz_78_;
-    _zz_79_[26] = _zz_78_;
-    _zz_79_[25] = _zz_78_;
-    _zz_79_[24] = _zz_78_;
-    _zz_79_[23] = _zz_78_;
-    _zz_79_[22] = _zz_78_;
-    _zz_79_[21] = _zz_78_;
-    _zz_79_[20] = _zz_78_;
-    _zz_79_[19] = _zz_78_;
-    _zz_79_[18] = _zz_78_;
-    _zz_79_[17] = _zz_78_;
-    _zz_79_[16] = _zz_78_;
-    _zz_79_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_79[31] = _zz_78;
+    _zz_79[30] = _zz_78;
+    _zz_79[29] = _zz_78;
+    _zz_79[28] = _zz_78;
+    _zz_79[27] = _zz_78;
+    _zz_79[26] = _zz_78;
+    _zz_79[25] = _zz_78;
+    _zz_79[24] = _zz_78;
+    _zz_79[23] = _zz_78;
+    _zz_79[22] = _zz_78;
+    _zz_79[21] = _zz_78;
+    _zz_79[20] = _zz_78;
+    _zz_79[19] = _zz_78;
+    _zz_79[18] = _zz_78;
+    _zz_79[17] = _zz_78;
+    _zz_79[16] = _zz_78;
+    _zz_79[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_291_)
+    case(_zz_308)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_77_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_77;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_79_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_79;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -5011,8 +3990,8 @@ module VexRiscv (
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_ready = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
-        if(_zz_252_)begin
+      if(_zz_269)begin
+        if(_zz_270)begin
           MmuPlugin_dBusAccess_cmd_ready = (! execute_arbitration_isStuck);
         end
       end
@@ -5022,228 +4001,272 @@ module VexRiscv (
   always @ (*) begin
     DBusCachedPlugin_forceDatapath = 1'b0;
     if(MmuPlugin_dBusAccess_cmd_valid)begin
-      if(_zz_251_)begin
+      if(_zz_269)begin
         DBusCachedPlugin_forceDatapath = 1'b1;
       end
     end
   end
 
-  assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1__io_cpu_writeBack_isWrite)) && (dataCache_1__io_cpu_redo || (! dataCache_1__io_cpu_writeBack_haltIt)));
-  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1__io_cpu_writeBack_data;
-  assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1__io_cpu_writeBack_unalignedAccess || dataCache_1__io_cpu_writeBack_accessError);
-  assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1__io_cpu_redo;
-  assign MmuPlugin_ports_0_cacheHits_0 = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_1 = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_2 = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHits_3 = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_0_cacheHit = ({MmuPlugin_ports_0_cacheHits_3,{MmuPlugin_ports_0_cacheHits_2,{MmuPlugin_ports_0_cacheHits_1,MmuPlugin_ports_0_cacheHits_0}}} != (4'b0000));
-  assign _zz_80_ = (MmuPlugin_ports_0_cacheHits_1 || MmuPlugin_ports_0_cacheHits_3);
-  assign _zz_81_ = (MmuPlugin_ports_0_cacheHits_2 || MmuPlugin_ports_0_cacheHits_3);
-  assign _zz_82_ = {_zz_81_,_zz_80_};
-  assign MmuPlugin_ports_0_cacheLine_valid = _zz_212_;
-  assign MmuPlugin_ports_0_cacheLine_exception = _zz_213_;
-  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_214_;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_215_;
-  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_216_;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_217_;
-  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_218_;
-  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_219_;
-  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_220_;
-  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_221_;
-  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_222_;
+  assign MmuPlugin_dBusAccess_rsp_valid = ((writeBack_IS_DBUS_SHARING && (! dataCache_1_io_cpu_writeBack_isWrite)) && (dataCache_1_io_cpu_redo || (! dataCache_1_io_cpu_writeBack_haltIt)));
+  assign MmuPlugin_dBusAccess_rsp_payload_data = dataCache_1_io_cpu_writeBack_data;
+  assign MmuPlugin_dBusAccess_rsp_payload_error = (dataCache_1_io_cpu_writeBack_unalignedAccess || dataCache_1_io_cpu_writeBack_accessError);
+  assign MmuPlugin_dBusAccess_rsp_payload_redo = dataCache_1_io_cpu_redo;
+  assign MmuPlugin_ports_0_dirty = 1'b0;
+  always @ (*) begin
+    MmuPlugin_ports_0_requireMmuLockupCalc = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
+    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+      MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
+    end
+    if((CsrPlugin_privilege == 2'b11))begin
+      MmuPlugin_ports_0_requireMmuLockupCalc = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    MmuPlugin_ports_0_cacheHitsCalc[0] = ((MmuPlugin_ports_0_cache_0_valid && (MmuPlugin_ports_0_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_0_superPage || (MmuPlugin_ports_0_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[1] = ((MmuPlugin_ports_0_cache_1_valid && (MmuPlugin_ports_0_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_1_superPage || (MmuPlugin_ports_0_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[2] = ((MmuPlugin_ports_0_cache_2_valid && (MmuPlugin_ports_0_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_2_superPage || (MmuPlugin_ports_0_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_0_cacheHitsCalc[3] = ((MmuPlugin_ports_0_cache_3_valid && (MmuPlugin_ports_0_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_0_cache_3_superPage || (MmuPlugin_ports_0_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+  end
+
+  assign MmuPlugin_ports_0_cacheHit = (MmuPlugin_ports_0_cacheHitsCalc != 4'b0000);
+  assign _zz_80 = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign _zz_81 = (MmuPlugin_ports_0_cacheHitsCalc[1] || _zz_80);
+  assign _zz_82 = (MmuPlugin_ports_0_cacheHitsCalc[2] || _zz_80);
+  assign _zz_83 = {_zz_82,_zz_81};
+  assign MmuPlugin_ports_0_cacheLine_valid = _zz_230;
+  assign MmuPlugin_ports_0_cacheLine_exception = _zz_231;
+  assign MmuPlugin_ports_0_cacheLine_superPage = _zz_232;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_0 = _zz_233;
+  assign MmuPlugin_ports_0_cacheLine_virtualAddress_1 = _zz_234;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_0 = _zz_235;
+  assign MmuPlugin_ports_0_cacheLine_physicalAddress_1 = _zz_236;
+  assign MmuPlugin_ports_0_cacheLine_allowRead = _zz_237;
+  assign MmuPlugin_ports_0_cacheLine_allowWrite = _zz_238;
+  assign MmuPlugin_ports_0_cacheLine_allowExecute = _zz_239;
+  assign MmuPlugin_ports_0_cacheLine_allowUser = _zz_240;
   always @ (*) begin
     MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b0;
-    if(_zz_254_)begin
-      if(_zz_255_)begin
+    if(_zz_272)begin
+      if(_zz_273)begin
         MmuPlugin_ports_0_entryToReplace_willIncrement = 1'b1;
       end
     end
   end
 
   assign MmuPlugin_ports_0_entryToReplace_willClear = 1'b0;
-  assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == (2'b11));
+  assign MmuPlugin_ports_0_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_0_entryToReplace_value == 2'b11);
   assign MmuPlugin_ports_0_entryToReplace_willOverflow = (MmuPlugin_ports_0_entryToReplace_willOverflowIfInc && MmuPlugin_ports_0_entryToReplace_willIncrement);
   always @ (*) begin
-    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_322_);
+    MmuPlugin_ports_0_entryToReplace_valueNext = (MmuPlugin_ports_0_entryToReplace_value + _zz_339);
     if(MmuPlugin_ports_0_entryToReplace_willClear)begin
-      MmuPlugin_ports_0_entryToReplace_valueNext = (2'b00);
+      MmuPlugin_ports_0_entryToReplace_valueNext = 2'b00;
     end
   end
 
   always @ (*) begin
-    MmuPlugin_ports_0_requireMmuLockup = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == (2'b11))))begin
-      MmuPlugin_ports_0_requireMmuLockup = 1'b0;
-    end
-    if((CsrPlugin_privilege == (2'b11)))begin
-      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == (2'b11))))begin
-        MmuPlugin_ports_0_requireMmuLockup = 1'b0;
-      end
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_virtualAddress[11 : 0]};
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_0_cacheLine_physicalAddress_1,(MmuPlugin_ports_0_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
+      IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_exception = (MmuPlugin_ports_0_cacheHit && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == (2'b01))) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == (2'b00)))));
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_0_requireMmuLockup)begin
-      DBusCachedPlugin_mmuBus_rsp_refilling = (! MmuPlugin_ports_0_cacheHit);
-    end else begin
-      DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
-    end
-  end
-
-  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = (((DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1011)) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1110))) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1111)));
-  assign MmuPlugin_ports_1_cacheHits_0 = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_1 = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_2 = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHits_3 = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12])));
-  assign MmuPlugin_ports_1_cacheHit = ({MmuPlugin_ports_1_cacheHits_3,{MmuPlugin_ports_1_cacheHits_2,{MmuPlugin_ports_1_cacheHits_1,MmuPlugin_ports_1_cacheHits_0}}} != (4'b0000));
-  assign _zz_83_ = (MmuPlugin_ports_1_cacheHits_1 || MmuPlugin_ports_1_cacheHits_3);
-  assign _zz_84_ = (MmuPlugin_ports_1_cacheHits_2 || MmuPlugin_ports_1_cacheHits_3);
-  assign _zz_85_ = {_zz_84_,_zz_83_};
-  assign MmuPlugin_ports_1_cacheLine_valid = _zz_223_;
-  assign MmuPlugin_ports_1_cacheLine_exception = _zz_224_;
-  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_225_;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_226_;
-  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_227_;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_228_;
-  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_229_;
-  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_230_;
-  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_231_;
-  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_232_;
-  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_233_;
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
-    if(_zz_254_)begin
-      if(_zz_256_)begin
-        MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
-      end
-    end
-  end
-
-  assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
-  assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == (2'b11));
-  assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
-  always @ (*) begin
-    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_324_);
-    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
-      MmuPlugin_ports_1_entryToReplace_valueNext = (2'b00);
-    end
-  end
-
-  always @ (*) begin
-    MmuPlugin_ports_1_requireMmuLockup = ((1'b1 && (! IBusCachedPlugin_mmuBus_cmd_bypassTranslation)) && MmuPlugin_satp_mode);
-    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == (2'b11))))begin
-      MmuPlugin_ports_1_requireMmuLockup = 1'b0;
-    end
-    if((CsrPlugin_privilege == (2'b11)))begin
-      MmuPlugin_ports_1_requireMmuLockup = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_virtualAddress[11 : 0]};
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-    end
-  end
-
-  always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_0_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_0_cacheLine_allowExecute));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_0_cacheLine_allowWrite;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_0_cacheLine_allowExecute;
     end else begin
       IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_exception = (MmuPlugin_ports_1_cacheHit && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == (2'b01))) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == (2'b00)))));
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_0_dirty) && MmuPlugin_ports_0_cacheHit) && ((MmuPlugin_ports_0_cacheLine_exception || ((MmuPlugin_ports_0_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_0_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
     end
   end
 
   always @ (*) begin
-    if(MmuPlugin_ports_1_requireMmuLockup)begin
-      IBusCachedPlugin_mmuBus_rsp_refilling = (! MmuPlugin_ports_1_cacheHit);
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_0_dirty || (! MmuPlugin_ports_0_cacheHit));
     end else begin
       IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
     end
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = (((IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1011)) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1110))) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == (4'b1111)));
-  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_325_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_326_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_327_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_328_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_329_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_330_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_331_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_332_[0];
-  assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_dBusAccess_rsp_payload_data[9 : 8];
-  assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_dBusAccess_rsp_payload_data[19 : 10];
-  assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_dBusAccess_rsp_payload_data[31 : 20];
-  assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_dBusAccess_rsp_payload_error);
+  always @ (*) begin
+    if(MmuPlugin_ports_0_requireMmuLockupCalc)begin
+      IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+    end
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = (((IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1011) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1110)) || (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1111));
+  assign IBusCachedPlugin_mmuBus_rsp_bypassTranslation = (! MmuPlugin_ports_0_requireMmuLockupCalc);
+  assign IBusCachedPlugin_mmuBus_rsp_ways_0_sel = MmuPlugin_ports_0_cacheHitsCalc[0];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_0_physical = {{MmuPlugin_ports_0_cache_0_physicalAddress_1,(MmuPlugin_ports_0_cache_0_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_0_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_1_sel = MmuPlugin_ports_0_cacheHitsCalc[1];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_1_physical = {{MmuPlugin_ports_0_cache_1_physicalAddress_1,(MmuPlugin_ports_0_cache_1_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_1_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_2_sel = MmuPlugin_ports_0_cacheHitsCalc[2];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_0_cache_2_physicalAddress_1,(MmuPlugin_ports_0_cache_2_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_2_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign IBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_0_cacheHitsCalc[3];
+  assign IBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_0_cache_3_physicalAddress_1,(MmuPlugin_ports_0_cache_3_superPage ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_0_cache_3_physicalAddress_0)},IBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign MmuPlugin_ports_1_dirty = 1'b0;
+  always @ (*) begin
+    MmuPlugin_ports_1_requireMmuLockupCalc = ((1'b1 && (! DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation)) && MmuPlugin_satp_mode);
+    if(((! MmuPlugin_status_mprv) && (CsrPlugin_privilege == 2'b11)))begin
+      MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
+    end
+    if((CsrPlugin_privilege == 2'b11))begin
+      if(((! MmuPlugin_status_mprv) || (CsrPlugin_mstatus_MPP == 2'b11)))begin
+        MmuPlugin_ports_1_requireMmuLockupCalc = 1'b0;
+      end
+    end
+  end
+
+  always @ (*) begin
+    MmuPlugin_ports_1_cacheHitsCalc[0] = ((MmuPlugin_ports_1_cache_0_valid && (MmuPlugin_ports_1_cache_0_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_0_superPage || (MmuPlugin_ports_1_cache_0_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[1] = ((MmuPlugin_ports_1_cache_1_valid && (MmuPlugin_ports_1_cache_1_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_1_superPage || (MmuPlugin_ports_1_cache_1_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[2] = ((MmuPlugin_ports_1_cache_2_valid && (MmuPlugin_ports_1_cache_2_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_2_superPage || (MmuPlugin_ports_1_cache_2_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+    MmuPlugin_ports_1_cacheHitsCalc[3] = ((MmuPlugin_ports_1_cache_3_valid && (MmuPlugin_ports_1_cache_3_virtualAddress_1 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[31 : 22])) && (MmuPlugin_ports_1_cache_3_superPage || (MmuPlugin_ports_1_cache_3_virtualAddress_0 == DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12])));
+  end
+
+  assign MmuPlugin_ports_1_cacheHit = (MmuPlugin_ports_1_cacheHitsCalc != 4'b0000);
+  assign _zz_84 = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign _zz_85 = (MmuPlugin_ports_1_cacheHitsCalc[1] || _zz_84);
+  assign _zz_86 = (MmuPlugin_ports_1_cacheHitsCalc[2] || _zz_84);
+  assign _zz_87 = {_zz_86,_zz_85};
+  assign MmuPlugin_ports_1_cacheLine_valid = _zz_241;
+  assign MmuPlugin_ports_1_cacheLine_exception = _zz_242;
+  assign MmuPlugin_ports_1_cacheLine_superPage = _zz_243;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_0 = _zz_244;
+  assign MmuPlugin_ports_1_cacheLine_virtualAddress_1 = _zz_245;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_0 = _zz_246;
+  assign MmuPlugin_ports_1_cacheLine_physicalAddress_1 = _zz_247;
+  assign MmuPlugin_ports_1_cacheLine_allowRead = _zz_248;
+  assign MmuPlugin_ports_1_cacheLine_allowWrite = _zz_249;
+  assign MmuPlugin_ports_1_cacheLine_allowExecute = _zz_250;
+  assign MmuPlugin_ports_1_cacheLine_allowUser = _zz_251;
+  always @ (*) begin
+    MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b0;
+    if(_zz_272)begin
+      if(_zz_274)begin
+        MmuPlugin_ports_1_entryToReplace_willIncrement = 1'b1;
+      end
+    end
+  end
+
+  assign MmuPlugin_ports_1_entryToReplace_willClear = 1'b0;
+  assign MmuPlugin_ports_1_entryToReplace_willOverflowIfInc = (MmuPlugin_ports_1_entryToReplace_value == 2'b11);
+  assign MmuPlugin_ports_1_entryToReplace_willOverflow = (MmuPlugin_ports_1_entryToReplace_willOverflowIfInc && MmuPlugin_ports_1_entryToReplace_willIncrement);
+  always @ (*) begin
+    MmuPlugin_ports_1_entryToReplace_valueNext = (MmuPlugin_ports_1_entryToReplace_value + _zz_341);
+    if(MmuPlugin_ports_1_entryToReplace_willClear)begin
+      MmuPlugin_ports_1_entryToReplace_valueNext = 2'b00;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_physicalAddress = {{MmuPlugin_ports_1_cacheLine_physicalAddress_1,(MmuPlugin_ports_1_cacheLine_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cacheLine_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = (MmuPlugin_ports_1_cacheLine_allowRead || (MmuPlugin_status_mxr && MmuPlugin_ports_1_cacheLine_allowExecute));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = MmuPlugin_ports_1_cacheLine_allowWrite;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = MmuPlugin_ports_1_cacheLine_allowExecute;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_exception = (((! MmuPlugin_ports_1_dirty) && MmuPlugin_ports_1_cacheHit) && ((MmuPlugin_ports_1_cacheLine_exception || ((MmuPlugin_ports_1_cacheLine_allowUser && (CsrPlugin_privilege == 2'b01)) && (! MmuPlugin_status_sum))) || ((! MmuPlugin_ports_1_cacheLine_allowUser) && (CsrPlugin_privilege == 2'b00))));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_refilling = (MmuPlugin_ports_1_dirty || (! MmuPlugin_ports_1_cacheHit));
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    if(MmuPlugin_ports_1_requireMmuLockupCalc)begin
+      DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b1;
+    end else begin
+      DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
+    end
+  end
+
+  assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = (((DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1011) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1110)) || (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31 : 28] == 4'b1111));
+  assign DBusCachedPlugin_mmuBus_rsp_bypassTranslation = (! MmuPlugin_ports_1_requireMmuLockupCalc);
+  assign DBusCachedPlugin_mmuBus_rsp_ways_0_sel = MmuPlugin_ports_1_cacheHitsCalc[0];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_0_physical = {{MmuPlugin_ports_1_cache_0_physicalAddress_1,(MmuPlugin_ports_1_cache_0_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_0_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_1_sel = MmuPlugin_ports_1_cacheHitsCalc[1];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_1_physical = {{MmuPlugin_ports_1_cache_1_physicalAddress_1,(MmuPlugin_ports_1_cache_1_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_1_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_2_sel = MmuPlugin_ports_1_cacheHitsCalc[2];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_2_physical = {{MmuPlugin_ports_1_cache_2_physicalAddress_1,(MmuPlugin_ports_1_cache_2_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_2_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign DBusCachedPlugin_mmuBus_rsp_ways_3_sel = MmuPlugin_ports_1_cacheHitsCalc[3];
+  assign DBusCachedPlugin_mmuBus_rsp_ways_3_physical = {{MmuPlugin_ports_1_cache_3_physicalAddress_1,(MmuPlugin_ports_1_cache_3_superPage ? DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[21 : 12] : MmuPlugin_ports_1_cache_3_physicalAddress_0)},DBusCachedPlugin_mmuBus_cmd_0_virtualAddress[11 : 0]};
+  assign MmuPlugin_shared_dBusRsp_pte_V = _zz_342[0];
+  assign MmuPlugin_shared_dBusRsp_pte_R = _zz_343[0];
+  assign MmuPlugin_shared_dBusRsp_pte_W = _zz_344[0];
+  assign MmuPlugin_shared_dBusRsp_pte_X = _zz_345[0];
+  assign MmuPlugin_shared_dBusRsp_pte_U = _zz_346[0];
+  assign MmuPlugin_shared_dBusRsp_pte_G = _zz_347[0];
+  assign MmuPlugin_shared_dBusRsp_pte_A = _zz_348[0];
+  assign MmuPlugin_shared_dBusRsp_pte_D = _zz_349[0];
+  assign MmuPlugin_shared_dBusRsp_pte_RSW = MmuPlugin_shared_dBusRspStaged_payload_data[9 : 8];
+  assign MmuPlugin_shared_dBusRsp_pte_PPN0 = MmuPlugin_shared_dBusRspStaged_payload_data[19 : 10];
+  assign MmuPlugin_shared_dBusRsp_pte_PPN1 = MmuPlugin_shared_dBusRspStaged_payload_data[31 : 20];
+  assign MmuPlugin_shared_dBusRsp_exception = (((! MmuPlugin_shared_dBusRsp_pte_V) || ((! MmuPlugin_shared_dBusRsp_pte_R) && MmuPlugin_shared_dBusRsp_pte_W)) || MmuPlugin_shared_dBusRspStaged_payload_error);
   assign MmuPlugin_shared_dBusRsp_leaf = (MmuPlugin_shared_dBusRsp_pte_R || MmuPlugin_shared_dBusRsp_pte_X);
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_valid = 1'b0;
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -5260,19 +4283,19 @@ module VexRiscv (
   end
 
   assign MmuPlugin_dBusAccess_cmd_payload_write = 1'b0;
-  assign MmuPlugin_dBusAccess_cmd_payload_size = (2'b10);
+  assign MmuPlugin_dBusAccess_cmd_payload_size = 2'b10;
   always @ (*) begin
     MmuPlugin_dBusAccess_cmd_payload_address = 32'h0;
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},(2'b00)};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{MmuPlugin_satp_ppn,MmuPlugin_shared_vpn_1},2'b00};
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
       end
       `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
-        MmuPlugin_dBusAccess_cmd_payload_address = {{{MmuPlugin_shared_pteBuffer_PPN1[9 : 0],MmuPlugin_shared_pteBuffer_PPN0},MmuPlugin_shared_vpn_0},(2'b00)};
+        MmuPlugin_dBusAccess_cmd_payload_address = {{{MmuPlugin_shared_pteBuffer_PPN1[9 : 0],MmuPlugin_shared_pteBuffer_PPN0},MmuPlugin_shared_vpn_0},2'b00};
       end
       default : begin
       end
@@ -5280,48 +4303,79 @@ module VexRiscv (
   end
 
   assign MmuPlugin_dBusAccess_cmd_payload_data = 32'h0;
-  assign MmuPlugin_dBusAccess_cmd_payload_writeMask = (4'bxxxx);
-  assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1_ != `MmuPlugin_shared_State_defaultEncoding_IDLE) && (MmuPlugin_shared_portId == (1'b1)));
-  assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1_ != `MmuPlugin_shared_State_defaultEncoding_IDLE) && (MmuPlugin_shared_portId == (1'b0)));
-  assign _zz_87_ = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
-  assign _zz_88_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_89_ = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
-  assign _zz_90_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_91_ = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_92_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_93_ = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
-  assign _zz_94_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_86_ = {({(_zz_445_ == _zz_446_),{_zz_447_,_zz_448_}} != (3'b000)),{((_zz_449_ == _zz_450_) != (1'b0)),{(_zz_88_ != (1'b0)),{(_zz_451_ != _zz_452_),{_zz_453_,{_zz_454_,_zz_455_}}}}}};
-  assign _zz_95_ = _zz_86_[7 : 6];
-  assign _zz_50_ = _zz_95_;
-  assign _zz_96_ = _zz_86_[10 : 9];
-  assign _zz_49_ = _zz_96_;
-  assign _zz_97_ = _zz_86_[19 : 18];
-  assign _zz_48_ = _zz_97_;
-  assign _zz_98_ = _zz_86_[24 : 23];
-  assign _zz_47_ = _zz_98_;
-  assign _zz_99_ = _zz_86_[26 : 25];
-  assign _zz_46_ = _zz_99_;
-  assign _zz_100_ = _zz_86_[29 : 28];
-  assign _zz_45_ = _zz_100_;
-  assign _zz_101_ = _zz_86_[33 : 32];
-  assign _zz_44_ = _zz_101_;
+  assign MmuPlugin_dBusAccess_cmd_payload_writeMask = 4'bxxxx;
+  always @ (*) begin
+    _zz_88[0] = (((IBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_0_requireMmuLockupCalc) && (! MmuPlugin_ports_0_dirty)) && (! MmuPlugin_ports_0_cacheHit));
+    _zz_88[1] = (((DBusCachedPlugin_mmuBus_cmd_0_isValid && MmuPlugin_ports_1_requireMmuLockupCalc) && (! MmuPlugin_ports_1_dirty)) && (! MmuPlugin_ports_1_cacheHit));
+  end
+
+  assign _zz_89 = _zz_88;
+  always @ (*) begin
+    _zz_90[0] = _zz_89[1];
+    _zz_90[1] = _zz_89[0];
+  end
+
+  assign _zz_91 = (_zz_90 & (~ _zz_350));
+  always @ (*) begin
+    _zz_92[0] = _zz_91[1];
+    _zz_92[1] = _zz_91[0];
+  end
+
+  assign MmuPlugin_shared_refills = _zz_92;
+  assign _zz_93 = (MmuPlugin_shared_refills[0] ? IBusCachedPlugin_mmuBus_cmd_0_virtualAddress : DBusCachedPlugin_mmuBus_cmd_0_virtualAddress);
+  assign IBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[0]);
+  assign DBusCachedPlugin_mmuBus_busy = ((MmuPlugin_shared_state_1 != `MmuPlugin_shared_State_defaultEncoding_IDLE) && MmuPlugin_shared_portSortedOh[1]);
+  assign _zz_95 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_96 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_97 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002000);
+  assign _zz_98 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_99 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_100 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_101 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
+  assign _zz_102 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
+  assign _zz_94 = {(((decode_INSTRUCTION & _zz_463) == 32'h02004020) != 1'b0),{({_zz_102,_zz_101} != 2'b00),{({_zz_464,_zz_465} != 3'b000),{(_zz_466 != _zz_467),{_zz_468,{_zz_469,_zz_470}}}}}};
+  assign _zz_103 = _zz_94[2 : 1];
+  assign _zz_50 = _zz_103;
+  assign _zz_104 = _zz_94[7 : 6];
+  assign _zz_49 = _zz_104;
+  assign _zz_105 = _zz_94[9 : 8];
+  assign _zz_48 = _zz_105;
+  assign _zz_106 = _zz_94[23 : 22];
+  assign _zz_47 = _zz_106;
+  assign _zz_107 = _zz_94[25 : 24];
+  assign _zz_46 = _zz_107;
+  assign _zz_108 = _zz_94[27 : 26];
+  assign _zz_45 = _zz_108;
+  assign _zz_109 = _zz_94[30 : 29];
+  assign _zz_44 = _zz_109;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_209_;
-  assign decode_RegFilePlugin_rs2Data = _zz_210_;
+  assign decode_RegFilePlugin_rs1Data = _zz_227;
+  assign decode_RegFilePlugin_rs2Data = _zz_228;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_42_ && writeBack_arbitration_isFiring);
-    if(_zz_102_)begin
+    lastStageRegFileWrite_valid = (_zz_42 && writeBack_arbitration_isFiring);
+    if(_zz_110)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_41_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_51_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_41[11 : 7];
+    if(_zz_110)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_51;
+    if(_zz_110)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -5339,13 +4393,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_103_ = execute_IntAluPlugin_bitwise;
+        _zz_111 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_103_ = {31'd0, _zz_333_};
+        _zz_111 = {31'd0, _zz_351};
       end
       default : begin
-        _zz_103_ = execute_SRC_ADD_SUB;
+        _zz_111 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -5353,87 +4407,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_104_ = execute_RS1;
+        _zz_112 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_104_ = {29'd0, _zz_334_};
+        _zz_112 = {29'd0, _zz_352};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_104_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_112 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_104_ = {27'd0, _zz_335_};
+        _zz_112 = {27'd0, _zz_353};
       end
     endcase
   end
 
-  assign _zz_105_ = _zz_336_[11];
+  assign _zz_113 = _zz_354[11];
   always @ (*) begin
-    _zz_106_[19] = _zz_105_;
-    _zz_106_[18] = _zz_105_;
-    _zz_106_[17] = _zz_105_;
-    _zz_106_[16] = _zz_105_;
-    _zz_106_[15] = _zz_105_;
-    _zz_106_[14] = _zz_105_;
-    _zz_106_[13] = _zz_105_;
-    _zz_106_[12] = _zz_105_;
-    _zz_106_[11] = _zz_105_;
-    _zz_106_[10] = _zz_105_;
-    _zz_106_[9] = _zz_105_;
-    _zz_106_[8] = _zz_105_;
-    _zz_106_[7] = _zz_105_;
-    _zz_106_[6] = _zz_105_;
-    _zz_106_[5] = _zz_105_;
-    _zz_106_[4] = _zz_105_;
-    _zz_106_[3] = _zz_105_;
-    _zz_106_[2] = _zz_105_;
-    _zz_106_[1] = _zz_105_;
-    _zz_106_[0] = _zz_105_;
+    _zz_114[19] = _zz_113;
+    _zz_114[18] = _zz_113;
+    _zz_114[17] = _zz_113;
+    _zz_114[16] = _zz_113;
+    _zz_114[15] = _zz_113;
+    _zz_114[14] = _zz_113;
+    _zz_114[13] = _zz_113;
+    _zz_114[12] = _zz_113;
+    _zz_114[11] = _zz_113;
+    _zz_114[10] = _zz_113;
+    _zz_114[9] = _zz_113;
+    _zz_114[8] = _zz_113;
+    _zz_114[7] = _zz_113;
+    _zz_114[6] = _zz_113;
+    _zz_114[5] = _zz_113;
+    _zz_114[4] = _zz_113;
+    _zz_114[3] = _zz_113;
+    _zz_114[2] = _zz_113;
+    _zz_114[1] = _zz_113;
+    _zz_114[0] = _zz_113;
   end
 
-  assign _zz_107_ = _zz_337_[11];
+  assign _zz_115 = _zz_355[11];
   always @ (*) begin
-    _zz_108_[19] = _zz_107_;
-    _zz_108_[18] = _zz_107_;
-    _zz_108_[17] = _zz_107_;
-    _zz_108_[16] = _zz_107_;
-    _zz_108_[15] = _zz_107_;
-    _zz_108_[14] = _zz_107_;
-    _zz_108_[13] = _zz_107_;
-    _zz_108_[12] = _zz_107_;
-    _zz_108_[11] = _zz_107_;
-    _zz_108_[10] = _zz_107_;
-    _zz_108_[9] = _zz_107_;
-    _zz_108_[8] = _zz_107_;
-    _zz_108_[7] = _zz_107_;
-    _zz_108_[6] = _zz_107_;
-    _zz_108_[5] = _zz_107_;
-    _zz_108_[4] = _zz_107_;
-    _zz_108_[3] = _zz_107_;
-    _zz_108_[2] = _zz_107_;
-    _zz_108_[1] = _zz_107_;
-    _zz_108_[0] = _zz_107_;
+    _zz_116[19] = _zz_115;
+    _zz_116[18] = _zz_115;
+    _zz_116[17] = _zz_115;
+    _zz_116[16] = _zz_115;
+    _zz_116[15] = _zz_115;
+    _zz_116[14] = _zz_115;
+    _zz_116[13] = _zz_115;
+    _zz_116[12] = _zz_115;
+    _zz_116[11] = _zz_115;
+    _zz_116[10] = _zz_115;
+    _zz_116[9] = _zz_115;
+    _zz_116[8] = _zz_115;
+    _zz_116[7] = _zz_115;
+    _zz_116[6] = _zz_115;
+    _zz_116[5] = _zz_115;
+    _zz_116[4] = _zz_115;
+    _zz_116[3] = _zz_115;
+    _zz_116[2] = _zz_115;
+    _zz_116[1] = _zz_115;
+    _zz_116[0] = _zz_115;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_109_ = execute_RS2;
+        _zz_117 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_109_ = {_zz_106_,execute_INSTRUCTION[31 : 20]};
+        _zz_117 = {_zz_114,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_109_ = {_zz_108_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_117 = {_zz_116,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_109_ = _zz_36_;
+        _zz_117 = _zz_36;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_338_;
+    execute_SrcPlugin_addSub = _zz_356;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -5442,340 +4496,340 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_110_[0] = execute_SRC1[31];
-    _zz_110_[1] = execute_SRC1[30];
-    _zz_110_[2] = execute_SRC1[29];
-    _zz_110_[3] = execute_SRC1[28];
-    _zz_110_[4] = execute_SRC1[27];
-    _zz_110_[5] = execute_SRC1[26];
-    _zz_110_[6] = execute_SRC1[25];
-    _zz_110_[7] = execute_SRC1[24];
-    _zz_110_[8] = execute_SRC1[23];
-    _zz_110_[9] = execute_SRC1[22];
-    _zz_110_[10] = execute_SRC1[21];
-    _zz_110_[11] = execute_SRC1[20];
-    _zz_110_[12] = execute_SRC1[19];
-    _zz_110_[13] = execute_SRC1[18];
-    _zz_110_[14] = execute_SRC1[17];
-    _zz_110_[15] = execute_SRC1[16];
-    _zz_110_[16] = execute_SRC1[15];
-    _zz_110_[17] = execute_SRC1[14];
-    _zz_110_[18] = execute_SRC1[13];
-    _zz_110_[19] = execute_SRC1[12];
-    _zz_110_[20] = execute_SRC1[11];
-    _zz_110_[21] = execute_SRC1[10];
-    _zz_110_[22] = execute_SRC1[9];
-    _zz_110_[23] = execute_SRC1[8];
-    _zz_110_[24] = execute_SRC1[7];
-    _zz_110_[25] = execute_SRC1[6];
-    _zz_110_[26] = execute_SRC1[5];
-    _zz_110_[27] = execute_SRC1[4];
-    _zz_110_[28] = execute_SRC1[3];
-    _zz_110_[29] = execute_SRC1[2];
-    _zz_110_[30] = execute_SRC1[1];
-    _zz_110_[31] = execute_SRC1[0];
+    _zz_118[0] = execute_SRC1[31];
+    _zz_118[1] = execute_SRC1[30];
+    _zz_118[2] = execute_SRC1[29];
+    _zz_118[3] = execute_SRC1[28];
+    _zz_118[4] = execute_SRC1[27];
+    _zz_118[5] = execute_SRC1[26];
+    _zz_118[6] = execute_SRC1[25];
+    _zz_118[7] = execute_SRC1[24];
+    _zz_118[8] = execute_SRC1[23];
+    _zz_118[9] = execute_SRC1[22];
+    _zz_118[10] = execute_SRC1[21];
+    _zz_118[11] = execute_SRC1[20];
+    _zz_118[12] = execute_SRC1[19];
+    _zz_118[13] = execute_SRC1[18];
+    _zz_118[14] = execute_SRC1[17];
+    _zz_118[15] = execute_SRC1[16];
+    _zz_118[16] = execute_SRC1[15];
+    _zz_118[17] = execute_SRC1[14];
+    _zz_118[18] = execute_SRC1[13];
+    _zz_118[19] = execute_SRC1[12];
+    _zz_118[20] = execute_SRC1[11];
+    _zz_118[21] = execute_SRC1[10];
+    _zz_118[22] = execute_SRC1[9];
+    _zz_118[23] = execute_SRC1[8];
+    _zz_118[24] = execute_SRC1[7];
+    _zz_118[25] = execute_SRC1[6];
+    _zz_118[26] = execute_SRC1[5];
+    _zz_118[27] = execute_SRC1[4];
+    _zz_118[28] = execute_SRC1[3];
+    _zz_118[29] = execute_SRC1[2];
+    _zz_118[30] = execute_SRC1[1];
+    _zz_118[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_110_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_118 : execute_SRC1);
   always @ (*) begin
-    _zz_111_[0] = memory_SHIFT_RIGHT[31];
-    _zz_111_[1] = memory_SHIFT_RIGHT[30];
-    _zz_111_[2] = memory_SHIFT_RIGHT[29];
-    _zz_111_[3] = memory_SHIFT_RIGHT[28];
-    _zz_111_[4] = memory_SHIFT_RIGHT[27];
-    _zz_111_[5] = memory_SHIFT_RIGHT[26];
-    _zz_111_[6] = memory_SHIFT_RIGHT[25];
-    _zz_111_[7] = memory_SHIFT_RIGHT[24];
-    _zz_111_[8] = memory_SHIFT_RIGHT[23];
-    _zz_111_[9] = memory_SHIFT_RIGHT[22];
-    _zz_111_[10] = memory_SHIFT_RIGHT[21];
-    _zz_111_[11] = memory_SHIFT_RIGHT[20];
-    _zz_111_[12] = memory_SHIFT_RIGHT[19];
-    _zz_111_[13] = memory_SHIFT_RIGHT[18];
-    _zz_111_[14] = memory_SHIFT_RIGHT[17];
-    _zz_111_[15] = memory_SHIFT_RIGHT[16];
-    _zz_111_[16] = memory_SHIFT_RIGHT[15];
-    _zz_111_[17] = memory_SHIFT_RIGHT[14];
-    _zz_111_[18] = memory_SHIFT_RIGHT[13];
-    _zz_111_[19] = memory_SHIFT_RIGHT[12];
-    _zz_111_[20] = memory_SHIFT_RIGHT[11];
-    _zz_111_[21] = memory_SHIFT_RIGHT[10];
-    _zz_111_[22] = memory_SHIFT_RIGHT[9];
-    _zz_111_[23] = memory_SHIFT_RIGHT[8];
-    _zz_111_[24] = memory_SHIFT_RIGHT[7];
-    _zz_111_[25] = memory_SHIFT_RIGHT[6];
-    _zz_111_[26] = memory_SHIFT_RIGHT[5];
-    _zz_111_[27] = memory_SHIFT_RIGHT[4];
-    _zz_111_[28] = memory_SHIFT_RIGHT[3];
-    _zz_111_[29] = memory_SHIFT_RIGHT[2];
-    _zz_111_[30] = memory_SHIFT_RIGHT[1];
-    _zz_111_[31] = memory_SHIFT_RIGHT[0];
+    _zz_119[0] = memory_SHIFT_RIGHT[31];
+    _zz_119[1] = memory_SHIFT_RIGHT[30];
+    _zz_119[2] = memory_SHIFT_RIGHT[29];
+    _zz_119[3] = memory_SHIFT_RIGHT[28];
+    _zz_119[4] = memory_SHIFT_RIGHT[27];
+    _zz_119[5] = memory_SHIFT_RIGHT[26];
+    _zz_119[6] = memory_SHIFT_RIGHT[25];
+    _zz_119[7] = memory_SHIFT_RIGHT[24];
+    _zz_119[8] = memory_SHIFT_RIGHT[23];
+    _zz_119[9] = memory_SHIFT_RIGHT[22];
+    _zz_119[10] = memory_SHIFT_RIGHT[21];
+    _zz_119[11] = memory_SHIFT_RIGHT[20];
+    _zz_119[12] = memory_SHIFT_RIGHT[19];
+    _zz_119[13] = memory_SHIFT_RIGHT[18];
+    _zz_119[14] = memory_SHIFT_RIGHT[17];
+    _zz_119[15] = memory_SHIFT_RIGHT[16];
+    _zz_119[16] = memory_SHIFT_RIGHT[15];
+    _zz_119[17] = memory_SHIFT_RIGHT[14];
+    _zz_119[18] = memory_SHIFT_RIGHT[13];
+    _zz_119[19] = memory_SHIFT_RIGHT[12];
+    _zz_119[20] = memory_SHIFT_RIGHT[11];
+    _zz_119[21] = memory_SHIFT_RIGHT[10];
+    _zz_119[22] = memory_SHIFT_RIGHT[9];
+    _zz_119[23] = memory_SHIFT_RIGHT[8];
+    _zz_119[24] = memory_SHIFT_RIGHT[7];
+    _zz_119[25] = memory_SHIFT_RIGHT[6];
+    _zz_119[26] = memory_SHIFT_RIGHT[5];
+    _zz_119[27] = memory_SHIFT_RIGHT[4];
+    _zz_119[28] = memory_SHIFT_RIGHT[3];
+    _zz_119[29] = memory_SHIFT_RIGHT[2];
+    _zz_119[30] = memory_SHIFT_RIGHT[1];
+    _zz_119[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_112_ = 1'b0;
-    if(_zz_257_)begin
-      if(_zz_258_)begin
-        if(_zz_117_)begin
-          _zz_112_ = 1'b1;
+    _zz_120 = 1'b0;
+    if(_zz_275)begin
+      if(_zz_276)begin
+        if(_zz_125)begin
+          _zz_120 = 1'b1;
         end
       end
     end
-    if(_zz_259_)begin
-      if(_zz_260_)begin
-        if(_zz_119_)begin
-          _zz_112_ = 1'b1;
+    if(_zz_277)begin
+      if(_zz_278)begin
+        if(_zz_127)begin
+          _zz_120 = 1'b1;
         end
       end
     end
-    if(_zz_261_)begin
-      if(_zz_262_)begin
-        if(_zz_121_)begin
-          _zz_112_ = 1'b1;
+    if(_zz_279)begin
+      if(_zz_280)begin
+        if(_zz_129)begin
+          _zz_120 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_112_ = 1'b0;
+      _zz_120 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_113_ = 1'b0;
-    if(_zz_257_)begin
-      if(_zz_258_)begin
-        if(_zz_118_)begin
-          _zz_113_ = 1'b1;
+    _zz_121 = 1'b0;
+    if(_zz_275)begin
+      if(_zz_276)begin
+        if(_zz_126)begin
+          _zz_121 = 1'b1;
         end
       end
     end
-    if(_zz_259_)begin
-      if(_zz_260_)begin
-        if(_zz_120_)begin
-          _zz_113_ = 1'b1;
+    if(_zz_277)begin
+      if(_zz_278)begin
+        if(_zz_128)begin
+          _zz_121 = 1'b1;
         end
       end
     end
-    if(_zz_261_)begin
-      if(_zz_262_)begin
-        if(_zz_122_)begin
-          _zz_113_ = 1'b1;
+    if(_zz_279)begin
+      if(_zz_280)begin
+        if(_zz_130)begin
+          _zz_121 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_113_ = 1'b0;
+      _zz_121 = 1'b0;
     end
   end
 
-  assign _zz_117_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_118_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_119_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_120_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_121_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_122_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_125 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_126 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_127 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_128 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_129 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_130 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_123_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_131 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_123_ == (3'b000))) begin
-        _zz_124_ = execute_BranchPlugin_eq;
-    end else if((_zz_123_ == (3'b001))) begin
-        _zz_124_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_123_ & (3'b101)) == (3'b101)))) begin
-        _zz_124_ = (! execute_SRC_LESS);
+    if((_zz_131 == 3'b000)) begin
+        _zz_132 = execute_BranchPlugin_eq;
+    end else if((_zz_131 == 3'b001)) begin
+        _zz_132 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_131 & 3'b101) == 3'b101))) begin
+        _zz_132 = (! execute_SRC_LESS);
     end else begin
-        _zz_124_ = execute_SRC_LESS;
+        _zz_132 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_125_ = 1'b0;
+        _zz_133 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_125_ = 1'b1;
+        _zz_133 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_125_ = 1'b1;
+        _zz_133 = 1'b1;
       end
       default : begin
-        _zz_125_ = _zz_124_;
+        _zz_133 = _zz_132;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_126_ = _zz_345_[19];
+  assign _zz_134 = _zz_363[19];
   always @ (*) begin
-    _zz_127_[10] = _zz_126_;
-    _zz_127_[9] = _zz_126_;
-    _zz_127_[8] = _zz_126_;
-    _zz_127_[7] = _zz_126_;
-    _zz_127_[6] = _zz_126_;
-    _zz_127_[5] = _zz_126_;
-    _zz_127_[4] = _zz_126_;
-    _zz_127_[3] = _zz_126_;
-    _zz_127_[2] = _zz_126_;
-    _zz_127_[1] = _zz_126_;
-    _zz_127_[0] = _zz_126_;
+    _zz_135[10] = _zz_134;
+    _zz_135[9] = _zz_134;
+    _zz_135[8] = _zz_134;
+    _zz_135[7] = _zz_134;
+    _zz_135[6] = _zz_134;
+    _zz_135[5] = _zz_134;
+    _zz_135[4] = _zz_134;
+    _zz_135[3] = _zz_134;
+    _zz_135[2] = _zz_134;
+    _zz_135[1] = _zz_134;
+    _zz_135[0] = _zz_134;
   end
 
-  assign _zz_128_ = _zz_346_[11];
+  assign _zz_136 = _zz_364[11];
   always @ (*) begin
-    _zz_129_[19] = _zz_128_;
-    _zz_129_[18] = _zz_128_;
-    _zz_129_[17] = _zz_128_;
-    _zz_129_[16] = _zz_128_;
-    _zz_129_[15] = _zz_128_;
-    _zz_129_[14] = _zz_128_;
-    _zz_129_[13] = _zz_128_;
-    _zz_129_[12] = _zz_128_;
-    _zz_129_[11] = _zz_128_;
-    _zz_129_[10] = _zz_128_;
-    _zz_129_[9] = _zz_128_;
-    _zz_129_[8] = _zz_128_;
-    _zz_129_[7] = _zz_128_;
-    _zz_129_[6] = _zz_128_;
-    _zz_129_[5] = _zz_128_;
-    _zz_129_[4] = _zz_128_;
-    _zz_129_[3] = _zz_128_;
-    _zz_129_[2] = _zz_128_;
-    _zz_129_[1] = _zz_128_;
-    _zz_129_[0] = _zz_128_;
+    _zz_137[19] = _zz_136;
+    _zz_137[18] = _zz_136;
+    _zz_137[17] = _zz_136;
+    _zz_137[16] = _zz_136;
+    _zz_137[15] = _zz_136;
+    _zz_137[14] = _zz_136;
+    _zz_137[13] = _zz_136;
+    _zz_137[12] = _zz_136;
+    _zz_137[11] = _zz_136;
+    _zz_137[10] = _zz_136;
+    _zz_137[9] = _zz_136;
+    _zz_137[8] = _zz_136;
+    _zz_137[7] = _zz_136;
+    _zz_137[6] = _zz_136;
+    _zz_137[5] = _zz_136;
+    _zz_137[4] = _zz_136;
+    _zz_137[3] = _zz_136;
+    _zz_137[2] = _zz_136;
+    _zz_137[1] = _zz_136;
+    _zz_137[0] = _zz_136;
   end
 
-  assign _zz_130_ = _zz_347_[11];
+  assign _zz_138 = _zz_365[11];
   always @ (*) begin
-    _zz_131_[18] = _zz_130_;
-    _zz_131_[17] = _zz_130_;
-    _zz_131_[16] = _zz_130_;
-    _zz_131_[15] = _zz_130_;
-    _zz_131_[14] = _zz_130_;
-    _zz_131_[13] = _zz_130_;
-    _zz_131_[12] = _zz_130_;
-    _zz_131_[11] = _zz_130_;
-    _zz_131_[10] = _zz_130_;
-    _zz_131_[9] = _zz_130_;
-    _zz_131_[8] = _zz_130_;
-    _zz_131_[7] = _zz_130_;
-    _zz_131_[6] = _zz_130_;
-    _zz_131_[5] = _zz_130_;
-    _zz_131_[4] = _zz_130_;
-    _zz_131_[3] = _zz_130_;
-    _zz_131_[2] = _zz_130_;
-    _zz_131_[1] = _zz_130_;
-    _zz_131_[0] = _zz_130_;
+    _zz_139[18] = _zz_138;
+    _zz_139[17] = _zz_138;
+    _zz_139[16] = _zz_138;
+    _zz_139[15] = _zz_138;
+    _zz_139[14] = _zz_138;
+    _zz_139[13] = _zz_138;
+    _zz_139[12] = _zz_138;
+    _zz_139[11] = _zz_138;
+    _zz_139[10] = _zz_138;
+    _zz_139[9] = _zz_138;
+    _zz_139[8] = _zz_138;
+    _zz_139[7] = _zz_138;
+    _zz_139[6] = _zz_138;
+    _zz_139[5] = _zz_138;
+    _zz_139[4] = _zz_138;
+    _zz_139[3] = _zz_138;
+    _zz_139[2] = _zz_138;
+    _zz_139[1] = _zz_138;
+    _zz_139[0] = _zz_138;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_132_ = {{_zz_127_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_140 = {{_zz_135,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_132_ = {_zz_129_,execute_INSTRUCTION[31 : 20]};
+        _zz_140 = {_zz_137,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_132_ = {{_zz_131_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_140 = {{_zz_139,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_132_;
+  assign execute_BranchPlugin_branch_src2 = _zz_140;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && BranchPlugin_jumpInterface_payload[1]);
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = BranchPlugin_jumpInterface_payload;
   always @ (*) begin
-    CsrPlugin_privilege = _zz_133_;
+    CsrPlugin_privilege = _zz_141;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0;
   assign CsrPlugin_sip_SEIP_OR = (CsrPlugin_sip_SEIP_SOFT || CsrPlugin_sip_SEIP_INPUT);
   always @ (*) begin
     CsrPlugin_redoInterface_valid = 1'b0;
     if(execute_CsrPlugin_csr_384)begin
-      if(execute_CsrPlugin_writeEnable)begin
+      if(execute_CsrPlugin_writeInstruction)begin
         CsrPlugin_redoInterface_valid = 1'b1;
       end
     end
   end
 
   assign CsrPlugin_redoInterface_payload = decode_PC;
-  assign _zz_134_ = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
-  assign _zz_135_ = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
-  assign _zz_136_ = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
-  assign _zz_137_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_138_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_139_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign _zz_142 = (CsrPlugin_sip_STIP && CsrPlugin_sie_STIE);
+  assign _zz_143 = (CsrPlugin_sip_SSIP && CsrPlugin_sie_SSIE);
+  assign _zz_144 = (CsrPlugin_sip_SEIP_OR && CsrPlugin_sie_SEIE);
+  assign _zz_145 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_146 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_147 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
   always @ (*) begin
-    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
     case(CsrPlugin_exceptionPortCtrl_exceptionContext_code)
-      4'b1000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0010 : begin
-        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b1101 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
-        end
-      end
-      4'b0111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0000 : begin
+        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0001 : begin
         if(((1'b1 && CsrPlugin_medeleg_IAF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1001 : begin
-        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0010 : begin
+        if(((1'b1 && CsrPlugin_medeleg_II) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1100 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0100 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LAM) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b1111 : begin
-        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0101 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LAF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       4'b0110 : begin
         if(((1'b1 && CsrPlugin_medeleg_SAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
-      4'b0000 : begin
-        if(((1'b1 && CsrPlugin_medeleg_IAM) && (! 1'b0)))begin
-          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b01);
+      4'b0111 : begin
+        if(((1'b1 && CsrPlugin_medeleg_SAF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1000 : begin
+        if(((1'b1 && CsrPlugin_medeleg_EU) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1001 : begin
+        if(((1'b1 && CsrPlugin_medeleg_ES) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1100 : begin
+        if(((1'b1 && CsrPlugin_medeleg_IPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1101 : begin
+        if(((1'b1 && CsrPlugin_medeleg_LPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
+        end
+      end
+      4'b1111 : begin
+        if(((1'b1 && CsrPlugin_medeleg_SPF) && (! 1'b0)))begin
+          CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b01;
         end
       end
       default : begin
@@ -5784,11 +4838,11 @@ module VexRiscv (
   end
 
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_140_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_141_ = _zz_348_[0];
+  assign _zz_148 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_149 = _zz_366[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_245_)begin
+    if(_zz_263)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -5834,7 +4888,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -5858,7 +4912,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b01 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_stvec_mode;
@@ -5886,7 +4940,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -5997,7 +5051,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_263_)begin
+    if(_zz_281)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -6016,29 +5070,29 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_264_)begin
+    if(_zz_282)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_265_)begin
+    if(_zz_283)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_264_)begin
-      CsrPlugin_selfException_payload_code = (4'b0010);
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_282)begin
+      CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_265_)begin
+    if(_zz_283)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         2'b01 : begin
-          CsrPlugin_selfException_payload_code = (4'b1001);
+          CsrPlugin_selfException_payload_code = 4'b1001;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -6047,14 +5101,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_263_)begin
+    if(_zz_281)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_263_)begin
+    if(_zz_281)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -6072,7 +5126,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_292_)
+    case(_zz_309)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -6086,8 +5140,8 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_239_)begin
-      if(_zz_247_)begin
+    if(_zz_257)begin
+      if(_zz_265)begin
         memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
       end
     end
@@ -6106,7 +5160,7 @@ module VexRiscv (
     if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_351_);
+      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_369);
     end
     if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
@@ -6115,8 +5169,8 @@ module VexRiscv (
 
   always @ (*) begin
     memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_240_)begin
-      if(_zz_266_)begin
+    if(_zz_258)begin
+      if(_zz_284)begin
         memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -6124,7 +5178,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_MulDivIterativePlugin_div_counter_willClear = 1'b0;
-    if(_zz_267_)begin
+    if(_zz_285)begin
       memory_MulDivIterativePlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -6135,61 +5189,61 @@ module VexRiscv (
     if(memory_MulDivIterativePlugin_div_counter_willOverflow)begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_359_);
+      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_377);
     end
     if(memory_MulDivIterativePlugin_div_counter_willClear)begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_142_ = memory_MulDivIterativePlugin_rs1[31 : 0];
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_142_[31]};
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_360_);
-  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_361_ : _zz_362_);
-  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_363_[31:0];
-  assign _zz_143_ = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
-  assign _zz_144_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_145_ = ((execute_IS_MUL && _zz_144_) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_150 = memory_MulDivIterativePlugin_rs1[31 : 0];
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_150[31]};
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_378);
+  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_379 : _zz_380);
+  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_381[31:0];
+  assign _zz_151 = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
+  assign _zz_152 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_153 = ((execute_IS_MUL && _zz_152) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_146_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_146_[31 : 0] = execute_RS1;
+    _zz_154[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_154[31 : 0] = execute_RS1;
   end
 
-  assign _zz_148_ = (_zz_147_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_148_ != 32'h0);
-  assign _zz_150_ = (_zz_149_ & externalInterruptArray_regNext);
-  assign externalInterruptS = (_zz_150_ != 32'h0);
-  assign _zz_27_ = decode_SRC1_CTRL;
-  assign _zz_25_ = _zz_47_;
-  assign _zz_38_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_24_ = decode_SHIFT_CTRL;
-  assign _zz_21_ = execute_SHIFT_CTRL;
-  assign _zz_22_ = _zz_46_;
-  assign _zz_35_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_34_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_19_ = decode_SRC2_CTRL;
-  assign _zz_17_ = _zz_49_;
-  assign _zz_37_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_16_ = decode_ALU_CTRL;
-  assign _zz_14_ = _zz_50_;
-  assign _zz_39_ = decode_to_execute_ALU_CTRL;
-  assign _zz_13_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_11_ = _zz_44_;
-  assign _zz_40_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_10_ = decode_BRANCH_CTRL;
-  assign _zz_8_ = _zz_48_;
-  assign _zz_31_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_7_ = decode_ENV_CTRL;
-  assign _zz_4_ = execute_ENV_CTRL;
-  assign _zz_2_ = memory_ENV_CTRL;
-  assign _zz_5_ = _zz_45_;
-  assign _zz_29_ = decode_to_execute_ENV_CTRL;
-  assign _zz_28_ = execute_to_memory_ENV_CTRL;
-  assign _zz_30_ = memory_to_writeBack_ENV_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_156 = (_zz_155 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_156 != 32'h0);
+  assign _zz_158 = (_zz_157 & externalInterruptArray_regNext);
+  assign externalInterruptS = (_zz_158 != 32'h0);
+  assign _zz_27 = decode_SRC1_CTRL;
+  assign _zz_25 = _zz_50;
+  assign _zz_38 = decode_to_execute_SRC1_CTRL;
+  assign _zz_24 = decode_ALU_CTRL;
+  assign _zz_22 = _zz_49;
+  assign _zz_39 = decode_to_execute_ALU_CTRL;
+  assign _zz_21 = decode_SRC2_CTRL;
+  assign _zz_19 = _zz_48;
+  assign _zz_37 = decode_to_execute_SRC2_CTRL;
+  assign _zz_18 = decode_ALU_BITWISE_CTRL;
+  assign _zz_16 = _zz_47;
+  assign _zz_40 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_15 = decode_SHIFT_CTRL;
+  assign _zz_12 = execute_SHIFT_CTRL;
+  assign _zz_13 = _zz_46;
+  assign _zz_35 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_34 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_10 = decode_BRANCH_CTRL;
+  assign _zz_8 = _zz_45;
+  assign _zz_31 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_44;
+  assign _zz_29 = decode_to_execute_ENV_CTRL;
+  assign _zz_28 = execute_to_memory_ENV_CTRL;
+  assign _zz_30 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -6207,245 +5261,246 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_151_ = 32'h0;
+    _zz_159 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_151_[12 : 0] = 13'h1000;
-      _zz_151_[25 : 20] = 6'h20;
+      _zz_159[12 : 0] = 13'h1000;
+      _zz_159[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_152_ = 32'h0;
+    _zz_160 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_152_[19 : 19] = MmuPlugin_status_mxr;
-      _zz_152_[18 : 18] = MmuPlugin_status_sum;
-      _zz_152_[17 : 17] = MmuPlugin_status_mprv;
-      _zz_152_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_152_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_152_[3 : 3] = CsrPlugin_mstatus_MIE;
-      _zz_152_[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_152_[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_152_[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_160[19 : 19] = MmuPlugin_status_mxr;
+      _zz_160[18 : 18] = MmuPlugin_status_sum;
+      _zz_160[17 : 17] = MmuPlugin_status_mprv;
+      _zz_160[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_160[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_160[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_160[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_160[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_160[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @ (*) begin
-    _zz_153_ = 32'h0;
+    _zz_161 = 32'h0;
     if(execute_CsrPlugin_csr_256)begin
-      _zz_153_[19 : 19] = MmuPlugin_status_mxr;
-      _zz_153_[18 : 18] = MmuPlugin_status_sum;
-      _zz_153_[17 : 17] = MmuPlugin_status_mprv;
-      _zz_153_[8 : 8] = CsrPlugin_sstatus_SPP;
-      _zz_153_[5 : 5] = CsrPlugin_sstatus_SPIE;
-      _zz_153_[1 : 1] = CsrPlugin_sstatus_SIE;
+      _zz_161[19 : 19] = MmuPlugin_status_mxr;
+      _zz_161[18 : 18] = MmuPlugin_status_sum;
+      _zz_161[17 : 17] = MmuPlugin_status_mprv;
+      _zz_161[8 : 8] = CsrPlugin_sstatus_SPP;
+      _zz_161[5 : 5] = CsrPlugin_sstatus_SPIE;
+      _zz_161[1 : 1] = CsrPlugin_sstatus_SIE;
     end
   end
 
   always @ (*) begin
-    _zz_154_ = 32'h0;
+    _zz_162 = 32'h0;
     if(execute_CsrPlugin_csr_384)begin
-      _zz_154_[31 : 31] = MmuPlugin_satp_mode;
-      _zz_154_[19 : 0] = MmuPlugin_satp_ppn;
+      _zz_162[31 : 31] = MmuPlugin_satp_mode;
+      _zz_162[30 : 22] = MmuPlugin_satp_asid;
+      _zz_162[19 : 0] = MmuPlugin_satp_ppn;
     end
   end
 
   always @ (*) begin
-    _zz_155_ = 32'h0;
+    _zz_163 = 32'h0;
     if(execute_CsrPlugin_csr_3857)begin
-      _zz_155_[0 : 0] = (1'b1);
+      _zz_163[0 : 0] = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_156_ = 32'h0;
+    _zz_164 = 32'h0;
     if(execute_CsrPlugin_csr_3858)begin
-      _zz_156_[1 : 0] = (2'b10);
+      _zz_164[1 : 0] = 2'b10;
     end
   end
 
   always @ (*) begin
-    _zz_157_ = 32'h0;
+    _zz_165 = 32'h0;
     if(execute_CsrPlugin_csr_3859)begin
-      _zz_157_[1 : 0] = (2'b11);
+      _zz_165[1 : 0] = 2'b11;
     end
   end
 
   always @ (*) begin
-    _zz_158_ = 32'h0;
+    _zz_166 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_158_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_158_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_158_[3 : 3] = CsrPlugin_mip_MSIP;
-      _zz_158_[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_158_[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_158_[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_166[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_166[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_166[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_166[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_166[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_166[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @ (*) begin
-    _zz_159_ = 32'h0;
+    _zz_167 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_159_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_159_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_159_[3 : 3] = CsrPlugin_mie_MSIE;
-      _zz_159_[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_159_[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_159_[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_167[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_167[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_167[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_167[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_167[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_167[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @ (*) begin
-    _zz_160_ = 32'h0;
+    _zz_168 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_160_[31 : 0] = CsrPlugin_mepc;
+      _zz_168[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_161_ = 32'h0;
+    _zz_169 = 32'h0;
     if(execute_CsrPlugin_csr_832)begin
-      _zz_161_[31 : 0] = CsrPlugin_mscratch;
+      _zz_169[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
-    _zz_162_ = 32'h0;
+    _zz_170 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_162_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_162_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_170[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_170[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_163_ = 32'h0;
+    _zz_171 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_163_[31 : 0] = CsrPlugin_mtval;
+      _zz_171[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_164_ = 32'h0;
+    _zz_172 = 32'h0;
     if(execute_CsrPlugin_csr_324)begin
-      _zz_164_[5 : 5] = CsrPlugin_sip_STIP;
-      _zz_164_[1 : 1] = CsrPlugin_sip_SSIP;
-      _zz_164_[9 : 9] = CsrPlugin_sip_SEIP_OR;
+      _zz_172[5 : 5] = CsrPlugin_sip_STIP;
+      _zz_172[1 : 1] = CsrPlugin_sip_SSIP;
+      _zz_172[9 : 9] = CsrPlugin_sip_SEIP_OR;
     end
   end
 
   always @ (*) begin
-    _zz_165_ = 32'h0;
+    _zz_173 = 32'h0;
     if(execute_CsrPlugin_csr_260)begin
-      _zz_165_[9 : 9] = CsrPlugin_sie_SEIE;
-      _zz_165_[5 : 5] = CsrPlugin_sie_STIE;
-      _zz_165_[1 : 1] = CsrPlugin_sie_SSIE;
+      _zz_173[9 : 9] = CsrPlugin_sie_SEIE;
+      _zz_173[5 : 5] = CsrPlugin_sie_STIE;
+      _zz_173[1 : 1] = CsrPlugin_sie_SSIE;
     end
   end
 
   always @ (*) begin
-    _zz_166_ = 32'h0;
+    _zz_174 = 32'h0;
     if(execute_CsrPlugin_csr_261)begin
-      _zz_166_[31 : 2] = CsrPlugin_stvec_base;
-      _zz_166_[1 : 0] = CsrPlugin_stvec_mode;
+      _zz_174[31 : 2] = CsrPlugin_stvec_base;
+      _zz_174[1 : 0] = CsrPlugin_stvec_mode;
     end
   end
 
   always @ (*) begin
-    _zz_167_ = 32'h0;
+    _zz_175 = 32'h0;
     if(execute_CsrPlugin_csr_321)begin
-      _zz_167_[31 : 0] = CsrPlugin_sepc;
+      _zz_175[31 : 0] = CsrPlugin_sepc;
     end
   end
 
   always @ (*) begin
-    _zz_168_ = 32'h0;
+    _zz_176 = 32'h0;
     if(execute_CsrPlugin_csr_320)begin
-      _zz_168_[31 : 0] = CsrPlugin_sscratch;
+      _zz_176[31 : 0] = CsrPlugin_sscratch;
     end
   end
 
   always @ (*) begin
-    _zz_169_ = 32'h0;
+    _zz_177 = 32'h0;
     if(execute_CsrPlugin_csr_322)begin
-      _zz_169_[31 : 31] = CsrPlugin_scause_interrupt;
-      _zz_169_[3 : 0] = CsrPlugin_scause_exceptionCode;
+      _zz_177[31 : 31] = CsrPlugin_scause_interrupt;
+      _zz_177[3 : 0] = CsrPlugin_scause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_170_ = 32'h0;
+    _zz_178 = 32'h0;
     if(execute_CsrPlugin_csr_323)begin
-      _zz_170_[31 : 0] = CsrPlugin_stval;
+      _zz_178[31 : 0] = CsrPlugin_stval;
     end
   end
 
   always @ (*) begin
-    _zz_171_ = 32'h0;
+    _zz_179 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_171_[31 : 0] = _zz_147_;
+      _zz_179[31 : 0] = _zz_155;
     end
   end
 
   always @ (*) begin
-    _zz_172_ = 32'h0;
+    _zz_180 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_172_[31 : 0] = _zz_148_;
+      _zz_180[31 : 0] = _zz_156;
     end
   end
 
   always @ (*) begin
-    _zz_173_ = 32'h0;
+    _zz_181 = 32'h0;
     if(execute_CsrPlugin_csr_2496)begin
-      _zz_173_[31 : 0] = _zz_149_;
+      _zz_181[31 : 0] = _zz_157;
     end
   end
 
   always @ (*) begin
-    _zz_174_ = 32'h0;
+    _zz_182 = 32'h0;
     if(execute_CsrPlugin_csr_3520)begin
-      _zz_174_[31 : 0] = _zz_150_;
+      _zz_182[31 : 0] = _zz_158;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_151_ | _zz_152_) | (_zz_153_ | _zz_154_)) | ((_zz_155_ | _zz_156_) | (_zz_157_ | _zz_620_))) | (((_zz_158_ | _zz_159_) | (_zz_160_ | _zz_161_)) | ((_zz_162_ | _zz_163_) | (_zz_164_ | _zz_165_)))) | ((((_zz_166_ | _zz_167_) | (_zz_168_ | _zz_169_)) | ((_zz_170_ | _zz_171_) | (_zz_172_ | _zz_173_))) | _zz_174_));
-  assign iBusWishbone_ADR = {_zz_418_,_zz_175_};
-  assign iBusWishbone_CTI = ((_zz_175_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((((_zz_159 | _zz_160) | (_zz_161 | _zz_162)) | ((_zz_163 | _zz_164) | (_zz_165 | _zz_653))) | (((_zz_166 | _zz_167) | (_zz_168 | _zz_169)) | ((_zz_170 | _zz_171) | (_zz_172 | _zz_173)))) | ((((_zz_174 | _zz_175) | (_zz_176 | _zz_177)) | ((_zz_178 | _zz_179) | (_zz_180 | _zz_181))) | _zz_182));
+  assign iBusWishbone_ADR = {_zz_436,_zz_183};
+  assign iBusWishbone_CTI = ((_zz_183 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_268_)begin
+    if(_zz_286)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_268_)begin
+    if(_zz_286)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_176_;
+  assign iBus_rsp_valid = _zz_184;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_182_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_178_ = dBus_cmd_valid;
-  assign _zz_180_ = dBus_cmd_payload_wr;
-  assign _zz_181_ = (_zz_177_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_179_ && (_zz_180_ || _zz_181_));
-  assign dBusWishbone_ADR = ((_zz_182_ ? {{dBus_cmd_payload_address[31 : 5],_zz_177_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_182_ ? (_zz_181_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_180_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_180_;
+  assign _zz_190 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_186 = dBus_cmd_valid;
+  assign _zz_188 = dBus_cmd_payload_wr;
+  assign _zz_189 = (_zz_185 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_187 && (_zz_188 || _zz_189));
+  assign dBusWishbone_ADR = ((_zz_190 ? {{dBus_cmd_payload_address[31 : 5],_zz_185},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_190 ? (_zz_189 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_188 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_188;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_179_ = (_zz_178_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_178_;
-  assign dBusWishbone_STB = _zz_178_;
-  assign dBus_rsp_valid = _zz_183_;
+  assign _zz_187 = (_zz_186 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_186;
+  assign dBusWishbone_STB = _zz_186;
+  assign dBus_rsp_valid = _zz_191;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -6454,20 +5509,20 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_66_ <= 1'b0;
-      _zz_68_ <= 1'b0;
-      _zz_71_ <= 1'b0;
+      _zz_66 <= 1'b0;
+      _zz_68 <= 1'b0;
+      _zz_71 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_5 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_73_;
+      IBusCachedPlugin_rspCounter <= _zz_73;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_74_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_74;
       DBusCachedPlugin_rspCounter <= 32'h0;
       MmuPlugin_status_sum <= 1'b0;
       MmuPlugin_status_mxr <= 1'b0;
@@ -6477,19 +5532,20 @@ module VexRiscv (
       MmuPlugin_ports_0_cache_1_valid <= 1'b0;
       MmuPlugin_ports_0_cache_2_valid <= 1'b0;
       MmuPlugin_ports_0_cache_3_valid <= 1'b0;
-      MmuPlugin_ports_0_entryToReplace_value <= (2'b00);
+      MmuPlugin_ports_0_entryToReplace_value <= 2'b00;
       MmuPlugin_ports_1_cache_0_valid <= 1'b0;
       MmuPlugin_ports_1_cache_1_valid <= 1'b0;
       MmuPlugin_ports_1_cache_2_valid <= 1'b0;
       MmuPlugin_ports_1_cache_3_valid <= 1'b0;
-      MmuPlugin_ports_1_entryToReplace_value <= (2'b00);
-      MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-      _zz_102_ <= 1'b1;
-      _zz_114_ <= 1'b0;
-      _zz_133_ <= (2'b11);
+      MmuPlugin_ports_1_entryToReplace_value <= 2'b00;
+      MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+      MmuPlugin_shared_dBusRspStaged_valid <= 1'b0;
+      _zz_110 <= 1'b1;
+      _zz_122 <= 1'b0;
+      _zz_141 <= 2'b11;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -6510,7 +5566,7 @@ module VexRiscv (
       CsrPlugin_mideleg_SS <= 1'b0;
       CsrPlugin_sstatus_SIE <= 1'b0;
       CsrPlugin_sstatus_SPIE <= 1'b0;
-      CsrPlugin_sstatus_SPP <= (1'b1);
+      CsrPlugin_sstatus_SPP <= 1'b1;
       CsrPlugin_sip_SEIP_SOFT <= 1'b0;
       CsrPlugin_sip_STIP <= 1'b0;
       CsrPlugin_sip_SSIP <= 1'b0;
@@ -6530,19 +5586,17 @@ module VexRiscv (
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
       memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_147_ <= 32'h0;
-      _zz_149_ <= 32'h0;
+      _zz_155 <= 32'h0;
+      _zz_157 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
       execute_to_memory_IS_DBUS_SHARING <= 1'b0;
       memory_to_writeBack_IS_DBUS_SHARING <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_175_ <= (3'b000);
-      _zz_176_ <= 1'b0;
-      _zz_177_ <= (3'b000);
-      _zz_183_ <= 1'b0;
+      _zz_183 <= 3'b000;
+      _zz_184 <= 1'b0;
+      _zz_185 <= 3'b000;
+      _zz_191 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -6564,22 +5618,22 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_66_ <= 1'b0;
+        _zz_66 <= 1'b0;
       end
-      if(_zz_64_)begin
-        _zz_66_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_64)begin
+        _zz_66 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_68_ <= 1'b0;
+        _zz_68 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_68_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_68 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_71_ <= 1'b0;
+        _zz_71 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_2_output_ready)begin
-        _zz_71_ <= (IBusCachedPlugin_iBusRsp_stages_2_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_71 <= (IBusCachedPlugin_iBusRsp_stages_2_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -6635,14 +5689,14 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_269_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_287)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
@@ -6677,71 +5731,69 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_3_valid <= 1'b0;
         end
       end
-      case(MmuPlugin_shared_state_1_)
+      MmuPlugin_shared_dBusRspStaged_valid <= MmuPlugin_dBusAccess_rsp_valid;
+      case(MmuPlugin_shared_state_1)
         `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-          if(_zz_270_)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
-          end
-          if(_zz_271_)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
+          if(_zz_288)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
           if(MmuPlugin_dBusAccess_cmd_ready)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_RSP;
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L1_RSP : begin
-          if(MmuPlugin_dBusAccess_rsp_valid)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
+          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             if((MmuPlugin_shared_dBusRsp_leaf || MmuPlugin_shared_dBusRsp_exception))begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
             end
-            if(MmuPlugin_dBusAccess_rsp_payload_redo)begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L1_CMD;
             end
           end
         end
         `MmuPlugin_shared_State_defaultEncoding_L0_CMD : begin
           if(MmuPlugin_dBusAccess_cmd_ready)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_RSP;
           end
         end
         default : begin
-          if(MmuPlugin_dBusAccess_rsp_valid)begin
-            MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
-            if(MmuPlugin_dBusAccess_rsp_payload_redo)begin
-              MmuPlugin_shared_state_1_ <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
+          if(MmuPlugin_shared_dBusRspStaged_valid)begin
+            MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_IDLE;
+            if(MmuPlugin_shared_dBusRspStaged_payload_redo)begin
+              MmuPlugin_shared_state_1 <= `MmuPlugin_shared_State_defaultEncoding_L0_CMD;
             end
           end
         end
       endcase
-      if(_zz_254_)begin
-        if(_zz_255_)begin
-          if(_zz_272_)begin
+      if(_zz_272)begin
+        if(_zz_273)begin
+          if(_zz_289)begin
             MmuPlugin_ports_0_cache_0_valid <= 1'b1;
           end
-          if(_zz_273_)begin
+          if(_zz_290)begin
             MmuPlugin_ports_0_cache_1_valid <= 1'b1;
           end
-          if(_zz_274_)begin
+          if(_zz_291)begin
             MmuPlugin_ports_0_cache_2_valid <= 1'b1;
           end
-          if(_zz_275_)begin
+          if(_zz_292)begin
             MmuPlugin_ports_0_cache_3_valid <= 1'b1;
           end
         end
-        if(_zz_256_)begin
-          if(_zz_276_)begin
+        if(_zz_274)begin
+          if(_zz_293)begin
             MmuPlugin_ports_1_cache_0_valid <= 1'b1;
           end
-          if(_zz_277_)begin
+          if(_zz_294)begin
             MmuPlugin_ports_1_cache_1_valid <= 1'b1;
           end
-          if(_zz_278_)begin
+          if(_zz_295)begin
             MmuPlugin_ports_1_cache_2_valid <= 1'b1;
           end
-          if(_zz_279_)begin
+          if(_zz_296)begin
             MmuPlugin_ports_1_cache_3_valid <= 1'b1;
           end
         end
@@ -6756,8 +5808,8 @@ module VexRiscv (
         MmuPlugin_ports_1_cache_2_valid <= 1'b0;
         MmuPlugin_ports_1_cache_3_valid <= 1'b0;
       end
-      _zz_102_ <= 1'b0;
-      _zz_114_ <= (_zz_42_ && writeBack_arbitration_isFiring);
+      _zz_110 <= 1'b0;
+      _zz_122 <= (_zz_42 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -6779,34 +5831,34 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_280_)begin
-        if(_zz_281_)begin
+      if(_zz_297)begin
+        if(_zz_298)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_282_)begin
+        if(_zz_299)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_283_)begin
+        if(_zz_300)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
-      if(_zz_284_)begin
-        if(_zz_285_)begin
+      if(_zz_301)begin
+        if(_zz_302)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_286_)begin
+        if(_zz_303)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_287_)begin
+        if(_zz_304)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_288_)begin
+        if(_zz_305)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_289_)begin
+        if(_zz_306)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_290_)begin
+        if(_zz_307)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -6831,8 +5883,8 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_248_)begin
-        _zz_133_ <= CsrPlugin_targetPrivilege;
+      if(_zz_266)begin
+        _zz_141 <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b01 : begin
             CsrPlugin_sstatus_SIE <= 1'b0;
@@ -6848,25 +5900,25 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_249_)begin
-        case(_zz_250_)
+      if(_zz_267)begin
+        case(_zz_268)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_133_ <= CsrPlugin_mstatus_MPP;
+            _zz_141 <= CsrPlugin_mstatus_MPP;
           end
           2'b01 : begin
-            CsrPlugin_sstatus_SPP <= (1'b0);
+            CsrPlugin_sstatus_SPP <= 1'b0;
             CsrPlugin_sstatus_SIE <= CsrPlugin_sstatus_SPIE;
             CsrPlugin_sstatus_SPIE <= 1'b1;
-            _zz_133_ <= {(1'b0),CsrPlugin_sstatus_SPP};
+            _zz_141 <= {1'b0,CsrPlugin_sstatus_SPP};
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_139_,{_zz_138_,{_zz_137_,{_zz_136_,{_zz_135_,_zz_134_}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_147,{_zz_146,{_zz_145,{_zz_144,{_zz_143,_zz_142}}}}} != 6'h0) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
       if((! memory_arbitration_isStuck))begin
@@ -6874,12 +5926,6 @@ module VexRiscv (
       end
       if((! writeBack_arbitration_isStuck))begin
         memory_to_writeBack_IS_DBUS_SHARING <= memory_IS_DBUS_SHARING;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_33_;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
       end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
@@ -6904,118 +5950,128 @@ module VexRiscv (
       end
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_373_[0];
-          MmuPlugin_status_sum <= _zz_374_[0];
-          MmuPlugin_status_mprv <= _zz_375_[0];
+          MmuPlugin_status_mxr <= _zz_391[0];
+          MmuPlugin_status_sum <= _zz_392[0];
+          MmuPlugin_status_mprv <= _zz_393[0];
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_376_[0];
-          CsrPlugin_mstatus_MIE <= _zz_377_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_394[0];
+          CsrPlugin_mstatus_MIE <= _zz_395[0];
           CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_378_[0];
-          CsrPlugin_sstatus_SIE <= _zz_379_[0];
+          CsrPlugin_sstatus_SPIE <= _zz_396[0];
+          CsrPlugin_sstatus_SIE <= _zz_397[0];
         end
       end
       if(execute_CsrPlugin_csr_256)begin
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_status_mxr <= _zz_380_[0];
-          MmuPlugin_status_sum <= _zz_381_[0];
-          MmuPlugin_status_mprv <= _zz_382_[0];
+          MmuPlugin_status_mxr <= _zz_398[0];
+          MmuPlugin_status_sum <= _zz_399[0];
+          MmuPlugin_status_mprv <= _zz_400[0];
           CsrPlugin_sstatus_SPP <= execute_CsrPlugin_writeData[8 : 8];
-          CsrPlugin_sstatus_SPIE <= _zz_383_[0];
-          CsrPlugin_sstatus_SIE <= _zz_384_[0];
+          CsrPlugin_sstatus_SPIE <= _zz_401[0];
+          CsrPlugin_sstatus_SIE <= _zz_402[0];
         end
       end
       if(execute_CsrPlugin_csr_384)begin
+        if(execute_CsrPlugin_writeInstruction)begin
+          MmuPlugin_ports_0_cache_0_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_1_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_2_valid <= 1'b0;
+          MmuPlugin_ports_0_cache_3_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_0_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_1_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_2_valid <= 1'b0;
+          MmuPlugin_ports_1_cache_3_valid <= 1'b0;
+        end
         if(execute_CsrPlugin_writeEnable)begin
-          MmuPlugin_satp_mode <= _zz_385_[0];
+          MmuPlugin_satp_mode <= _zz_403[0];
         end
       end
       if(execute_CsrPlugin_csr_836)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_387_[0];
-          CsrPlugin_sip_SSIP <= _zz_388_[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_389_[0];
+          CsrPlugin_sip_STIP <= _zz_405[0];
+          CsrPlugin_sip_SSIP <= _zz_406[0];
+          CsrPlugin_sip_SEIP_SOFT <= _zz_407[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_390_[0];
-          CsrPlugin_mie_MTIE <= _zz_391_[0];
-          CsrPlugin_mie_MSIE <= _zz_392_[0];
-          CsrPlugin_sie_SEIE <= _zz_393_[0];
-          CsrPlugin_sie_STIE <= _zz_394_[0];
-          CsrPlugin_sie_SSIE <= _zz_395_[0];
+          CsrPlugin_mie_MEIE <= _zz_408[0];
+          CsrPlugin_mie_MTIE <= _zz_409[0];
+          CsrPlugin_mie_MSIE <= _zz_410[0];
+          CsrPlugin_sie_SEIE <= _zz_411[0];
+          CsrPlugin_sie_STIE <= _zz_412[0];
+          CsrPlugin_sie_SSIE <= _zz_413[0];
         end
       end
       if(execute_CsrPlugin_csr_770)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_medeleg_EU <= _zz_396_[0];
-          CsrPlugin_medeleg_II <= _zz_397_[0];
-          CsrPlugin_medeleg_LAF <= _zz_398_[0];
-          CsrPlugin_medeleg_LPF <= _zz_399_[0];
-          CsrPlugin_medeleg_LAM <= _zz_400_[0];
-          CsrPlugin_medeleg_SAF <= _zz_401_[0];
-          CsrPlugin_medeleg_IAF <= _zz_402_[0];
-          CsrPlugin_medeleg_ES <= _zz_403_[0];
-          CsrPlugin_medeleg_IPF <= _zz_404_[0];
-          CsrPlugin_medeleg_SPF <= _zz_405_[0];
-          CsrPlugin_medeleg_SAM <= _zz_406_[0];
-          CsrPlugin_medeleg_IAM <= _zz_407_[0];
+          CsrPlugin_medeleg_IAM <= _zz_414[0];
+          CsrPlugin_medeleg_IAF <= _zz_415[0];
+          CsrPlugin_medeleg_II <= _zz_416[0];
+          CsrPlugin_medeleg_LAM <= _zz_417[0];
+          CsrPlugin_medeleg_LAF <= _zz_418[0];
+          CsrPlugin_medeleg_SAM <= _zz_419[0];
+          CsrPlugin_medeleg_SAF <= _zz_420[0];
+          CsrPlugin_medeleg_EU <= _zz_421[0];
+          CsrPlugin_medeleg_ES <= _zz_422[0];
+          CsrPlugin_medeleg_IPF <= _zz_423[0];
+          CsrPlugin_medeleg_LPF <= _zz_424[0];
+          CsrPlugin_medeleg_SPF <= _zz_425[0];
         end
       end
       if(execute_CsrPlugin_csr_771)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mideleg_SE <= _zz_408_[0];
-          CsrPlugin_mideleg_ST <= _zz_409_[0];
-          CsrPlugin_mideleg_SS <= _zz_410_[0];
+          CsrPlugin_mideleg_SE <= _zz_426[0];
+          CsrPlugin_mideleg_ST <= _zz_427[0];
+          CsrPlugin_mideleg_SS <= _zz_428[0];
         end
       end
       if(execute_CsrPlugin_csr_324)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sip_STIP <= _zz_411_[0];
-          CsrPlugin_sip_SSIP <= _zz_412_[0];
-          CsrPlugin_sip_SEIP_SOFT <= _zz_413_[0];
+          CsrPlugin_sip_STIP <= _zz_429[0];
+          CsrPlugin_sip_SSIP <= _zz_430[0];
+          CsrPlugin_sip_SEIP_SOFT <= _zz_431[0];
         end
       end
       if(execute_CsrPlugin_csr_260)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_sie_SEIE <= _zz_414_[0];
-          CsrPlugin_sie_STIE <= _zz_415_[0];
-          CsrPlugin_sie_SSIE <= _zz_416_[0];
+          CsrPlugin_sie_SEIE <= _zz_432[0];
+          CsrPlugin_sie_STIE <= _zz_433[0];
+          CsrPlugin_sie_SSIE <= _zz_434[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_147_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_155 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
       if(execute_CsrPlugin_csr_2496)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_149_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_157 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_268_)begin
+      if(_zz_286)begin
         if(iBusWishbone_ACK)begin
-          _zz_175_ <= (_zz_175_ + (3'b001));
+          _zz_183 <= (_zz_183 + 3'b001);
         end
       end
-      _zz_176_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_178_ && _zz_179_))begin
-        _zz_177_ <= (_zz_177_ + (3'b001));
-        if(_zz_181_)begin
-          _zz_177_ <= (3'b000);
+      _zz_184 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_186 && _zz_187))begin
+        _zz_185 <= (_zz_185 + 3'b001);
+        if(_zz_189)begin
+          _zz_185 <= 3'b000;
         end
       end
-      _zz_183_ <= ((_zz_178_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_191 <= ((_zz_186 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_69_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_69 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_2_output_ready)begin
-      _zz_72_ <= IBusCachedPlugin_iBusRsp_stages_2_output_payload;
+      _zz_72 <= IBusCachedPlugin_iBusRsp_stages_2_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -7023,23 +6079,28 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_3_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_269_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_287)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if((MmuPlugin_dBusAccess_rsp_valid && (! MmuPlugin_dBusAccess_rsp_payload_redo)))begin
+    MmuPlugin_shared_dBusRspStaged_payload_data <= MmuPlugin_dBusAccess_rsp_payload_data;
+    MmuPlugin_shared_dBusRspStaged_payload_error <= MmuPlugin_dBusAccess_rsp_payload_error;
+    MmuPlugin_shared_dBusRspStaged_payload_redo <= MmuPlugin_dBusAccess_rsp_payload_redo;
+    if((MmuPlugin_shared_dBusRspStaged_valid && (! MmuPlugin_shared_dBusRspStaged_payload_redo)))begin
       MmuPlugin_shared_pteBuffer_V <= MmuPlugin_shared_dBusRsp_pte_V;
       MmuPlugin_shared_pteBuffer_R <= MmuPlugin_shared_dBusRsp_pte_R;
       MmuPlugin_shared_pteBuffer_W <= MmuPlugin_shared_dBusRsp_pte_W;
@@ -7052,17 +6113,12 @@ module VexRiscv (
       MmuPlugin_shared_pteBuffer_PPN0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
       MmuPlugin_shared_pteBuffer_PPN1 <= MmuPlugin_shared_dBusRsp_pte_PPN1;
     end
-    case(MmuPlugin_shared_state_1_)
+    case(MmuPlugin_shared_state_1)
       `MmuPlugin_shared_State_defaultEncoding_IDLE : begin
-        if(_zz_270_)begin
-          MmuPlugin_shared_vpn_1 <= IBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22];
-          MmuPlugin_shared_vpn_0 <= IBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12];
-          MmuPlugin_shared_portId <= (1'b0);
-        end
-        if(_zz_271_)begin
-          MmuPlugin_shared_vpn_1 <= DBusCachedPlugin_mmuBus_cmd_virtualAddress[31 : 22];
-          MmuPlugin_shared_vpn_0 <= DBusCachedPlugin_mmuBus_cmd_virtualAddress[21 : 12];
-          MmuPlugin_shared_portId <= (1'b1);
+        if(_zz_288)begin
+          MmuPlugin_shared_portSortedOh <= MmuPlugin_shared_refills;
+          MmuPlugin_shared_vpn_1 <= _zz_93[31 : 22];
+          MmuPlugin_shared_vpn_0 <= _zz_93[21 : 12];
         end
       end
       `MmuPlugin_shared_State_defaultEncoding_L1_CMD : begin
@@ -7074,10 +6130,10 @@ module VexRiscv (
       default : begin
       end
     endcase
-    if(_zz_254_)begin
-      if(_zz_255_)begin
-        if(_zz_272_)begin
-          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+    if(_zz_272)begin
+      if(_zz_273)begin
+        if(_zz_289)begin
+          MmuPlugin_ports_0_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7086,10 +6142,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_273_)begin
-          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_290)begin
+          MmuPlugin_ports_0_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7098,10 +6154,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_274_)begin
-          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_291)begin
+          MmuPlugin_ports_0_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7110,10 +6166,10 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_275_)begin
-          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_292)begin
+          MmuPlugin_ports_0_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_0_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_0_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_0_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7122,12 +6178,12 @@ module VexRiscv (
           MmuPlugin_ports_0_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_0_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_0_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_0_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
-      if(_zz_256_)begin
-        if(_zz_276_)begin
-          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+      if(_zz_274)begin
+        if(_zz_293)begin
+          MmuPlugin_ports_1_cache_0_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_0_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_0_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_0_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7136,10 +6192,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_0_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_0_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_0_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_0_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_277_)begin
-          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_294)begin
+          MmuPlugin_ports_1_cache_1_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_1_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_1_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_1_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7148,10 +6204,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_1_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_1_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_1_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_1_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_278_)begin
-          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_295)begin
+          MmuPlugin_ports_1_cache_2_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_2_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_2_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_2_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7160,10 +6216,10 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_2_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_2_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_2_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_2_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
-        if(_zz_279_)begin
-          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
+        if(_zz_296)begin
+          MmuPlugin_ports_1_cache_3_exception <= (MmuPlugin_shared_dBusRsp_exception || ((MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP) && (MmuPlugin_shared_dBusRsp_pte_PPN0 != 10'h0)));
           MmuPlugin_ports_1_cache_3_virtualAddress_0 <= MmuPlugin_shared_vpn_0;
           MmuPlugin_ports_1_cache_3_virtualAddress_1 <= MmuPlugin_shared_vpn_1;
           MmuPlugin_ports_1_cache_3_physicalAddress_0 <= MmuPlugin_shared_dBusRsp_pte_PPN0;
@@ -7172,12 +6228,12 @@ module VexRiscv (
           MmuPlugin_ports_1_cache_3_allowWrite <= MmuPlugin_shared_dBusRsp_pte_W;
           MmuPlugin_ports_1_cache_3_allowExecute <= MmuPlugin_shared_dBusRsp_pte_X;
           MmuPlugin_ports_1_cache_3_allowUser <= MmuPlugin_shared_dBusRsp_pte_U;
-          MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1_ == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
+          MmuPlugin_ports_1_cache_3_superPage <= (MmuPlugin_shared_state_1 == `MmuPlugin_shared_State_defaultEncoding_L1_RSP);
         end
       end
     end
-    _zz_115_ <= _zz_41_[11 : 7];
-    _zz_116_ <= _zz_51_;
+    _zz_123 <= _zz_41[11 : 7];
+    _zz_124 <= _zz_51;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -7186,9 +6242,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_245_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_141_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_141_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_263)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_149 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_149 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -7202,47 +6258,47 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_280_)begin
-      if(_zz_281_)begin
-        CsrPlugin_interrupt_code <= (4'b0101);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
+    if(_zz_297)begin
+      if(_zz_298)begin
+        CsrPlugin_interrupt_code <= 4'b0101;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_282_)begin
-        CsrPlugin_interrupt_code <= (4'b0001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
+      if(_zz_299)begin
+        CsrPlugin_interrupt_code <= 4'b0001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
-      if(_zz_283_)begin
-        CsrPlugin_interrupt_code <= (4'b1001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b01);
-      end
-    end
-    if(_zz_284_)begin
-      if(_zz_285_)begin
-        CsrPlugin_interrupt_code <= (4'b0101);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_286_)begin
-        CsrPlugin_interrupt_code <= (4'b0001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_287_)begin
-        CsrPlugin_interrupt_code <= (4'b1001);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_288_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_289_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
-      end
-      if(_zz_290_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_300)begin
+        CsrPlugin_interrupt_code <= 4'b1001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b01;
       end
     end
-    if(_zz_248_)begin
+    if(_zz_301)begin
+      if(_zz_302)begin
+        CsrPlugin_interrupt_code <= 4'b0101;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_303)begin
+        CsrPlugin_interrupt_code <= 4'b0001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_304)begin
+        CsrPlugin_interrupt_code <= 4'b1001;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_305)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_306)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+      if(_zz_307)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
+      end
+    end
+    if(_zz_266)begin
       case(CsrPlugin_targetPrivilege)
         2'b01 : begin
           CsrPlugin_scause_interrupt <= (! CsrPlugin_hadException);
@@ -7264,10 +6320,10 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_239_)begin
-      if(_zz_247_)begin
+    if(_zz_257)begin
+      if(_zz_265)begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_352_,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_370,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
       end
     end
     if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
@@ -7276,57 +6332,57 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_MulDivIterativePlugin_div_done <= 1'b0;
     end
-    if(_zz_240_)begin
-      if(_zz_266_)begin
+    if(_zz_258)begin
+      if(_zz_284)begin
         memory_MulDivIterativePlugin_rs1[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outNumerator;
         memory_MulDivIterativePlugin_accumulator[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outRemainder;
         if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
-          memory_MulDivIterativePlugin_div_result <= _zz_364_[31:0];
+          memory_MulDivIterativePlugin_div_result <= _zz_382[31:0];
         end
       end
     end
-    if(_zz_267_)begin
+    if(_zz_285)begin
       memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_145_ ? (~ _zz_146_) : _zz_146_) + _zz_370_);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_144_ ? (~ execute_RS2) : execute_RS2) + _zz_372_);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_145_ ^ (_zz_144_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_153 ? (~ _zz_154) : _zz_154) + _zz_388);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_152 ? (~ execute_RS2) : execute_RS2) + _zz_390);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_153 ^ (_zz_152 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_26_;
+      decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      execute_to_memory_PC <= _zz_36;
+    end
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      execute_to_memory_FORMAL_PC_NEXT <= _zz_53;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_23_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_20_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_32_;
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_SRC1_CTRL <= _zz_26;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -7338,103 +6394,10 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_18_;
+      decode_to_execute_ALU_CTRL <= _zz_23;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_15_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_12_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_SFENCE_VMA <= execute_IS_SFENCE_VMA;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_SFENCE_VMA <= memory_IS_SFENCE_VMA;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= _zz_53_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_54_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_9_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_36_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+      decode_to_execute_SRC2_CTRL <= _zz_20;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
@@ -7446,19 +6409,121 @@ module VexRiscv (
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_6_;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_3_;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_1_;
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_LRSC <= decode_MEMORY_LRSC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_AMO <= decode_MEMORY_AMO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_SFENCE_VMA <= decode_IS_SFENCE_VMA;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_SFENCE_VMA <= execute_IS_SFENCE_VMA;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_SFENCE_VMA <= memory_IS_SFENCE_VMA;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_17;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_14;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_11;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_9;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_32;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_33;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -7546,12 +6611,13 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_384)begin
       if(execute_CsrPlugin_writeEnable)begin
+        MmuPlugin_satp_asid <= execute_CsrPlugin_writeData[30 : 22];
         MmuPlugin_satp_ppn <= execute_CsrPlugin_writeData[19 : 0];
       end
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_386_[0];
+        CsrPlugin_mip_MSIP <= _zz_404[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -7588,7 +6654,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_322)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_scause_interrupt <= _zz_417_[0];
+        CsrPlugin_scause_interrupt <= _zz_435[0];
         CsrPlugin_scause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -7599,6 +6665,1271 @@ module VexRiscv (
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_isLrsc,
+  input               io_cpu_execute_args_isAmo,
+  input               io_cpu_execute_args_amoCtrl_swap,
+  input      [2:0]    io_cpu_execute_args_amoCtrl_alu,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_memory_mmuRsp_ways_0_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_0_physical,
+  input               io_cpu_memory_mmuRsp_ways_1_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_1_physical,
+  input               io_cpu_memory_mmuRsp_ways_2_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_2_physical,
+  input               io_cpu_memory_mmuRsp_ways_3_sel,
+  input      [31:0]   io_cpu_memory_mmuRsp_ways_3_physical,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire                _zz_19;
+  wire                _zz_20;
+  wire                _zz_21;
+  wire                _zz_22;
+  wire       [2:0]    _zz_23;
+  wire       [0:0]    _zz_24;
+  wire       [0:0]    _zz_25;
+  wire       [9:0]    _zz_26;
+  wire       [9:0]    _zz_27;
+  wire       [31:0]   _zz_28;
+  wire       [31:0]   _zz_29;
+  wire       [31:0]   _zz_30;
+  wire       [31:0]   _zz_31;
+  wire       [1:0]    _zz_32;
+  wire       [31:0]   _zz_33;
+  wire       [1:0]    _zz_34;
+  wire       [1:0]    _zz_35;
+  wire       [0:0]    _zz_36;
+  wire       [0:0]    _zz_37;
+  wire       [0:0]    _zz_38;
+  wire       [2:0]    _zz_39;
+  wire       [1:0]    _zz_40;
+  wire       [21:0]   _zz_41;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_isLrsc;
+  reg                 stageA_request_isAmo;
+  reg                 stageA_request_amoCtrl_swap;
+  reg        [2:0]    stageA_request_amoCtrl_alu;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_isLrsc;
+  reg                 stageB_request_isAmo;
+  reg                 stageB_request_amoCtrl_swap;
+  reg        [2:0]    stageB_request_amoCtrl_alu;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_mmuRsp_ways_0_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_0_physical;
+  reg                 stageB_mmuRsp_ways_1_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_1_physical;
+  reg                 stageB_mmuRsp_ways_2_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_2_physical;
+  reg                 stageB_mmuRsp_ways_3_sel;
+  reg        [31:0]   stageB_mmuRsp_ways_3_physical;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  reg                 stageB_lrSc_reserved;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  reg        [31:0]   stageB_requestDataBypass;
+  wire                stageB_amo_compare;
+  wire                stageB_amo_unsigned;
+  wire       [31:0]   stageB_amo_addSub;
+  wire                stageB_amo_less;
+  wire                stageB_amo_selectRf;
+  reg        [31:0]   stageB_amo_result;
+  reg        [31:0]   stageB_amo_resultReg;
+  reg                 stageB_amo_internal_resultRegValid;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_42;
+  reg [7:0] _zz_43;
+  reg [7:0] _zz_44;
+  reg [7:0] _zz_45;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_15 = (stageB_waysHit || (stageB_request_wr && (! stageB_request_isAmo)));
+  assign _zz_16 = (! stageB_amo_internal_resultRegValid);
+  assign _zz_17 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_18 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_19 = (stageB_request_isLrsc && (! stageB_lrSc_reserved));
+  assign _zz_20 = (((! stageB_request_wr) || stageB_request_isAmo) && ((stageB_dataColisions & stageB_waysHits) != 1'b0));
+  assign _zz_21 = (! stageB_flusher_hold);
+  assign _zz_22 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_23 = (stageB_request_amoCtrl_alu | {stageB_request_amoCtrl_swap,2'b00});
+  assign _zz_24 = _zz_4[0 : 0];
+  assign _zz_25 = _zz_4[1 : 1];
+  assign _zz_26 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_27 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_28 = ($signed(_zz_29) + $signed(_zz_33));
+  assign _zz_29 = ($signed(_zz_30) + $signed(_zz_31));
+  assign _zz_30 = stageB_request_data;
+  assign _zz_31 = (stageB_amo_compare ? (~ stageB_dataMux) : stageB_dataMux);
+  assign _zz_32 = (stageB_amo_compare ? _zz_34 : _zz_35);
+  assign _zz_33 = {{30{_zz_32[1]}}, _zz_32};
+  assign _zz_34 = 2'b01;
+  assign _zz_35 = 2'b00;
+  assign _zz_36 = 1'b1;
+  assign _zz_37 = (! stageB_lrSc_reserved);
+  assign _zz_38 = loader_counter_willIncrement;
+  assign _zz_39 = {2'd0, _zz_38};
+  assign _zz_40 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_41 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_41;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_45, _zz_44, _zz_43, _zz_42};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_42 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_43 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_44 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_45 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_24[0];
+  assign ways_0_tagsReadRsp_error = _zz_25[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                dataWriteCmd_valid = 1'b0;
+              end
+            end
+            if(_zz_17)begin
+              dataWriteCmd_valid = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_36[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_18)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_26)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_27)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+          if(_zz_19)begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                io_cpu_writeBack_haltIt = 1'b1;
+              end
+            end
+            if(_zz_17)begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  always @ (*) begin
+    stageB_requestDataBypass = stageB_request_data;
+    if(stageB_request_isAmo)begin
+      stageB_requestDataBypass = stageB_amo_resultReg;
+    end
+  end
+
+  assign stageB_amo_compare = stageB_request_amoCtrl_alu[2];
+  assign stageB_amo_unsigned = (stageB_request_amoCtrl_alu[2 : 1] == 2'b11);
+  assign stageB_amo_addSub = _zz_28;
+  assign stageB_amo_less = ((stageB_request_data[31] == stageB_dataMux[31]) ? stageB_amo_addSub[31] : (stageB_amo_unsigned ? stageB_dataMux[31] : stageB_request_data[31]));
+  assign stageB_amo_selectRf = (stageB_request_amoCtrl_swap ? 1'b1 : (stageB_request_amoCtrl_alu[0] ^ stageB_amo_less));
+  always @ (*) begin
+    case(_zz_23)
+      3'b000 : begin
+        stageB_amo_result = stageB_amo_addSub;
+      end
+      3'b001 : begin
+        stageB_amo_result = (stageB_request_data ^ stageB_dataMux);
+      end
+      3'b010 : begin
+        stageB_amo_result = (stageB_request_data | stageB_dataMux);
+      end
+      3'b011 : begin
+        stageB_amo_result = (stageB_request_data & stageB_dataMux);
+      end
+      default : begin
+        stageB_amo_result = (stageB_amo_selectRf ? stageB_request_data : stageB_dataMux);
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_request_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            if(_zz_20)begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_14)begin
+          io_mem_cmd_valid = (! memCmdSent);
+          if(_zz_19)begin
+            io_mem_cmd_valid = 1'b0;
+          end
+        end else begin
+          if(_zz_15)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+            if(stageB_request_isAmo)begin
+              if(_zz_16)begin
+                io_mem_cmd_valid = 1'b0;
+              end
+            end
+            if(_zz_20)begin
+              io_mem_cmd_valid = 1'b0;
+            end
+            if(_zz_17)begin
+              io_mem_cmd_valid = 1'b0;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(_zz_15)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_14) begin
+          if(! _zz_15) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+    if((stageB_request_isLrsc && stageB_request_wr))begin
+      io_cpu_writeBack_data = {31'd0, _zz_37};
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_18)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_39);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_isLrsc <= io_cpu_execute_args_isLrsc;
+      stageA_request_isAmo <= io_cpu_execute_args_isAmo;
+      stageA_request_amoCtrl_swap <= io_cpu_execute_args_amoCtrl_swap;
+      stageA_request_amoCtrl_alu <= io_cpu_execute_args_amoCtrl_alu;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_isLrsc <= stageA_request_isLrsc;
+      stageB_request_isAmo <= stageA_request_isAmo;
+      stageB_request_amoCtrl_swap <= stageA_request_amoCtrl_swap;
+      stageB_request_amoCtrl_alu <= stageA_request_amoCtrl_alu;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+      stageB_mmuRsp_ways_0_sel <= io_cpu_memory_mmuRsp_ways_0_sel;
+      stageB_mmuRsp_ways_0_physical <= io_cpu_memory_mmuRsp_ways_0_physical;
+      stageB_mmuRsp_ways_1_sel <= io_cpu_memory_mmuRsp_ways_1_sel;
+      stageB_mmuRsp_ways_1_physical <= io_cpu_memory_mmuRsp_ways_1_physical;
+      stageB_mmuRsp_ways_2_sel <= io_cpu_memory_mmuRsp_ways_2_sel;
+      stageB_mmuRsp_ways_2_physical <= io_cpu_memory_mmuRsp_ways_2_physical;
+      stageB_mmuRsp_ways_3_sel <= io_cpu_memory_mmuRsp_ways_3_sel;
+      stageB_mmuRsp_ways_3_physical <= io_cpu_memory_mmuRsp_ways_3_physical;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_21)begin
+        if(_zz_22)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    stageB_amo_internal_resultRegValid <= io_cpu_writeBack_isStuck;
+    stageB_amo_resultReg <= stageB_amo_result;
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      stageB_lrSc_reserved <= 1'b0;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_21)begin
+          if(! _zz_22) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      if(((io_cpu_writeBack_isValid && (! io_cpu_writeBack_isStuck)) && stageB_request_isLrsc))begin
+        stageB_lrSc_reserved <= (! stageB_request_wr);
+      end
+      if(_zz_13)begin
+        stageB_lrSc_reserved <= stageB_lrSc_reserved;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_18)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_40[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  input               io_cpu_fetch_mmuRsp_ways_0_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_0_physical,
+  input               io_cpu_fetch_mmuRsp_ways_1_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_1_physical,
+  input               io_cpu_fetch_mmuRsp_ways_2_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_2_physical,
+  input               io_cpu_fetch_mmuRsp_ways_3_sel,
+  input      [31:0]   io_cpu_fetch_mmuRsp_ways_3_physical,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_9;
+  reg        [21:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [21:0]   _zz_15;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_mmuRsp_ways_0_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_0_physical;
+  reg                 decodeStage_mmuRsp_ways_1_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_1_physical;
+  reg                 decodeStage_mmuRsp_ways_2_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_2_physical;
+  reg                 decodeStage_mmuRsp_ways_3_sel;
+  reg        [31:0]   decodeStage_mmuRsp_ways_3_physical;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_11 = (! lineLoader_flushCounter[7]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_9 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_10 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_11)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_12)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_11)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_12)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+      decodeStage_mmuRsp_ways_0_sel <= io_cpu_fetch_mmuRsp_ways_0_sel;
+      decodeStage_mmuRsp_ways_0_physical <= io_cpu_fetch_mmuRsp_ways_0_physical;
+      decodeStage_mmuRsp_ways_1_sel <= io_cpu_fetch_mmuRsp_ways_1_sel;
+      decodeStage_mmuRsp_ways_1_physical <= io_cpu_fetch_mmuRsp_ways_1_physical;
+      decodeStage_mmuRsp_ways_2_sel <= io_cpu_fetch_mmuRsp_ways_2_sel;
+      decodeStage_mmuRsp_ways_2_physical <= io_cpu_fetch_mmuRsp_ways_2_physical;
+      decodeStage_mmuRsp_ways_3_sel <= io_cpu_fetch_mmuRsp_ways_3_sel;
+      decodeStage_mmuRsp_ways_3_physical <= io_cpu_fetch_mmuRsp_ways_3_physical;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
   end
 
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Lite.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Lite.v
@@ -1,7 +1,12 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:37:57
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
+
+`define EnvCtrlEnum_defaultEncoding_type [1:0]
+`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
+`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
+`define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
 
 `define BranchCtrlEnum_defaultEncoding_type [1:0]
 `define BranchCtrlEnum_defaultEncoding_INC 2'b00
@@ -9,32 +14,16 @@
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
-`define EnvCtrlEnum_defaultEncoding_type [1:0]
-`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
-`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
-`define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
-
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
 `define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
 `define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
 `define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
 `define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
-
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
 `define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
 `define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
 `define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
-
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
 `define Src2CtrlEnum_defaultEncoding_type [1:0]
 `define Src2CtrlEnum_defaultEncoding_RS 2'b00
@@ -42,296 +31,17 @@
 `define Src2CtrlEnum_defaultEncoding_IMS 2'b10
 `define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [22:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire       [0:0]    _zz_14_;
-  wire       [0:0]    _zz_15_;
-  wire       [22:0]   _zz_16_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [6:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [5:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [20:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [8:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [5:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [22:0]   _zz_7_;
-  wire       [8:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:511];
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-  assign _zz_12_ = (! lineLoader_flushCounter[6]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[6]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[6] ? lineLoader_address[10 : 5] : lineLoader_flushCounter[5 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[6];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 11];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[10 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[22 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[10 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[6];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= 7'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -347,8 +57,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -358,30 +68,26 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output reg [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset 
+  input               reset
 );
-  wire                _zz_160_;
-  wire                _zz_161_;
-  wire                _zz_162_;
-  wire                _zz_163_;
-  wire                _zz_164_;
-  wire                _zz_165_;
-  wire                _zz_166_;
-  reg                 _zz_167_;
-  reg        [31:0]   _zz_168_;
-  reg        [31:0]   _zz_169_;
-  reg        [31:0]   _zz_170_;
+  wire                _zz_158;
+  wire                _zz_159;
+  wire                _zz_160;
+  wire                _zz_161;
+  wire                _zz_162;
+  wire                _zz_163;
+  wire                _zz_164;
+  wire                _zz_165;
+  reg                 _zz_166;
+  reg        [31:0]   _zz_167;
+  reg        [31:0]   _zz_168;
+  reg        [31:0]   _zz_169;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -391,357 +97,365 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                _zz_171_;
-  wire                _zz_172_;
-  wire                _zz_173_;
-  wire                _zz_174_;
-  wire                _zz_175_;
-  wire                _zz_176_;
-  wire                _zz_177_;
-  wire                _zz_178_;
-  wire                _zz_179_;
-  wire                _zz_180_;
-  wire                _zz_181_;
-  wire                _zz_182_;
-  wire                _zz_183_;
-  wire                _zz_184_;
-  wire                _zz_185_;
-  wire                _zz_186_;
-  wire                _zz_187_;
-  wire                _zz_188_;
-  wire       [1:0]    _zz_189_;
-  wire                _zz_190_;
-  wire                _zz_191_;
-  wire                _zz_192_;
-  wire                _zz_193_;
-  wire                _zz_194_;
-  wire                _zz_195_;
-  wire                _zz_196_;
-  wire                _zz_197_;
-  wire                _zz_198_;
-  wire                _zz_199_;
-  wire                _zz_200_;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire                _zz_203_;
-  wire                _zz_204_;
-  wire                _zz_205_;
-  wire                _zz_206_;
-  wire                _zz_207_;
-  wire       [1:0]    _zz_208_;
-  wire                _zz_209_;
-  wire       [0:0]    _zz_210_;
-  wire       [0:0]    _zz_211_;
-  wire       [0:0]    _zz_212_;
-  wire       [0:0]    _zz_213_;
-  wire       [0:0]    _zz_214_;
-  wire       [0:0]    _zz_215_;
-  wire       [0:0]    _zz_216_;
-  wire       [0:0]    _zz_217_;
-  wire       [0:0]    _zz_218_;
-  wire       [0:0]    _zz_219_;
-  wire       [0:0]    _zz_220_;
-  wire       [0:0]    _zz_221_;
-  wire       [0:0]    _zz_222_;
-  wire       [0:0]    _zz_223_;
-  wire       [0:0]    _zz_224_;
-  wire       [0:0]    _zz_225_;
-  wire       [3:0]    _zz_226_;
-  wire       [2:0]    _zz_227_;
-  wire       [31:0]   _zz_228_;
-  wire       [11:0]   _zz_229_;
-  wire       [31:0]   _zz_230_;
-  wire       [19:0]   _zz_231_;
-  wire       [11:0]   _zz_232_;
-  wire       [31:0]   _zz_233_;
-  wire       [31:0]   _zz_234_;
-  wire       [19:0]   _zz_235_;
-  wire       [11:0]   _zz_236_;
-  wire       [2:0]    _zz_237_;
-  wire       [0:0]    _zz_238_;
-  wire       [2:0]    _zz_239_;
-  wire       [4:0]    _zz_240_;
-  wire       [11:0]   _zz_241_;
-  wire       [11:0]   _zz_242_;
-  wire       [31:0]   _zz_243_;
-  wire       [31:0]   _zz_244_;
-  wire       [31:0]   _zz_245_;
-  wire       [31:0]   _zz_246_;
-  wire       [31:0]   _zz_247_;
-  wire       [31:0]   _zz_248_;
-  wire       [31:0]   _zz_249_;
-  wire       [31:0]   _zz_250_;
-  wire       [32:0]   _zz_251_;
-  wire       [11:0]   _zz_252_;
-  wire       [19:0]   _zz_253_;
-  wire       [11:0]   _zz_254_;
-  wire       [31:0]   _zz_255_;
-  wire       [31:0]   _zz_256_;
-  wire       [31:0]   _zz_257_;
-  wire       [11:0]   _zz_258_;
-  wire       [19:0]   _zz_259_;
-  wire       [11:0]   _zz_260_;
-  wire       [2:0]    _zz_261_;
-  wire       [1:0]    _zz_262_;
-  wire       [1:0]    _zz_263_;
-  wire       [1:0]    _zz_264_;
-  wire       [1:0]    _zz_265_;
-  wire       [0:0]    _zz_266_;
-  wire       [5:0]    _zz_267_;
-  wire       [33:0]   _zz_268_;
-  wire       [32:0]   _zz_269_;
-  wire       [33:0]   _zz_270_;
-  wire       [32:0]   _zz_271_;
-  wire       [33:0]   _zz_272_;
-  wire       [32:0]   _zz_273_;
-  wire       [0:0]    _zz_274_;
-  wire       [5:0]    _zz_275_;
-  wire       [32:0]   _zz_276_;
-  wire       [31:0]   _zz_277_;
-  wire       [31:0]   _zz_278_;
-  wire       [32:0]   _zz_279_;
-  wire       [32:0]   _zz_280_;
-  wire       [32:0]   _zz_281_;
-  wire       [32:0]   _zz_282_;
-  wire       [0:0]    _zz_283_;
-  wire       [32:0]   _zz_284_;
-  wire       [0:0]    _zz_285_;
-  wire       [32:0]   _zz_286_;
-  wire       [0:0]    _zz_287_;
-  wire       [31:0]   _zz_288_;
-  wire       [0:0]    _zz_289_;
-  wire       [0:0]    _zz_290_;
-  wire       [0:0]    _zz_291_;
-  wire       [0:0]    _zz_292_;
-  wire       [0:0]    _zz_293_;
-  wire       [0:0]    _zz_294_;
-  wire       [26:0]   _zz_295_;
-  wire                _zz_296_;
-  wire                _zz_297_;
-  wire       [1:0]    _zz_298_;
-  wire       [31:0]   _zz_299_;
-  wire       [31:0]   _zz_300_;
-  wire       [31:0]   _zz_301_;
-  wire                _zz_302_;
-  wire       [0:0]    _zz_303_;
-  wire       [12:0]   _zz_304_;
-  wire       [31:0]   _zz_305_;
-  wire       [31:0]   _zz_306_;
-  wire       [31:0]   _zz_307_;
-  wire                _zz_308_;
-  wire       [0:0]    _zz_309_;
-  wire       [6:0]    _zz_310_;
-  wire       [31:0]   _zz_311_;
-  wire       [31:0]   _zz_312_;
-  wire       [31:0]   _zz_313_;
-  wire                _zz_314_;
-  wire       [0:0]    _zz_315_;
-  wire       [0:0]    _zz_316_;
-  wire                _zz_317_;
-  wire                _zz_318_;
-  wire                _zz_319_;
-  wire       [31:0]   _zz_320_;
-  wire       [31:0]   _zz_321_;
-  wire                _zz_322_;
-  wire                _zz_323_;
-  wire                _zz_324_;
-  wire                _zz_325_;
-  wire       [0:0]    _zz_326_;
-  wire       [0:0]    _zz_327_;
-  wire       [2:0]    _zz_328_;
-  wire       [2:0]    _zz_329_;
-  wire                _zz_330_;
-  wire       [0:0]    _zz_331_;
-  wire       [24:0]   _zz_332_;
-  wire       [31:0]   _zz_333_;
-  wire       [31:0]   _zz_334_;
-  wire       [31:0]   _zz_335_;
-  wire       [31:0]   _zz_336_;
-  wire       [0:0]    _zz_337_;
-  wire       [0:0]    _zz_338_;
-  wire       [0:0]    _zz_339_;
-  wire       [1:0]    _zz_340_;
-  wire       [3:0]    _zz_341_;
-  wire       [3:0]    _zz_342_;
-  wire                _zz_343_;
-  wire       [0:0]    _zz_344_;
-  wire       [22:0]   _zz_345_;
-  wire       [31:0]   _zz_346_;
-  wire       [31:0]   _zz_347_;
-  wire       [31:0]   _zz_348_;
-  wire       [31:0]   _zz_349_;
-  wire                _zz_350_;
-  wire       [0:0]    _zz_351_;
-  wire       [0:0]    _zz_352_;
-  wire                _zz_353_;
-  wire       [0:0]    _zz_354_;
-  wire       [0:0]    _zz_355_;
-  wire       [0:0]    _zz_356_;
-  wire       [0:0]    _zz_357_;
-  wire                _zz_358_;
-  wire       [0:0]    _zz_359_;
-  wire       [19:0]   _zz_360_;
-  wire       [31:0]   _zz_361_;
-  wire       [31:0]   _zz_362_;
-  wire       [31:0]   _zz_363_;
-  wire       [31:0]   _zz_364_;
-  wire                _zz_365_;
-  wire       [0:0]    _zz_366_;
-  wire       [0:0]    _zz_367_;
-  wire       [0:0]    _zz_368_;
-  wire       [0:0]    _zz_369_;
-  wire                _zz_370_;
-  wire       [0:0]    _zz_371_;
-  wire       [16:0]   _zz_372_;
-  wire       [31:0]   _zz_373_;
-  wire       [31:0]   _zz_374_;
-  wire                _zz_375_;
-  wire                _zz_376_;
-  wire       [0:0]    _zz_377_;
-  wire       [0:0]    _zz_378_;
-  wire       [0:0]    _zz_379_;
-  wire       [0:0]    _zz_380_;
-  wire                _zz_381_;
-  wire       [0:0]    _zz_382_;
-  wire       [13:0]   _zz_383_;
-  wire       [31:0]   _zz_384_;
-  wire       [31:0]   _zz_385_;
-  wire       [31:0]   _zz_386_;
-  wire       [0:0]    _zz_387_;
-  wire       [1:0]    _zz_388_;
-  wire       [0:0]    _zz_389_;
-  wire       [0:0]    _zz_390_;
-  wire                _zz_391_;
-  wire       [0:0]    _zz_392_;
-  wire       [10:0]   _zz_393_;
-  wire       [31:0]   _zz_394_;
-  wire       [31:0]   _zz_395_;
-  wire       [31:0]   _zz_396_;
-  wire       [31:0]   _zz_397_;
-  wire       [31:0]   _zz_398_;
-  wire       [31:0]   _zz_399_;
-  wire       [31:0]   _zz_400_;
-  wire       [31:0]   _zz_401_;
-  wire       [0:0]    _zz_402_;
-  wire       [0:0]    _zz_403_;
-  wire       [2:0]    _zz_404_;
-  wire       [2:0]    _zz_405_;
-  wire                _zz_406_;
-  wire       [0:0]    _zz_407_;
-  wire       [7:0]    _zz_408_;
-  wire       [31:0]   _zz_409_;
-  wire       [31:0]   _zz_410_;
-  wire       [31:0]   _zz_411_;
-  wire       [31:0]   _zz_412_;
-  wire                _zz_413_;
-  wire                _zz_414_;
-  wire       [0:0]    _zz_415_;
-  wire       [3:0]    _zz_416_;
-  wire       [0:0]    _zz_417_;
-  wire       [0:0]    _zz_418_;
-  wire       [0:0]    _zz_419_;
-  wire       [0:0]    _zz_420_;
-  wire                _zz_421_;
-  wire       [0:0]    _zz_422_;
-  wire       [4:0]    _zz_423_;
-  wire       [31:0]   _zz_424_;
-  wire       [31:0]   _zz_425_;
-  wire       [31:0]   _zz_426_;
-  wire       [31:0]   _zz_427_;
-  wire                _zz_428_;
-  wire       [0:0]    _zz_429_;
-  wire       [1:0]    _zz_430_;
-  wire       [31:0]   _zz_431_;
-  wire       [31:0]   _zz_432_;
-  wire       [31:0]   _zz_433_;
-  wire       [31:0]   _zz_434_;
-  wire       [0:0]    _zz_435_;
-  wire       [1:0]    _zz_436_;
-  wire       [0:0]    _zz_437_;
-  wire       [0:0]    _zz_438_;
-  wire                _zz_439_;
-  wire       [0:0]    _zz_440_;
-  wire       [2:0]    _zz_441_;
-  wire       [31:0]   _zz_442_;
-  wire       [31:0]   _zz_443_;
-  wire       [31:0]   _zz_444_;
-  wire                _zz_445_;
-  wire                _zz_446_;
-  wire       [31:0]   _zz_447_;
-  wire       [31:0]   _zz_448_;
-  wire                _zz_449_;
-  wire                _zz_450_;
-  wire       [31:0]   _zz_451_;
-  wire       [31:0]   _zz_452_;
-  wire                _zz_453_;
-  wire       [0:0]    _zz_454_;
-  wire       [0:0]    _zz_455_;
-  wire                _zz_456_;
-  wire       [0:0]    _zz_457_;
-  wire       [0:0]    _zz_458_;
-  wire       [31:0]   _zz_459_;
-  wire                _zz_460_;
-  wire                _zz_461_;
-  wire                _zz_462_;
-  wire                _zz_463_;
-  wire                _zz_464_;
-  wire                _zz_465_;
-  wire                _zz_466_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9_;
+  wire                _zz_170;
+  wire                _zz_171;
+  wire                _zz_172;
+  wire                _zz_173;
+  wire                _zz_174;
+  wire                _zz_175;
+  wire                _zz_176;
+  wire                _zz_177;
+  wire                _zz_178;
+  wire                _zz_179;
+  wire                _zz_180;
+  wire                _zz_181;
+  wire                _zz_182;
+  wire                _zz_183;
+  wire                _zz_184;
+  wire                _zz_185;
+  wire                _zz_186;
+  wire       [1:0]    _zz_187;
+  wire                _zz_188;
+  wire                _zz_189;
+  wire                _zz_190;
+  wire                _zz_191;
+  wire                _zz_192;
+  wire                _zz_193;
+  wire                _zz_194;
+  wire                _zz_195;
+  wire                _zz_196;
+  wire                _zz_197;
+  wire                _zz_198;
+  wire                _zz_199;
+  wire                _zz_200;
+  wire                _zz_201;
+  wire                _zz_202;
+  wire                _zz_203;
+  wire                _zz_204;
+  wire                _zz_205;
+  wire       [1:0]    _zz_206;
+  wire                _zz_207;
+  wire       [0:0]    _zz_208;
+  wire       [0:0]    _zz_209;
+  wire       [0:0]    _zz_210;
+  wire       [0:0]    _zz_211;
+  wire       [0:0]    _zz_212;
+  wire       [0:0]    _zz_213;
+  wire       [0:0]    _zz_214;
+  wire       [0:0]    _zz_215;
+  wire       [0:0]    _zz_216;
+  wire       [0:0]    _zz_217;
+  wire       [0:0]    _zz_218;
+  wire       [0:0]    _zz_219;
+  wire       [0:0]    _zz_220;
+  wire       [0:0]    _zz_221;
+  wire       [0:0]    _zz_222;
+  wire       [0:0]    _zz_223;
+  wire       [2:0]    _zz_224;
+  wire       [2:0]    _zz_225;
+  wire       [31:0]   _zz_226;
+  wire       [11:0]   _zz_227;
+  wire       [31:0]   _zz_228;
+  wire       [19:0]   _zz_229;
+  wire       [11:0]   _zz_230;
+  wire       [31:0]   _zz_231;
+  wire       [31:0]   _zz_232;
+  wire       [19:0]   _zz_233;
+  wire       [11:0]   _zz_234;
+  wire       [2:0]    _zz_235;
+  wire       [0:0]    _zz_236;
+  wire       [2:0]    _zz_237;
+  wire       [4:0]    _zz_238;
+  wire       [11:0]   _zz_239;
+  wire       [11:0]   _zz_240;
+  wire       [31:0]   _zz_241;
+  wire       [31:0]   _zz_242;
+  wire       [31:0]   _zz_243;
+  wire       [31:0]   _zz_244;
+  wire       [31:0]   _zz_245;
+  wire       [31:0]   _zz_246;
+  wire       [31:0]   _zz_247;
+  wire       [31:0]   _zz_248;
+  wire       [32:0]   _zz_249;
+  wire       [11:0]   _zz_250;
+  wire       [19:0]   _zz_251;
+  wire       [11:0]   _zz_252;
+  wire       [31:0]   _zz_253;
+  wire       [31:0]   _zz_254;
+  wire       [31:0]   _zz_255;
+  wire       [11:0]   _zz_256;
+  wire       [19:0]   _zz_257;
+  wire       [11:0]   _zz_258;
+  wire       [2:0]    _zz_259;
+  wire       [1:0]    _zz_260;
+  wire       [1:0]    _zz_261;
+  wire       [1:0]    _zz_262;
+  wire       [1:0]    _zz_263;
+  wire       [0:0]    _zz_264;
+  wire       [5:0]    _zz_265;
+  wire       [33:0]   _zz_266;
+  wire       [32:0]   _zz_267;
+  wire       [33:0]   _zz_268;
+  wire       [32:0]   _zz_269;
+  wire       [33:0]   _zz_270;
+  wire       [32:0]   _zz_271;
+  wire       [0:0]    _zz_272;
+  wire       [5:0]    _zz_273;
+  wire       [32:0]   _zz_274;
+  wire       [31:0]   _zz_275;
+  wire       [31:0]   _zz_276;
+  wire       [32:0]   _zz_277;
+  wire       [32:0]   _zz_278;
+  wire       [32:0]   _zz_279;
+  wire       [32:0]   _zz_280;
+  wire       [0:0]    _zz_281;
+  wire       [32:0]   _zz_282;
+  wire       [0:0]    _zz_283;
+  wire       [32:0]   _zz_284;
+  wire       [0:0]    _zz_285;
+  wire       [31:0]   _zz_286;
+  wire       [0:0]    _zz_287;
+  wire       [0:0]    _zz_288;
+  wire       [0:0]    _zz_289;
+  wire       [0:0]    _zz_290;
+  wire       [0:0]    _zz_291;
+  wire       [0:0]    _zz_292;
+  wire       [26:0]   _zz_293;
+  wire                _zz_294;
+  wire                _zz_295;
+  wire       [1:0]    _zz_296;
+  wire       [31:0]   _zz_297;
+  wire       [31:0]   _zz_298;
+  wire       [31:0]   _zz_299;
+  wire                _zz_300;
+  wire       [0:0]    _zz_301;
+  wire       [12:0]   _zz_302;
+  wire       [31:0]   _zz_303;
+  wire       [31:0]   _zz_304;
+  wire       [31:0]   _zz_305;
+  wire                _zz_306;
+  wire       [0:0]    _zz_307;
+  wire       [6:0]    _zz_308;
+  wire       [31:0]   _zz_309;
+  wire       [31:0]   _zz_310;
+  wire       [31:0]   _zz_311;
+  wire                _zz_312;
+  wire       [0:0]    _zz_313;
+  wire       [0:0]    _zz_314;
+  wire                _zz_315;
+  wire                _zz_316;
+  wire                _zz_317;
+  wire       [31:0]   _zz_318;
+  wire       [0:0]    _zz_319;
+  wire       [1:0]    _zz_320;
+  wire       [0:0]    _zz_321;
+  wire       [0:0]    _zz_322;
+  wire                _zz_323;
+  wire       [0:0]    _zz_324;
+  wire       [24:0]   _zz_325;
+  wire       [31:0]   _zz_326;
+  wire       [31:0]   _zz_327;
+  wire       [31:0]   _zz_328;
+  wire       [0:0]    _zz_329;
+  wire       [0:0]    _zz_330;
+  wire       [1:0]    _zz_331;
+  wire       [1:0]    _zz_332;
+  wire                _zz_333;
+  wire       [0:0]    _zz_334;
+  wire       [20:0]   _zz_335;
+  wire       [31:0]   _zz_336;
+  wire       [31:0]   _zz_337;
+  wire       [31:0]   _zz_338;
+  wire       [31:0]   _zz_339;
+  wire       [31:0]   _zz_340;
+  wire       [31:0]   _zz_341;
+  wire       [0:0]    _zz_342;
+  wire       [0:0]    _zz_343;
+  wire       [2:0]    _zz_344;
+  wire       [2:0]    _zz_345;
+  wire                _zz_346;
+  wire       [0:0]    _zz_347;
+  wire       [17:0]   _zz_348;
+  wire       [31:0]   _zz_349;
+  wire       [31:0]   _zz_350;
+  wire       [31:0]   _zz_351;
+  wire       [31:0]   _zz_352;
+  wire                _zz_353;
+  wire                _zz_354;
+  wire                _zz_355;
+  wire       [0:0]    _zz_356;
+  wire       [0:0]    _zz_357;
+  wire                _zz_358;
+  wire       [0:0]    _zz_359;
+  wire       [0:0]    _zz_360;
+  wire                _zz_361;
+  wire       [0:0]    _zz_362;
+  wire       [14:0]   _zz_363;
+  wire       [31:0]   _zz_364;
+  wire       [31:0]   _zz_365;
+  wire       [31:0]   _zz_366;
+  wire       [31:0]   _zz_367;
+  wire       [31:0]   _zz_368;
+  wire       [31:0]   _zz_369;
+  wire       [31:0]   _zz_370;
+  wire       [31:0]   _zz_371;
+  wire       [0:0]    _zz_372;
+  wire       [0:0]    _zz_373;
+  wire       [1:0]    _zz_374;
+  wire       [1:0]    _zz_375;
+  wire                _zz_376;
+  wire       [0:0]    _zz_377;
+  wire       [12:0]   _zz_378;
+  wire       [31:0]   _zz_379;
+  wire       [31:0]   _zz_380;
+  wire       [31:0]   _zz_381;
+  wire       [31:0]   _zz_382;
+  wire       [31:0]   _zz_383;
+  wire       [31:0]   _zz_384;
+  wire                _zz_385;
+  wire       [0:0]    _zz_386;
+  wire       [0:0]    _zz_387;
+  wire                _zz_388;
+  wire       [0:0]    _zz_389;
+  wire       [0:0]    _zz_390;
+  wire                _zz_391;
+  wire       [0:0]    _zz_392;
+  wire       [9:0]    _zz_393;
+  wire       [31:0]   _zz_394;
+  wire       [31:0]   _zz_395;
+  wire       [31:0]   _zz_396;
+  wire       [0:0]    _zz_397;
+  wire       [0:0]    _zz_398;
+  wire       [0:0]    _zz_399;
+  wire       [4:0]    _zz_400;
+  wire       [1:0]    _zz_401;
+  wire       [1:0]    _zz_402;
+  wire                _zz_403;
+  wire       [0:0]    _zz_404;
+  wire       [6:0]    _zz_405;
+  wire       [31:0]   _zz_406;
+  wire       [31:0]   _zz_407;
+  wire       [31:0]   _zz_408;
+  wire       [31:0]   _zz_409;
+  wire                _zz_410;
+  wire       [0:0]    _zz_411;
+  wire       [1:0]    _zz_412;
+  wire       [31:0]   _zz_413;
+  wire       [31:0]   _zz_414;
+  wire                _zz_415;
+  wire       [0:0]    _zz_416;
+  wire       [0:0]    _zz_417;
+  wire       [0:0]    _zz_418;
+  wire       [0:0]    _zz_419;
+  wire                _zz_420;
+  wire       [0:0]    _zz_421;
+  wire       [3:0]    _zz_422;
+  wire       [31:0]   _zz_423;
+  wire       [31:0]   _zz_424;
+  wire       [31:0]   _zz_425;
+  wire                _zz_426;
+  wire                _zz_427;
+  wire       [31:0]   _zz_428;
+  wire       [31:0]   _zz_429;
+  wire       [31:0]   _zz_430;
+  wire       [31:0]   _zz_431;
+  wire       [31:0]   _zz_432;
+  wire       [31:0]   _zz_433;
+  wire       [31:0]   _zz_434;
+  wire       [0:0]    _zz_435;
+  wire       [2:0]    _zz_436;
+  wire       [0:0]    _zz_437;
+  wire       [0:0]    _zz_438;
+  wire                _zz_439;
+  wire       [0:0]    _zz_440;
+  wire       [1:0]    _zz_441;
+  wire       [31:0]   _zz_442;
+  wire       [31:0]   _zz_443;
+  wire       [31:0]   _zz_444;
+  wire       [31:0]   _zz_445;
+  wire                _zz_446;
+  wire       [0:0]    _zz_447;
+  wire       [0:0]    _zz_448;
+  wire       [31:0]   _zz_449;
+  wire       [31:0]   _zz_450;
+  wire       [0:0]    _zz_451;
+  wire       [1:0]    _zz_452;
+  wire       [1:0]    _zz_453;
+  wire       [1:0]    _zz_454;
+  wire                _zz_455;
+  wire                _zz_456;
+  wire       [31:0]   _zz_457;
+  wire       [31:0]   _zz_458;
+  wire       [31:0]   _zz_459;
+  wire       [31:0]   _zz_460;
+  wire       [31:0]   _zz_461;
+  wire       [31:0]   _zz_462;
+  wire       [31:0]   _zz_463;
+  wire       [31:0]   _zz_464;
+  wire       [31:0]   _zz_465;
+  wire                _zz_466;
+  wire       [31:0]   _zz_467;
+  wire       [31:0]   _zz_468;
+  wire                _zz_469;
+  wire                _zz_470;
+  wire                _zz_471;
+  wire       [31:0]   memory_MEMORY_READ_DATA;
+  wire       [31:0]   execute_BRANCH_CALC;
   wire                execute_BRANCH_DO;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
   wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_DIV;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
   wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_STORE;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_16;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_19;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire                decode_MEMORY_ENABLE;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_22;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12_;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_15_;
-  wire                decode_IS_MUL;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire                decode_CSR_READ_OPCODE;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_21_;
-  wire                decode_IS_CSR;
-  wire                decode_IS_RS1_SIGNED;
-  wire                decode_MEMORY_STORE;
-  wire       [31:0]   memory_MEMORY_READ_DATA;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_24_;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire                decode_IS_DIV;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                decode_IS_RS2_SIGNED;
+  wire       [31:0]   memory_PC;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_MUL;
@@ -752,11 +466,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_25_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_25;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -764,99 +478,81 @@ module VexRiscv (
   wire       [31:0]   execute_RS1;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_28;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [31:0]   _zz_29_;
+  reg        [31:0]   _zz_29;
   wire                memory_REGFILE_WRITE_VALID;
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
-  reg        [31:0]   _zz_30_;
+  reg        [31:0]   _zz_30;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_32_;
+  wire       [31:0]   _zz_32;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_35_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_35;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36_;
-  wire       [31:0]   _zz_37_;
-  wire                _zz_38_;
-  reg                 _zz_39_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36;
+  wire       [31:0]   _zz_37;
+  wire                _zz_38;
+  reg                 _zz_39;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_40_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_41_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_42_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_46_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_40;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_41;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_47_;
+  reg        [31:0]   _zz_47;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
-  wire                memory_MMU_FAULT;
-  wire       [31:0]   memory_MMU_RSP_physicalAddress;
-  wire                memory_MMU_RSP_isIoAccess;
-  wire                memory_MMU_RSP_allowRead;
-  wire                memory_MMU_RSP_allowWrite;
-  wire                memory_MMU_RSP_allowExecute;
-  wire                memory_MMU_RSP_exception;
-  wire                memory_MMU_RSP_refilling;
-  wire       [31:0]   memory_PC;
   wire                memory_ALIGNEMENT_FAULT;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_STORE;
   wire                memory_MEMORY_ENABLE;
-  wire                execute_MMU_FAULT;
-  wire       [31:0]   execute_MMU_RSP_physicalAddress;
-  wire                execute_MMU_RSP_isIoAccess;
-  wire                execute_MMU_RSP_allowRead;
-  wire                execute_MMU_RSP_allowWrite;
-  wire                execute_MMU_RSP_allowExecute;
-  wire                execute_MMU_RSP_exception;
-  wire                execute_MMU_RSP_refilling;
   wire       [31:0]   execute_SRC_ADD;
   wire       [31:0]   execute_RS2;
   wire       [31:0]   execute_INSTRUCTION;
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
   wire                execute_ALIGNEMENT_FAULT;
-  wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_48_;
-  reg                 _zz_48__2;
-  reg                 _zz_48__1;
-  reg                 _zz_48__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_49_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_48;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_50_;
-  reg        [31:0]   _zz_51_;
+  reg        [31:0]   _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
-  reg                 decode_arbitration_haltItself;
+  wire                decode_arbitration_haltItself;
   reg                 decode_arbitration_haltByOther;
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
@@ -881,7 +577,7 @@ module VexRiscv (
   reg                 memory_arbitration_haltItself;
   wire                memory_arbitration_haltByOther;
   reg                 memory_arbitration_removeIt;
-  reg                 memory_arbitration_flushIt;
+  wire                memory_arbitration_flushIt;
   reg                 memory_arbitration_flushNext;
   reg                 memory_arbitration_isValid;
   wire                memory_arbitration_isStuck;
@@ -917,35 +613,24 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
   reg                 DBusSimplePlugin_memoryExceptionPort_valid;
   reg        [3:0]    DBusSimplePlugin_memoryExceptionPort_payload_code;
   wire       [31:0]   DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
-  wire                DBusSimplePlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusSimplePlugin_mmuBus_cmd_bypassTranslation;
-  wire       [31:0]   DBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  wire                DBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowRead;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowWrite;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowExecute;
-  wire                DBusSimplePlugin_mmuBus_rsp_exception;
-  wire                DBusSimplePlugin_mmuBus_rsp_refilling;
-  wire                DBusSimplePlugin_mmuBus_end;
-  wire                DBusSimplePlugin_mmuBus_busy;
-  reg                 DBusSimplePlugin_redoBranch_valid;
-  wire       [31:0]   DBusSimplePlugin_redoBranch_payload;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -974,11 +659,10 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_52_;
-  wire       [3:0]    _zz_53_;
-  wire                _zz_54_;
-  wire                _zz_55_;
-  wire                _zz_56_;
+  wire       [2:0]    _zz_51;
+  wire       [2:0]    _zz_52;
+  wire                _zz_53;
+  wire                _zz_54;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -1015,16 +699,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
+  wire                _zz_55;
+  wire                _zz_56;
+  wire                _zz_57;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_60_;
-  wire                _zz_61_;
-  reg                 _zz_62_;
-  wire                _zz_63_;
-  reg                 _zz_64_;
-  reg        [31:0]   _zz_65_;
+  wire                _zz_58;
+  wire                _zz_59;
+  reg                 _zz_60;
+  wire                _zz_61;
+  reg                 _zz_62;
+  reg        [31:0]   _zz_63;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1037,17 +721,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_66_;
-  reg        [18:0]   _zz_67_;
-  wire                _zz_68_;
-  reg        [10:0]   _zz_69_;
-  wire                _zz_70_;
-  reg        [18:0]   _zz_71_;
-  reg                 _zz_72_;
-  wire                _zz_73_;
-  reg        [10:0]   _zz_74_;
-  wire                _zz_75_;
-  reg        [18:0]   _zz_76_;
+  wire                _zz_64;
+  reg        [18:0]   _zz_65;
+  wire                _zz_66;
+  reg        [10:0]   _zz_67;
+  wire                _zz_68;
+  reg        [18:0]   _zz_69;
+  reg                 _zz_70;
+  wire                _zz_71;
+  reg        [10:0]   _zz_72;
+  wire                _zz_73;
+  reg        [18:0]   _zz_74;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1055,7 +739,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_77_;
+  wire       [31:0]   _zz_75;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1072,47 +756,47 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_78_;
+  wire                _zz_76;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_79_;
-  reg        [3:0]    _zz_80_;
+  reg        [31:0]   _zz_77;
+  reg        [3:0]    _zz_78;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_81_;
-  reg        [31:0]   _zz_82_;
-  wire                _zz_83_;
-  reg        [31:0]   _zz_84_;
+  wire                _zz_79;
+  reg        [31:0]   _zz_80;
+  wire                _zz_81;
+  reg        [31:0]   _zz_82;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [30:0]   _zz_85_;
-  wire                _zz_86_;
-  wire                _zz_87_;
-  wire                _zz_88_;
-  wire                _zz_89_;
-  wire                _zz_90_;
-  wire                _zz_91_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_92_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_93_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_94_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_95_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_96_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_97_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_98_;
+  wire       [30:0]   _zz_83;
+  wire                _zz_84;
+  wire                _zz_85;
+  wire                _zz_86;
+  wire                _zz_87;
+  wire                _zz_88;
+  wire                _zz_89;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_90;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_91;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_92;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_93;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_94;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_95;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_96;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_99_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_97;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_100_;
-  reg        [31:0]   _zz_101_;
-  wire                _zz_102_;
-  reg        [19:0]   _zz_103_;
-  wire                _zz_104_;
-  reg        [19:0]   _zz_105_;
-  reg        [31:0]   _zz_106_;
+  reg        [31:0]   _zz_98;
+  reg        [31:0]   _zz_99;
+  wire                _zz_100;
+  reg        [19:0]   _zz_101;
+  wire                _zz_102;
+  reg        [19:0]   _zz_103;
+  reg        [31:0]   _zz_104;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -1121,38 +805,38 @@ module VexRiscv (
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_107_;
-  reg                 _zz_108_;
-  reg                 _zz_109_;
-  reg                 _zz_110_;
-  reg        [4:0]    _zz_111_;
-  reg        [31:0]   _zz_112_;
-  wire                _zz_113_;
-  wire                _zz_114_;
-  wire                _zz_115_;
-  wire                _zz_116_;
-  wire                _zz_117_;
-  wire                _zz_118_;
+  reg        [31:0]   _zz_105;
+  reg                 _zz_106;
+  reg                 _zz_107;
+  reg                 _zz_108;
+  reg        [4:0]    _zz_109;
+  reg        [31:0]   _zz_110;
+  wire                _zz_111;
+  wire                _zz_112;
+  wire                _zz_113;
+  wire                _zz_114;
+  wire                _zz_115;
+  wire                _zz_116;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_119_;
-  reg                 _zz_120_;
-  reg                 _zz_121_;
-  wire                _zz_122_;
-  reg        [19:0]   _zz_123_;
-  wire                _zz_124_;
-  reg        [10:0]   _zz_125_;
-  wire                _zz_126_;
-  reg        [18:0]   _zz_127_;
-  reg                 _zz_128_;
+  wire       [2:0]    _zz_117;
+  reg                 _zz_118;
+  reg                 _zz_119;
+  wire                _zz_120;
+  reg        [19:0]   _zz_121;
+  wire                _zz_122;
+  reg        [10:0]   _zz_123;
+  wire                _zz_124;
+  reg        [18:0]   _zz_125;
+  reg                 _zz_126;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_129_;
-  reg        [19:0]   _zz_130_;
-  wire                _zz_131_;
-  reg        [10:0]   _zz_132_;
-  wire                _zz_133_;
-  reg        [18:0]   _zz_134_;
+  wire                _zz_127;
+  reg        [19:0]   _zz_128;
+  wire                _zz_129;
+  reg        [10:0]   _zz_130;
+  wire                _zz_131;
+  reg        [18:0]   _zz_132;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
@@ -1173,9 +857,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_135_;
-  wire                _zz_136_;
-  wire                _zz_137_;
+  wire                _zz_133;
+  wire                _zz_134;
+  wire                _zz_135;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1188,10 +872,10 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_138_;
-  wire                _zz_139_;
-  wire       [1:0]    _zz_140_;
-  wire                _zz_141_;
+  wire       [1:0]    _zz_136;
+  wire                _zz_137;
+  wire       [1:0]    _zz_138;
+  wire                _zz_139;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -1203,7 +887,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -1239,79 +923,71 @@ module VexRiscv (
   wire                memory_MulDivIterativePlugin_div_counter_willOverflow;
   reg                 memory_MulDivIterativePlugin_div_done;
   reg        [31:0]   memory_MulDivIterativePlugin_div_result;
-  wire       [31:0]   _zz_142_;
+  wire       [31:0]   _zz_140;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_143_;
-  wire                _zz_144_;
-  wire                _zz_145_;
-  reg        [32:0]   _zz_146_;
+  wire       [31:0]   _zz_141;
+  wire                _zz_142;
+  wire                _zz_143;
+  reg        [32:0]   _zz_144;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_147_;
-  wire       [31:0]   _zz_148_;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   _zz_145;
+  wire       [31:0]   _zz_146;
+  reg        [31:0]   decode_to_execute_PC;
+  reg        [31:0]   execute_to_memory_PC;
+  reg        [31:0]   memory_to_writeBack_PC;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   reg                 decode_to_execute_MEMORY_ENABLE;
   reg                 execute_to_memory_MEMORY_ENABLE;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
   reg                 decode_to_execute_REGFILE_WRITE_VALID;
   reg                 execute_to_memory_REGFILE_WRITE_VALID;
   reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_MMU_FAULT;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   reg                 decode_to_execute_MEMORY_STORE;
   reg                 execute_to_memory_MEMORY_STORE;
   reg                 memory_to_writeBack_MEMORY_STORE;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg                 decode_to_execute_IS_CSR;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg        [31:0]   decode_to_execute_INSTRUCTION;
-  reg        [31:0]   execute_to_memory_INSTRUCTION;
-  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
   reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg        [31:0]   decode_to_execute_PC;
-  reg        [31:0]   execute_to_memory_PC;
-  reg        [31:0]   memory_to_writeBack_PC;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 execute_to_memory_BRANCH_DO;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
   reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
   reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
   reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg        [31:0]   execute_to_memory_MMU_RSP_physicalAddress;
-  reg                 execute_to_memory_MMU_RSP_isIoAccess;
-  reg                 execute_to_memory_MMU_RSP_allowRead;
-  reg                 execute_to_memory_MMU_RSP_allowWrite;
-  reg                 execute_to_memory_MMU_RSP_allowExecute;
-  reg                 execute_to_memory_MMU_RSP_exception;
-  reg                 execute_to_memory_MMU_RSP_refilling;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
   reg                 execute_CsrPlugin_csr_772;
@@ -1321,16 +997,16 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_835;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_149_;
-  reg        [31:0]   _zz_150_;
-  reg        [31:0]   _zz_151_;
-  reg        [31:0]   _zz_152_;
-  reg        [31:0]   _zz_153_;
-  reg        [31:0]   _zz_154_;
-  reg        [31:0]   _zz_155_;
-  reg        [31:0]   _zz_156_;
-  reg        [2:0]    _zz_157_;
-  reg                 _zz_158_;
+  reg        [31:0]   _zz_147;
+  reg        [31:0]   _zz_148;
+  reg        [31:0]   _zz_149;
+  reg        [31:0]   _zz_150;
+  reg        [31:0]   _zz_151;
+  reg        [31:0]   _zz_152;
+  reg        [31:0]   _zz_153;
+  reg        [31:0]   _zz_154;
+  reg        [2:0]    _zz_155;
+  reg                 _zz_156;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
@@ -1344,511 +1020,492 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_159_;
+  reg        [3:0]    _zz_157;
   `ifndef SYNTHESIS
-  reg [31:0] _zz_1__string;
-  reg [31:0] _zz_2__string;
-  reg [39:0] _zz_3__string;
-  reg [39:0] _zz_4__string;
-  reg [39:0] _zz_5__string;
-  reg [39:0] _zz_6__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_7__string;
-  reg [39:0] _zz_8__string;
-  reg [39:0] _zz_9__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
   reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_10__string;
-  reg [71:0] _zz_11__string;
-  reg [71:0] _zz_12__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_13__string;
-  reg [63:0] _zz_14__string;
-  reg [63:0] _zz_15__string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] _zz_12_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_16__string;
-  reg [39:0] _zz_17__string;
-  reg [39:0] _zz_18__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_19__string;
-  reg [95:0] _zz_20__string;
-  reg [95:0] _zz_21__string;
+  reg [39:0] _zz_13_string;
+  reg [39:0] _zz_14_string;
+  reg [39:0] _zz_15_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_22__string;
-  reg [23:0] _zz_23__string;
-  reg [23:0] _zz_24__string;
+  reg [23:0] _zz_16_string;
+  reg [23:0] _zz_17_string;
+  reg [23:0] _zz_18_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_19_string;
+  reg [63:0] _zz_20_string;
+  reg [63:0] _zz_21_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_22_string;
+  reg [95:0] _zz_23_string;
+  reg [95:0] _zz_24_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_25__string;
+  reg [39:0] _zz_25_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_26__string;
+  reg [39:0] _zz_26_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_28__string;
+  reg [31:0] _zz_28_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_31__string;
+  reg [71:0] _zz_31_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_33__string;
+  reg [23:0] _zz_33_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_34__string;
+  reg [95:0] _zz_34_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_35__string;
+  reg [63:0] _zz_35_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_36__string;
-  reg [23:0] _zz_40__string;
-  reg [95:0] _zz_41__string;
-  reg [39:0] _zz_42__string;
-  reg [71:0] _zz_43__string;
-  reg [31:0] _zz_44__string;
-  reg [39:0] _zz_45__string;
-  reg [63:0] _zz_46__string;
+  reg [39:0] _zz_36_string;
+  reg [39:0] _zz_40_string;
+  reg [31:0] _zz_41_string;
+  reg [71:0] _zz_42_string;
+  reg [39:0] _zz_43_string;
+  reg [23:0] _zz_44_string;
+  reg [63:0] _zz_45_string;
+  reg [95:0] _zz_46_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_49__string;
-  reg [63:0] _zz_92__string;
-  reg [39:0] _zz_93__string;
-  reg [31:0] _zz_94__string;
-  reg [71:0] _zz_95__string;
-  reg [39:0] _zz_96__string;
-  reg [95:0] _zz_97__string;
-  reg [23:0] _zz_98__string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [31:0] _zz_48_string;
+  reg [95:0] _zz_90_string;
+  reg [63:0] _zz_91_string;
+  reg [23:0] _zz_92_string;
+  reg [39:0] _zz_93_string;
+  reg [71:0] _zz_94_string;
+  reg [31:0] _zz_95_string;
+  reg [39:0] _zz_96_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_171_ = (memory_arbitration_isValid && memory_IS_MUL);
-  assign _zz_172_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_173_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_174_ = 1'b1;
-  assign _zz_175_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_176_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_177_ = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_178_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_179_ = ((_zz_164_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_48__2));
-  assign _zz_180_ = ((_zz_164_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_48__1));
-  assign _zz_181_ = ((_zz_164_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_48__0));
-  assign _zz_182_ = ((_zz_164_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_183_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_184_ = (! execute_arbitration_isStuckByOthers);
-  assign _zz_185_ = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_186_ = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != (2'b00));
-  assign _zz_187_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_188_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_189_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_190_ = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign _zz_191_ = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
-  assign _zz_192_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_193_ = (1'b0 || (! 1'b1));
-  assign _zz_194_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_195_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_196_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_197_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_198_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_199_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_200_ = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
-  assign _zz_201_ = (! memory_arbitration_isStuck);
-  assign _zz_202_ = (iBus_cmd_valid || (_zz_157_ != (3'b000)));
-  assign _zz_203_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_204_ = ((_zz_135_ && 1'b1) && (! 1'b0));
-  assign _zz_205_ = ((_zz_136_ && 1'b1) && (! 1'b0));
-  assign _zz_206_ = ((_zz_137_ && 1'b1) && (! 1'b0));
-  assign _zz_207_ = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_208_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_209_ = execute_INSTRUCTION[13];
-  assign _zz_210_ = _zz_85_[29 : 29];
-  assign _zz_211_ = _zz_85_[12 : 12];
-  assign _zz_212_ = _zz_85_[13 : 13];
-  assign _zz_213_ = _zz_85_[18 : 18];
-  assign _zz_214_ = _zz_85_[26 : 26];
-  assign _zz_215_ = _zz_85_[3 : 3];
-  assign _zz_216_ = _zz_85_[27 : 27];
-  assign _zz_217_ = _zz_85_[19 : 19];
-  assign _zz_218_ = _zz_85_[28 : 28];
-  assign _zz_219_ = _zz_85_[17 : 17];
-  assign _zz_220_ = _zz_85_[25 : 25];
-  assign _zz_221_ = _zz_85_[6 : 6];
-  assign _zz_222_ = _zz_85_[30 : 30];
-  assign _zz_223_ = _zz_85_[9 : 9];
-  assign _zz_224_ = _zz_85_[22 : 22];
-  assign _zz_225_ = _zz_85_[0 : 0];
-  assign _zz_226_ = (_zz_52_ - (4'b0001));
-  assign _zz_227_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_228_ = {29'd0, _zz_227_};
-  assign _zz_229_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_230_ = {{_zz_67_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_231_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_232_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_233_ = {{_zz_69_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_234_ = {{_zz_71_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_235_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_236_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_237_ = (memory_MEMORY_STORE ? (3'b110) : (3'b100));
-  assign _zz_238_ = execute_SRC_LESS;
-  assign _zz_239_ = (3'b100);
-  assign _zz_240_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_241_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_242_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_243_ = ($signed(_zz_244_) + $signed(_zz_247_));
-  assign _zz_244_ = ($signed(_zz_245_) + $signed(_zz_246_));
-  assign _zz_245_ = execute_SRC1;
-  assign _zz_246_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_247_ = (execute_SRC_USE_SUB_LESS ? _zz_248_ : _zz_249_);
-  assign _zz_248_ = 32'h00000001;
-  assign _zz_249_ = 32'h0;
-  assign _zz_250_ = (_zz_251_ >>> 1);
-  assign _zz_251_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_252_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_253_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_254_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_255_ = {_zz_123_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_256_ = {{_zz_125_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_257_ = {{_zz_127_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_258_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_259_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_260_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_261_ = (3'b100);
-  assign _zz_262_ = (_zz_138_ & (~ _zz_263_));
-  assign _zz_263_ = (_zz_138_ - (2'b01));
-  assign _zz_264_ = (_zz_140_ & (~ _zz_265_));
-  assign _zz_265_ = (_zz_140_ - (2'b01));
-  assign _zz_266_ = memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_267_ = {5'd0, _zz_266_};
-  assign _zz_268_ = (_zz_270_ + _zz_272_);
-  assign _zz_269_ = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_270_ = {{1{_zz_269_[32]}}, _zz_269_};
-  assign _zz_271_ = _zz_273_;
-  assign _zz_272_ = {{1{_zz_271_[32]}}, _zz_271_};
-  assign _zz_273_ = (memory_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_274_ = memory_MulDivIterativePlugin_div_counter_willIncrement;
-  assign _zz_275_ = {5'd0, _zz_274_};
-  assign _zz_276_ = {1'd0, memory_MulDivIterativePlugin_rs2};
-  assign _zz_277_ = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_278_ = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_279_ = {_zz_142_,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_280_ = _zz_281_;
-  assign _zz_281_ = _zz_282_;
-  assign _zz_282_ = ({1'b0,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_143_) : _zz_143_)} + _zz_284_);
-  assign _zz_283_ = memory_MulDivIterativePlugin_div_needRevert;
-  assign _zz_284_ = {32'd0, _zz_283_};
-  assign _zz_285_ = _zz_145_;
-  assign _zz_286_ = {32'd0, _zz_285_};
-  assign _zz_287_ = _zz_144_;
-  assign _zz_288_ = {31'd0, _zz_287_};
-  assign _zz_289_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_290_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_291_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_292_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_293_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_294_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_295_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_296_ = 1'b1;
-  assign _zz_297_ = 1'b1;
-  assign _zz_298_ = {_zz_56_,_zz_55_};
-  assign _zz_299_ = 32'h0000107f;
-  assign _zz_300_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_301_ = 32'h00002073;
-  assign _zz_302_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_303_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_304_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_305_) == 32'h00000003),{(_zz_306_ == _zz_307_),{_zz_308_,{_zz_309_,_zz_310_}}}}}};
-  assign _zz_305_ = 32'h0000505f;
-  assign _zz_306_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_307_ = 32'h00000063;
-  assign _zz_308_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_309_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_310_ = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_311_) == 32'h00005033),{(_zz_312_ == _zz_313_),{_zz_314_,{_zz_315_,_zz_316_}}}}}};
-  assign _zz_311_ = 32'hbe00707f;
-  assign _zz_312_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_313_ = 32'h00000033;
-  assign _zz_314_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_315_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_316_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz_317_ = decode_INSTRUCTION[31];
-  assign _zz_318_ = decode_INSTRUCTION[31];
-  assign _zz_319_ = decode_INSTRUCTION[7];
-  assign _zz_320_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_321_ = 32'h00000024;
-  assign _zz_322_ = ((decode_INSTRUCTION & _zz_333_) == 32'h00001010);
-  assign _zz_323_ = ((decode_INSTRUCTION & _zz_334_) == 32'h00001010);
-  assign _zz_324_ = ((decode_INSTRUCTION & _zz_335_) == 32'h00002000);
-  assign _zz_325_ = ((decode_INSTRUCTION & _zz_336_) == 32'h00001000);
-  assign _zz_326_ = _zz_91_;
-  assign _zz_327_ = _zz_90_;
-  assign _zz_328_ = {_zz_89_,{_zz_337_,_zz_338_}};
-  assign _zz_329_ = (3'b000);
-  assign _zz_330_ = ({_zz_339_,_zz_340_} != (3'b000));
-  assign _zz_331_ = (_zz_341_ != _zz_342_);
-  assign _zz_332_ = {_zz_343_,{_zz_344_,_zz_345_}};
-  assign _zz_333_ = 32'h00003034;
-  assign _zz_334_ = 32'h02003054;
-  assign _zz_335_ = 32'h00002010;
-  assign _zz_336_ = 32'h00005000;
-  assign _zz_337_ = ((decode_INSTRUCTION & _zz_346_) == 32'h00000010);
-  assign _zz_338_ = ((decode_INSTRUCTION & _zz_347_) == 32'h00000020);
-  assign _zz_339_ = _zz_91_;
-  assign _zz_340_ = {_zz_87_,_zz_90_};
-  assign _zz_341_ = {(_zz_348_ == _zz_349_),{_zz_350_,{_zz_351_,_zz_352_}}};
-  assign _zz_342_ = (4'b0000);
-  assign _zz_343_ = ({_zz_89_,_zz_353_} != (2'b00));
-  assign _zz_344_ = ({_zz_354_,_zz_355_} != (2'b00));
-  assign _zz_345_ = {(_zz_356_ != _zz_357_),{_zz_358_,{_zz_359_,_zz_360_}}};
-  assign _zz_346_ = 32'h00000030;
-  assign _zz_347_ = 32'h02000060;
-  assign _zz_348_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_349_ = 32'h0;
-  assign _zz_350_ = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_351_ = ((decode_INSTRUCTION & _zz_361_) == 32'h00002000);
-  assign _zz_352_ = ((decode_INSTRUCTION & _zz_362_) == 32'h00001000);
-  assign _zz_353_ = ((decode_INSTRUCTION & 32'h00000070) == 32'h00000020);
-  assign _zz_354_ = _zz_89_;
-  assign _zz_355_ = ((decode_INSTRUCTION & _zz_363_) == 32'h0);
-  assign _zz_356_ = ((decode_INSTRUCTION & _zz_364_) == 32'h0);
-  assign _zz_357_ = (1'b0);
-  assign _zz_358_ = ({_zz_365_,_zz_88_} != (2'b00));
-  assign _zz_359_ = ({_zz_366_,_zz_367_} != (2'b00));
-  assign _zz_360_ = {(_zz_368_ != _zz_369_),{_zz_370_,{_zz_371_,_zz_372_}}};
-  assign _zz_361_ = 32'h00006004;
-  assign _zz_362_ = 32'h00005004;
-  assign _zz_363_ = 32'h00000020;
-  assign _zz_364_ = 32'h00000058;
-  assign _zz_365_ = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_366_ = ((decode_INSTRUCTION & _zz_373_) == 32'h00000004);
-  assign _zz_367_ = _zz_88_;
-  assign _zz_368_ = ((decode_INSTRUCTION & _zz_374_) == 32'h02004020);
-  assign _zz_369_ = (1'b0);
-  assign _zz_370_ = ({_zz_375_,_zz_376_} != (2'b00));
-  assign _zz_371_ = ({_zz_377_,_zz_378_} != (2'b00));
-  assign _zz_372_ = {(_zz_379_ != _zz_380_),{_zz_381_,{_zz_382_,_zz_383_}}};
-  assign _zz_373_ = 32'h00000044;
-  assign _zz_374_ = 32'h02004064;
-  assign _zz_375_ = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_376_ = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_377_ = ((decode_INSTRUCTION & _zz_384_) == 32'h00000020);
-  assign _zz_378_ = ((decode_INSTRUCTION & _zz_385_) == 32'h00000020);
-  assign _zz_379_ = ((decode_INSTRUCTION & _zz_386_) == 32'h00001000);
-  assign _zz_380_ = (1'b0);
-  assign _zz_381_ = (_zz_87_ != (1'b0));
-  assign _zz_382_ = ({_zz_387_,_zz_388_} != (3'b000));
-  assign _zz_383_ = {(_zz_389_ != _zz_390_),{_zz_391_,{_zz_392_,_zz_393_}}};
-  assign _zz_384_ = 32'h00000034;
-  assign _zz_385_ = 32'h00000064;
-  assign _zz_386_ = 32'h00001000;
-  assign _zz_387_ = ((decode_INSTRUCTION & _zz_394_) == 32'h00000040);
-  assign _zz_388_ = {(_zz_395_ == _zz_396_),(_zz_397_ == _zz_398_)};
-  assign _zz_389_ = ((decode_INSTRUCTION & _zz_399_) == 32'h02000030);
-  assign _zz_390_ = (1'b0);
-  assign _zz_391_ = ((_zz_400_ == _zz_401_) != (1'b0));
-  assign _zz_392_ = ({_zz_402_,_zz_403_} != (2'b00));
-  assign _zz_393_ = {(_zz_404_ != _zz_405_),{_zz_406_,{_zz_407_,_zz_408_}}};
-  assign _zz_394_ = 32'h00000050;
-  assign _zz_395_ = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_396_ = 32'h0;
-  assign _zz_397_ = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz_398_ = 32'h00000040;
-  assign _zz_399_ = 32'h02004074;
-  assign _zz_400_ = (decode_INSTRUCTION & 32'h00000010);
-  assign _zz_401_ = 32'h00000010;
-  assign _zz_402_ = ((decode_INSTRUCTION & _zz_409_) == 32'h00005010);
-  assign _zz_403_ = ((decode_INSTRUCTION & _zz_410_) == 32'h00005020);
-  assign _zz_404_ = {(_zz_411_ == _zz_412_),{_zz_413_,_zz_414_}};
-  assign _zz_405_ = (3'b000);
-  assign _zz_406_ = ({_zz_86_,{_zz_415_,_zz_416_}} != 6'h0);
-  assign _zz_407_ = ({_zz_417_,_zz_418_} != (2'b00));
-  assign _zz_408_ = {(_zz_419_ != _zz_420_),{_zz_421_,{_zz_422_,_zz_423_}}};
-  assign _zz_409_ = 32'h00007034;
-  assign _zz_410_ = 32'h02007064;
-  assign _zz_411_ = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_412_ = 32'h40001010;
-  assign _zz_413_ = ((decode_INSTRUCTION & _zz_424_) == 32'h00001010);
-  assign _zz_414_ = ((decode_INSTRUCTION & _zz_425_) == 32'h00001010);
-  assign _zz_415_ = (_zz_426_ == _zz_427_);
-  assign _zz_416_ = {_zz_428_,{_zz_429_,_zz_430_}};
-  assign _zz_417_ = _zz_86_;
-  assign _zz_418_ = (_zz_431_ == _zz_432_);
-  assign _zz_419_ = (_zz_433_ == _zz_434_);
-  assign _zz_420_ = (1'b0);
-  assign _zz_421_ = ({_zz_435_,_zz_436_} != (3'b000));
-  assign _zz_422_ = (_zz_437_ != _zz_438_);
-  assign _zz_423_ = {_zz_439_,{_zz_440_,_zz_441_}};
-  assign _zz_424_ = 32'h00007034;
-  assign _zz_425_ = 32'h02007054;
-  assign _zz_426_ = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_427_ = 32'h00001010;
-  assign _zz_428_ = ((decode_INSTRUCTION & _zz_442_) == 32'h00002010);
-  assign _zz_429_ = (_zz_443_ == _zz_444_);
-  assign _zz_430_ = {_zz_445_,_zz_446_};
-  assign _zz_431_ = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_432_ = 32'h00000004;
-  assign _zz_433_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_434_ = 32'h00000040;
-  assign _zz_435_ = (_zz_447_ == _zz_448_);
-  assign _zz_436_ = {_zz_449_,_zz_450_};
-  assign _zz_437_ = (_zz_451_ == _zz_452_);
-  assign _zz_438_ = (1'b0);
-  assign _zz_439_ = (_zz_453_ != (1'b0));
-  assign _zz_440_ = (_zz_454_ != _zz_455_);
-  assign _zz_441_ = {_zz_456_,{_zz_457_,_zz_458_}};
-  assign _zz_442_ = 32'h00002010;
-  assign _zz_443_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_444_ = 32'h00000010;
-  assign _zz_445_ = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_446_ = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz_447_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_448_ = 32'h00000040;
-  assign _zz_449_ = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
-  assign _zz_450_ = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
-  assign _zz_451_ = (decode_INSTRUCTION & 32'h10003050);
-  assign _zz_452_ = 32'h00000050;
-  assign _zz_453_ = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz_454_ = ((decode_INSTRUCTION & _zz_459_) == 32'h00000020);
-  assign _zz_455_ = (1'b0);
-  assign _zz_456_ = ({_zz_460_,_zz_461_} != (2'b00));
-  assign _zz_457_ = (_zz_462_ != (1'b0));
-  assign _zz_458_ = (_zz_463_ != (1'b0));
-  assign _zz_459_ = 32'h00000020;
-  assign _zz_460_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00006010);
-  assign _zz_461_ = ((decode_INSTRUCTION & 32'h00005014) == 32'h00004010);
-  assign _zz_462_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz_463_ = ((decode_INSTRUCTION & 32'h00001048) == 32'h00001008);
-  assign _zz_464_ = execute_INSTRUCTION[31];
-  assign _zz_465_ = execute_INSTRUCTION[31];
-  assign _zz_466_ = execute_INSTRUCTION[7];
+  assign _zz_170 = (memory_arbitration_isValid && memory_IS_MUL);
+  assign _zz_171 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_172 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_173 = 1'b1;
+  assign _zz_174 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_175 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_176 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign _zz_177 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_178 = ((_zz_163 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_179 = ((_zz_163 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_180 = ((_zz_163 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_181 = ((_zz_163 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_182 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_183 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign _zz_184 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz_185 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_186 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_187 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_188 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign _zz_189 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_190 = (1'b0 || (! 1'b1));
+  assign _zz_191 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_192 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_193 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_194 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_195 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_196 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_197 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
+  assign _zz_198 = (! memory_arbitration_isStuck);
+  assign _zz_199 = (iBus_cmd_valid || (_zz_155 != 3'b000));
+  assign _zz_200 = (! execute_arbitration_isStuckByOthers);
+  assign _zz_201 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_202 = ((_zz_133 && 1'b1) && (! 1'b0));
+  assign _zz_203 = ((_zz_134 && 1'b1) && (! 1'b0));
+  assign _zz_204 = ((_zz_135 && 1'b1) && (! 1'b0));
+  assign _zz_205 = (! dBus_cmd_halfPipe_regs_valid);
+  assign _zz_206 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_207 = execute_INSTRUCTION[13];
+  assign _zz_208 = _zz_83[30 : 30];
+  assign _zz_209 = _zz_83[29 : 29];
+  assign _zz_210 = _zz_83[28 : 28];
+  assign _zz_211 = _zz_83[27 : 27];
+  assign _zz_212 = _zz_83[24 : 24];
+  assign _zz_213 = _zz_83[16 : 16];
+  assign _zz_214 = _zz_83[13 : 13];
+  assign _zz_215 = _zz_83[12 : 12];
+  assign _zz_216 = _zz_83[11 : 11];
+  assign _zz_217 = _zz_83[4 : 4];
+  assign _zz_218 = _zz_83[15 : 15];
+  assign _zz_219 = _zz_83[5 : 5];
+  assign _zz_220 = _zz_83[3 : 3];
+  assign _zz_221 = _zz_83[19 : 19];
+  assign _zz_222 = _zz_83[10 : 10];
+  assign _zz_223 = _zz_83[0 : 0];
+  assign _zz_224 = (_zz_51 - 3'b001);
+  assign _zz_225 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_226 = {29'd0, _zz_225};
+  assign _zz_227 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_228 = {{_zz_65,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_229 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_230 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_231 = {{_zz_67,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_232 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_233 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_234 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_235 = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz_236 = execute_SRC_LESS;
+  assign _zz_237 = 3'b100;
+  assign _zz_238 = execute_INSTRUCTION[19 : 15];
+  assign _zz_239 = execute_INSTRUCTION[31 : 20];
+  assign _zz_240 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_241 = ($signed(_zz_242) + $signed(_zz_245));
+  assign _zz_242 = ($signed(_zz_243) + $signed(_zz_244));
+  assign _zz_243 = execute_SRC1;
+  assign _zz_244 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_245 = (execute_SRC_USE_SUB_LESS ? _zz_246 : _zz_247);
+  assign _zz_246 = 32'h00000001;
+  assign _zz_247 = 32'h0;
+  assign _zz_248 = (_zz_249 >>> 1);
+  assign _zz_249 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz_250 = execute_INSTRUCTION[31 : 20];
+  assign _zz_251 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_252 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_253 = {_zz_121,execute_INSTRUCTION[31 : 20]};
+  assign _zz_254 = {{_zz_123,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_255 = {{_zz_125,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_256 = execute_INSTRUCTION[31 : 20];
+  assign _zz_257 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_258 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_259 = 3'b100;
+  assign _zz_260 = (_zz_136 & (~ _zz_261));
+  assign _zz_261 = (_zz_136 - 2'b01);
+  assign _zz_262 = (_zz_138 & (~ _zz_263));
+  assign _zz_263 = (_zz_138 - 2'b01);
+  assign _zz_264 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  assign _zz_265 = {5'd0, _zz_264};
+  assign _zz_266 = (_zz_268 + _zz_270);
+  assign _zz_267 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_268 = {{1{_zz_267[32]}}, _zz_267};
+  assign _zz_269 = _zz_271;
+  assign _zz_270 = {{1{_zz_269[32]}}, _zz_269};
+  assign _zz_271 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_272 = memory_MulDivIterativePlugin_div_counter_willIncrement;
+  assign _zz_273 = {5'd0, _zz_272};
+  assign _zz_274 = {1'd0, memory_MulDivIterativePlugin_rs2};
+  assign _zz_275 = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_276 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_277 = {_zz_140,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_278 = _zz_279;
+  assign _zz_279 = _zz_280;
+  assign _zz_280 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_141) : _zz_141)} + _zz_282);
+  assign _zz_281 = memory_MulDivIterativePlugin_div_needRevert;
+  assign _zz_282 = {32'd0, _zz_281};
+  assign _zz_283 = _zz_143;
+  assign _zz_284 = {32'd0, _zz_283};
+  assign _zz_285 = _zz_142;
+  assign _zz_286 = {31'd0, _zz_285};
+  assign _zz_287 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_288 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_289 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_290 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_291 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_292 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_293 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_294 = 1'b1;
+  assign _zz_295 = 1'b1;
+  assign _zz_296 = {_zz_54,_zz_53};
+  assign _zz_297 = 32'h0000107f;
+  assign _zz_298 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_299 = 32'h00002073;
+  assign _zz_300 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_301 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_302 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_303) == 32'h00000003),{(_zz_304 == _zz_305),{_zz_306,{_zz_307,_zz_308}}}}}};
+  assign _zz_303 = 32'h0000505f;
+  assign _zz_304 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_305 = 32'h00000063;
+  assign _zz_306 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_307 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_308 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_309) == 32'h00005033),{(_zz_310 == _zz_311),{_zz_312,{_zz_313,_zz_314}}}}}};
+  assign _zz_309 = 32'hbe00707f;
+  assign _zz_310 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_311 = 32'h00000033;
+  assign _zz_312 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_313 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_314 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_315 = decode_INSTRUCTION[31];
+  assign _zz_316 = decode_INSTRUCTION[31];
+  assign _zz_317 = decode_INSTRUCTION[7];
+  assign _zz_318 = 32'h02004064;
+  assign _zz_319 = _zz_89;
+  assign _zz_320 = {_zz_87,_zz_88};
+  assign _zz_321 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz_322 = 1'b0;
+  assign _zz_323 = (((decode_INSTRUCTION & _zz_326) == 32'h00000050) != 1'b0);
+  assign _zz_324 = ((_zz_327 == _zz_328) != 1'b0);
+  assign _zz_325 = {({_zz_329,_zz_330} != 2'b00),{(_zz_331 != _zz_332),{_zz_333,{_zz_334,_zz_335}}}};
+  assign _zz_326 = 32'h10003050;
+  assign _zz_327 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz_328 = 32'h10000050;
+  assign _zz_329 = ((decode_INSTRUCTION & _zz_336) == 32'h00001050);
+  assign _zz_330 = ((decode_INSTRUCTION & _zz_337) == 32'h00002050);
+  assign _zz_331 = {_zz_86,(_zz_338 == _zz_339)};
+  assign _zz_332 = 2'b00;
+  assign _zz_333 = ((_zz_340 == _zz_341) != 1'b0);
+  assign _zz_334 = ({_zz_342,_zz_343} != 2'b00);
+  assign _zz_335 = {(_zz_344 != _zz_345),{_zz_346,{_zz_347,_zz_348}}};
+  assign _zz_336 = 32'h00001050;
+  assign _zz_337 = 32'h00002050;
+  assign _zz_338 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz_339 = 32'h00000004;
+  assign _zz_340 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_341 = 32'h00000040;
+  assign _zz_342 = ((decode_INSTRUCTION & _zz_349) == 32'h00005010);
+  assign _zz_343 = ((decode_INSTRUCTION & _zz_350) == 32'h00005020);
+  assign _zz_344 = {(_zz_351 == _zz_352),{_zz_353,_zz_354}};
+  assign _zz_345 = 3'b000;
+  assign _zz_346 = ({_zz_355,{_zz_356,_zz_357}} != 3'b000);
+  assign _zz_347 = (_zz_358 != 1'b0);
+  assign _zz_348 = {(_zz_359 != _zz_360),{_zz_361,{_zz_362,_zz_363}}};
+  assign _zz_349 = 32'h00007034;
+  assign _zz_350 = 32'h02007064;
+  assign _zz_351 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz_352 = 32'h40001010;
+  assign _zz_353 = ((decode_INSTRUCTION & _zz_364) == 32'h00001010);
+  assign _zz_354 = ((decode_INSTRUCTION & _zz_365) == 32'h00001010);
+  assign _zz_355 = ((decode_INSTRUCTION & _zz_366) == 32'h00000024);
+  assign _zz_356 = (_zz_367 == _zz_368);
+  assign _zz_357 = (_zz_369 == _zz_370);
+  assign _zz_358 = ((decode_INSTRUCTION & _zz_371) == 32'h00001000);
+  assign _zz_359 = _zz_87;
+  assign _zz_360 = 1'b0;
+  assign _zz_361 = ({_zz_372,_zz_373} != 2'b00);
+  assign _zz_362 = (_zz_374 != _zz_375);
+  assign _zz_363 = {_zz_376,{_zz_377,_zz_378}};
+  assign _zz_364 = 32'h00007034;
+  assign _zz_365 = 32'h02007054;
+  assign _zz_366 = 32'h00000064;
+  assign _zz_367 = (decode_INSTRUCTION & 32'h00003034);
+  assign _zz_368 = 32'h00001010;
+  assign _zz_369 = (decode_INSTRUCTION & 32'h02003054);
+  assign _zz_370 = 32'h00001010;
+  assign _zz_371 = 32'h00001000;
+  assign _zz_372 = ((decode_INSTRUCTION & _zz_379) == 32'h00002000);
+  assign _zz_373 = ((decode_INSTRUCTION & _zz_380) == 32'h00001000);
+  assign _zz_374 = {(_zz_381 == _zz_382),(_zz_383 == _zz_384)};
+  assign _zz_375 = 2'b00;
+  assign _zz_376 = ({_zz_385,{_zz_386,_zz_387}} != 3'b000);
+  assign _zz_377 = (_zz_388 != 1'b0);
+  assign _zz_378 = {(_zz_389 != _zz_390),{_zz_391,{_zz_392,_zz_393}}};
+  assign _zz_379 = 32'h00002010;
+  assign _zz_380 = 32'h00005000;
+  assign _zz_381 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz_382 = 32'h00000020;
+  assign _zz_383 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_384 = 32'h00000020;
+  assign _zz_385 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz_386 = ((decode_INSTRUCTION & _zz_394) == 32'h0);
+  assign _zz_387 = ((decode_INSTRUCTION & _zz_395) == 32'h00000040);
+  assign _zz_388 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz_389 = ((decode_INSTRUCTION & _zz_396) == 32'h00000010);
+  assign _zz_390 = 1'b0;
+  assign _zz_391 = ({_zz_85,{_zz_397,_zz_398}} != 3'b000);
+  assign _zz_392 = ({_zz_399,_zz_400} != 6'h0);
+  assign _zz_393 = {(_zz_401 != _zz_402),{_zz_403,{_zz_404,_zz_405}}};
+  assign _zz_394 = 32'h00000038;
+  assign _zz_395 = 32'h00403040;
+  assign _zz_396 = 32'h00000010;
+  assign _zz_397 = ((decode_INSTRUCTION & _zz_406) == 32'h00000010);
+  assign _zz_398 = ((decode_INSTRUCTION & _zz_407) == 32'h00000020);
+  assign _zz_399 = _zz_86;
+  assign _zz_400 = {(_zz_408 == _zz_409),{_zz_410,{_zz_411,_zz_412}}};
+  assign _zz_401 = {_zz_85,(_zz_413 == _zz_414)};
+  assign _zz_402 = 2'b00;
+  assign _zz_403 = ({_zz_85,_zz_415} != 2'b00);
+  assign _zz_404 = ({_zz_416,_zz_417} != 2'b00);
+  assign _zz_405 = {(_zz_418 != _zz_419),{_zz_420,{_zz_421,_zz_422}}};
+  assign _zz_406 = 32'h00000030;
+  assign _zz_407 = 32'h02000060;
+  assign _zz_408 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_409 = 32'h00001010;
+  assign _zz_410 = ((decode_INSTRUCTION & _zz_423) == 32'h00002010);
+  assign _zz_411 = (_zz_424 == _zz_425);
+  assign _zz_412 = {_zz_426,_zz_427};
+  assign _zz_413 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_414 = 32'h00000020;
+  assign _zz_415 = ((decode_INSTRUCTION & _zz_428) == 32'h0);
+  assign _zz_416 = (_zz_429 == _zz_430);
+  assign _zz_417 = (_zz_431 == _zz_432);
+  assign _zz_418 = (_zz_433 == _zz_434);
+  assign _zz_419 = 1'b0;
+  assign _zz_420 = ({_zz_435,_zz_436} != 4'b0000);
+  assign _zz_421 = (_zz_437 != _zz_438);
+  assign _zz_422 = {_zz_439,{_zz_440,_zz_441}};
+  assign _zz_423 = 32'h00002010;
+  assign _zz_424 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_425 = 32'h00000010;
+  assign _zz_426 = ((decode_INSTRUCTION & _zz_442) == 32'h00000004);
+  assign _zz_427 = ((decode_INSTRUCTION & _zz_443) == 32'h0);
+  assign _zz_428 = 32'h00000020;
+  assign _zz_429 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_430 = 32'h00006010;
+  assign _zz_431 = (decode_INSTRUCTION & 32'h00005014);
+  assign _zz_432 = 32'h00004010;
+  assign _zz_433 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_434 = 32'h00002010;
+  assign _zz_435 = (_zz_444 == _zz_445);
+  assign _zz_436 = {_zz_446,{_zz_447,_zz_448}};
+  assign _zz_437 = (_zz_449 == _zz_450);
+  assign _zz_438 = 1'b0;
+  assign _zz_439 = ({_zz_451,_zz_452} != 3'b000);
+  assign _zz_440 = (_zz_453 != _zz_454);
+  assign _zz_441 = {_zz_455,_zz_456};
+  assign _zz_442 = 32'h0000000c;
+  assign _zz_443 = 32'h00000028;
+  assign _zz_444 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_445 = 32'h0;
+  assign _zz_446 = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
+  assign _zz_447 = ((decode_INSTRUCTION & _zz_457) == 32'h00002000);
+  assign _zz_448 = ((decode_INSTRUCTION & _zz_458) == 32'h00001000);
+  assign _zz_449 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_450 = 32'h0;
+  assign _zz_451 = ((decode_INSTRUCTION & _zz_459) == 32'h00000040);
+  assign _zz_452 = {(_zz_460 == _zz_461),(_zz_462 == _zz_463)};
+  assign _zz_453 = {(_zz_464 == _zz_465),_zz_84};
+  assign _zz_454 = 2'b00;
+  assign _zz_455 = ({_zz_466,_zz_84} != 2'b00);
+  assign _zz_456 = ((_zz_467 == _zz_468) != 1'b0);
+  assign _zz_457 = 32'h00006004;
+  assign _zz_458 = 32'h00005004;
+  assign _zz_459 = 32'h00000044;
+  assign _zz_460 = (decode_INSTRUCTION & 32'h00002014);
+  assign _zz_461 = 32'h00002010;
+  assign _zz_462 = (decode_INSTRUCTION & 32'h40004034);
+  assign _zz_463 = 32'h40000030;
+  assign _zz_464 = (decode_INSTRUCTION & 32'h00000014);
+  assign _zz_465 = 32'h00000004;
+  assign _zz_466 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_467 = (decode_INSTRUCTION & 32'h00001048);
+  assign _zz_468 = 32'h00001008;
+  assign _zz_469 = execute_INSTRUCTION[31];
+  assign _zz_470 = execute_INSTRUCTION[31];
+  assign _zz_471 = execute_INSTRUCTION[7];
   always @ (posedge clk) begin
-    if(_zz_296_) begin
-      _zz_168_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_294) begin
+      _zz_167 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_297_) begin
-      _zz_169_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_295) begin
+      _zz_168 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_39_) begin
+    if(_zz_39) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_160_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_161_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_162_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_163_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_164_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_165_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_166_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_167_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_158                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_159                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_160                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_161                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_162                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_163                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_164                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_165                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_166                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
   always @(*) begin
-    case(_zz_298_)
+    case(_zz_296)
       2'b00 : begin
-        _zz_170_ = CsrPlugin_jumpInterface_payload;
+        _zz_169 = CsrPlugin_jumpInterface_payload;
       end
       2'b01 : begin
-        _zz_170_ = DBusSimplePlugin_redoBranch_payload;
-      end
-      2'b10 : begin
-        _zz_170_ = BranchPlugin_jumpInterface_payload;
+        _zz_169 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_170_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_169 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_1__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_1__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_1__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_1__string = "JALR";
-      default : _zz_1__string = "????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_2__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_2__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_2__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_2__string = "JALR";
-      default : _zz_2__string = "????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3__string = "ECALL";
-      default : _zz_3__string = "?????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_4_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4__string = "ECALL";
-      default : _zz_4__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5__string = "ECALL";
-      default : _zz_5__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6__string = "ECALL";
-      default : _zz_6__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1860,27 +1517,45 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_7_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7__string = "ECALL";
-      default : _zz_7__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_8_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8__string = "ECALL";
-      default : _zz_8__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_9_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9__string = "ECALL";
-      default : _zz_9__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
@@ -1893,62 +1568,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_10_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10__string = "SRA_1    ";
-      default : _zz_10__string = "?????????";
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_11_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11__string = "SRA_1    ";
-      default : _zz_11__string = "?????????";
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_12_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12__string = "SRA_1    ";
-      default : _zz_12__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_13__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_13__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_13__string = "BITWISE ";
-      default : _zz_13__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_14__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_14__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_14__string = "BITWISE ";
-      default : _zz_14__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_15__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_15__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_15__string = "BITWISE ";
-      default : _zz_15__string = "????????";
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1960,63 +1603,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_16_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16__string = "AND_1";
-      default : _zz_16__string = "?????";
+    case(_zz_13)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13_string = "AND_1";
+      default : _zz_13_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_17_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17__string = "AND_1";
-      default : _zz_17__string = "?????";
+    case(_zz_14)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
+      default : _zz_14_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_18_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_18__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_18__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_18__string = "AND_1";
-      default : _zz_18__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_19__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_19__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_19__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_19__string = "URS1        ";
-      default : _zz_19__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_20__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_20__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_20__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_20__string = "URS1        ";
-      default : _zz_20__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_21_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_21__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_21__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_21__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_21__string = "URS1        ";
-      default : _zz_21__string = "????????????";
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2029,30 +1636,98 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_22__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_22__string = "PC ";
-      default : _zz_22__string = "???";
+    case(_zz_16)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_16_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_16_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_16_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_16_string = "PC ";
+      default : _zz_16_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_23__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_23__string = "PC ";
-      default : _zz_23__string = "???";
+    case(_zz_17)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_17_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_17_string = "PC ";
+      default : _zz_17_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_24__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_24__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_24__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_24__string = "PC ";
-      default : _zz_24__string = "???";
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_19_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_19_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_19_string = "BITWISE ";
+      default : _zz_19_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
+      default : _zz_20_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_22_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_22_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_22_string = "URS1        ";
+      default : _zz_22_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
+      default : _zz_23_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2064,11 +1739,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_25__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_25__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_25__string = "ECALL";
-      default : _zz_25__string = "?????";
+    case(_zz_25)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_25_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_25_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_25_string = "ECALL";
+      default : _zz_25_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2080,11 +1755,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26__string = "ECALL";
-      default : _zz_26__string = "?????";
+    case(_zz_26)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26_string = "ECALL";
+      default : _zz_26_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2096,11 +1771,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2113,12 +1788,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_28__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_28__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_28__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_28__string = "JALR";
-      default : _zz_28__string = "????";
+    case(_zz_28)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_28_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_28_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_28_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_28_string = "JALR";
+      default : _zz_28_string = "????";
     endcase
   end
   always @(*) begin
@@ -2131,12 +1806,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_31_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31__string = "SRA_1    ";
-      default : _zz_31__string = "?????????";
+    case(_zz_31)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
+      default : _zz_31_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2149,12 +1824,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_33__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_33__string = "PC ";
-      default : _zz_33__string = "???";
+    case(_zz_33)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_33_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_33_string = "PC ";
+      default : _zz_33_string = "???";
     endcase
   end
   always @(*) begin
@@ -2167,12 +1842,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_34__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34__string = "URS1        ";
-      default : _zz_34__string = "????????????";
+    case(_zz_34)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34_string = "URS1        ";
+      default : _zz_34_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2184,11 +1859,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35__string = "BITWISE ";
-      default : _zz_35__string = "????????";
+    case(_zz_35)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35_string = "BITWISE ";
+      default : _zz_35_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2200,71 +1875,71 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36__string = "AND_1";
-      default : _zz_36__string = "?????";
+    case(_zz_36)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36_string = "AND_1";
+      default : _zz_36_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_40_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_40__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_40__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_40__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_40__string = "PC ";
-      default : _zz_40__string = "???";
+    case(_zz_40)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_40_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_40_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_40_string = "ECALL";
+      default : _zz_40_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_41_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_41__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_41__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_41__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_41__string = "URS1        ";
-      default : _zz_41__string = "????????????";
+    case(_zz_41)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_41_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_41_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41_string = "JALR";
+      default : _zz_41_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_42_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_42__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_42__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_42__string = "AND_1";
-      default : _zz_42__string = "?????";
+    case(_zz_42)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_42_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_42_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_42_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_42_string = "SRA_1    ";
+      default : _zz_42_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_43__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_43__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_43__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_43__string = "SRA_1    ";
-      default : _zz_43__string = "?????????";
+    case(_zz_43)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_44__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_44__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44__string = "JALR";
-      default : _zz_44__string = "????";
+    case(_zz_44)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_44_string = "PC ";
+      default : _zz_44_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_45__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_45__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_45__string = "ECALL";
-      default : _zz_45__string = "?????";
+    case(_zz_45)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
+      default : _zz_45_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_46__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_46__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_46__string = "BITWISE ";
-      default : _zz_46__string = "????????";
+    case(_zz_46)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46_string = "URS1        ";
+      default : _zz_46_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2277,81 +1952,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_49__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_49__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_49__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_49__string = "JALR";
-      default : _zz_49__string = "????";
+    case(_zz_48)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_48_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_48_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_48_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_48_string = "JALR";
+      default : _zz_48_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_92_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_92__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_92__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_92__string = "BITWISE ";
-      default : _zz_92__string = "????????";
+    case(_zz_90)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_90_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_90_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_90_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_90_string = "URS1        ";
+      default : _zz_90_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_93__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_93__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_93__string = "ECALL";
-      default : _zz_93__string = "?????";
+    case(_zz_91)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_91_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_91_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_91_string = "BITWISE ";
+      default : _zz_91_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_94_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_94__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_94__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_94__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_94__string = "JALR";
-      default : _zz_94__string = "????";
+    case(_zz_92)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_92_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_92_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_92_string = "PC ";
+      default : _zz_92_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_95__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_95__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_95__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_95__string = "SRA_1    ";
-      default : _zz_95__string = "?????????";
+    case(_zz_93)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_93_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_93_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_93_string = "AND_1";
+      default : _zz_93_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_96_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_96__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_96__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_96__string = "AND_1";
-      default : _zz_96__string = "?????";
+    case(_zz_94)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_94_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_94_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_94_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_94_string = "SRA_1    ";
+      default : _zz_94_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_97_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_97__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_97__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_97__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_97__string = "URS1        ";
-      default : _zz_97__string = "????????????";
+    case(_zz_95)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_95_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_95_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_95_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_95_string = "JALR";
+      default : _zz_95_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_98_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_98__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_98__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_98__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_98__string = "PC ";
-      default : _zz_98__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
+    case(_zz_96)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_96_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_96_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_96_string = "ECALL";
+      default : _zz_96_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2364,19 +2030,28 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
     case(decode_to_execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
       `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2386,6 +2061,15 @@ module VexRiscv (
       `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
       `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -2412,57 +2096,50 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
-      default : decode_to_execute_BRANCH_CTRL_string = "????";
-    endcase
-  end
   `endif
 
-  assign _zz_1_ = _zz_2_;
-  assign _zz_3_ = _zz_4_;
-  assign _zz_5_ = _zz_6_;
-  assign decode_ENV_CTRL = _zz_7_;
-  assign _zz_8_ = _zz_9_;
+  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
+  assign execute_REGFILE_WRITE_DATA = _zz_98;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
-  assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_100_;
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_SRC_LESS_UNSIGNED = _zz_210_[0];
+  assign decode_IS_DIV = _zz_208[0];
+  assign decode_IS_RS2_SIGNED = _zz_209[0];
+  assign decode_IS_RS1_SIGNED = _zz_210[0];
+  assign decode_IS_MUL = _zz_211[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_212[0];
+  assign _zz_8 = _zz_9;
+  assign decode_SHIFT_CTRL = _zz_10;
+  assign _zz_11 = _zz_12;
+  assign decode_ALU_BITWISE_CTRL = _zz_13;
+  assign _zz_14 = _zz_15;
+  assign decode_SRC_LESS_UNSIGNED = _zz_213[0];
+  assign decode_MEMORY_STORE = _zz_214[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_215[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_216[0];
+  assign decode_SRC2_CTRL = _zz_16;
+  assign _zz_17 = _zz_18;
+  assign decode_ALU_CTRL = _zz_19;
+  assign _zz_20 = _zz_21;
+  assign decode_MEMORY_ENABLE = _zz_217[0];
+  assign decode_SRC1_CTRL = _zz_22;
+  assign _zz_23 = _zz_24;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign decode_SHIFT_CTRL = _zz_10_;
-  assign _zz_11_ = _zz_12_;
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_211_[0];
-  assign decode_ALU_CTRL = _zz_13_;
-  assign _zz_14_ = _zz_15_;
-  assign decode_IS_MUL = _zz_212_[0];
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_ALU_BITWISE_CTRL = _zz_16_;
-  assign _zz_17_ = _zz_18_;
-  assign decode_SRC1_CTRL = _zz_19_;
-  assign _zz_20_ = _zz_21_;
-  assign decode_IS_CSR = _zz_213_[0];
-  assign decode_IS_RS1_SIGNED = _zz_214_[0];
-  assign decode_MEMORY_STORE = _zz_215_[0];
-  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign decode_SRC2_CTRL = _zz_22_;
-  assign _zz_23_ = _zz_24_;
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_216_[0];
-  assign decode_IS_DIV = _zz_217_[0];
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_IS_RS2_SIGNED = _zz_218_[0];
+  assign memory_PC = execute_to_memory_PC;
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
@@ -2472,27 +2149,27 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_25_;
-  assign execute_ENV_CTRL = _zz_26_;
-  assign writeBack_ENV_CTRL = _zz_27_;
+  assign memory_ENV_CTRL = _zz_25;
+  assign execute_ENV_CTRL = _zz_26;
+  assign writeBack_ENV_CTRL = _zz_27;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_121_;
-  assign execute_BRANCH_CTRL = _zz_28_;
-  assign decode_RS2_USE = _zz_219_[0];
-  assign decode_RS1_USE = _zz_220_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_119;
+  assign execute_BRANCH_CTRL = _zz_28;
+  assign decode_RS2_USE = _zz_218[0];
+  assign decode_RS1_USE = _zz_219[0];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   always @ (*) begin
-    _zz_29_ = memory_REGFILE_WRITE_DATA;
-    if(_zz_171_)begin
-      _zz_29_ = ((memory_INSTRUCTION[13 : 12] == (2'b00)) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+    _zz_29 = memory_REGFILE_WRITE_DATA;
+    if(_zz_170)begin
+      _zz_29 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
     end
-    if(_zz_172_)begin
-      _zz_29_ = memory_MulDivIterativePlugin_div_result;
+    if(_zz_171)begin
+      _zz_29 = memory_MulDivIterativePlugin_div_result;
     end
   end
 
@@ -2502,29 +2179,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_110_)begin
-      if((_zz_111_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_112_;
+    if(_zz_108)begin
+      if((_zz_109 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_110;
       end
     end
-    if(_zz_173_)begin
-      if(_zz_174_)begin
-        if(_zz_114_)begin
-          decode_RS2 = _zz_47_;
+    if(_zz_172)begin
+      if(_zz_173)begin
+        if(_zz_112)begin
+          decode_RS2 = _zz_47;
         end
       end
     end
-    if(_zz_175_)begin
+    if(_zz_174)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116_)begin
-          decode_RS2 = _zz_29_;
+        if(_zz_114)begin
+          decode_RS2 = _zz_29;
         end
       end
     end
-    if(_zz_176_)begin
+    if(_zz_175)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118_)begin
-          decode_RS2 = _zz_30_;
+        if(_zz_116)begin
+          decode_RS2 = _zz_30;
         end
       end
     end
@@ -2532,190 +2209,163 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_110_)begin
-      if((_zz_111_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_112_;
+    if(_zz_108)begin
+      if((_zz_109 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_110;
       end
     end
-    if(_zz_173_)begin
-      if(_zz_174_)begin
-        if(_zz_113_)begin
-          decode_RS1 = _zz_47_;
+    if(_zz_172)begin
+      if(_zz_173)begin
+        if(_zz_111)begin
+          decode_RS1 = _zz_47;
         end
       end
     end
-    if(_zz_175_)begin
+    if(_zz_174)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_115_)begin
-          decode_RS1 = _zz_29_;
+        if(_zz_113)begin
+          decode_RS1 = _zz_29;
         end
       end
     end
-    if(_zz_176_)begin
+    if(_zz_175)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_117_)begin
-          decode_RS1 = _zz_30_;
+        if(_zz_115)begin
+          decode_RS1 = _zz_30;
         end
       end
     end
   end
 
   always @ (*) begin
-    _zz_30_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_177_)begin
-      _zz_30_ = _zz_107_;
+    _zz_30 = execute_REGFILE_WRITE_DATA;
+    if(_zz_176)begin
+      _zz_30 = _zz_105;
     end
-    if(_zz_178_)begin
-      _zz_30_ = execute_CsrPlugin_readData;
+    if(_zz_177)begin
+      _zz_30 = execute_CsrPlugin_readData;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_31_;
+  assign execute_SHIFT_CTRL = _zz_31;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_32_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_33_;
-  assign execute_SRC1_CTRL = _zz_34_;
-  assign decode_SRC_USE_SUB_LESS = _zz_221_[0];
-  assign decode_SRC_ADD_ZERO = _zz_222_[0];
+  assign _zz_32 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_33;
+  assign execute_SRC1_CTRL = _zz_34;
+  assign decode_SRC_USE_SUB_LESS = _zz_220[0];
+  assign decode_SRC_ADD_ZERO = _zz_221[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_35_;
-  assign execute_SRC2 = _zz_106_;
-  assign execute_SRC1 = _zz_101_;
-  assign execute_ALU_BITWISE_CTRL = _zz_36_;
-  assign _zz_37_ = writeBack_INSTRUCTION;
-  assign _zz_38_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_35;
+  assign execute_SRC2 = _zz_104;
+  assign execute_SRC1 = _zz_99;
+  assign execute_ALU_BITWISE_CTRL = _zz_36;
+  assign _zz_37 = writeBack_INSTRUCTION;
+  assign _zz_38 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_39_ = 1'b0;
+    _zz_39 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_39_ = 1'b1;
+      _zz_39 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_223_[0];
+    decode_REGFILE_WRITE_VALID = _zz_222[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_299_) == 32'h00001073),{(_zz_300_ == _zz_301_),{_zz_302_,{_zz_303_,_zz_304_}}}}}}} != 20'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_297) == 32'h00001073),{(_zz_298 == _zz_299),{_zz_300,{_zz_301,_zz_302}}}}}}} != 20'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @ (*) begin
-    _zz_47_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_47 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_47_ = writeBack_DBusSimplePlugin_rspFormated;
+      _zz_47 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_READ_DATA = memory_to_writeBack_MEMORY_READ_DATA;
-  assign memory_MMU_FAULT = execute_to_memory_MMU_FAULT;
-  assign memory_MMU_RSP_physicalAddress = execute_to_memory_MMU_RSP_physicalAddress;
-  assign memory_MMU_RSP_isIoAccess = execute_to_memory_MMU_RSP_isIoAccess;
-  assign memory_MMU_RSP_allowRead = execute_to_memory_MMU_RSP_allowRead;
-  assign memory_MMU_RSP_allowWrite = execute_to_memory_MMU_RSP_allowWrite;
-  assign memory_MMU_RSP_allowExecute = execute_to_memory_MMU_RSP_allowExecute;
-  assign memory_MMU_RSP_exception = execute_to_memory_MMU_RSP_exception;
-  assign memory_MMU_RSP_refilling = execute_to_memory_MMU_RSP_refilling;
-  assign memory_PC = execute_to_memory_PC;
   assign memory_ALIGNEMENT_FAULT = execute_to_memory_ALIGNEMENT_FAULT;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_STORE = execute_to_memory_MEMORY_STORE;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
-  assign execute_MMU_FAULT = ((execute_MMU_RSP_exception || ((! execute_MMU_RSP_allowWrite) && execute_MEMORY_STORE)) || ((! execute_MMU_RSP_allowRead) && (! execute_MEMORY_STORE)));
-  assign execute_MMU_RSP_physicalAddress = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  assign execute_MMU_RSP_isIoAccess = DBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  assign execute_MMU_RSP_allowRead = DBusSimplePlugin_mmuBus_rsp_allowRead;
-  assign execute_MMU_RSP_allowWrite = DBusSimplePlugin_mmuBus_rsp_allowWrite;
-  assign execute_MMU_RSP_allowExecute = DBusSimplePlugin_mmuBus_rsp_allowExecute;
-  assign execute_MMU_RSP_exception = DBusSimplePlugin_mmuBus_rsp_exception;
-  assign execute_MMU_RSP_refilling = DBusSimplePlugin_mmuBus_rsp_refilling;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
-  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == (2'b10)) && (dBus_cmd_payload_address[1 : 0] != (2'b00))) || ((dBus_cmd_payload_size == (2'b01)) && (dBus_cmd_payload_address[0 : 0] != (1'b0))));
-  assign decode_MEMORY_ENABLE = _zz_224_[0];
-  assign decode_FLUSH_ALL = _zz_225_[0];
+  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
+  assign decode_FLUSH_ALL = _zz_223[0];
   always @ (*) begin
-    _zz_48_ = _zz_48__2;
-    if(_zz_179_)begin
-      _zz_48_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_178)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_48__2 = _zz_48__1;
-    if(_zz_180_)begin
-      _zz_48__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_179)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_48__1 = _zz_48__0;
-    if(_zz_181_)begin
-      _zz_48__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_180)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_48__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_182_)begin
-      _zz_48__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_181)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_49_;
+  assign decode_BRANCH_CTRL = _zz_48;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_50_ = memory_FORMAL_PC_NEXT;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      _zz_50_ = DBusSimplePlugin_redoBranch_payload;
-    end
+    _zz_49 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_50_ = BranchPlugin_jumpInterface_payload;
+      _zz_49 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_51_ = decode_FORMAL_PC_NEXT;
+    _zz_50 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_51_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_50 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
   assign decode_PC = IBusCachedPlugin_iBusRsp_output_payload_pc;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
-    decode_arbitration_haltItself = 1'b0;
-    if(((DBusSimplePlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
-      decode_arbitration_haltItself = 1'b1;
-    end
-  end
-
+  assign decode_arbitration_haltItself = 1'b0;
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_108_ || _zz_109_)))begin
+    if((decode_arbitration_isValid && (_zz_106 || _zz_107)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_183_)begin
+    if(_zz_182)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -2729,24 +2379,22 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_183_)begin
+    if(_zz_182)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_78_)))begin
+    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_76)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_177_)begin
-      if(_zz_184_)begin
-        if(! execute_LightShifterPlugin_done) begin
-          execute_arbitration_haltItself = 1'b1;
-        end
+    if(_zz_176)begin
+      if((! execute_LightShifterPlugin_done))begin
+        execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_178_)begin
+    if(_zz_177)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2777,15 +2425,15 @@ module VexRiscv (
     if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
       memory_arbitration_haltItself = 1'b1;
     end
-    if(_zz_171_)begin
+    if(_zz_170)begin
       if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
         memory_arbitration_haltItself = 1'b1;
       end
-      if(_zz_185_)begin
+      if(_zz_183)begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_172_)begin
+    if(_zz_171)begin
       if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -2795,7 +2443,7 @@ module VexRiscv (
   assign memory_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_186_)begin
+    if(_zz_184)begin
       memory_arbitration_removeIt = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -2803,22 +2451,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
-    memory_arbitration_flushIt = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      memory_arbitration_flushIt = 1'b1;
-    end
-  end
-
+  assign memory_arbitration_flushIt = 1'b0;
   always @ (*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      memory_arbitration_flushNext = 1'b1;
-    end
     if(BranchPlugin_jumpInterface_valid)begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_186_)begin
+    if(_zz_184)begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
@@ -2835,10 +2474,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @ (*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_187_)begin
+    if(_zz_185)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_188_)begin
+    if(_zz_186)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2849,13 +2488,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_187_)begin
+    if(_zz_185)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_188_)begin
+    if(_zz_186)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2871,21 +2510,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_187_)begin
+    if(_zz_185)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_188_)begin
+    if(_zz_186)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_187_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_185)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_188_)begin
-      case(_zz_189_)
+    if(_zz_186)begin
+      case(_zz_187)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2898,14 +2537,13 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_52_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}}};
-  assign _zz_53_ = (_zz_52_ & (~ _zz_226_));
-  assign _zz_54_ = _zz_53_[3];
-  assign _zz_55_ = (_zz_53_[1] || _zz_54_);
-  assign _zz_56_ = (_zz_53_[2] || _zz_54_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_170_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,IBusCachedPlugin_predictionJumpInterface_valid}} != 3'b000);
+  assign _zz_51 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
+  assign _zz_52 = (_zz_51 & (~ _zz_224));
+  assign _zz_53 = _zz_52[1];
+  assign _zz_54 = _zz_52[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_169;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -2925,7 +2563,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_228_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_226);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -2965,44 +2603,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_57_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_57_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_57_);
+  assign _zz_55 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_55);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_55);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_58_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_58_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_58_);
+  assign _zz_56 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_56);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_56);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_48_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_59_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_59_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_59_);
+  assign _zz_57 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_57);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_57);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_60_;
-  assign _zz_60_ = ((1'b0 && (! _zz_61_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_61_ = _zz_62_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_61_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_58;
+  assign _zz_58 = ((1'b0 && (! _zz_59)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_59 = _zz_60;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_59;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_63_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_63_ = _zz_64_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_63_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_65_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_61)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_61 = _zz_62;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_61;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_63;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -3016,125 +2654,125 @@ module VexRiscv (
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_66_ = _zz_229_[11];
+  assign _zz_64 = _zz_227[11];
   always @ (*) begin
-    _zz_67_[18] = _zz_66_;
-    _zz_67_[17] = _zz_66_;
-    _zz_67_[16] = _zz_66_;
-    _zz_67_[15] = _zz_66_;
-    _zz_67_[14] = _zz_66_;
-    _zz_67_[13] = _zz_66_;
-    _zz_67_[12] = _zz_66_;
-    _zz_67_[11] = _zz_66_;
-    _zz_67_[10] = _zz_66_;
-    _zz_67_[9] = _zz_66_;
-    _zz_67_[8] = _zz_66_;
-    _zz_67_[7] = _zz_66_;
-    _zz_67_[6] = _zz_66_;
-    _zz_67_[5] = _zz_66_;
-    _zz_67_[4] = _zz_66_;
-    _zz_67_[3] = _zz_66_;
-    _zz_67_[2] = _zz_66_;
-    _zz_67_[1] = _zz_66_;
-    _zz_67_[0] = _zz_66_;
+    _zz_65[18] = _zz_64;
+    _zz_65[17] = _zz_64;
+    _zz_65[16] = _zz_64;
+    _zz_65[15] = _zz_64;
+    _zz_65[14] = _zz_64;
+    _zz_65[13] = _zz_64;
+    _zz_65[12] = _zz_64;
+    _zz_65[11] = _zz_64;
+    _zz_65[10] = _zz_64;
+    _zz_65[9] = _zz_64;
+    _zz_65[8] = _zz_64;
+    _zz_65[7] = _zz_64;
+    _zz_65[6] = _zz_64;
+    _zz_65[5] = _zz_64;
+    _zz_65[4] = _zz_64;
+    _zz_65[3] = _zz_64;
+    _zz_65[2] = _zz_64;
+    _zz_65[1] = _zz_64;
+    _zz_65[0] = _zz_64;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_230_[31]));
-    if(_zz_72_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_228[31]));
+    if(_zz_70)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_68_ = _zz_231_[19];
+  assign _zz_66 = _zz_229[19];
   always @ (*) begin
-    _zz_69_[10] = _zz_68_;
-    _zz_69_[9] = _zz_68_;
-    _zz_69_[8] = _zz_68_;
-    _zz_69_[7] = _zz_68_;
-    _zz_69_[6] = _zz_68_;
-    _zz_69_[5] = _zz_68_;
-    _zz_69_[4] = _zz_68_;
-    _zz_69_[3] = _zz_68_;
-    _zz_69_[2] = _zz_68_;
-    _zz_69_[1] = _zz_68_;
-    _zz_69_[0] = _zz_68_;
+    _zz_67[10] = _zz_66;
+    _zz_67[9] = _zz_66;
+    _zz_67[8] = _zz_66;
+    _zz_67[7] = _zz_66;
+    _zz_67[6] = _zz_66;
+    _zz_67[5] = _zz_66;
+    _zz_67[4] = _zz_66;
+    _zz_67[3] = _zz_66;
+    _zz_67[2] = _zz_66;
+    _zz_67[1] = _zz_66;
+    _zz_67[0] = _zz_66;
   end
 
-  assign _zz_70_ = _zz_232_[11];
+  assign _zz_68 = _zz_230[11];
   always @ (*) begin
-    _zz_71_[18] = _zz_70_;
-    _zz_71_[17] = _zz_70_;
-    _zz_71_[16] = _zz_70_;
-    _zz_71_[15] = _zz_70_;
-    _zz_71_[14] = _zz_70_;
-    _zz_71_[13] = _zz_70_;
-    _zz_71_[12] = _zz_70_;
-    _zz_71_[11] = _zz_70_;
-    _zz_71_[10] = _zz_70_;
-    _zz_71_[9] = _zz_70_;
-    _zz_71_[8] = _zz_70_;
-    _zz_71_[7] = _zz_70_;
-    _zz_71_[6] = _zz_70_;
-    _zz_71_[5] = _zz_70_;
-    _zz_71_[4] = _zz_70_;
-    _zz_71_[3] = _zz_70_;
-    _zz_71_[2] = _zz_70_;
-    _zz_71_[1] = _zz_70_;
-    _zz_71_[0] = _zz_70_;
+    _zz_69[18] = _zz_68;
+    _zz_69[17] = _zz_68;
+    _zz_69[16] = _zz_68;
+    _zz_69[15] = _zz_68;
+    _zz_69[14] = _zz_68;
+    _zz_69[13] = _zz_68;
+    _zz_69[12] = _zz_68;
+    _zz_69[11] = _zz_68;
+    _zz_69[10] = _zz_68;
+    _zz_69[9] = _zz_68;
+    _zz_69[8] = _zz_68;
+    _zz_69[7] = _zz_68;
+    _zz_69[6] = _zz_68;
+    _zz_69[5] = _zz_68;
+    _zz_69[4] = _zz_68;
+    _zz_69[3] = _zz_68;
+    _zz_69[2] = _zz_68;
+    _zz_69[1] = _zz_68;
+    _zz_69[0] = _zz_68;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_72_ = _zz_233_[1];
+        _zz_70 = _zz_231[1];
       end
       default : begin
-        _zz_72_ = _zz_234_[1];
+        _zz_70 = _zz_232[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_73_ = _zz_235_[19];
+  assign _zz_71 = _zz_233[19];
   always @ (*) begin
-    _zz_74_[10] = _zz_73_;
-    _zz_74_[9] = _zz_73_;
-    _zz_74_[8] = _zz_73_;
-    _zz_74_[7] = _zz_73_;
-    _zz_74_[6] = _zz_73_;
-    _zz_74_[5] = _zz_73_;
-    _zz_74_[4] = _zz_73_;
-    _zz_74_[3] = _zz_73_;
-    _zz_74_[2] = _zz_73_;
-    _zz_74_[1] = _zz_73_;
-    _zz_74_[0] = _zz_73_;
+    _zz_72[10] = _zz_71;
+    _zz_72[9] = _zz_71;
+    _zz_72[8] = _zz_71;
+    _zz_72[7] = _zz_71;
+    _zz_72[6] = _zz_71;
+    _zz_72[5] = _zz_71;
+    _zz_72[4] = _zz_71;
+    _zz_72[3] = _zz_71;
+    _zz_72[2] = _zz_71;
+    _zz_72[1] = _zz_71;
+    _zz_72[0] = _zz_71;
   end
 
-  assign _zz_75_ = _zz_236_[11];
+  assign _zz_73 = _zz_234[11];
   always @ (*) begin
-    _zz_76_[18] = _zz_75_;
-    _zz_76_[17] = _zz_75_;
-    _zz_76_[16] = _zz_75_;
-    _zz_76_[15] = _zz_75_;
-    _zz_76_[14] = _zz_75_;
-    _zz_76_[13] = _zz_75_;
-    _zz_76_[12] = _zz_75_;
-    _zz_76_[11] = _zz_75_;
-    _zz_76_[10] = _zz_75_;
-    _zz_76_[9] = _zz_75_;
-    _zz_76_[8] = _zz_75_;
-    _zz_76_[7] = _zz_75_;
-    _zz_76_[6] = _zz_75_;
-    _zz_76_[5] = _zz_75_;
-    _zz_76_[4] = _zz_75_;
-    _zz_76_[3] = _zz_75_;
-    _zz_76_[2] = _zz_75_;
-    _zz_76_[1] = _zz_75_;
-    _zz_76_[0] = _zz_75_;
+    _zz_74[18] = _zz_73;
+    _zz_74[17] = _zz_73;
+    _zz_74[16] = _zz_73;
+    _zz_74[15] = _zz_73;
+    _zz_74[14] = _zz_73;
+    _zz_74[13] = _zz_73;
+    _zz_74[12] = _zz_73;
+    _zz_74[11] = _zz_73;
+    _zz_74[10] = _zz_73;
+    _zz_74[9] = _zz_73;
+    _zz_74[8] = _zz_73;
+    _zz_74[7] = _zz_73;
+    _zz_74[6] = _zz_73;
+    _zz_74[5] = _zz_73;
+    _zz_74[4] = _zz_73;
+    _zz_74[3] = _zz_73;
+    _zz_74[2] = _zz_73;
+    _zz_74[1] = _zz_73;
+    _zz_74[0] = _zz_73;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_74_,{{{_zz_317_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_76_,{{{_zz_318_,_zz_319_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_72,{{{_zz_315,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_74,{{{_zz_316,_zz_317},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3143,157 +2781,128 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_161_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_162_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_163_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_164_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_165_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_166_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_159 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_160 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_161 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_160;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_163 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_164 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_165 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_182_)begin
+    if(_zz_181)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_180_)begin
+    if(_zz_179)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_167_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_180_)begin
-      _zz_167_ = 1'b1;
+    _zz_166 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_179)begin
+      _zz_166 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_181_)begin
+    if(_zz_180)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_179_)begin
+    if(_zz_178)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_181_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_180)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_179_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_178)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_160_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign _zz_78_ = 1'b0;
+  assign _zz_158 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_76 = 1'b0;
   always @ (*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
     if(execute_ALIGNEMENT_FAULT)begin
       execute_DBusSimplePlugin_skipCmd = 1'b1;
     end
-    if((execute_MMU_FAULT || execute_MMU_RSP_refilling))begin
-      execute_DBusSimplePlugin_skipCmd = 1'b1;
-    end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_78_));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_76));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_79_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_77 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_79_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_77 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_79_ = execute_RS2[31 : 0];
+        _zz_77 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_79_;
+  assign dBus_cmd_payload_data = _zz_77;
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_80_ = (4'b0001);
+        _zz_78 = 4'b0001;
       end
       2'b01 : begin
-        _zz_80_ = (4'b0011);
+        _zz_78 = 4'b0011;
       end
       default : begin
-        _zz_80_ = (4'b1111);
+        _zz_78 = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_80_ <<< dBus_cmd_payload_address[1 : 0]);
-  assign DBusSimplePlugin_mmuBus_cmd_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign DBusSimplePlugin_mmuBus_cmd_virtualAddress = execute_SRC_ADD;
-  assign DBusSimplePlugin_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign DBusSimplePlugin_mmuBus_end = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
-  assign dBus_cmd_payload_address = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
+  assign execute_DBusSimplePlugin_formalMask = (_zz_78 <<< dBus_cmd_payload_address[1 : 0]);
+  assign dBus_cmd_payload_address = execute_SRC_ADD;
   always @ (*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(_zz_190_)begin
+    if(_zz_188)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(memory_MMU_RSP_refilling)begin
-      DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    end else begin
-      if(memory_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
-      end
-    end
-    if(_zz_191_)begin
+    if((! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers)))))begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @ (*) begin
-    DBusSimplePlugin_memoryExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_190_)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = (4'b0101);
+    DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_188)begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_237_};
-    end
-    if(! memory_MMU_RSP_refilling) begin
-      if(memory_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? (4'b1111) : (4'b1101));
-      end
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_235};
     end
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  always @ (*) begin
-    DBusSimplePlugin_redoBranch_valid = 1'b0;
-    if(memory_MMU_RSP_refilling)begin
-      DBusSimplePlugin_redoBranch_valid = 1'b1;
-    end
-    if(_zz_191_)begin
-      DBusSimplePlugin_redoBranch_valid = 1'b0;
-    end
-  end
-
-  assign DBusSimplePlugin_redoBranch_payload = memory_PC;
   always @ (*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -3311,63 +2920,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_81_ = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_79 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_82_[31] = _zz_81_;
-    _zz_82_[30] = _zz_81_;
-    _zz_82_[29] = _zz_81_;
-    _zz_82_[28] = _zz_81_;
-    _zz_82_[27] = _zz_81_;
-    _zz_82_[26] = _zz_81_;
-    _zz_82_[25] = _zz_81_;
-    _zz_82_[24] = _zz_81_;
-    _zz_82_[23] = _zz_81_;
-    _zz_82_[22] = _zz_81_;
-    _zz_82_[21] = _zz_81_;
-    _zz_82_[20] = _zz_81_;
-    _zz_82_[19] = _zz_81_;
-    _zz_82_[18] = _zz_81_;
-    _zz_82_[17] = _zz_81_;
-    _zz_82_[16] = _zz_81_;
-    _zz_82_[15] = _zz_81_;
-    _zz_82_[14] = _zz_81_;
-    _zz_82_[13] = _zz_81_;
-    _zz_82_[12] = _zz_81_;
-    _zz_82_[11] = _zz_81_;
-    _zz_82_[10] = _zz_81_;
-    _zz_82_[9] = _zz_81_;
-    _zz_82_[8] = _zz_81_;
-    _zz_82_[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+    _zz_80[31] = _zz_79;
+    _zz_80[30] = _zz_79;
+    _zz_80[29] = _zz_79;
+    _zz_80[28] = _zz_79;
+    _zz_80[27] = _zz_79;
+    _zz_80[26] = _zz_79;
+    _zz_80[25] = _zz_79;
+    _zz_80[24] = _zz_79;
+    _zz_80[23] = _zz_79;
+    _zz_80[22] = _zz_79;
+    _zz_80[21] = _zz_79;
+    _zz_80[20] = _zz_79;
+    _zz_80[19] = _zz_79;
+    _zz_80[18] = _zz_79;
+    _zz_80[17] = _zz_79;
+    _zz_80[16] = _zz_79;
+    _zz_80[15] = _zz_79;
+    _zz_80[14] = _zz_79;
+    _zz_80[13] = _zz_79;
+    _zz_80[12] = _zz_79;
+    _zz_80[11] = _zz_79;
+    _zz_80[10] = _zz_79;
+    _zz_80[9] = _zz_79;
+    _zz_80[8] = _zz_79;
+    _zz_80[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_83_ = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_81 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_84_[31] = _zz_83_;
-    _zz_84_[30] = _zz_83_;
-    _zz_84_[29] = _zz_83_;
-    _zz_84_[28] = _zz_83_;
-    _zz_84_[27] = _zz_83_;
-    _zz_84_[26] = _zz_83_;
-    _zz_84_[25] = _zz_83_;
-    _zz_84_[24] = _zz_83_;
-    _zz_84_[23] = _zz_83_;
-    _zz_84_[22] = _zz_83_;
-    _zz_84_[21] = _zz_83_;
-    _zz_84_[20] = _zz_83_;
-    _zz_84_[19] = _zz_83_;
-    _zz_84_[18] = _zz_83_;
-    _zz_84_[17] = _zz_83_;
-    _zz_84_[16] = _zz_83_;
-    _zz_84_[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+    _zz_82[31] = _zz_81;
+    _zz_82[30] = _zz_81;
+    _zz_82[29] = _zz_81;
+    _zz_82[28] = _zz_81;
+    _zz_82[27] = _zz_81;
+    _zz_82[26] = _zz_81;
+    _zz_82[25] = _zz_81;
+    _zz_82[24] = _zz_81;
+    _zz_82[23] = _zz_81;
+    _zz_82[22] = _zz_81;
+    _zz_82[21] = _zz_81;
+    _zz_82[20] = _zz_81;
+    _zz_82[19] = _zz_81;
+    _zz_82[18] = _zz_81;
+    _zz_82[17] = _zz_81;
+    _zz_82[16] = _zz_81;
+    _zz_82[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_208_)
+    case(_zz_206)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_82_;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_80;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_84_;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_82;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -3375,59 +2984,64 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusSimplePlugin_mmuBus_rsp_physicalAddress = DBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  assign DBusSimplePlugin_mmuBus_rsp_allowRead = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_allowWrite = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_allowExecute = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_isIoAccess = DBusSimplePlugin_mmuBus_rsp_physicalAddress[31];
-  assign DBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
-  assign DBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
-  assign DBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign _zz_86_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_87_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_88_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_89_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_90_ = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
-  assign _zz_91_ = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
-  assign _zz_85_ = {({(_zz_320_ == _zz_321_),{_zz_322_,_zz_323_}} != (3'b000)),{({_zz_324_,_zz_325_} != (2'b00)),{({_zz_326_,_zz_327_} != (2'b00)),{(_zz_328_ != _zz_329_),{_zz_330_,{_zz_331_,_zz_332_}}}}}};
-  assign _zz_92_ = _zz_85_[2 : 1];
-  assign _zz_46_ = _zz_92_;
-  assign _zz_93_ = _zz_85_[5 : 4];
-  assign _zz_45_ = _zz_93_;
-  assign _zz_94_ = _zz_85_[8 : 7];
-  assign _zz_44_ = _zz_94_;
-  assign _zz_95_ = _zz_85_[11 : 10];
-  assign _zz_43_ = _zz_95_;
-  assign _zz_96_ = _zz_85_[16 : 15];
-  assign _zz_42_ = _zz_96_;
-  assign _zz_97_ = _zz_85_[21 : 20];
-  assign _zz_41_ = _zz_97_;
-  assign _zz_98_ = _zz_85_[24 : 23];
-  assign _zz_40_ = _zz_98_;
+  assign _zz_84 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_85 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_86 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_87 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_88 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
+  assign _zz_89 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
+  assign _zz_83 = {(((decode_INSTRUCTION & _zz_318) == 32'h02004020) != 1'b0),{({_zz_89,_zz_88} != 2'b00),{({_zz_319,_zz_320} != 3'b000),{(_zz_321 != _zz_322),{_zz_323,{_zz_324,_zz_325}}}}}};
+  assign _zz_90 = _zz_83[2 : 1];
+  assign _zz_46 = _zz_90;
+  assign _zz_91 = _zz_83[7 : 6];
+  assign _zz_45 = _zz_91;
+  assign _zz_92 = _zz_83[9 : 8];
+  assign _zz_44 = _zz_92;
+  assign _zz_93 = _zz_83[18 : 17];
+  assign _zz_43 = _zz_93;
+  assign _zz_94 = _zz_83[21 : 20];
+  assign _zz_42 = _zz_94;
+  assign _zz_95 = _zz_83[23 : 22];
+  assign _zz_41 = _zz_95;
+  assign _zz_96 = _zz_83[26 : 25];
+  assign _zz_40 = _zz_96;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_168_;
-  assign decode_RegFilePlugin_rs2Data = _zz_169_;
+  assign decode_RegFilePlugin_rs1Data = _zz_167;
+  assign decode_RegFilePlugin_rs2Data = _zz_168;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_38_ && writeBack_arbitration_isFiring);
-    if(_zz_99_)begin
+    lastStageRegFileWrite_valid = (_zz_38 && writeBack_arbitration_isFiring);
+    if(_zz_97)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_37_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_47_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_37[11 : 7];
+    if(_zz_97)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_47;
+    if(_zz_97)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -3445,13 +3059,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_100_ = execute_IntAluPlugin_bitwise;
+        _zz_98 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_100_ = {31'd0, _zz_238_};
+        _zz_98 = {31'd0, _zz_236};
       end
       default : begin
-        _zz_100_ = execute_SRC_ADD_SUB;
+        _zz_98 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -3459,87 +3073,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_101_ = execute_RS1;
+        _zz_99 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_101_ = {29'd0, _zz_239_};
+        _zz_99 = {29'd0, _zz_237};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_101_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_99 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_101_ = {27'd0, _zz_240_};
+        _zz_99 = {27'd0, _zz_238};
       end
     endcase
   end
 
-  assign _zz_102_ = _zz_241_[11];
+  assign _zz_100 = _zz_239[11];
   always @ (*) begin
-    _zz_103_[19] = _zz_102_;
-    _zz_103_[18] = _zz_102_;
-    _zz_103_[17] = _zz_102_;
-    _zz_103_[16] = _zz_102_;
-    _zz_103_[15] = _zz_102_;
-    _zz_103_[14] = _zz_102_;
-    _zz_103_[13] = _zz_102_;
-    _zz_103_[12] = _zz_102_;
-    _zz_103_[11] = _zz_102_;
-    _zz_103_[10] = _zz_102_;
-    _zz_103_[9] = _zz_102_;
-    _zz_103_[8] = _zz_102_;
-    _zz_103_[7] = _zz_102_;
-    _zz_103_[6] = _zz_102_;
-    _zz_103_[5] = _zz_102_;
-    _zz_103_[4] = _zz_102_;
-    _zz_103_[3] = _zz_102_;
-    _zz_103_[2] = _zz_102_;
-    _zz_103_[1] = _zz_102_;
-    _zz_103_[0] = _zz_102_;
+    _zz_101[19] = _zz_100;
+    _zz_101[18] = _zz_100;
+    _zz_101[17] = _zz_100;
+    _zz_101[16] = _zz_100;
+    _zz_101[15] = _zz_100;
+    _zz_101[14] = _zz_100;
+    _zz_101[13] = _zz_100;
+    _zz_101[12] = _zz_100;
+    _zz_101[11] = _zz_100;
+    _zz_101[10] = _zz_100;
+    _zz_101[9] = _zz_100;
+    _zz_101[8] = _zz_100;
+    _zz_101[7] = _zz_100;
+    _zz_101[6] = _zz_100;
+    _zz_101[5] = _zz_100;
+    _zz_101[4] = _zz_100;
+    _zz_101[3] = _zz_100;
+    _zz_101[2] = _zz_100;
+    _zz_101[1] = _zz_100;
+    _zz_101[0] = _zz_100;
   end
 
-  assign _zz_104_ = _zz_242_[11];
+  assign _zz_102 = _zz_240[11];
   always @ (*) begin
-    _zz_105_[19] = _zz_104_;
-    _zz_105_[18] = _zz_104_;
-    _zz_105_[17] = _zz_104_;
-    _zz_105_[16] = _zz_104_;
-    _zz_105_[15] = _zz_104_;
-    _zz_105_[14] = _zz_104_;
-    _zz_105_[13] = _zz_104_;
-    _zz_105_[12] = _zz_104_;
-    _zz_105_[11] = _zz_104_;
-    _zz_105_[10] = _zz_104_;
-    _zz_105_[9] = _zz_104_;
-    _zz_105_[8] = _zz_104_;
-    _zz_105_[7] = _zz_104_;
-    _zz_105_[6] = _zz_104_;
-    _zz_105_[5] = _zz_104_;
-    _zz_105_[4] = _zz_104_;
-    _zz_105_[3] = _zz_104_;
-    _zz_105_[2] = _zz_104_;
-    _zz_105_[1] = _zz_104_;
-    _zz_105_[0] = _zz_104_;
+    _zz_103[19] = _zz_102;
+    _zz_103[18] = _zz_102;
+    _zz_103[17] = _zz_102;
+    _zz_103[16] = _zz_102;
+    _zz_103[15] = _zz_102;
+    _zz_103[14] = _zz_102;
+    _zz_103[13] = _zz_102;
+    _zz_103[12] = _zz_102;
+    _zz_103[11] = _zz_102;
+    _zz_103[10] = _zz_102;
+    _zz_103[9] = _zz_102;
+    _zz_103[8] = _zz_102;
+    _zz_103[7] = _zz_102;
+    _zz_103[6] = _zz_102;
+    _zz_103[5] = _zz_102;
+    _zz_103[4] = _zz_102;
+    _zz_103[3] = _zz_102;
+    _zz_103[2] = _zz_102;
+    _zz_103[1] = _zz_102;
+    _zz_103[0] = _zz_102;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_106_ = execute_RS2;
+        _zz_104 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_106_ = {_zz_103_,execute_INSTRUCTION[31 : 20]};
+        _zz_104 = {_zz_101,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_106_ = {_zz_105_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_104 = {_zz_103,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_106_ = _zz_32_;
+        _zz_104 = _zz_32;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_243_;
+    execute_SrcPlugin_addSub = _zz_241;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -3549,188 +3163,188 @@ module VexRiscv (
   assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
-  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == (4'b0000));
+  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
   always @ (*) begin
     case(execute_SHIFT_CTRL)
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_107_ = (execute_LightShifterPlugin_shiftInput <<< 1);
+        _zz_105 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_107_ = _zz_250_;
+        _zz_105 = _zz_248;
       end
     endcase
   end
 
   always @ (*) begin
-    _zz_108_ = 1'b0;
-    if(_zz_192_)begin
-      if(_zz_193_)begin
-        if(_zz_113_)begin
-          _zz_108_ = 1'b1;
+    _zz_106 = 1'b0;
+    if(_zz_189)begin
+      if(_zz_190)begin
+        if(_zz_111)begin
+          _zz_106 = 1'b1;
         end
       end
     end
-    if(_zz_194_)begin
-      if(_zz_195_)begin
-        if(_zz_115_)begin
-          _zz_108_ = 1'b1;
+    if(_zz_191)begin
+      if(_zz_192)begin
+        if(_zz_113)begin
+          _zz_106 = 1'b1;
         end
       end
     end
-    if(_zz_196_)begin
-      if(_zz_197_)begin
-        if(_zz_117_)begin
-          _zz_108_ = 1'b1;
+    if(_zz_193)begin
+      if(_zz_194)begin
+        if(_zz_115)begin
+          _zz_106 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_108_ = 1'b0;
+      _zz_106 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_109_ = 1'b0;
-    if(_zz_192_)begin
-      if(_zz_193_)begin
-        if(_zz_114_)begin
-          _zz_109_ = 1'b1;
+    _zz_107 = 1'b0;
+    if(_zz_189)begin
+      if(_zz_190)begin
+        if(_zz_112)begin
+          _zz_107 = 1'b1;
         end
       end
     end
-    if(_zz_194_)begin
-      if(_zz_195_)begin
-        if(_zz_116_)begin
-          _zz_109_ = 1'b1;
+    if(_zz_191)begin
+      if(_zz_192)begin
+        if(_zz_114)begin
+          _zz_107 = 1'b1;
         end
       end
     end
-    if(_zz_196_)begin
-      if(_zz_197_)begin
-        if(_zz_118_)begin
-          _zz_109_ = 1'b1;
+    if(_zz_193)begin
+      if(_zz_194)begin
+        if(_zz_116)begin
+          _zz_107 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_109_ = 1'b0;
+      _zz_107 = 1'b0;
     end
   end
 
-  assign _zz_113_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_114_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_115_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_116_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_117_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_118_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_111 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_112 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_113 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_114 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_115 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_116 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_119_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_117 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_119_ == (3'b000))) begin
-        _zz_120_ = execute_BranchPlugin_eq;
-    end else if((_zz_119_ == (3'b001))) begin
-        _zz_120_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_119_ & (3'b101)) == (3'b101)))) begin
-        _zz_120_ = (! execute_SRC_LESS);
+    if((_zz_117 == 3'b000)) begin
+        _zz_118 = execute_BranchPlugin_eq;
+    end else if((_zz_117 == 3'b001)) begin
+        _zz_118 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_117 & 3'b101) == 3'b101))) begin
+        _zz_118 = (! execute_SRC_LESS);
     end else begin
-        _zz_120_ = execute_SRC_LESS;
+        _zz_118 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_121_ = 1'b0;
+        _zz_119 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_121_ = 1'b1;
+        _zz_119 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_121_ = 1'b1;
+        _zz_119 = 1'b1;
       end
       default : begin
-        _zz_121_ = _zz_120_;
+        _zz_119 = _zz_118;
       end
     endcase
   end
 
-  assign _zz_122_ = _zz_252_[11];
+  assign _zz_120 = _zz_250[11];
   always @ (*) begin
-    _zz_123_[19] = _zz_122_;
-    _zz_123_[18] = _zz_122_;
-    _zz_123_[17] = _zz_122_;
-    _zz_123_[16] = _zz_122_;
-    _zz_123_[15] = _zz_122_;
-    _zz_123_[14] = _zz_122_;
-    _zz_123_[13] = _zz_122_;
-    _zz_123_[12] = _zz_122_;
-    _zz_123_[11] = _zz_122_;
-    _zz_123_[10] = _zz_122_;
-    _zz_123_[9] = _zz_122_;
-    _zz_123_[8] = _zz_122_;
-    _zz_123_[7] = _zz_122_;
-    _zz_123_[6] = _zz_122_;
-    _zz_123_[5] = _zz_122_;
-    _zz_123_[4] = _zz_122_;
-    _zz_123_[3] = _zz_122_;
-    _zz_123_[2] = _zz_122_;
-    _zz_123_[1] = _zz_122_;
-    _zz_123_[0] = _zz_122_;
+    _zz_121[19] = _zz_120;
+    _zz_121[18] = _zz_120;
+    _zz_121[17] = _zz_120;
+    _zz_121[16] = _zz_120;
+    _zz_121[15] = _zz_120;
+    _zz_121[14] = _zz_120;
+    _zz_121[13] = _zz_120;
+    _zz_121[12] = _zz_120;
+    _zz_121[11] = _zz_120;
+    _zz_121[10] = _zz_120;
+    _zz_121[9] = _zz_120;
+    _zz_121[8] = _zz_120;
+    _zz_121[7] = _zz_120;
+    _zz_121[6] = _zz_120;
+    _zz_121[5] = _zz_120;
+    _zz_121[4] = _zz_120;
+    _zz_121[3] = _zz_120;
+    _zz_121[2] = _zz_120;
+    _zz_121[1] = _zz_120;
+    _zz_121[0] = _zz_120;
   end
 
-  assign _zz_124_ = _zz_253_[19];
+  assign _zz_122 = _zz_251[19];
   always @ (*) begin
-    _zz_125_[10] = _zz_124_;
-    _zz_125_[9] = _zz_124_;
-    _zz_125_[8] = _zz_124_;
-    _zz_125_[7] = _zz_124_;
-    _zz_125_[6] = _zz_124_;
-    _zz_125_[5] = _zz_124_;
-    _zz_125_[4] = _zz_124_;
-    _zz_125_[3] = _zz_124_;
-    _zz_125_[2] = _zz_124_;
-    _zz_125_[1] = _zz_124_;
-    _zz_125_[0] = _zz_124_;
+    _zz_123[10] = _zz_122;
+    _zz_123[9] = _zz_122;
+    _zz_123[8] = _zz_122;
+    _zz_123[7] = _zz_122;
+    _zz_123[6] = _zz_122;
+    _zz_123[5] = _zz_122;
+    _zz_123[4] = _zz_122;
+    _zz_123[3] = _zz_122;
+    _zz_123[2] = _zz_122;
+    _zz_123[1] = _zz_122;
+    _zz_123[0] = _zz_122;
   end
 
-  assign _zz_126_ = _zz_254_[11];
+  assign _zz_124 = _zz_252[11];
   always @ (*) begin
-    _zz_127_[18] = _zz_126_;
-    _zz_127_[17] = _zz_126_;
-    _zz_127_[16] = _zz_126_;
-    _zz_127_[15] = _zz_126_;
-    _zz_127_[14] = _zz_126_;
-    _zz_127_[13] = _zz_126_;
-    _zz_127_[12] = _zz_126_;
-    _zz_127_[11] = _zz_126_;
-    _zz_127_[10] = _zz_126_;
-    _zz_127_[9] = _zz_126_;
-    _zz_127_[8] = _zz_126_;
-    _zz_127_[7] = _zz_126_;
-    _zz_127_[6] = _zz_126_;
-    _zz_127_[5] = _zz_126_;
-    _zz_127_[4] = _zz_126_;
-    _zz_127_[3] = _zz_126_;
-    _zz_127_[2] = _zz_126_;
-    _zz_127_[1] = _zz_126_;
-    _zz_127_[0] = _zz_126_;
+    _zz_125[18] = _zz_124;
+    _zz_125[17] = _zz_124;
+    _zz_125[16] = _zz_124;
+    _zz_125[15] = _zz_124;
+    _zz_125[14] = _zz_124;
+    _zz_125[13] = _zz_124;
+    _zz_125[12] = _zz_124;
+    _zz_125[11] = _zz_124;
+    _zz_125[10] = _zz_124;
+    _zz_125[9] = _zz_124;
+    _zz_125[8] = _zz_124;
+    _zz_125[7] = _zz_124;
+    _zz_125[6] = _zz_124;
+    _zz_125[5] = _zz_124;
+    _zz_125[4] = _zz_124;
+    _zz_125[3] = _zz_124;
+    _zz_125[2] = _zz_124;
+    _zz_125[1] = _zz_124;
+    _zz_125[0] = _zz_124;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_128_ = (_zz_255_[1] ^ execute_RS1[1]);
+        _zz_126 = (_zz_253[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_128_ = _zz_256_[1];
+        _zz_126 = _zz_254[1];
       end
       default : begin
-        _zz_128_ = _zz_257_[1];
+        _zz_126 = _zz_255[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_128_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_126);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -3742,110 +3356,110 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_129_ = _zz_258_[11];
+  assign _zz_127 = _zz_256[11];
   always @ (*) begin
-    _zz_130_[19] = _zz_129_;
-    _zz_130_[18] = _zz_129_;
-    _zz_130_[17] = _zz_129_;
-    _zz_130_[16] = _zz_129_;
-    _zz_130_[15] = _zz_129_;
-    _zz_130_[14] = _zz_129_;
-    _zz_130_[13] = _zz_129_;
-    _zz_130_[12] = _zz_129_;
-    _zz_130_[11] = _zz_129_;
-    _zz_130_[10] = _zz_129_;
-    _zz_130_[9] = _zz_129_;
-    _zz_130_[8] = _zz_129_;
-    _zz_130_[7] = _zz_129_;
-    _zz_130_[6] = _zz_129_;
-    _zz_130_[5] = _zz_129_;
-    _zz_130_[4] = _zz_129_;
-    _zz_130_[3] = _zz_129_;
-    _zz_130_[2] = _zz_129_;
-    _zz_130_[1] = _zz_129_;
-    _zz_130_[0] = _zz_129_;
+    _zz_128[19] = _zz_127;
+    _zz_128[18] = _zz_127;
+    _zz_128[17] = _zz_127;
+    _zz_128[16] = _zz_127;
+    _zz_128[15] = _zz_127;
+    _zz_128[14] = _zz_127;
+    _zz_128[13] = _zz_127;
+    _zz_128[12] = _zz_127;
+    _zz_128[11] = _zz_127;
+    _zz_128[10] = _zz_127;
+    _zz_128[9] = _zz_127;
+    _zz_128[8] = _zz_127;
+    _zz_128[7] = _zz_127;
+    _zz_128[6] = _zz_127;
+    _zz_128[5] = _zz_127;
+    _zz_128[4] = _zz_127;
+    _zz_128[3] = _zz_127;
+    _zz_128[2] = _zz_127;
+    _zz_128[1] = _zz_127;
+    _zz_128[0] = _zz_127;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_130_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_128,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_132_,{{{_zz_464_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_134_,{{{_zz_465_,_zz_466_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_130,{{{_zz_469,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_132,{{{_zz_470,_zz_471},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_261_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_259};
         end
       end
     endcase
   end
 
-  assign _zz_131_ = _zz_259_[19];
+  assign _zz_129 = _zz_257[19];
   always @ (*) begin
-    _zz_132_[10] = _zz_131_;
-    _zz_132_[9] = _zz_131_;
-    _zz_132_[8] = _zz_131_;
-    _zz_132_[7] = _zz_131_;
-    _zz_132_[6] = _zz_131_;
-    _zz_132_[5] = _zz_131_;
-    _zz_132_[4] = _zz_131_;
-    _zz_132_[3] = _zz_131_;
-    _zz_132_[2] = _zz_131_;
-    _zz_132_[1] = _zz_131_;
-    _zz_132_[0] = _zz_131_;
+    _zz_130[10] = _zz_129;
+    _zz_130[9] = _zz_129;
+    _zz_130[8] = _zz_129;
+    _zz_130[7] = _zz_129;
+    _zz_130[6] = _zz_129;
+    _zz_130[5] = _zz_129;
+    _zz_130[4] = _zz_129;
+    _zz_130[3] = _zz_129;
+    _zz_130[2] = _zz_129;
+    _zz_130[1] = _zz_129;
+    _zz_130[0] = _zz_129;
   end
 
-  assign _zz_133_ = _zz_260_[11];
+  assign _zz_131 = _zz_258[11];
   always @ (*) begin
-    _zz_134_[18] = _zz_133_;
-    _zz_134_[17] = _zz_133_;
-    _zz_134_[16] = _zz_133_;
-    _zz_134_[15] = _zz_133_;
-    _zz_134_[14] = _zz_133_;
-    _zz_134_[13] = _zz_133_;
-    _zz_134_[12] = _zz_133_;
-    _zz_134_[11] = _zz_133_;
-    _zz_134_[10] = _zz_133_;
-    _zz_134_[9] = _zz_133_;
-    _zz_134_[8] = _zz_133_;
-    _zz_134_[7] = _zz_133_;
-    _zz_134_[6] = _zz_133_;
-    _zz_134_[5] = _zz_133_;
-    _zz_134_[4] = _zz_133_;
-    _zz_134_[3] = _zz_133_;
-    _zz_134_[2] = _zz_133_;
-    _zz_134_[1] = _zz_133_;
-    _zz_134_[0] = _zz_133_;
+    _zz_132[18] = _zz_131;
+    _zz_132[17] = _zz_131;
+    _zz_132[16] = _zz_131;
+    _zz_132[15] = _zz_131;
+    _zz_132[14] = _zz_131;
+    _zz_132[13] = _zz_131;
+    _zz_132[12] = _zz_131;
+    _zz_132[11] = _zz_131;
+    _zz_132[10] = _zz_131;
+    _zz_132[9] = _zz_131;
+    _zz_132[8] = _zz_131;
+    _zz_132[7] = _zz_131;
+    _zz_132[6] = _zz_131;
+    _zz_132[5] = _zz_131;
+    _zz_132[4] = _zz_131;
+    _zz_132[3] = _zz_131;
+    _zz_132[2] = _zz_131;
+    _zz_132[1] = _zz_131;
+    _zz_132[0] = _zz_131;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_135_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_136_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_137_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_133 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_134 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_135 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_138_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_139_ = _zz_262_[0];
-  assign _zz_140_ = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_141_ = _zz_264_[0];
+  assign _zz_136 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_137 = _zz_260[0];
+  assign _zz_138 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_139 = _zz_262[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_183_)begin
+    if(_zz_182)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3865,7 +3479,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_186_)begin
+    if(_zz_184)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -3889,7 +3503,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -3913,7 +3527,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -3935,7 +3549,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768)begin
@@ -3973,7 +3587,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_198_)begin
+    if(_zz_195)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -3992,20 +3606,20 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_199_)begin
+    if(_zz_196)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_199_)begin
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_196)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -4014,14 +3628,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_198_)begin
+    if(_zz_195)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_198_)begin
+    if(_zz_195)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4030,7 +3644,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_209_)
+    case(_zz_207)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -4044,8 +3658,8 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_171_)begin
-      if(_zz_185_)begin
+    if(_zz_170)begin
+      if(_zz_183)begin
         memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
       end
     end
@@ -4064,7 +3678,7 @@ module VexRiscv (
     if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_267_);
+      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_265);
     end
     if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
@@ -4073,8 +3687,8 @@ module VexRiscv (
 
   always @ (*) begin
     memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_172_)begin
-      if(_zz_200_)begin
+    if(_zz_171)begin
+      if(_zz_197)begin
         memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -4082,7 +3696,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_MulDivIterativePlugin_div_counter_willClear = 1'b0;
-    if(_zz_201_)begin
+    if(_zz_198)begin
       memory_MulDivIterativePlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -4093,57 +3707,57 @@ module VexRiscv (
     if(memory_MulDivIterativePlugin_div_counter_willOverflow)begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_275_);
+      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_273);
     end
     if(memory_MulDivIterativePlugin_div_counter_willClear)begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_142_ = memory_MulDivIterativePlugin_rs1[31 : 0];
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_142_[31]};
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_276_);
-  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_277_ : _zz_278_);
-  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_279_[31:0];
-  assign _zz_143_ = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
-  assign _zz_144_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_145_ = ((execute_IS_MUL && _zz_144_) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_140 = memory_MulDivIterativePlugin_rs1[31 : 0];
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_140[31]};
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_274);
+  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_275 : _zz_276);
+  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_277[31:0];
+  assign _zz_141 = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
+  assign _zz_142 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_143 = ((execute_IS_MUL && _zz_142) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_146_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_146_[31 : 0] = execute_RS1;
+    _zz_144[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_144[31 : 0] = execute_RS1;
   end
 
-  assign _zz_148_ = (_zz_147_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_148_ != 32'h0);
-  assign _zz_24_ = decode_SRC2_CTRL;
-  assign _zz_22_ = _zz_40_;
-  assign _zz_33_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_21_ = decode_SRC1_CTRL;
-  assign _zz_19_ = _zz_41_;
-  assign _zz_34_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_18_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_16_ = _zz_42_;
-  assign _zz_36_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_15_ = decode_ALU_CTRL;
-  assign _zz_13_ = _zz_46_;
-  assign _zz_35_ = decode_to_execute_ALU_CTRL;
-  assign _zz_12_ = decode_SHIFT_CTRL;
-  assign _zz_10_ = _zz_43_;
-  assign _zz_31_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_9_ = decode_ENV_CTRL;
-  assign _zz_6_ = execute_ENV_CTRL;
-  assign _zz_4_ = memory_ENV_CTRL;
-  assign _zz_7_ = _zz_45_;
-  assign _zz_26_ = decode_to_execute_ENV_CTRL;
-  assign _zz_25_ = execute_to_memory_ENV_CTRL;
-  assign _zz_27_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_2_ = decode_BRANCH_CTRL;
-  assign _zz_49_ = _zz_44_;
-  assign _zz_28_ = decode_to_execute_BRANCH_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_146 = (_zz_145 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_146 != 32'h0);
+  assign _zz_24 = decode_SRC1_CTRL;
+  assign _zz_22 = _zz_46;
+  assign _zz_34 = decode_to_execute_SRC1_CTRL;
+  assign _zz_21 = decode_ALU_CTRL;
+  assign _zz_19 = _zz_45;
+  assign _zz_35 = decode_to_execute_ALU_CTRL;
+  assign _zz_18 = decode_SRC2_CTRL;
+  assign _zz_16 = _zz_44;
+  assign _zz_33 = decode_to_execute_SRC2_CTRL;
+  assign _zz_15 = decode_ALU_BITWISE_CTRL;
+  assign _zz_13 = _zz_43;
+  assign _zz_36 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_12 = decode_SHIFT_CTRL;
+  assign _zz_10 = _zz_42;
+  assign _zz_31 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_48 = _zz_41;
+  assign _zz_28 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_40;
+  assign _zz_26 = decode_to_execute_ENV_CTRL;
+  assign _zz_25 = execute_to_memory_ENV_CTRL;
+  assign _zz_27 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -4161,91 +3775,91 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_149_ = 32'h0;
+    _zz_147 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_149_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_149_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_149_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_147[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_147[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_147[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_150_ = 32'h0;
+    _zz_148 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_150_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_150_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_150_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_148[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_148[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_148[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_151_ = 32'h0;
+    _zz_149 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_151_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_151_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_151_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_149[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_149[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_149[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_152_ = 32'h0;
+    _zz_150 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_152_[31 : 0] = CsrPlugin_mepc;
+      _zz_150[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_153_ = 32'h0;
+    _zz_151 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_153_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_153_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_151[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_151[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_154_ = 32'h0;
+    _zz_152 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_154_[31 : 0] = CsrPlugin_mtval;
+      _zz_152[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_155_ = 32'h0;
+    _zz_153 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_155_[31 : 0] = _zz_147_;
+      _zz_153[31 : 0] = _zz_145;
     end
   end
 
   always @ (*) begin
-    _zz_156_ = 32'h0;
+    _zz_154 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_156_[31 : 0] = _zz_148_;
+      _zz_154[31 : 0] = _zz_146;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((_zz_149_ | _zz_150_) | (_zz_151_ | _zz_152_)) | ((_zz_153_ | _zz_154_) | (_zz_155_ | _zz_156_)));
-  assign iBusWishbone_ADR = {_zz_295_,_zz_157_};
-  assign iBusWishbone_CTI = ((_zz_157_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((_zz_147 | _zz_148) | (_zz_149 | _zz_150)) | ((_zz_151 | _zz_152) | (_zz_153 | _zz_154)));
+  assign iBusWishbone_ADR = {_zz_293,_zz_155};
+  assign iBusWishbone_CTI = ((_zz_155 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_202_)begin
+    if(_zz_199)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_202_)begin
+    if(_zz_199)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_158_;
+  assign iBus_rsp_valid = _zz_156;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
@@ -4255,26 +3869,26 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_halfPipe_regs_payload_size;
   assign dBus_cmd_ready = dBus_cmd_halfPipe_regs_ready;
   assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
-  assign dBusWishbone_CTI = (3'b000);
-  assign dBusWishbone_BTE = (2'b00);
+  assign dBusWishbone_CTI = 3'b000;
+  assign dBusWishbone_BTE = 2'b00;
   always @ (*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_159_ = (4'b0001);
+        _zz_157 = 4'b0001;
       end
       2'b01 : begin
-        _zz_159_ = (4'b0011);
+        _zz_157 = 4'b0011;
       end
       default : begin
-        _zz_159_ = (4'b1111);
+        _zz_157 = 4'b1111;
       end
     endcase
   end
 
   always @ (*) begin
-    dBusWishbone_SEL = (_zz_159_ <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    dBusWishbone_SEL = (_zz_157 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
     if((! dBus_cmd_halfPipe_payload_wr))begin
-      dBusWishbone_SEL = (4'b1111);
+      dBusWishbone_SEL = 4'b1111;
     end
   end
 
@@ -4292,21 +3906,21 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_62_ <= 1'b0;
-      _zz_64_ <= 1'b0;
+      _zz_60 <= 1'b0;
+      _zz_62 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_77_;
+      IBusCachedPlugin_rspCounter <= _zz_75;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_99_ <= 1'b1;
+      _zz_97 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_110_ <= 1'b0;
+      _zz_108 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -4322,14 +3936,12 @@ module VexRiscv (
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
       memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_147_ <= 32'h0;
+      _zz_145 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_157_ <= (3'b000);
-      _zz_158_ <= 1'b0;
+      _zz_155 <= 3'b000;
+      _zz_156 <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
@@ -4353,16 +3965,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_62_ <= 1'b0;
+        _zz_60 <= 1'b0;
       end
-      if(_zz_60_)begin
-        _zz_62_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_58)begin
+        _zz_60 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_64_ <= 1'b0;
+        _zz_62 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_64_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_62 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -4409,9 +4021,29 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_99_ <= 1'b0;
-      if(_zz_177_)begin
-        if(_zz_184_)begin
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
+        `else
+          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
+        `else
+          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      _zz_97 <= 1'b0;
+      if(_zz_176)begin
+        if(_zz_200)begin
           execute_LightShifterPlugin_isActive <= 1'b1;
           if(execute_LightShifterPlugin_done)begin
             execute_LightShifterPlugin_isActive <= 1'b0;
@@ -4421,7 +4053,7 @@ module VexRiscv (
       if(execute_arbitration_removeIt)begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_110_ <= (_zz_38_ && writeBack_arbitration_isFiring);
+      _zz_108 <= (_zz_38 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -4443,14 +4075,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_203_)begin
-        if(_zz_204_)begin
+      if(_zz_201)begin
+        if(_zz_202)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_205_)begin
+        if(_zz_203)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_206_)begin
+        if(_zz_204)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -4474,7 +4106,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_187_)begin
+      if(_zz_185)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4485,10 +4117,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_188_)begin
-        case(_zz_189_)
+      if(_zz_186)begin
+        case(_zz_187)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -4496,15 +4128,9 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_137_,{_zz_136_,_zz_135_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_135,{_zz_134,_zz_133}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_29_;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -4526,29 +4152,29 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_289_[0];
-          CsrPlugin_mstatus_MIE <= _zz_290_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_287[0];
+          CsrPlugin_mstatus_MIE <= _zz_288[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_292_[0];
-          CsrPlugin_mie_MTIE <= _zz_293_[0];
-          CsrPlugin_mie_MSIE <= _zz_294_[0];
+          CsrPlugin_mie_MEIE <= _zz_290[0];
+          CsrPlugin_mie_MTIE <= _zz_291[0];
+          CsrPlugin_mie_MSIE <= _zz_292[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_147_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_145 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_202_)begin
+      if(_zz_199)begin
         if(iBusWishbone_ACK)begin
-          _zz_157_ <= (_zz_157_ + (3'b001));
+          _zz_155 <= (_zz_155 + 3'b001);
         end
       end
-      _zz_158_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if(_zz_207_)begin
+      _zz_156 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(_zz_205)begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -4560,7 +4186,7 @@ module VexRiscv (
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_65_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_63 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -4568,33 +4194,13 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)))
-      `else
-        if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
-          $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
-          $finish;
-        end
-      `endif
-    `endif
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)))
-      `else
-        if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
-          $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
-          $finish;
-        end
-      `endif
-    `endif
-    if(_zz_177_)begin
-      if(_zz_184_)begin
+    if(_zz_176)begin
+      if(_zz_200)begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_111_ <= _zz_37_[11 : 7];
-    _zz_112_ <= _zz_47_;
+    _zz_109 <= _zz_37[11 : 7];
+    _zz_110 <= _zz_47;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -4602,33 +4208,33 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_183_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_182)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_137 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_137 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_186_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_141_ ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_141_ ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
+    if(_zz_184)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(_zz_203_)begin
-      if(_zz_204_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_201)begin
+      if(_zz_202)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_205_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_203)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_206_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_204)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_187_)begin
+    if(_zz_185)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -4642,10 +4248,10 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_171_)begin
-      if(_zz_185_)begin
+    if(_zz_170)begin
+      if(_zz_183)begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_268_,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_266,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
       end
     end
     if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
@@ -4654,24 +4260,54 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_MulDivIterativePlugin_div_done <= 1'b0;
     end
-    if(_zz_172_)begin
-      if(_zz_200_)begin
+    if(_zz_171)begin
+      if(_zz_197)begin
         memory_MulDivIterativePlugin_rs1[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outNumerator;
         memory_MulDivIterativePlugin_accumulator[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outRemainder;
         if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
-          memory_MulDivIterativePlugin_div_result <= _zz_280_[31:0];
+          memory_MulDivIterativePlugin_div_result <= _zz_278[31:0];
         end
       end
     end
-    if(_zz_201_)begin
+    if(_zz_198)begin
       memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_145_ ? (~ _zz_146_) : _zz_146_) + _zz_286_);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_144_ ? (~ execute_RS2) : execute_RS2) + _zz_288_);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_145_ ^ (_zz_144_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_143 ? (~ _zz_144) : _zz_144) + _zz_284);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_142 ? (~ execute_RS2) : execute_RS2) + _zz_286);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_143 ^ (_zz_142 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+      decode_to_execute_PC <= decode_PC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_PC <= _zz_32;
+    end
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_50;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_49;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_23;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -4683,25 +4319,10 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+      decode_to_execute_ALU_CTRL <= _zz_20;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_23_;
+      decode_to_execute_SRC2_CTRL <= _zz_17;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
@@ -4712,14 +4333,14 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MMU_FAULT <= execute_MMU_FAULT;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
@@ -4731,25 +4352,28 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_14;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_11;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_20_;
+      decode_to_execute_ENV_CTRL <= _zz_6;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_17_;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_MUL <= decode_IS_MUL;
@@ -4758,40 +4382,37 @@ module VexRiscv (
       execute_to_memory_IS_MUL <= execute_IS_MUL;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_14_;
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_11_;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_51_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_50_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30_;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
@@ -4799,41 +4420,20 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
+    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_32_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_29;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_8_;
-    end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_5_;
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_3_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MMU_RSP_physicalAddress <= execute_MMU_RSP_physicalAddress;
-      execute_to_memory_MMU_RSP_isIoAccess <= execute_MMU_RSP_isIoAccess;
-      execute_to_memory_MMU_RSP_allowRead <= execute_MMU_RSP_allowRead;
-      execute_to_memory_MMU_RSP_allowWrite <= execute_MMU_RSP_allowWrite;
-      execute_to_memory_MMU_RSP_allowExecute <= execute_MMU_RSP_allowExecute;
-      execute_to_memory_MMU_RSP_exception <= execute_MMU_RSP_exception;
-      execute_to_memory_MMU_RSP_refilling <= execute_MMU_RSP_refilling;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_1_;
+      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
@@ -4864,7 +4464,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_291_[0];
+        CsrPlugin_mip_MSIP <= _zz_289[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -4879,11 +4479,296 @@ module VexRiscv (
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    if(_zz_207_)begin
+    if(_zz_205)begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
       dBus_cmd_halfPipe_regs_payload_size <= dBus_cmd_payload_size;
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_9;
+  reg        [22:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [22:0]   _zz_15;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [6:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [5:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [20:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [8:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [8:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [5:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [22:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+
+  assign _zz_11 = (! lineLoader_flushCounter[6]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_9 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_10 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_11)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[6]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[6] ? lineLoader_address[10 : 5] : lineLoader_flushCounter[5 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[6];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 11];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[10 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[10 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[22 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_12)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_11)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[6];
+    if(_zz_12)begin
+      lineLoader_flushCounter <= 7'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_LiteDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_LiteDebug.v
@@ -1,34 +1,12 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:38:04
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
-
-`define Src2CtrlEnum_defaultEncoding_type [1:0]
-`define Src2CtrlEnum_defaultEncoding_RS 2'b00
-`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
-`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
-`define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
 `define EnvCtrlEnum_defaultEncoding_XRET 2'b01
 `define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
-
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
-
-`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
-
-`define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
 `define BranchCtrlEnum_defaultEncoding_type [1:0]
 `define BranchCtrlEnum_defaultEncoding_INC 2'b00
@@ -36,307 +14,34 @@
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
+`define ShiftCtrlEnum_defaultEncoding_type [1:0]
+`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+
+`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+
+`define Src2CtrlEnum_defaultEncoding_type [1:0]
+`define Src2CtrlEnum_defaultEncoding_RS 2'b00
+`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
+`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
+`define Src2CtrlEnum_defaultEncoding_PC 2'b11
+
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
+
 `define Src1CtrlEnum_defaultEncoding_type [1:0]
 `define Src1CtrlEnum_defaultEncoding_RS 2'b00
 `define Src1CtrlEnum_defaultEncoding_IMU 2'b01
 `define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
 `define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_10_,
-  input      [31:0]   _zz_11_,
-  input               clk,
-  input               reset 
-);
-  reg        [22:0]   _zz_12_;
-  reg        [31:0]   _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire       [0:0]    _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [22:0]   _zz_18_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [6:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [5:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [20:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [8:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [5:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [22:0]   _zz_7_;
-  wire       [8:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:511];
-
-  assign _zz_14_ = (! lineLoader_flushCounter[6]);
-  assign _zz_15_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_16_ = _zz_7_[0 : 0];
-  assign _zz_17_ = _zz_7_[1 : 1];
-  assign _zz_18_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_18_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_12_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_13_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_14_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[6]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[6] ? lineLoader_address[10 : 5] : lineLoader_flushCounter[5 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[6];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 11];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[10 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_12_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_16_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_17_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[22 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[10 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_13_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 11]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_15_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_14_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[6];
-    if(_zz_15_)begin
-      lineLoader_flushCounter <= 7'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-    if((_zz_10_ != (3'b000)))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_11_;
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -359,8 +64,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -370,31 +75,27 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output reg [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
   input               reset,
-  input               debugReset 
+  input               debugReset
 );
-  wire                _zz_162_;
-  wire                _zz_163_;
-  wire                _zz_164_;
-  wire                _zz_165_;
-  wire                _zz_166_;
-  wire                _zz_167_;
-  wire                _zz_168_;
-  reg                 _zz_169_;
-  reg        [31:0]   _zz_170_;
-  reg        [31:0]   _zz_171_;
-  reg        [31:0]   _zz_172_;
+  wire                _zz_160;
+  wire                _zz_161;
+  wire                _zz_162;
+  wire                _zz_163;
+  wire                _zz_164;
+  wire                _zz_165;
+  wire                _zz_166;
+  wire                _zz_167;
+  reg                 _zz_168;
+  reg        [31:0]   _zz_169;
+  reg        [31:0]   _zz_170;
+  reg        [31:0]   _zz_171;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -404,364 +105,370 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                _zz_173_;
-  wire                _zz_174_;
-  wire                _zz_175_;
-  wire                _zz_176_;
-  wire                _zz_177_;
-  wire                _zz_178_;
-  wire                _zz_179_;
-  wire                _zz_180_;
-  wire                _zz_181_;
-  wire                _zz_182_;
-  wire                _zz_183_;
-  wire                _zz_184_;
-  wire                _zz_185_;
-  wire                _zz_186_;
-  wire                _zz_187_;
-  wire                _zz_188_;
-  wire                _zz_189_;
-  wire                _zz_190_;
-  wire                _zz_191_;
-  wire                _zz_192_;
-  wire                _zz_193_;
-  wire       [1:0]    _zz_194_;
-  wire                _zz_195_;
-  wire                _zz_196_;
-  wire                _zz_197_;
-  wire                _zz_198_;
-  wire                _zz_199_;
-  wire                _zz_200_;
-  wire                _zz_201_;
-  wire                _zz_202_;
-  wire                _zz_203_;
-  wire                _zz_204_;
-  wire                _zz_205_;
-  wire                _zz_206_;
-  wire       [5:0]    _zz_207_;
-  wire                _zz_208_;
-  wire                _zz_209_;
-  wire                _zz_210_;
-  wire                _zz_211_;
-  wire                _zz_212_;
-  wire                _zz_213_;
-  wire       [1:0]    _zz_214_;
-  wire                _zz_215_;
-  wire       [0:0]    _zz_216_;
-  wire       [0:0]    _zz_217_;
-  wire       [0:0]    _zz_218_;
-  wire       [0:0]    _zz_219_;
-  wire       [0:0]    _zz_220_;
-  wire       [0:0]    _zz_221_;
-  wire       [0:0]    _zz_222_;
-  wire       [0:0]    _zz_223_;
-  wire       [0:0]    _zz_224_;
-  wire       [0:0]    _zz_225_;
-  wire       [0:0]    _zz_226_;
-  wire       [0:0]    _zz_227_;
-  wire       [0:0]    _zz_228_;
-  wire       [0:0]    _zz_229_;
-  wire       [0:0]    _zz_230_;
-  wire       [0:0]    _zz_231_;
-  wire       [0:0]    _zz_232_;
-  wire       [3:0]    _zz_233_;
-  wire       [2:0]    _zz_234_;
-  wire       [31:0]   _zz_235_;
-  wire       [11:0]   _zz_236_;
-  wire       [31:0]   _zz_237_;
-  wire       [19:0]   _zz_238_;
-  wire       [11:0]   _zz_239_;
-  wire       [31:0]   _zz_240_;
-  wire       [31:0]   _zz_241_;
-  wire       [19:0]   _zz_242_;
-  wire       [11:0]   _zz_243_;
-  wire       [2:0]    _zz_244_;
-  wire       [0:0]    _zz_245_;
-  wire       [2:0]    _zz_246_;
-  wire       [4:0]    _zz_247_;
-  wire       [11:0]   _zz_248_;
-  wire       [11:0]   _zz_249_;
-  wire       [31:0]   _zz_250_;
-  wire       [31:0]   _zz_251_;
-  wire       [31:0]   _zz_252_;
-  wire       [31:0]   _zz_253_;
-  wire       [31:0]   _zz_254_;
-  wire       [31:0]   _zz_255_;
-  wire       [31:0]   _zz_256_;
-  wire       [31:0]   _zz_257_;
-  wire       [32:0]   _zz_258_;
-  wire       [11:0]   _zz_259_;
-  wire       [19:0]   _zz_260_;
-  wire       [11:0]   _zz_261_;
-  wire       [31:0]   _zz_262_;
-  wire       [31:0]   _zz_263_;
-  wire       [31:0]   _zz_264_;
-  wire       [11:0]   _zz_265_;
-  wire       [19:0]   _zz_266_;
-  wire       [11:0]   _zz_267_;
-  wire       [2:0]    _zz_268_;
-  wire       [1:0]    _zz_269_;
-  wire       [1:0]    _zz_270_;
-  wire       [1:0]    _zz_271_;
-  wire       [1:0]    _zz_272_;
-  wire       [0:0]    _zz_273_;
-  wire       [5:0]    _zz_274_;
-  wire       [33:0]   _zz_275_;
-  wire       [32:0]   _zz_276_;
-  wire       [33:0]   _zz_277_;
-  wire       [32:0]   _zz_278_;
-  wire       [33:0]   _zz_279_;
-  wire       [32:0]   _zz_280_;
-  wire       [0:0]    _zz_281_;
-  wire       [5:0]    _zz_282_;
-  wire       [32:0]   _zz_283_;
-  wire       [31:0]   _zz_284_;
-  wire       [31:0]   _zz_285_;
-  wire       [32:0]   _zz_286_;
-  wire       [32:0]   _zz_287_;
-  wire       [32:0]   _zz_288_;
-  wire       [32:0]   _zz_289_;
-  wire       [0:0]    _zz_290_;
-  wire       [32:0]   _zz_291_;
-  wire       [0:0]    _zz_292_;
-  wire       [32:0]   _zz_293_;
-  wire       [0:0]    _zz_294_;
-  wire       [31:0]   _zz_295_;
-  wire       [0:0]    _zz_296_;
-  wire       [0:0]    _zz_297_;
-  wire       [0:0]    _zz_298_;
-  wire       [0:0]    _zz_299_;
-  wire       [0:0]    _zz_300_;
-  wire       [0:0]    _zz_301_;
-  wire       [26:0]   _zz_302_;
-  wire                _zz_303_;
-  wire                _zz_304_;
-  wire       [1:0]    _zz_305_;
-  wire       [31:0]   _zz_306_;
-  wire       [31:0]   _zz_307_;
-  wire       [31:0]   _zz_308_;
-  wire                _zz_309_;
-  wire       [0:0]    _zz_310_;
-  wire       [12:0]   _zz_311_;
-  wire       [31:0]   _zz_312_;
-  wire       [31:0]   _zz_313_;
-  wire       [31:0]   _zz_314_;
-  wire                _zz_315_;
-  wire       [0:0]    _zz_316_;
-  wire       [6:0]    _zz_317_;
-  wire       [31:0]   _zz_318_;
-  wire       [31:0]   _zz_319_;
-  wire       [31:0]   _zz_320_;
-  wire                _zz_321_;
-  wire       [0:0]    _zz_322_;
-  wire       [0:0]    _zz_323_;
-  wire                _zz_324_;
-  wire                _zz_325_;
-  wire                _zz_326_;
-  wire                _zz_327_;
-  wire       [0:0]    _zz_328_;
-  wire       [2:0]    _zz_329_;
-  wire                _zz_330_;
-  wire                _zz_331_;
-  wire       [0:0]    _zz_332_;
-  wire       [0:0]    _zz_333_;
-  wire       [0:0]    _zz_334_;
-  wire       [0:0]    _zz_335_;
-  wire                _zz_336_;
-  wire       [0:0]    _zz_337_;
-  wire       [25:0]   _zz_338_;
-  wire       [31:0]   _zz_339_;
-  wire       [31:0]   _zz_340_;
-  wire       [31:0]   _zz_341_;
-  wire                _zz_342_;
-  wire       [0:0]    _zz_343_;
-  wire       [0:0]    _zz_344_;
-  wire       [31:0]   _zz_345_;
-  wire       [31:0]   _zz_346_;
-  wire       [31:0]   _zz_347_;
-  wire       [31:0]   _zz_348_;
-  wire       [31:0]   _zz_349_;
-  wire       [31:0]   _zz_350_;
-  wire       [0:0]    _zz_351_;
-  wire       [0:0]    _zz_352_;
-  wire       [0:0]    _zz_353_;
-  wire       [0:0]    _zz_354_;
-  wire                _zz_355_;
-  wire       [0:0]    _zz_356_;
-  wire       [23:0]   _zz_357_;
-  wire       [31:0]   _zz_358_;
-  wire       [31:0]   _zz_359_;
-  wire       [31:0]   _zz_360_;
-  wire       [31:0]   _zz_361_;
-  wire       [31:0]   _zz_362_;
-  wire       [31:0]   _zz_363_;
-  wire       [31:0]   _zz_364_;
-  wire       [31:0]   _zz_365_;
-  wire       [31:0]   _zz_366_;
-  wire       [31:0]   _zz_367_;
-  wire       [31:0]   _zz_368_;
-  wire       [0:0]    _zz_369_;
-  wire       [0:0]    _zz_370_;
-  wire       [1:0]    _zz_371_;
-  wire       [1:0]    _zz_372_;
-  wire                _zz_373_;
-  wire       [0:0]    _zz_374_;
-  wire       [21:0]   _zz_375_;
-  wire       [31:0]   _zz_376_;
-  wire       [31:0]   _zz_377_;
-  wire       [31:0]   _zz_378_;
-  wire       [0:0]    _zz_379_;
-  wire       [0:0]    _zz_380_;
-  wire       [0:0]    _zz_381_;
-  wire       [2:0]    _zz_382_;
-  wire       [1:0]    _zz_383_;
-  wire       [1:0]    _zz_384_;
-  wire                _zz_385_;
-  wire       [0:0]    _zz_386_;
-  wire       [18:0]   _zz_387_;
-  wire       [31:0]   _zz_388_;
-  wire       [31:0]   _zz_389_;
-  wire       [31:0]   _zz_390_;
-  wire                _zz_391_;
-  wire                _zz_392_;
-  wire       [31:0]   _zz_393_;
-  wire       [31:0]   _zz_394_;
-  wire       [31:0]   _zz_395_;
-  wire       [31:0]   _zz_396_;
-  wire                _zz_397_;
-  wire       [0:0]    _zz_398_;
-  wire       [0:0]    _zz_399_;
-  wire                _zz_400_;
-  wire       [0:0]    _zz_401_;
-  wire       [15:0]   _zz_402_;
-  wire       [31:0]   _zz_403_;
-  wire       [31:0]   _zz_404_;
-  wire       [31:0]   _zz_405_;
-  wire                _zz_406_;
-  wire       [2:0]    _zz_407_;
-  wire       [2:0]    _zz_408_;
-  wire                _zz_409_;
-  wire       [0:0]    _zz_410_;
-  wire       [12:0]   _zz_411_;
-  wire       [31:0]   _zz_412_;
-  wire       [31:0]   _zz_413_;
-  wire                _zz_414_;
-  wire                _zz_415_;
-  wire       [31:0]   _zz_416_;
-  wire       [31:0]   _zz_417_;
-  wire       [0:0]    _zz_418_;
-  wire       [0:0]    _zz_419_;
-  wire       [2:0]    _zz_420_;
-  wire       [2:0]    _zz_421_;
-  wire                _zz_422_;
-  wire       [0:0]    _zz_423_;
-  wire       [9:0]    _zz_424_;
-  wire       [31:0]   _zz_425_;
-  wire       [31:0]   _zz_426_;
-  wire       [31:0]   _zz_427_;
-  wire       [31:0]   _zz_428_;
-  wire                _zz_429_;
-  wire                _zz_430_;
-  wire       [31:0]   _zz_431_;
-  wire       [31:0]   _zz_432_;
-  wire                _zz_433_;
-  wire       [1:0]    _zz_434_;
-  wire       [1:0]    _zz_435_;
-  wire                _zz_436_;
-  wire       [0:0]    _zz_437_;
-  wire       [6:0]    _zz_438_;
-  wire       [31:0]   _zz_439_;
-  wire       [31:0]   _zz_440_;
-  wire                _zz_441_;
-  wire                _zz_442_;
-  wire       [1:0]    _zz_443_;
-  wire       [1:0]    _zz_444_;
-  wire                _zz_445_;
-  wire       [0:0]    _zz_446_;
-  wire       [3:0]    _zz_447_;
-  wire       [31:0]   _zz_448_;
-  wire       [31:0]   _zz_449_;
-  wire       [31:0]   _zz_450_;
-  wire       [31:0]   _zz_451_;
-  wire                _zz_452_;
-  wire       [0:0]    _zz_453_;
-  wire       [0:0]    _zz_454_;
-  wire       [0:0]    _zz_455_;
-  wire       [1:0]    _zz_456_;
-  wire       [0:0]    _zz_457_;
-  wire       [0:0]    _zz_458_;
-  wire                _zz_459_;
-  wire       [0:0]    _zz_460_;
-  wire       [0:0]    _zz_461_;
-  wire       [31:0]   _zz_462_;
-  wire       [31:0]   _zz_463_;
-  wire       [31:0]   _zz_464_;
-  wire       [31:0]   _zz_465_;
-  wire       [31:0]   _zz_466_;
-  wire       [31:0]   _zz_467_;
-  wire       [31:0]   _zz_468_;
-  wire       [0:0]    _zz_469_;
-  wire       [1:0]    _zz_470_;
-  wire                _zz_471_;
-  wire                _zz_472_;
-  wire                _zz_473_;
-  wire                _zz_474_;
+  wire                _zz_172;
+  wire                _zz_173;
+  wire                _zz_174;
+  wire                _zz_175;
+  wire                _zz_176;
+  wire                _zz_177;
+  wire                _zz_178;
+  wire                _zz_179;
+  wire                _zz_180;
+  wire                _zz_181;
+  wire                _zz_182;
+  wire                _zz_183;
+  wire                _zz_184;
+  wire                _zz_185;
+  wire                _zz_186;
+  wire                _zz_187;
+  wire                _zz_188;
+  wire                _zz_189;
+  wire                _zz_190;
+  wire                _zz_191;
+  wire       [1:0]    _zz_192;
+  wire                _zz_193;
+  wire                _zz_194;
+  wire                _zz_195;
+  wire                _zz_196;
+  wire                _zz_197;
+  wire                _zz_198;
+  wire                _zz_199;
+  wire                _zz_200;
+  wire                _zz_201;
+  wire                _zz_202;
+  wire                _zz_203;
+  wire       [5:0]    _zz_204;
+  wire                _zz_205;
+  wire                _zz_206;
+  wire                _zz_207;
+  wire                _zz_208;
+  wire                _zz_209;
+  wire                _zz_210;
+  wire                _zz_211;
+  wire       [1:0]    _zz_212;
+  wire                _zz_213;
+  wire       [0:0]    _zz_214;
+  wire       [0:0]    _zz_215;
+  wire       [0:0]    _zz_216;
+  wire       [0:0]    _zz_217;
+  wire       [0:0]    _zz_218;
+  wire       [0:0]    _zz_219;
+  wire       [0:0]    _zz_220;
+  wire       [0:0]    _zz_221;
+  wire       [0:0]    _zz_222;
+  wire       [0:0]    _zz_223;
+  wire       [0:0]    _zz_224;
+  wire       [0:0]    _zz_225;
+  wire       [0:0]    _zz_226;
+  wire       [0:0]    _zz_227;
+  wire       [0:0]    _zz_228;
+  wire       [0:0]    _zz_229;
+  wire       [0:0]    _zz_230;
+  wire       [2:0]    _zz_231;
+  wire       [2:0]    _zz_232;
+  wire       [31:0]   _zz_233;
+  wire       [11:0]   _zz_234;
+  wire       [31:0]   _zz_235;
+  wire       [19:0]   _zz_236;
+  wire       [11:0]   _zz_237;
+  wire       [31:0]   _zz_238;
+  wire       [31:0]   _zz_239;
+  wire       [19:0]   _zz_240;
+  wire       [11:0]   _zz_241;
+  wire       [2:0]    _zz_242;
+  wire       [0:0]    _zz_243;
+  wire       [2:0]    _zz_244;
+  wire       [4:0]    _zz_245;
+  wire       [11:0]   _zz_246;
+  wire       [11:0]   _zz_247;
+  wire       [31:0]   _zz_248;
+  wire       [31:0]   _zz_249;
+  wire       [31:0]   _zz_250;
+  wire       [31:0]   _zz_251;
+  wire       [31:0]   _zz_252;
+  wire       [31:0]   _zz_253;
+  wire       [31:0]   _zz_254;
+  wire       [31:0]   _zz_255;
+  wire       [32:0]   _zz_256;
+  wire       [11:0]   _zz_257;
+  wire       [19:0]   _zz_258;
+  wire       [11:0]   _zz_259;
+  wire       [31:0]   _zz_260;
+  wire       [31:0]   _zz_261;
+  wire       [31:0]   _zz_262;
+  wire       [11:0]   _zz_263;
+  wire       [19:0]   _zz_264;
+  wire       [11:0]   _zz_265;
+  wire       [2:0]    _zz_266;
+  wire       [1:0]    _zz_267;
+  wire       [1:0]    _zz_268;
+  wire       [1:0]    _zz_269;
+  wire       [1:0]    _zz_270;
+  wire       [0:0]    _zz_271;
+  wire       [5:0]    _zz_272;
+  wire       [33:0]   _zz_273;
+  wire       [32:0]   _zz_274;
+  wire       [33:0]   _zz_275;
+  wire       [32:0]   _zz_276;
+  wire       [33:0]   _zz_277;
+  wire       [32:0]   _zz_278;
+  wire       [0:0]    _zz_279;
+  wire       [5:0]    _zz_280;
+  wire       [32:0]   _zz_281;
+  wire       [31:0]   _zz_282;
+  wire       [31:0]   _zz_283;
+  wire       [32:0]   _zz_284;
+  wire       [32:0]   _zz_285;
+  wire       [32:0]   _zz_286;
+  wire       [32:0]   _zz_287;
+  wire       [0:0]    _zz_288;
+  wire       [32:0]   _zz_289;
+  wire       [0:0]    _zz_290;
+  wire       [32:0]   _zz_291;
+  wire       [0:0]    _zz_292;
+  wire       [31:0]   _zz_293;
+  wire       [0:0]    _zz_294;
+  wire       [0:0]    _zz_295;
+  wire       [0:0]    _zz_296;
+  wire       [0:0]    _zz_297;
+  wire       [0:0]    _zz_298;
+  wire       [0:0]    _zz_299;
+  wire       [26:0]   _zz_300;
+  wire                _zz_301;
+  wire                _zz_302;
+  wire       [1:0]    _zz_303;
+  wire       [31:0]   _zz_304;
+  wire       [31:0]   _zz_305;
+  wire       [31:0]   _zz_306;
+  wire                _zz_307;
+  wire       [0:0]    _zz_308;
+  wire       [12:0]   _zz_309;
+  wire       [31:0]   _zz_310;
+  wire       [31:0]   _zz_311;
+  wire       [31:0]   _zz_312;
+  wire                _zz_313;
+  wire       [0:0]    _zz_314;
+  wire       [6:0]    _zz_315;
+  wire       [31:0]   _zz_316;
+  wire       [31:0]   _zz_317;
+  wire       [31:0]   _zz_318;
+  wire                _zz_319;
+  wire       [0:0]    _zz_320;
+  wire       [0:0]    _zz_321;
+  wire                _zz_322;
+  wire                _zz_323;
+  wire                _zz_324;
+  wire       [31:0]   _zz_325;
+  wire       [31:0]   _zz_326;
+  wire       [31:0]   _zz_327;
+  wire       [0:0]    _zz_328;
+  wire       [0:0]    _zz_329;
+  wire       [2:0]    _zz_330;
+  wire       [2:0]    _zz_331;
+  wire                _zz_332;
+  wire       [0:0]    _zz_333;
+  wire       [25:0]   _zz_334;
+  wire       [31:0]   _zz_335;
+  wire       [31:0]   _zz_336;
+  wire       [31:0]   _zz_337;
+  wire                _zz_338;
+  wire       [1:0]    _zz_339;
+  wire       [1:0]    _zz_340;
+  wire                _zz_341;
+  wire       [0:0]    _zz_342;
+  wire       [21:0]   _zz_343;
+  wire       [31:0]   _zz_344;
+  wire       [31:0]   _zz_345;
+  wire       [31:0]   _zz_346;
+  wire       [31:0]   _zz_347;
+  wire                _zz_348;
+  wire                _zz_349;
+  wire       [1:0]    _zz_350;
+  wire       [1:0]    _zz_351;
+  wire                _zz_352;
+  wire       [0:0]    _zz_353;
+  wire       [18:0]   _zz_354;
+  wire       [31:0]   _zz_355;
+  wire       [31:0]   _zz_356;
+  wire       [31:0]   _zz_357;
+  wire       [31:0]   _zz_358;
+  wire                _zz_359;
+  wire       [0:0]    _zz_360;
+  wire       [0:0]    _zz_361;
+  wire       [0:0]    _zz_362;
+  wire       [1:0]    _zz_363;
+  wire       [0:0]    _zz_364;
+  wire       [0:0]    _zz_365;
+  wire                _zz_366;
+  wire       [0:0]    _zz_367;
+  wire       [15:0]   _zz_368;
+  wire       [31:0]   _zz_369;
+  wire       [31:0]   _zz_370;
+  wire       [31:0]   _zz_371;
+  wire       [31:0]   _zz_372;
+  wire       [31:0]   _zz_373;
+  wire       [31:0]   _zz_374;
+  wire       [31:0]   _zz_375;
+  wire                _zz_376;
+  wire                _zz_377;
+  wire       [31:0]   _zz_378;
+  wire       [31:0]   _zz_379;
+  wire       [1:0]    _zz_380;
+  wire       [1:0]    _zz_381;
+  wire                _zz_382;
+  wire       [0:0]    _zz_383;
+  wire       [13:0]   _zz_384;
+  wire       [31:0]   _zz_385;
+  wire       [31:0]   _zz_386;
+  wire       [31:0]   _zz_387;
+  wire       [31:0]   _zz_388;
+  wire                _zz_389;
+  wire                _zz_390;
+  wire       [0:0]    _zz_391;
+  wire       [1:0]    _zz_392;
+  wire       [0:0]    _zz_393;
+  wire       [0:0]    _zz_394;
+  wire                _zz_395;
+  wire       [0:0]    _zz_396;
+  wire       [10:0]   _zz_397;
+  wire       [31:0]   _zz_398;
+  wire       [31:0]   _zz_399;
+  wire       [31:0]   _zz_400;
+  wire       [31:0]   _zz_401;
+  wire       [31:0]   _zz_402;
+  wire       [31:0]   _zz_403;
+  wire       [31:0]   _zz_404;
+  wire       [31:0]   _zz_405;
+  wire       [0:0]    _zz_406;
+  wire       [1:0]    _zz_407;
+  wire       [5:0]    _zz_408;
+  wire       [5:0]    _zz_409;
+  wire                _zz_410;
+  wire       [0:0]    _zz_411;
+  wire       [7:0]    _zz_412;
+  wire       [31:0]   _zz_413;
+  wire       [31:0]   _zz_414;
+  wire       [31:0]   _zz_415;
+  wire       [31:0]   _zz_416;
+  wire                _zz_417;
+  wire       [0:0]    _zz_418;
+  wire       [2:0]    _zz_419;
+  wire                _zz_420;
+  wire       [0:0]    _zz_421;
+  wire       [0:0]    _zz_422;
+  wire       [1:0]    _zz_423;
+  wire       [1:0]    _zz_424;
+  wire                _zz_425;
+  wire       [0:0]    _zz_426;
+  wire       [4:0]    _zz_427;
+  wire       [31:0]   _zz_428;
+  wire       [31:0]   _zz_429;
+  wire       [31:0]   _zz_430;
+  wire                _zz_431;
+  wire       [0:0]    _zz_432;
+  wire       [0:0]    _zz_433;
+  wire       [31:0]   _zz_434;
+  wire       [31:0]   _zz_435;
+  wire       [31:0]   _zz_436;
+  wire                _zz_437;
+  wire                _zz_438;
+  wire                _zz_439;
+  wire       [3:0]    _zz_440;
+  wire       [3:0]    _zz_441;
+  wire                _zz_442;
+  wire       [0:0]    _zz_443;
+  wire       [2:0]    _zz_444;
+  wire       [31:0]   _zz_445;
+  wire       [31:0]   _zz_446;
+  wire       [31:0]   _zz_447;
+  wire       [31:0]   _zz_448;
+  wire       [31:0]   _zz_449;
+  wire       [31:0]   _zz_450;
+  wire       [31:0]   _zz_451;
+  wire       [31:0]   _zz_452;
+  wire                _zz_453;
+  wire       [0:0]    _zz_454;
+  wire       [1:0]    _zz_455;
+  wire                _zz_456;
+  wire       [2:0]    _zz_457;
+  wire       [2:0]    _zz_458;
+  wire                _zz_459;
+  wire       [0:0]    _zz_460;
+  wire       [0:0]    _zz_461;
+  wire       [31:0]   _zz_462;
+  wire       [31:0]   _zz_463;
+  wire       [31:0]   _zz_464;
+  wire       [31:0]   _zz_465;
+  wire       [31:0]   _zz_466;
+  wire       [31:0]   _zz_467;
+  wire       [31:0]   _zz_468;
+  wire                _zz_469;
+  wire                _zz_470;
+  wire                _zz_471;
+  wire       [0:0]    _zz_472;
+  wire       [0:0]    _zz_473;
+  wire                _zz_474;
+  wire                _zz_475;
+  wire                _zz_476;
+  wire                _zz_477;
   wire       [31:0]   memory_MEMORY_READ_DATA;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire                decode_IS_DIV;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_3_;
-  wire                execute_BRANCH_DO;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_13_;
-  wire                decode_IS_CSR;
-  wire                decode_MEMORY_STORE;
   wire       [31:0]   execute_BRANCH_CALC;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_19_;
-  wire                decode_IS_RS2_SIGNED;
+  wire                execute_BRANCH_DO;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire                decode_IS_RS1_SIGNED;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
   wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
   wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_21_;
-  wire                decode_CSR_READ_OPCODE;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24_;
   wire                decode_DO_EBREAK;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_DIV;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_STORE;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_16;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_19;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire                decode_MEMORY_ENABLE;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_22;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire                decode_IS_MUL;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire                decode_SRC_LESS_UNSIGNED;
+  wire       [31:0]   memory_PC;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -774,11 +481,11 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_25_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_25;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
@@ -786,95 +493,77 @@ module VexRiscv (
   wire       [31:0]   execute_RS1;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_28;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [31:0]   _zz_29_;
+  reg        [31:0]   _zz_29;
   wire                memory_REGFILE_WRITE_VALID;
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
-  reg        [31:0]   _zz_30_;
+  reg        [31:0]   _zz_30;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_32_;
+  wire       [31:0]   _zz_32;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_35_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_35;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36_;
-  wire       [31:0]   _zz_37_;
-  wire                _zz_38_;
-  reg                 _zz_39_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36;
+  wire       [31:0]   _zz_37;
+  wire                _zz_38;
+  reg                 _zz_39;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_40_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_41_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_42_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_40;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_41;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_47_;
+  reg        [31:0]   _zz_47;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
-  wire                memory_MMU_FAULT;
-  wire       [31:0]   memory_MMU_RSP_physicalAddress;
-  wire                memory_MMU_RSP_isIoAccess;
-  wire                memory_MMU_RSP_allowRead;
-  wire                memory_MMU_RSP_allowWrite;
-  wire                memory_MMU_RSP_allowExecute;
-  wire                memory_MMU_RSP_exception;
-  wire                memory_MMU_RSP_refilling;
-  wire       [31:0]   memory_PC;
   wire                memory_ALIGNEMENT_FAULT;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_STORE;
   wire                memory_MEMORY_ENABLE;
-  wire                execute_MMU_FAULT;
-  wire       [31:0]   execute_MMU_RSP_physicalAddress;
-  wire                execute_MMU_RSP_isIoAccess;
-  wire                execute_MMU_RSP_allowRead;
-  wire                execute_MMU_RSP_allowWrite;
-  wire                execute_MMU_RSP_allowExecute;
-  wire                execute_MMU_RSP_exception;
-  wire                execute_MMU_RSP_refilling;
   wire       [31:0]   execute_SRC_ADD;
   wire       [31:0]   execute_RS2;
   wire       [31:0]   execute_INSTRUCTION;
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
   wire                execute_ALIGNEMENT_FAULT;
-  wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_48_;
-  reg                 _zz_48__2;
-  reg                 _zz_48__1;
-  reg                 _zz_48__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_49_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_48;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_50_;
-  reg        [31:0]   _zz_51_;
+  reg        [31:0]   _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -903,7 +592,7 @@ module VexRiscv (
   reg                 memory_arbitration_haltItself;
   wire                memory_arbitration_haltByOther;
   reg                 memory_arbitration_removeIt;
-  reg                 memory_arbitration_flushIt;
+  wire                memory_arbitration_flushIt;
   reg                 memory_arbitration_flushNext;
   reg                 memory_arbitration_isValid;
   wire                memory_arbitration_isStuck;
@@ -939,35 +628,24 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   wire                IBusCachedPlugin_mmuBus_rsp_allowRead;
   wire                IBusCachedPlugin_mmuBus_rsp_allowWrite;
   wire                IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
   reg                 DBusSimplePlugin_memoryExceptionPort_valid;
   reg        [3:0]    DBusSimplePlugin_memoryExceptionPort_payload_code;
   wire       [31:0]   DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
-  wire                DBusSimplePlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusSimplePlugin_mmuBus_cmd_bypassTranslation;
-  wire       [31:0]   DBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  wire                DBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowRead;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowWrite;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowExecute;
-  wire                DBusSimplePlugin_mmuBus_rsp_exception;
-  wire                DBusSimplePlugin_mmuBus_rsp_refilling;
-  wire                DBusSimplePlugin_mmuBus_end;
-  wire                DBusSimplePlugin_mmuBus_busy;
-  reg                 DBusSimplePlugin_redoBranch_valid;
-  wire       [31:0]   DBusSimplePlugin_redoBranch_payload;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -999,11 +677,10 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_52_;
-  wire       [3:0]    _zz_53_;
-  wire                _zz_54_;
-  wire                _zz_55_;
-  wire                _zz_56_;
+  wire       [2:0]    _zz_51;
+  wire       [2:0]    _zz_52;
+  wire                _zz_53;
+  wire                _zz_54;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -1040,16 +717,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_57_;
-  wire                _zz_58_;
-  wire                _zz_59_;
+  wire                _zz_55;
+  wire                _zz_56;
+  wire                _zz_57;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_60_;
-  wire                _zz_61_;
-  reg                 _zz_62_;
-  wire                _zz_63_;
-  reg                 _zz_64_;
-  reg        [31:0]   _zz_65_;
+  wire                _zz_58;
+  wire                _zz_59;
+  reg                 _zz_60;
+  wire                _zz_61;
+  reg                 _zz_62;
+  reg        [31:0]   _zz_63;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -1062,17 +739,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_66_;
-  reg        [18:0]   _zz_67_;
-  wire                _zz_68_;
-  reg        [10:0]   _zz_69_;
-  wire                _zz_70_;
-  reg        [18:0]   _zz_71_;
-  reg                 _zz_72_;
-  wire                _zz_73_;
-  reg        [10:0]   _zz_74_;
-  wire                _zz_75_;
-  reg        [18:0]   _zz_76_;
+  wire                _zz_64;
+  reg        [18:0]   _zz_65;
+  wire                _zz_66;
+  reg        [10:0]   _zz_67;
+  wire                _zz_68;
+  reg        [18:0]   _zz_69;
+  reg                 _zz_70;
+  wire                _zz_71;
+  reg        [10:0]   _zz_72;
+  wire                _zz_73;
+  reg        [18:0]   _zz_74;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -1080,7 +757,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_77_;
+  wire       [31:0]   _zz_75;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -1097,47 +774,47 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_78_;
+  wire                _zz_76;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_79_;
-  reg        [3:0]    _zz_80_;
+  reg        [31:0]   _zz_77;
+  reg        [3:0]    _zz_78;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_81_;
-  reg        [31:0]   _zz_82_;
-  wire                _zz_83_;
-  reg        [31:0]   _zz_84_;
+  wire                _zz_79;
+  reg        [31:0]   _zz_80;
+  wire                _zz_81;
+  reg        [31:0]   _zz_82;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [31:0]   _zz_85_;
-  wire                _zz_86_;
-  wire                _zz_87_;
-  wire                _zz_88_;
-  wire                _zz_89_;
-  wire                _zz_90_;
-  wire                _zz_91_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_92_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_93_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_94_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_95_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_96_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_97_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_98_;
+  wire       [31:0]   _zz_83;
+  wire                _zz_84;
+  wire                _zz_85;
+  wire                _zz_86;
+  wire                _zz_87;
+  wire                _zz_88;
+  wire                _zz_89;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_90;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_91;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_92;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_93;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_94;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_95;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_96;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_99_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_97;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_100_;
-  reg        [31:0]   _zz_101_;
-  wire                _zz_102_;
-  reg        [19:0]   _zz_103_;
-  wire                _zz_104_;
-  reg        [19:0]   _zz_105_;
-  reg        [31:0]   _zz_106_;
+  reg        [31:0]   _zz_98;
+  reg        [31:0]   _zz_99;
+  wire                _zz_100;
+  reg        [19:0]   _zz_101;
+  wire                _zz_102;
+  reg        [19:0]   _zz_103;
+  reg        [31:0]   _zz_104;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -1146,38 +823,38 @@ module VexRiscv (
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_107_;
-  reg                 _zz_108_;
-  reg                 _zz_109_;
-  reg                 _zz_110_;
-  reg        [4:0]    _zz_111_;
-  reg        [31:0]   _zz_112_;
-  wire                _zz_113_;
-  wire                _zz_114_;
-  wire                _zz_115_;
-  wire                _zz_116_;
-  wire                _zz_117_;
-  wire                _zz_118_;
+  reg        [31:0]   _zz_105;
+  reg                 _zz_106;
+  reg                 _zz_107;
+  reg                 _zz_108;
+  reg        [4:0]    _zz_109;
+  reg        [31:0]   _zz_110;
+  wire                _zz_111;
+  wire                _zz_112;
+  wire                _zz_113;
+  wire                _zz_114;
+  wire                _zz_115;
+  wire                _zz_116;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_119_;
-  reg                 _zz_120_;
-  reg                 _zz_121_;
-  wire                _zz_122_;
-  reg        [19:0]   _zz_123_;
-  wire                _zz_124_;
-  reg        [10:0]   _zz_125_;
-  wire                _zz_126_;
-  reg        [18:0]   _zz_127_;
-  reg                 _zz_128_;
+  wire       [2:0]    _zz_117;
+  reg                 _zz_118;
+  reg                 _zz_119;
+  wire                _zz_120;
+  reg        [19:0]   _zz_121;
+  wire                _zz_122;
+  reg        [10:0]   _zz_123;
+  wire                _zz_124;
+  reg        [18:0]   _zz_125;
+  reg                 _zz_126;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_129_;
-  reg        [19:0]   _zz_130_;
-  wire                _zz_131_;
-  reg        [10:0]   _zz_132_;
-  wire                _zz_133_;
-  reg        [18:0]   _zz_134_;
+  wire                _zz_127;
+  reg        [19:0]   _zz_128;
+  wire                _zz_129;
+  reg        [10:0]   _zz_130;
+  wire                _zz_131;
+  reg        [18:0]   _zz_132;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
   wire       [25:0]   CsrPlugin_misa_extensions;
@@ -1198,9 +875,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_135_;
-  wire                _zz_136_;
-  wire                _zz_137_;
+  wire                _zz_133;
+  wire                _zz_134;
+  wire                _zz_135;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -1213,10 +890,10 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_138_;
-  wire                _zz_139_;
-  wire       [1:0]    _zz_140_;
-  wire                _zz_141_;
+  wire       [1:0]    _zz_136;
+  wire                _zz_137;
+  wire       [1:0]    _zz_138;
+  wire                _zz_139;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -1228,7 +905,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -1264,18 +941,18 @@ module VexRiscv (
   wire                memory_MulDivIterativePlugin_div_counter_willOverflow;
   reg                 memory_MulDivIterativePlugin_div_done;
   reg        [31:0]   memory_MulDivIterativePlugin_div_result;
-  wire       [31:0]   _zz_142_;
+  wire       [31:0]   _zz_140;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_MulDivIterativePlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_143_;
-  wire                _zz_144_;
-  wire                _zz_145_;
-  reg        [32:0]   _zz_146_;
+  wire       [31:0]   _zz_141;
+  wire                _zz_142;
+  wire                _zz_143;
+  reg        [32:0]   _zz_144;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_147_;
-  wire       [31:0]   _zz_148_;
+  reg        [31:0]   _zz_145;
+  wire       [31:0]   _zz_146;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -1285,72 +962,64 @@ module VexRiscv (
   reg                 DebugPlugin_godmode;
   reg                 DebugPlugin_haltedByBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_149_;
+  reg                 _zz_147;
   wire                DebugPlugin_allowEBreak;
   reg                 DebugPlugin_resetIt_regNext;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg                 decode_to_execute_DO_EBREAK;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg        [31:0]   execute_to_memory_MMU_RSP_physicalAddress;
-  reg                 execute_to_memory_MMU_RSP_isIoAccess;
-  reg                 execute_to_memory_MMU_RSP_allowRead;
-  reg                 execute_to_memory_MMU_RSP_allowWrite;
-  reg                 execute_to_memory_MMU_RSP_allowExecute;
-  reg                 execute_to_memory_MMU_RSP_exception;
-  reg                 execute_to_memory_MMU_RSP_refilling;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 decode_to_execute_MEMORY_STORE;
-  reg                 execute_to_memory_MEMORY_STORE;
-  reg                 memory_to_writeBack_MEMORY_STORE;
-  reg                 decode_to_execute_IS_CSR;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg                 execute_to_memory_MMU_FAULT;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
+  reg                 decode_to_execute_MEMORY_STORE;
+  reg                 execute_to_memory_MEMORY_STORE;
+  reg                 memory_to_writeBack_MEMORY_STORE;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
   reg                 decode_to_execute_IS_DIV;
   reg                 execute_to_memory_IS_DIV;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_DO_EBREAK;
   reg                 execute_to_memory_ALIGNEMENT_FAULT;
-  reg        [2:0]    _zz_150_;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  reg        [2:0]    _zz_148;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
   reg                 execute_CsrPlugin_csr_772;
@@ -1360,16 +1029,16 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_835;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_151_;
-  reg        [31:0]   _zz_152_;
-  reg        [31:0]   _zz_153_;
-  reg        [31:0]   _zz_154_;
-  reg        [31:0]   _zz_155_;
-  reg        [31:0]   _zz_156_;
-  reg        [31:0]   _zz_157_;
-  reg        [31:0]   _zz_158_;
-  reg        [2:0]    _zz_159_;
-  reg                 _zz_160_;
+  reg        [31:0]   _zz_149;
+  reg        [31:0]   _zz_150;
+  reg        [31:0]   _zz_151;
+  reg        [31:0]   _zz_152;
+  reg        [31:0]   _zz_153;
+  reg        [31:0]   _zz_154;
+  reg        [31:0]   _zz_155;
+  reg        [31:0]   _zz_156;
+  reg        [2:0]    _zz_157;
+  reg                 _zz_158;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
   wire                dBus_cmd_halfPipe_valid;
   wire                dBus_cmd_halfPipe_ready;
@@ -1383,537 +1052,498 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_161_;
+  reg        [3:0]    _zz_159;
   `ifndef SYNTHESIS
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_1__string;
-  reg [23:0] _zz_2__string;
-  reg [23:0] _zz_3__string;
-  reg [39:0] _zz_4__string;
-  reg [39:0] _zz_5__string;
-  reg [39:0] _zz_6__string;
-  reg [39:0] _zz_7__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_8__string;
-  reg [39:0] _zz_9__string;
-  reg [39:0] _zz_10__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_11__string;
-  reg [63:0] _zz_12__string;
-  reg [63:0] _zz_13__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_14__string;
-  reg [39:0] _zz_15__string;
-  reg [39:0] _zz_16__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
   reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_17__string;
-  reg [71:0] _zz_18__string;
-  reg [71:0] _zz_19__string;
-  reg [31:0] _zz_20__string;
-  reg [31:0] _zz_21__string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] _zz_12_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_13_string;
+  reg [39:0] _zz_14_string;
+  reg [39:0] _zz_15_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_16_string;
+  reg [23:0] _zz_17_string;
+  reg [23:0] _zz_18_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_19_string;
+  reg [63:0] _zz_20_string;
+  reg [63:0] _zz_21_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_22__string;
-  reg [95:0] _zz_23__string;
-  reg [95:0] _zz_24__string;
+  reg [95:0] _zz_22_string;
+  reg [95:0] _zz_23_string;
+  reg [95:0] _zz_24_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_25__string;
+  reg [39:0] _zz_25_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_26__string;
+  reg [39:0] _zz_26_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_28__string;
+  reg [31:0] _zz_28_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_31__string;
+  reg [71:0] _zz_31_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_33__string;
+  reg [23:0] _zz_33_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_34__string;
+  reg [95:0] _zz_34_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_35__string;
+  reg [63:0] _zz_35_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_36__string;
-  reg [31:0] _zz_40__string;
-  reg [63:0] _zz_41__string;
-  reg [95:0] _zz_42__string;
-  reg [39:0] _zz_43__string;
-  reg [23:0] _zz_44__string;
-  reg [71:0] _zz_45__string;
-  reg [39:0] _zz_46__string;
+  reg [39:0] _zz_36_string;
+  reg [39:0] _zz_40_string;
+  reg [31:0] _zz_41_string;
+  reg [71:0] _zz_42_string;
+  reg [39:0] _zz_43_string;
+  reg [23:0] _zz_44_string;
+  reg [63:0] _zz_45_string;
+  reg [95:0] _zz_46_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_49__string;
-  reg [39:0] _zz_92__string;
-  reg [71:0] _zz_93__string;
-  reg [23:0] _zz_94__string;
-  reg [39:0] _zz_95__string;
-  reg [95:0] _zz_96__string;
-  reg [63:0] _zz_97__string;
-  reg [31:0] _zz_98__string;
+  reg [31:0] _zz_48_string;
+  reg [95:0] _zz_90_string;
+  reg [63:0] _zz_91_string;
+  reg [23:0] _zz_92_string;
+  reg [39:0] _zz_93_string;
+  reg [71:0] _zz_94_string;
+  reg [31:0] _zz_95_string;
+  reg [39:0] _zz_96_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_173_ = (memory_arbitration_isValid && memory_IS_MUL);
-  assign _zz_174_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_175_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_176_ = 1'b1;
-  assign _zz_177_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_178_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_179_ = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_180_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_181_ = ((_zz_166_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_48__2));
-  assign _zz_182_ = ((_zz_166_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_48__1));
-  assign _zz_183_ = ((_zz_166_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_48__0));
-  assign _zz_184_ = ((_zz_166_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_185_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_186_ = (! execute_arbitration_isStuckByOthers);
-  assign _zz_187_ = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_188_ = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00)) == 1'b0);
-  assign _zz_189_ = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
-  assign _zz_190_ = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != (2'b00));
-  assign _zz_191_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_192_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_193_ = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_194_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_195_ = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign _zz_196_ = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
-  assign _zz_197_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_198_ = (1'b0 || (! 1'b1));
-  assign _zz_199_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_200_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_201_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_202_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_203_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_204_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_205_ = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
-  assign _zz_206_ = (! memory_arbitration_isStuck);
-  assign _zz_207_ = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_208_ = (iBus_cmd_valid || (_zz_159_ != (3'b000)));
-  assign _zz_209_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_210_ = ((_zz_135_ && 1'b1) && (! 1'b0));
-  assign _zz_211_ = ((_zz_136_ && 1'b1) && (! 1'b0));
-  assign _zz_212_ = ((_zz_137_ && 1'b1) && (! 1'b0));
-  assign _zz_213_ = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_214_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_215_ = execute_INSTRUCTION[13];
-  assign _zz_216_ = _zz_85_[4 : 4];
-  assign _zz_217_ = _zz_85_[18 : 18];
-  assign _zz_218_ = _zz_85_[30 : 30];
-  assign _zz_219_ = _zz_85_[7 : 7];
-  assign _zz_220_ = _zz_85_[20 : 20];
-  assign _zz_221_ = _zz_85_[23 : 23];
-  assign _zz_222_ = _zz_85_[0 : 0];
-  assign _zz_223_ = _zz_85_[19 : 19];
-  assign _zz_224_ = _zz_85_[13 : 13];
-  assign _zz_225_ = _zz_85_[17 : 17];
-  assign _zz_226_ = _zz_85_[21 : 21];
-  assign _zz_227_ = _zz_85_[22 : 22];
-  assign _zz_228_ = _zz_85_[1 : 1];
-  assign _zz_229_ = _zz_85_[12 : 12];
-  assign _zz_230_ = _zz_85_[31 : 31];
-  assign _zz_231_ = _zz_85_[14 : 14];
-  assign _zz_232_ = _zz_85_[16 : 16];
-  assign _zz_233_ = (_zz_52_ - (4'b0001));
-  assign _zz_234_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_235_ = {29'd0, _zz_234_};
-  assign _zz_236_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_237_ = {{_zz_67_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_238_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_239_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_240_ = {{_zz_69_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_241_ = {{_zz_71_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_242_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_243_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_244_ = (memory_MEMORY_STORE ? (3'b110) : (3'b100));
-  assign _zz_245_ = execute_SRC_LESS;
-  assign _zz_246_ = (3'b100);
-  assign _zz_247_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_248_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_249_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_250_ = ($signed(_zz_251_) + $signed(_zz_254_));
-  assign _zz_251_ = ($signed(_zz_252_) + $signed(_zz_253_));
-  assign _zz_252_ = execute_SRC1;
-  assign _zz_253_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_254_ = (execute_SRC_USE_SUB_LESS ? _zz_255_ : _zz_256_);
-  assign _zz_255_ = 32'h00000001;
-  assign _zz_256_ = 32'h0;
-  assign _zz_257_ = (_zz_258_ >>> 1);
-  assign _zz_258_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_259_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_260_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_261_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_262_ = {_zz_123_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_263_ = {{_zz_125_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_264_ = {{_zz_127_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_265_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_266_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_267_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_268_ = (3'b100);
-  assign _zz_269_ = (_zz_138_ & (~ _zz_270_));
-  assign _zz_270_ = (_zz_138_ - (2'b01));
-  assign _zz_271_ = (_zz_140_ & (~ _zz_272_));
-  assign _zz_272_ = (_zz_140_ - (2'b01));
-  assign _zz_273_ = memory_MulDivIterativePlugin_mul_counter_willIncrement;
-  assign _zz_274_ = {5'd0, _zz_273_};
-  assign _zz_275_ = (_zz_277_ + _zz_279_);
-  assign _zz_276_ = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
-  assign _zz_277_ = {{1{_zz_276_[32]}}, _zz_276_};
-  assign _zz_278_ = _zz_280_;
-  assign _zz_279_ = {{1{_zz_278_[32]}}, _zz_278_};
-  assign _zz_280_ = (memory_MulDivIterativePlugin_accumulator >>> 32);
-  assign _zz_281_ = memory_MulDivIterativePlugin_div_counter_willIncrement;
-  assign _zz_282_ = {5'd0, _zz_281_};
-  assign _zz_283_ = {1'd0, memory_MulDivIterativePlugin_rs2};
-  assign _zz_284_ = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_285_ = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_286_ = {_zz_142_,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_287_ = _zz_288_;
-  assign _zz_288_ = _zz_289_;
-  assign _zz_289_ = ({1'b0,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_143_) : _zz_143_)} + _zz_291_);
-  assign _zz_290_ = memory_MulDivIterativePlugin_div_needRevert;
-  assign _zz_291_ = {32'd0, _zz_290_};
-  assign _zz_292_ = _zz_145_;
-  assign _zz_293_ = {32'd0, _zz_292_};
-  assign _zz_294_ = _zz_144_;
-  assign _zz_295_ = {31'd0, _zz_294_};
-  assign _zz_296_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_297_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_298_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_299_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_300_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_301_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_302_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_303_ = 1'b1;
-  assign _zz_304_ = 1'b1;
-  assign _zz_305_ = {_zz_56_,_zz_55_};
-  assign _zz_306_ = 32'h0000107f;
-  assign _zz_307_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_308_ = 32'h00002073;
-  assign _zz_309_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_310_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_311_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_312_) == 32'h00000003),{(_zz_313_ == _zz_314_),{_zz_315_,{_zz_316_,_zz_317_}}}}}};
-  assign _zz_312_ = 32'h0000505f;
-  assign _zz_313_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_314_ = 32'h00000063;
-  assign _zz_315_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_316_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_317_ = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_318_) == 32'h00005033),{(_zz_319_ == _zz_320_),{_zz_321_,{_zz_322_,_zz_323_}}}}}};
-  assign _zz_318_ = 32'hbe00707f;
-  assign _zz_319_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_320_ = 32'h00000033;
-  assign _zz_321_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_322_ = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_323_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_324_ = decode_INSTRUCTION[31];
-  assign _zz_325_ = decode_INSTRUCTION[31];
-  assign _zz_326_ = decode_INSTRUCTION[7];
-  assign _zz_327_ = ((decode_INSTRUCTION & _zz_339_) == 32'h00001010);
-  assign _zz_328_ = (_zz_340_ == _zz_341_);
-  assign _zz_329_ = {_zz_342_,{_zz_343_,_zz_344_}};
-  assign _zz_330_ = ((decode_INSTRUCTION & _zz_345_) == 32'h00001050);
-  assign _zz_331_ = ((decode_INSTRUCTION & _zz_346_) == 32'h00002050);
-  assign _zz_332_ = _zz_91_;
-  assign _zz_333_ = (_zz_347_ == _zz_348_);
-  assign _zz_334_ = (_zz_349_ == _zz_350_);
-  assign _zz_335_ = (1'b0);
-  assign _zz_336_ = ({_zz_351_,_zz_352_} != (2'b00));
-  assign _zz_337_ = (_zz_353_ != _zz_354_);
-  assign _zz_338_ = {_zz_355_,{_zz_356_,_zz_357_}};
-  assign _zz_339_ = 32'h00001010;
-  assign _zz_340_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_341_ = 32'h00002010;
-  assign _zz_342_ = ((decode_INSTRUCTION & _zz_358_) == 32'h00000010);
-  assign _zz_343_ = (_zz_359_ == _zz_360_);
-  assign _zz_344_ = (_zz_361_ == _zz_362_);
-  assign _zz_345_ = 32'h00001050;
-  assign _zz_346_ = 32'h00002050;
-  assign _zz_347_ = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_348_ = 32'h00000004;
-  assign _zz_349_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_350_ = 32'h00000040;
-  assign _zz_351_ = (_zz_363_ == _zz_364_);
-  assign _zz_352_ = (_zz_365_ == _zz_366_);
-  assign _zz_353_ = (_zz_367_ == _zz_368_);
-  assign _zz_354_ = (1'b0);
-  assign _zz_355_ = ({_zz_369_,_zz_370_} != (2'b00));
-  assign _zz_356_ = (_zz_371_ != _zz_372_);
-  assign _zz_357_ = {_zz_373_,{_zz_374_,_zz_375_}};
-  assign _zz_358_ = 32'h00000050;
-  assign _zz_359_ = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_360_ = 32'h00000004;
-  assign _zz_361_ = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_362_ = 32'h0;
-  assign _zz_363_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_364_ = 32'h00006010;
-  assign _zz_365_ = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz_366_ = 32'h00004010;
-  assign _zz_367_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_368_ = 32'h00002010;
-  assign _zz_369_ = ((decode_INSTRUCTION & _zz_376_) == 32'h00000004);
-  assign _zz_370_ = _zz_90_;
-  assign _zz_371_ = {(_zz_377_ == _zz_378_),_zz_90_};
-  assign _zz_372_ = (2'b00);
-  assign _zz_373_ = ({_zz_89_,{_zz_379_,_zz_380_}} != (3'b000));
-  assign _zz_374_ = ({_zz_381_,_zz_382_} != (4'b0000));
-  assign _zz_375_ = {(_zz_383_ != _zz_384_),{_zz_385_,{_zz_386_,_zz_387_}}};
-  assign _zz_376_ = 32'h00000014;
-  assign _zz_377_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_378_ = 32'h00000004;
-  assign _zz_379_ = _zz_86_;
-  assign _zz_380_ = _zz_88_;
-  assign _zz_381_ = ((decode_INSTRUCTION & _zz_388_) == 32'h0);
-  assign _zz_382_ = {(_zz_389_ == _zz_390_),{_zz_391_,_zz_392_}};
-  assign _zz_383_ = {(_zz_393_ == _zz_394_),(_zz_395_ == _zz_396_)};
-  assign _zz_384_ = (2'b00);
-  assign _zz_385_ = ({_zz_89_,_zz_88_} != (2'b00));
-  assign _zz_386_ = (_zz_397_ != (1'b0));
-  assign _zz_387_ = {(_zz_398_ != _zz_399_),{_zz_400_,{_zz_401_,_zz_402_}}};
-  assign _zz_388_ = 32'h00000044;
-  assign _zz_389_ = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_390_ = 32'h0;
-  assign _zz_391_ = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_392_ = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_393_ = (decode_INSTRUCTION & 32'h00000034);
-  assign _zz_394_ = 32'h00000020;
-  assign _zz_395_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_396_ = 32'h00000020;
-  assign _zz_397_ = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
-  assign _zz_398_ = ((decode_INSTRUCTION & _zz_403_) == 32'h02004020);
-  assign _zz_399_ = (1'b0);
-  assign _zz_400_ = ((_zz_404_ == _zz_405_) != (1'b0));
-  assign _zz_401_ = (_zz_406_ != (1'b0));
-  assign _zz_402_ = {(_zz_407_ != _zz_408_),{_zz_409_,{_zz_410_,_zz_411_}}};
-  assign _zz_403_ = 32'h02004064;
-  assign _zz_404_ = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz_405_ = 32'h00100050;
-  assign _zz_406_ = ((decode_INSTRUCTION & 32'h00001048) == 32'h00001008);
-  assign _zz_407_ = {(_zz_412_ == _zz_413_),{_zz_414_,_zz_415_}};
-  assign _zz_408_ = (3'b000);
-  assign _zz_409_ = ((_zz_416_ == _zz_417_) != (1'b0));
-  assign _zz_410_ = ({_zz_418_,_zz_419_} != (2'b00));
-  assign _zz_411_ = {(_zz_420_ != _zz_421_),{_zz_422_,{_zz_423_,_zz_424_}}};
-  assign _zz_412_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_413_ = 32'h00000040;
-  assign _zz_414_ = ((decode_INSTRUCTION & 32'h00000038) == 32'h0);
-  assign _zz_415_ = ((decode_INSTRUCTION & 32'h00103040) == 32'h00000040);
-  assign _zz_416_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_417_ = 32'h0;
-  assign _zz_418_ = ((decode_INSTRUCTION & _zz_425_) == 32'h00002000);
-  assign _zz_419_ = ((decode_INSTRUCTION & _zz_426_) == 32'h00001000);
-  assign _zz_420_ = {(_zz_427_ == _zz_428_),{_zz_429_,_zz_430_}};
-  assign _zz_421_ = (3'b000);
-  assign _zz_422_ = ((_zz_431_ == _zz_432_) != (1'b0));
-  assign _zz_423_ = (_zz_433_ != (1'b0));
-  assign _zz_424_ = {(_zz_434_ != _zz_435_),{_zz_436_,{_zz_437_,_zz_438_}}};
-  assign _zz_425_ = 32'h00002010;
-  assign _zz_426_ = 32'h00005000;
-  assign _zz_427_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_428_ = 32'h00000024;
-  assign _zz_429_ = ((decode_INSTRUCTION & 32'h00003034) == 32'h00001010);
-  assign _zz_430_ = ((decode_INSTRUCTION & 32'h02003054) == 32'h00001010);
-  assign _zz_431_ = (decode_INSTRUCTION & 32'h10103050);
-  assign _zz_432_ = 32'h00000050;
-  assign _zz_433_ = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz_434_ = {_zz_87_,(_zz_439_ == _zz_440_)};
-  assign _zz_435_ = (2'b00);
-  assign _zz_436_ = ({_zz_87_,_zz_441_} != (2'b00));
-  assign _zz_437_ = (_zz_442_ != (1'b0));
-  assign _zz_438_ = {(_zz_443_ != _zz_444_),{_zz_445_,{_zz_446_,_zz_447_}}};
-  assign _zz_439_ = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_440_ = 32'h00000020;
-  assign _zz_441_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz_442_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_443_ = {(_zz_448_ == _zz_449_),(_zz_450_ == _zz_451_)};
-  assign _zz_444_ = (2'b00);
-  assign _zz_445_ = ({_zz_452_,{_zz_453_,_zz_454_}} != (3'b000));
-  assign _zz_446_ = ({_zz_455_,_zz_456_} != (3'b000));
-  assign _zz_447_ = {(_zz_457_ != _zz_458_),{_zz_459_,{_zz_460_,_zz_461_}}};
-  assign _zz_448_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_449_ = 32'h00005010;
-  assign _zz_450_ = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_451_ = 32'h00005020;
-  assign _zz_452_ = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_453_ = ((decode_INSTRUCTION & _zz_462_) == 32'h00001010);
-  assign _zz_454_ = ((decode_INSTRUCTION & _zz_463_) == 32'h00001010);
-  assign _zz_455_ = _zz_87_;
-  assign _zz_456_ = {(_zz_464_ == _zz_465_),(_zz_466_ == _zz_467_)};
-  assign _zz_457_ = ((decode_INSTRUCTION & _zz_468_) == 32'h00001000);
-  assign _zz_458_ = (1'b0);
-  assign _zz_459_ = (_zz_86_ != (1'b0));
-  assign _zz_460_ = ({_zz_469_,_zz_470_} != (3'b000));
-  assign _zz_461_ = (_zz_471_ != (1'b0));
-  assign _zz_462_ = 32'h00007034;
-  assign _zz_463_ = 32'h02007054;
-  assign _zz_464_ = (decode_INSTRUCTION & 32'h00000030);
-  assign _zz_465_ = 32'h00000010;
-  assign _zz_466_ = (decode_INSTRUCTION & 32'h02000060);
-  assign _zz_467_ = 32'h00000020;
-  assign _zz_468_ = 32'h00001000;
-  assign _zz_469_ = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_470_ = {((decode_INSTRUCTION & 32'h00002014) == 32'h00002010),((decode_INSTRUCTION & 32'h40004034) == 32'h40000030)};
-  assign _zz_471_ = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
-  assign _zz_472_ = execute_INSTRUCTION[31];
-  assign _zz_473_ = execute_INSTRUCTION[31];
-  assign _zz_474_ = execute_INSTRUCTION[7];
+  assign _zz_172 = (memory_arbitration_isValid && memory_IS_MUL);
+  assign _zz_173 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_174 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_175 = 1'b1;
+  assign _zz_176 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_177 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_178 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign _zz_179 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_180 = ((_zz_165 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_181 = ((_zz_165 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_182 = ((_zz_165 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_183 = ((_zz_165 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_184 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_185 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign _zz_186 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign _zz_187 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc));
+  assign _zz_188 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz_189 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_190 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_191 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign _zz_192 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_193 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign _zz_194 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_195 = (1'b0 || (! 1'b1));
+  assign _zz_196 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_197 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_198 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_199 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_200 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_201 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_202 = (memory_MulDivIterativePlugin_frontendOk && (! memory_MulDivIterativePlugin_div_done));
+  assign _zz_203 = (! memory_arbitration_isStuck);
+  assign _zz_204 = debug_bus_cmd_payload_address[7 : 2];
+  assign _zz_205 = (iBus_cmd_valid || (_zz_157 != 3'b000));
+  assign _zz_206 = (! execute_arbitration_isStuckByOthers);
+  assign _zz_207 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_208 = ((_zz_133 && 1'b1) && (! 1'b0));
+  assign _zz_209 = ((_zz_134 && 1'b1) && (! 1'b0));
+  assign _zz_210 = ((_zz_135 && 1'b1) && (! 1'b0));
+  assign _zz_211 = (! dBus_cmd_halfPipe_regs_valid);
+  assign _zz_212 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_213 = execute_INSTRUCTION[13];
+  assign _zz_214 = _zz_83[30 : 30];
+  assign _zz_215 = _zz_83[29 : 29];
+  assign _zz_216 = _zz_83[28 : 28];
+  assign _zz_217 = _zz_83[27 : 27];
+  assign _zz_218 = _zz_83[24 : 24];
+  assign _zz_219 = _zz_83[16 : 16];
+  assign _zz_220 = _zz_83[13 : 13];
+  assign _zz_221 = _zz_83[12 : 12];
+  assign _zz_222 = _zz_83[11 : 11];
+  assign _zz_223 = _zz_83[4 : 4];
+  assign _zz_224 = _zz_83[31 : 31];
+  assign _zz_225 = _zz_83[15 : 15];
+  assign _zz_226 = _zz_83[5 : 5];
+  assign _zz_227 = _zz_83[3 : 3];
+  assign _zz_228 = _zz_83[19 : 19];
+  assign _zz_229 = _zz_83[10 : 10];
+  assign _zz_230 = _zz_83[0 : 0];
+  assign _zz_231 = (_zz_51 - 3'b001);
+  assign _zz_232 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_233 = {29'd0, _zz_232};
+  assign _zz_234 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_235 = {{_zz_65,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_236 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_237 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_238 = {{_zz_67,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_239 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_240 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_241 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_242 = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz_243 = execute_SRC_LESS;
+  assign _zz_244 = 3'b100;
+  assign _zz_245 = execute_INSTRUCTION[19 : 15];
+  assign _zz_246 = execute_INSTRUCTION[31 : 20];
+  assign _zz_247 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_248 = ($signed(_zz_249) + $signed(_zz_252));
+  assign _zz_249 = ($signed(_zz_250) + $signed(_zz_251));
+  assign _zz_250 = execute_SRC1;
+  assign _zz_251 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_252 = (execute_SRC_USE_SUB_LESS ? _zz_253 : _zz_254);
+  assign _zz_253 = 32'h00000001;
+  assign _zz_254 = 32'h0;
+  assign _zz_255 = (_zz_256 >>> 1);
+  assign _zz_256 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz_257 = execute_INSTRUCTION[31 : 20];
+  assign _zz_258 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_259 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_260 = {_zz_121,execute_INSTRUCTION[31 : 20]};
+  assign _zz_261 = {{_zz_123,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_262 = {{_zz_125,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_263 = execute_INSTRUCTION[31 : 20];
+  assign _zz_264 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_265 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_266 = 3'b100;
+  assign _zz_267 = (_zz_136 & (~ _zz_268));
+  assign _zz_268 = (_zz_136 - 2'b01);
+  assign _zz_269 = (_zz_138 & (~ _zz_270));
+  assign _zz_270 = (_zz_138 - 2'b01);
+  assign _zz_271 = memory_MulDivIterativePlugin_mul_counter_willIncrement;
+  assign _zz_272 = {5'd0, _zz_271};
+  assign _zz_273 = (_zz_275 + _zz_277);
+  assign _zz_274 = (memory_MulDivIterativePlugin_rs2[0] ? memory_MulDivIterativePlugin_rs1 : 33'h0);
+  assign _zz_275 = {{1{_zz_274[32]}}, _zz_274};
+  assign _zz_276 = _zz_278;
+  assign _zz_277 = {{1{_zz_276[32]}}, _zz_276};
+  assign _zz_278 = (memory_MulDivIterativePlugin_accumulator >>> 32);
+  assign _zz_279 = memory_MulDivIterativePlugin_div_counter_willIncrement;
+  assign _zz_280 = {5'd0, _zz_279};
+  assign _zz_281 = {1'd0, memory_MulDivIterativePlugin_rs2};
+  assign _zz_282 = memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_283 = memory_MulDivIterativePlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_284 = {_zz_140,(! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_285 = _zz_286;
+  assign _zz_286 = _zz_287;
+  assign _zz_287 = ({memory_MulDivIterativePlugin_div_needRevert,(memory_MulDivIterativePlugin_div_needRevert ? (~ _zz_141) : _zz_141)} + _zz_289);
+  assign _zz_288 = memory_MulDivIterativePlugin_div_needRevert;
+  assign _zz_289 = {32'd0, _zz_288};
+  assign _zz_290 = _zz_143;
+  assign _zz_291 = {32'd0, _zz_290};
+  assign _zz_292 = _zz_142;
+  assign _zz_293 = {31'd0, _zz_292};
+  assign _zz_294 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_295 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_296 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_297 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_298 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_299 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_300 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_301 = 1'b1;
+  assign _zz_302 = 1'b1;
+  assign _zz_303 = {_zz_54,_zz_53};
+  assign _zz_304 = 32'h0000107f;
+  assign _zz_305 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_306 = 32'h00002073;
+  assign _zz_307 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_308 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_309 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_310) == 32'h00000003),{(_zz_311 == _zz_312),{_zz_313,{_zz_314,_zz_315}}}}}};
+  assign _zz_310 = 32'h0000505f;
+  assign _zz_311 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_312 = 32'h00000063;
+  assign _zz_313 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_314 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_315 = {((decode_INSTRUCTION & 32'hfc00305f) == 32'h00001013),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_316) == 32'h00005033),{(_zz_317 == _zz_318),{_zz_319,{_zz_320,_zz_321}}}}}};
+  assign _zz_316 = 32'hbe00707f;
+  assign _zz_317 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_318 = 32'h00000033;
+  assign _zz_319 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_320 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_321 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_322 = decode_INSTRUCTION[31];
+  assign _zz_323 = decode_INSTRUCTION[31];
+  assign _zz_324 = decode_INSTRUCTION[7];
+  assign _zz_325 = 32'h10103050;
+  assign _zz_326 = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz_327 = 32'h02004020;
+  assign _zz_328 = _zz_89;
+  assign _zz_329 = _zz_88;
+  assign _zz_330 = {_zz_89,{_zz_87,_zz_88}};
+  assign _zz_331 = 3'b000;
+  assign _zz_332 = (((decode_INSTRUCTION & _zz_335) == 32'h02000030) != 1'b0);
+  assign _zz_333 = ((_zz_336 == _zz_337) != 1'b0);
+  assign _zz_334 = {(_zz_338 != 1'b0),{(_zz_339 != _zz_340),{_zz_341,{_zz_342,_zz_343}}}};
+  assign _zz_335 = 32'h02004074;
+  assign _zz_336 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz_337 = 32'h00000050;
+  assign _zz_338 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
+  assign _zz_339 = {(_zz_344 == _zz_345),(_zz_346 == _zz_347)};
+  assign _zz_340 = 2'b00;
+  assign _zz_341 = ({_zz_86,_zz_348} != 2'b00);
+  assign _zz_342 = (_zz_349 != 1'b0);
+  assign _zz_343 = {(_zz_350 != _zz_351),{_zz_352,{_zz_353,_zz_354}}};
+  assign _zz_344 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_345 = 32'h00001050;
+  assign _zz_346 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_347 = 32'h00002050;
+  assign _zz_348 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_349 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_350 = {(_zz_355 == _zz_356),(_zz_357 == _zz_358)};
+  assign _zz_351 = 2'b00;
+  assign _zz_352 = ({_zz_359,{_zz_360,_zz_361}} != 3'b000);
+  assign _zz_353 = ({_zz_362,_zz_363} != 3'b000);
+  assign _zz_354 = {(_zz_364 != _zz_365),{_zz_366,{_zz_367,_zz_368}}};
+  assign _zz_355 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_356 = 32'h00005010;
+  assign _zz_357 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz_358 = 32'h00005020;
+  assign _zz_359 = ((decode_INSTRUCTION & _zz_369) == 32'h40001010);
+  assign _zz_360 = (_zz_370 == _zz_371);
+  assign _zz_361 = (_zz_372 == _zz_373);
+  assign _zz_362 = (_zz_374 == _zz_375);
+  assign _zz_363 = {_zz_376,_zz_377};
+  assign _zz_364 = (_zz_378 == _zz_379);
+  assign _zz_365 = 1'b0;
+  assign _zz_366 = (_zz_87 != 1'b0);
+  assign _zz_367 = (_zz_380 != _zz_381);
+  assign _zz_368 = {_zz_382,{_zz_383,_zz_384}};
+  assign _zz_369 = 32'h40003054;
+  assign _zz_370 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_371 = 32'h00001010;
+  assign _zz_372 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz_373 = 32'h00001010;
+  assign _zz_374 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_375 = 32'h00000024;
+  assign _zz_376 = ((decode_INSTRUCTION & 32'h00003034) == 32'h00001010);
+  assign _zz_377 = ((decode_INSTRUCTION & 32'h02003054) == 32'h00001010);
+  assign _zz_378 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz_379 = 32'h00001000;
+  assign _zz_380 = {(_zz_385 == _zz_386),(_zz_387 == _zz_388)};
+  assign _zz_381 = 2'b00;
+  assign _zz_382 = ({_zz_389,_zz_390} != 2'b00);
+  assign _zz_383 = ({_zz_391,_zz_392} != 3'b000);
+  assign _zz_384 = {(_zz_393 != _zz_394),{_zz_395,{_zz_396,_zz_397}}};
+  assign _zz_385 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_386 = 32'h00002000;
+  assign _zz_387 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz_388 = 32'h00001000;
+  assign _zz_389 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz_390 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz_391 = ((decode_INSTRUCTION & _zz_398) == 32'h00000040);
+  assign _zz_392 = {(_zz_399 == _zz_400),(_zz_401 == _zz_402)};
+  assign _zz_393 = ((decode_INSTRUCTION & _zz_403) == 32'h00000020);
+  assign _zz_394 = 1'b0;
+  assign _zz_395 = ((_zz_404 == _zz_405) != 1'b0);
+  assign _zz_396 = ({_zz_406,_zz_407} != 3'b000);
+  assign _zz_397 = {(_zz_408 != _zz_409),{_zz_410,{_zz_411,_zz_412}}};
+  assign _zz_398 = 32'h00000050;
+  assign _zz_399 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_400 = 32'h0;
+  assign _zz_401 = (decode_INSTRUCTION & 32'h00103040);
+  assign _zz_402 = 32'h00000040;
+  assign _zz_403 = 32'h00000020;
+  assign _zz_404 = (decode_INSTRUCTION & 32'h00000010);
+  assign _zz_405 = 32'h00000010;
+  assign _zz_406 = _zz_85;
+  assign _zz_407 = {(_zz_413 == _zz_414),(_zz_415 == _zz_416)};
+  assign _zz_408 = {_zz_86,{_zz_417,{_zz_418,_zz_419}}};
+  assign _zz_409 = 6'h0;
+  assign _zz_410 = ({_zz_85,_zz_420} != 2'b00);
+  assign _zz_411 = ({_zz_421,_zz_422} != 2'b00);
+  assign _zz_412 = {(_zz_423 != _zz_424),{_zz_425,{_zz_426,_zz_427}}};
+  assign _zz_413 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_414 = 32'h00000010;
+  assign _zz_415 = (decode_INSTRUCTION & 32'h02000060);
+  assign _zz_416 = 32'h00000020;
+  assign _zz_417 = ((decode_INSTRUCTION & _zz_428) == 32'h00001010);
+  assign _zz_418 = (_zz_429 == _zz_430);
+  assign _zz_419 = {_zz_431,{_zz_432,_zz_433}};
+  assign _zz_420 = ((decode_INSTRUCTION & _zz_434) == 32'h00000020);
+  assign _zz_421 = _zz_85;
+  assign _zz_422 = (_zz_435 == _zz_436);
+  assign _zz_423 = {_zz_437,_zz_438};
+  assign _zz_424 = 2'b00;
+  assign _zz_425 = (_zz_439 != 1'b0);
+  assign _zz_426 = (_zz_440 != _zz_441);
+  assign _zz_427 = {_zz_442,{_zz_443,_zz_444}};
+  assign _zz_428 = 32'h00001010;
+  assign _zz_429 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_430 = 32'h00002010;
+  assign _zz_431 = ((decode_INSTRUCTION & _zz_445) == 32'h00000010);
+  assign _zz_432 = (_zz_446 == _zz_447);
+  assign _zz_433 = (_zz_448 == _zz_449);
+  assign _zz_434 = 32'h00000070;
+  assign _zz_435 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_436 = 32'h0;
+  assign _zz_437 = ((decode_INSTRUCTION & _zz_450) == 32'h00006010);
+  assign _zz_438 = ((decode_INSTRUCTION & _zz_451) == 32'h00004010);
+  assign _zz_439 = ((decode_INSTRUCTION & _zz_452) == 32'h00002010);
+  assign _zz_440 = {_zz_453,{_zz_454,_zz_455}};
+  assign _zz_441 = 4'b0000;
+  assign _zz_442 = (_zz_456 != 1'b0);
+  assign _zz_443 = (_zz_457 != _zz_458);
+  assign _zz_444 = {_zz_459,{_zz_460,_zz_461}};
+  assign _zz_445 = 32'h00000050;
+  assign _zz_446 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz_447 = 32'h00000004;
+  assign _zz_448 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_449 = 32'h0;
+  assign _zz_450 = 32'h00006014;
+  assign _zz_451 = 32'h00005014;
+  assign _zz_452 = 32'h00006014;
+  assign _zz_453 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz_454 = ((decode_INSTRUCTION & _zz_462) == 32'h0);
+  assign _zz_455 = {(_zz_463 == _zz_464),(_zz_465 == _zz_466)};
+  assign _zz_456 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz_457 = {(_zz_467 == _zz_468),{_zz_469,_zz_470}};
+  assign _zz_458 = 3'b000;
+  assign _zz_459 = ({_zz_471,_zz_84} != 2'b00);
+  assign _zz_460 = ({_zz_472,_zz_473} != 2'b00);
+  assign _zz_461 = (_zz_474 != 1'b0);
+  assign _zz_462 = 32'h00000018;
+  assign _zz_463 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz_464 = 32'h00002000;
+  assign _zz_465 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz_466 = 32'h00001000;
+  assign _zz_467 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_468 = 32'h00000040;
+  assign _zz_469 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_470 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz_471 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz_472 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_473 = _zz_84;
+  assign _zz_474 = ((decode_INSTRUCTION & 32'h00001048) == 32'h00001008);
+  assign _zz_475 = execute_INSTRUCTION[31];
+  assign _zz_476 = execute_INSTRUCTION[31];
+  assign _zz_477 = execute_INSTRUCTION[7];
   always @ (posedge clk) begin
-    if(_zz_303_) begin
-      _zz_170_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_301) begin
+      _zz_169 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_304_) begin
-      _zz_171_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_302) begin
+      _zz_170 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_39_) begin
+    if(_zz_39) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_162_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_163_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_164_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_165_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_166_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_167_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_168_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_169_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    ._zz_10_                                      (_zz_150_[2:0]                                                        ), //i
-    ._zz_11_                                      (IBusCachedPlugin_injectionPort_payload[31:0]                         ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_160                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_161                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_162                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_163                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_164                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_165                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_166                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_167                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_168                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    ._zz_9                                    (_zz_148[2:0]                                                ), //i
+    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
   always @(*) begin
-    case(_zz_305_)
+    case(_zz_303)
       2'b00 : begin
-        _zz_172_ = CsrPlugin_jumpInterface_payload;
+        _zz_171 = CsrPlugin_jumpInterface_payload;
       end
       2'b01 : begin
-        _zz_172_ = DBusSimplePlugin_redoBranch_payload;
-      end
-      2'b10 : begin
-        _zz_172_ = BranchPlugin_jumpInterface_payload;
+        _zz_171 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_172_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_171 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_1_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_1__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_1__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_1__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_1__string = "PC ";
-      default : _zz_1__string = "???";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_2__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_2__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_2__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_2__string = "PC ";
-      default : _zz_2__string = "???";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_3__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_3__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_3__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_3__string = "PC ";
-      default : _zz_3__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4__string = "ECALL";
-      default : _zz_4__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5__string = "ECALL";
-      default : _zz_5__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6__string = "ECALL";
-      default : _zz_6__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7__string = "ECALL";
-      default : _zz_7__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1925,91 +1555,45 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_8_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8__string = "ECALL";
-      default : _zz_8__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_9_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9__string = "ECALL";
-      default : _zz_9__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_10_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10__string = "ECALL";
-      default : _zz_10__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_11_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_11__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_11__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_11__string = "BITWISE ";
-      default : _zz_11__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_12__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_12__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_12__string = "BITWISE ";
-      default : _zz_12__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_13__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_13__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_13__string = "BITWISE ";
-      default : _zz_13__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14__string = "AND_1";
-      default : _zz_14__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15__string = "AND_1";
-      default : _zz_15__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16__string = "AND_1";
-      default : _zz_16__string = "?????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
@@ -2022,48 +1606,130 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_17_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17__string = "SRA_1    ";
-      default : _zz_17__string = "?????????";
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_18_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_18__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_18__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_18__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_18__string = "SRA_1    ";
-      default : _zz_18__string = "?????????";
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_19_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_19__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_19__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_19__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_19__string = "SRA_1    ";
-      default : _zz_19__string = "?????????";
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_20_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_20__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_20__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_20__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_20__string = "JALR";
-      default : _zz_20__string = "????";
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_21__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_21__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_21__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_21__string = "JALR";
-      default : _zz_21__string = "????";
+    case(_zz_13)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_13_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_13_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_13_string = "AND_1";
+      default : _zz_13_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
+      default : _zz_14_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_16_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_16_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_16_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_16_string = "PC ";
+      default : _zz_16_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_17_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_17_string = "PC ";
+      default : _zz_17_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_19_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_19_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_19_string = "BITWISE ";
+      default : _zz_19_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
+      default : _zz_20_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2076,30 +1742,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_22__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_22__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_22__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_22__string = "URS1        ";
-      default : _zz_22__string = "????????????";
+    case(_zz_22)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_22_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_22_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_22_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_22_string = "URS1        ";
+      default : _zz_22_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_23__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23__string = "URS1        ";
-      default : _zz_23__string = "????????????";
+    case(_zz_23)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
+      default : _zz_23_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24__string = "URS1        ";
-      default : _zz_24__string = "????????????";
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2111,11 +1777,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_25__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_25__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_25__string = "ECALL";
-      default : _zz_25__string = "?????";
+    case(_zz_25)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_25_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_25_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_25_string = "ECALL";
+      default : _zz_25_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2127,11 +1793,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26__string = "ECALL";
-      default : _zz_26__string = "?????";
+    case(_zz_26)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26_string = "ECALL";
+      default : _zz_26_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2143,11 +1809,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2160,12 +1826,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_28__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_28__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_28__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_28__string = "JALR";
-      default : _zz_28__string = "????";
+    case(_zz_28)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_28_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_28_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_28_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_28_string = "JALR";
+      default : _zz_28_string = "????";
     endcase
   end
   always @(*) begin
@@ -2178,12 +1844,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_31_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31__string = "SRA_1    ";
-      default : _zz_31__string = "?????????";
+    case(_zz_31)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
+      default : _zz_31_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -2196,12 +1862,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_33__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_33__string = "PC ";
-      default : _zz_33__string = "???";
+    case(_zz_33)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_33_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_33_string = "PC ";
+      default : _zz_33_string = "???";
     endcase
   end
   always @(*) begin
@@ -2214,12 +1880,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_34__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34__string = "URS1        ";
-      default : _zz_34__string = "????????????";
+    case(_zz_34)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34_string = "URS1        ";
+      default : _zz_34_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2231,11 +1897,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35__string = "BITWISE ";
-      default : _zz_35__string = "????????";
+    case(_zz_35)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35_string = "BITWISE ";
+      default : _zz_35_string = "????????";
     endcase
   end
   always @(*) begin
@@ -2247,71 +1913,71 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36__string = "AND_1";
-      default : _zz_36__string = "?????";
+    case(_zz_36)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36_string = "AND_1";
+      default : _zz_36_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_40_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_40__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_40__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_40__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_40__string = "JALR";
-      default : _zz_40__string = "????";
+    case(_zz_40)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_40_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_40_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_40_string = "ECALL";
+      default : _zz_40_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_41_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_41__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_41__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_41__string = "BITWISE ";
-      default : _zz_41__string = "????????";
+    case(_zz_41)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_41_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_41_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41_string = "JALR";
+      default : _zz_41_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_42_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_42__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_42__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_42__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_42__string = "URS1        ";
-      default : _zz_42__string = "????????????";
+    case(_zz_42)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_42_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_42_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_42_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_42_string = "SRA_1    ";
+      default : _zz_42_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43__string = "ECALL";
-      default : _zz_43__string = "?????";
+    case(_zz_43)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_44__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_44__string = "PC ";
-      default : _zz_44__string = "???";
+    case(_zz_44)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_44_string = "PC ";
+      default : _zz_44_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45__string = "SRA_1    ";
-      default : _zz_45__string = "?????????";
+    case(_zz_45)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
+      default : _zz_45_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46__string = "AND_1";
-      default : _zz_46__string = "?????";
+    case(_zz_46)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46_string = "URS1        ";
+      default : _zz_46_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -2324,72 +1990,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_49__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_49__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_49__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_49__string = "JALR";
-      default : _zz_49__string = "????";
+    case(_zz_48)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_48_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_48_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_48_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_48_string = "JALR";
+      default : _zz_48_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_92_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_92__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_92__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_92__string = "AND_1";
-      default : _zz_92__string = "?????";
+    case(_zz_90)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_90_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_90_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_90_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_90_string = "URS1        ";
+      default : _zz_90_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_93_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_93__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_93__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_93__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_93__string = "SRA_1    ";
-      default : _zz_93__string = "?????????";
+    case(_zz_91)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_91_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_91_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_91_string = "BITWISE ";
+      default : _zz_91_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_94_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_94__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_94__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_94__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_94__string = "PC ";
-      default : _zz_94__string = "???";
+    case(_zz_92)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_92_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_92_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_92_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_92_string = "PC ";
+      default : _zz_92_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_95_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_95__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_95__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_95__string = "ECALL";
-      default : _zz_95__string = "?????";
+    case(_zz_93)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_93_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_93_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_93_string = "AND_1";
+      default : _zz_93_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_96_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_96__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_96__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_96__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_96__string = "URS1        ";
-      default : _zz_96__string = "????????????";
+    case(_zz_94)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_94_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_94_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_94_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_94_string = "SRA_1    ";
+      default : _zz_94_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_97_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_97__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_97__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_97__string = "BITWISE ";
-      default : _zz_97__string = "????????";
+    case(_zz_95)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_95_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_95_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_95_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_95_string = "JALR";
+      default : _zz_95_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_98_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_98__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_98__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_98__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_98__string = "JALR";
-      default : _zz_98__string = "????";
+    case(_zz_96)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_96_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_96_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_96_string = "ECALL";
+      default : _zz_96_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2402,12 +2068,28 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
-      default : decode_to_execute_BRANCH_CTRL_string = "????";
+    case(decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -2420,19 +2102,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
-      default : decode_to_execute_ALU_CTRL_string = "????????";
+    case(decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -2459,60 +2134,53 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
   `endif
 
   assign memory_MEMORY_READ_DATA = dBus_rsp_data;
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_216_[0];
-  assign decode_IS_DIV = _zz_217_[0];
-  assign decode_SRC2_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign _zz_4_ = _zz_5_;
-  assign _zz_6_ = _zz_7_;
-  assign decode_ENV_CTRL = _zz_8_;
-  assign _zz_9_ = _zz_10_;
-  assign decode_ALU_CTRL = _zz_11_;
-  assign _zz_12_ = _zz_13_;
-  assign decode_IS_CSR = _zz_218_[0];
-  assign decode_MEMORY_STORE = _zz_219_[0];
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_ALU_BITWISE_CTRL = _zz_14_;
-  assign _zz_15_ = _zz_16_;
-  assign decode_SHIFT_CTRL = _zz_17_;
-  assign _zz_18_ = _zz_19_;
-  assign decode_IS_RS2_SIGNED = _zz_220_[0];
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_100_;
-  assign decode_IS_RS1_SIGNED = _zz_221_[0];
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_222_[0];
+  assign execute_REGFILE_WRITE_DATA = _zz_98;
   assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
   assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
-  assign _zz_20_ = _zz_21_;
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_SRC1_CTRL = _zz_22_;
-  assign _zz_23_ = _zz_24_;
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_DIV = _zz_214[0];
+  assign decode_IS_RS2_SIGNED = _zz_215[0];
+  assign decode_IS_RS1_SIGNED = _zz_216[0];
+  assign decode_IS_MUL = _zz_217[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_218[0];
+  assign _zz_8 = _zz_9;
+  assign decode_SHIFT_CTRL = _zz_10;
+  assign _zz_11 = _zz_12;
+  assign decode_ALU_BITWISE_CTRL = _zz_13;
+  assign _zz_14 = _zz_15;
+  assign decode_SRC_LESS_UNSIGNED = _zz_219[0];
+  assign decode_MEMORY_STORE = _zz_220[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_221[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_222[0];
+  assign decode_SRC2_CTRL = _zz_16;
+  assign _zz_17 = _zz_18;
+  assign decode_ALU_CTRL = _zz_19;
+  assign _zz_20 = _zz_21;
+  assign decode_MEMORY_ENABLE = _zz_223[0];
+  assign decode_SRC1_CTRL = _zz_22;
+  assign _zz_23 = _zz_24;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_IS_MUL = _zz_223_[0];
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign decode_SRC_LESS_UNSIGNED = _zz_224_[0];
+  assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_225_[0];
+  assign decode_IS_EBREAK = _zz_224[0];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_MUL = decode_to_execute_IS_MUL;
@@ -2522,27 +2190,27 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_25_;
-  assign execute_ENV_CTRL = _zz_26_;
-  assign writeBack_ENV_CTRL = _zz_27_;
+  assign memory_ENV_CTRL = _zz_25;
+  assign execute_ENV_CTRL = _zz_26;
+  assign writeBack_ENV_CTRL = _zz_27;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_121_;
-  assign execute_BRANCH_CTRL = _zz_28_;
-  assign decode_RS2_USE = _zz_226_[0];
-  assign decode_RS1_USE = _zz_227_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_119;
+  assign execute_BRANCH_CTRL = _zz_28;
+  assign decode_RS2_USE = _zz_225[0];
+  assign decode_RS1_USE = _zz_226[0];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   always @ (*) begin
-    _zz_29_ = memory_REGFILE_WRITE_DATA;
-    if(_zz_173_)begin
-      _zz_29_ = ((memory_INSTRUCTION[13 : 12] == (2'b00)) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
+    _zz_29 = memory_REGFILE_WRITE_DATA;
+    if(_zz_172)begin
+      _zz_29 = ((memory_INSTRUCTION[13 : 12] == 2'b00) ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_accumulator[63 : 32]);
     end
-    if(_zz_174_)begin
-      _zz_29_ = memory_MulDivIterativePlugin_div_result;
+    if(_zz_173)begin
+      _zz_29 = memory_MulDivIterativePlugin_div_result;
     end
   end
 
@@ -2552,29 +2220,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_110_)begin
-      if((_zz_111_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_112_;
+    if(_zz_108)begin
+      if((_zz_109 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_110;
       end
     end
-    if(_zz_175_)begin
-      if(_zz_176_)begin
-        if(_zz_114_)begin
-          decode_RS2 = _zz_47_;
+    if(_zz_174)begin
+      if(_zz_175)begin
+        if(_zz_112)begin
+          decode_RS2 = _zz_47;
         end
       end
     end
-    if(_zz_177_)begin
+    if(_zz_176)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_116_)begin
-          decode_RS2 = _zz_29_;
+        if(_zz_114)begin
+          decode_RS2 = _zz_29;
         end
       end
     end
-    if(_zz_178_)begin
+    if(_zz_177)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_118_)begin
-          decode_RS2 = _zz_30_;
+        if(_zz_116)begin
+          decode_RS2 = _zz_30;
         end
       end
     end
@@ -2582,161 +2250,140 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_110_)begin
-      if((_zz_111_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_112_;
+    if(_zz_108)begin
+      if((_zz_109 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_110;
       end
     end
-    if(_zz_175_)begin
-      if(_zz_176_)begin
-        if(_zz_113_)begin
-          decode_RS1 = _zz_47_;
+    if(_zz_174)begin
+      if(_zz_175)begin
+        if(_zz_111)begin
+          decode_RS1 = _zz_47;
         end
       end
     end
-    if(_zz_177_)begin
+    if(_zz_176)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_115_)begin
-          decode_RS1 = _zz_29_;
+        if(_zz_113)begin
+          decode_RS1 = _zz_29;
         end
       end
     end
-    if(_zz_178_)begin
+    if(_zz_177)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_117_)begin
-          decode_RS1 = _zz_30_;
+        if(_zz_115)begin
+          decode_RS1 = _zz_30;
         end
       end
     end
   end
 
   always @ (*) begin
-    _zz_30_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_179_)begin
-      _zz_30_ = _zz_107_;
+    _zz_30 = execute_REGFILE_WRITE_DATA;
+    if(_zz_178)begin
+      _zz_30 = _zz_105;
     end
-    if(_zz_180_)begin
-      _zz_30_ = execute_CsrPlugin_readData;
+    if(_zz_179)begin
+      _zz_30 = execute_CsrPlugin_readData;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_31_;
+  assign execute_SHIFT_CTRL = _zz_31;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_32_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_33_;
-  assign execute_SRC1_CTRL = _zz_34_;
-  assign decode_SRC_USE_SUB_LESS = _zz_228_[0];
-  assign decode_SRC_ADD_ZERO = _zz_229_[0];
+  assign _zz_32 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_33;
+  assign execute_SRC1_CTRL = _zz_34;
+  assign decode_SRC_USE_SUB_LESS = _zz_227[0];
+  assign decode_SRC_ADD_ZERO = _zz_228[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_35_;
-  assign execute_SRC2 = _zz_106_;
-  assign execute_SRC1 = _zz_101_;
-  assign execute_ALU_BITWISE_CTRL = _zz_36_;
-  assign _zz_37_ = writeBack_INSTRUCTION;
-  assign _zz_38_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_35;
+  assign execute_SRC2 = _zz_104;
+  assign execute_SRC1 = _zz_99;
+  assign execute_ALU_BITWISE_CTRL = _zz_36;
+  assign _zz_37 = writeBack_INSTRUCTION;
+  assign _zz_38 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_39_ = 1'b0;
+    _zz_39 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_39_ = 1'b1;
+      _zz_39 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_230_[0];
+    decode_REGFILE_WRITE_VALID = _zz_229[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_306_) == 32'h00001073),{(_zz_307_ == _zz_308_),{_zz_309_,{_zz_310_,_zz_311_}}}}}}} != 20'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_304) == 32'h00001073),{(_zz_305 == _zz_306),{_zz_307,{_zz_308,_zz_309}}}}}}} != 20'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @ (*) begin
-    _zz_47_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_47 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_47_ = writeBack_DBusSimplePlugin_rspFormated;
+      _zz_47 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_READ_DATA = memory_to_writeBack_MEMORY_READ_DATA;
-  assign memory_MMU_FAULT = execute_to_memory_MMU_FAULT;
-  assign memory_MMU_RSP_physicalAddress = execute_to_memory_MMU_RSP_physicalAddress;
-  assign memory_MMU_RSP_isIoAccess = execute_to_memory_MMU_RSP_isIoAccess;
-  assign memory_MMU_RSP_allowRead = execute_to_memory_MMU_RSP_allowRead;
-  assign memory_MMU_RSP_allowWrite = execute_to_memory_MMU_RSP_allowWrite;
-  assign memory_MMU_RSP_allowExecute = execute_to_memory_MMU_RSP_allowExecute;
-  assign memory_MMU_RSP_exception = execute_to_memory_MMU_RSP_exception;
-  assign memory_MMU_RSP_refilling = execute_to_memory_MMU_RSP_refilling;
-  assign memory_PC = execute_to_memory_PC;
   assign memory_ALIGNEMENT_FAULT = execute_to_memory_ALIGNEMENT_FAULT;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_STORE = execute_to_memory_MEMORY_STORE;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
-  assign execute_MMU_FAULT = ((execute_MMU_RSP_exception || ((! execute_MMU_RSP_allowWrite) && execute_MEMORY_STORE)) || ((! execute_MMU_RSP_allowRead) && (! execute_MEMORY_STORE)));
-  assign execute_MMU_RSP_physicalAddress = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  assign execute_MMU_RSP_isIoAccess = DBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  assign execute_MMU_RSP_allowRead = DBusSimplePlugin_mmuBus_rsp_allowRead;
-  assign execute_MMU_RSP_allowWrite = DBusSimplePlugin_mmuBus_rsp_allowWrite;
-  assign execute_MMU_RSP_allowExecute = DBusSimplePlugin_mmuBus_rsp_allowExecute;
-  assign execute_MMU_RSP_exception = DBusSimplePlugin_mmuBus_rsp_exception;
-  assign execute_MMU_RSP_refilling = DBusSimplePlugin_mmuBus_rsp_refilling;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
-  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == (2'b10)) && (dBus_cmd_payload_address[1 : 0] != (2'b00))) || ((dBus_cmd_payload_size == (2'b01)) && (dBus_cmd_payload_address[0 : 0] != (1'b0))));
-  assign decode_MEMORY_ENABLE = _zz_231_[0];
-  assign decode_FLUSH_ALL = _zz_232_[0];
+  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
+  assign decode_FLUSH_ALL = _zz_230[0];
   always @ (*) begin
-    _zz_48_ = _zz_48__2;
-    if(_zz_181_)begin
-      _zz_48_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_180)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_48__2 = _zz_48__1;
-    if(_zz_182_)begin
-      _zz_48__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_181)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_48__1 = _zz_48__0;
-    if(_zz_183_)begin
-      _zz_48__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_182)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_48__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_184_)begin
-      _zz_48__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_183)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_49_;
+  assign decode_BRANCH_CTRL = _zz_48;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_50_ = memory_FORMAL_PC_NEXT;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      _zz_50_ = DBusSimplePlugin_redoBranch_payload;
-    end
+    _zz_49 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_50_ = BranchPlugin_jumpInterface_payload;
+      _zz_49 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_51_ = decode_FORMAL_PC_NEXT;
+    _zz_50 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_51_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_50 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -2745,20 +2392,9 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @ (*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusSimplePlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
-      decode_arbitration_haltItself = 1'b1;
-    end
-    case(_zz_150_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_148)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
-      end
-      3'b011 : begin
-      end
-      3'b100 : begin
       end
       default : begin
       end
@@ -2767,20 +2403,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_108_ || _zz_109_)))begin
+    if((decode_arbitration_isValid && (_zz_106 || _zz_107)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_185_)begin
+    if(_zz_184)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -2794,24 +2430,22 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_185_)begin
+    if(_zz_184)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_78_)))begin
+    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_76)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_179_)begin
-      if(_zz_186_)begin
-        if(! execute_LightShifterPlugin_done) begin
-          execute_arbitration_haltItself = 1'b1;
-        end
+    if(_zz_178)begin
+      if((! execute_LightShifterPlugin_done))begin
+        execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_180_)begin
+    if(_zz_179)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2820,7 +2454,7 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(_zz_187_)begin
+    if(_zz_185)begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2837,8 +2471,8 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_187_)begin
-      if(_zz_188_)begin
+    if(_zz_185)begin
+      if(_zz_186)begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2849,8 +2483,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_187_)begin
-      if(_zz_188_)begin
+    if(_zz_185)begin
+      if(_zz_186)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2861,15 +2495,15 @@ module VexRiscv (
     if((((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (! memory_MEMORY_STORE)) && ((! dBus_rsp_ready) || 1'b0)))begin
       memory_arbitration_haltItself = 1'b1;
     end
-    if(_zz_173_)begin
+    if(_zz_172)begin
       if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_mul_counter_willOverflowIfInc)))begin
         memory_arbitration_haltItself = 1'b1;
       end
-      if(_zz_189_)begin
+      if(_zz_187)begin
         memory_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_174_)begin
+    if(_zz_173)begin
       if(((! memory_MulDivIterativePlugin_frontendOk) || (! memory_MulDivIterativePlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -2879,7 +2513,7 @@ module VexRiscv (
   assign memory_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_190_)begin
+    if(_zz_188)begin
       memory_arbitration_removeIt = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -2887,22 +2521,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
-    memory_arbitration_flushIt = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      memory_arbitration_flushIt = 1'b1;
-    end
-  end
-
+  assign memory_arbitration_flushIt = 1'b0;
   always @ (*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      memory_arbitration_flushNext = 1'b1;
-    end
     if(BranchPlugin_jumpInterface_valid)begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_190_)begin
+    if(_zz_188)begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
@@ -2919,10 +2544,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @ (*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_191_)begin
+    if(_zz_189)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_192_)begin
+    if(_zz_190)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2933,24 +2558,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_191_)begin
+    if(_zz_189)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_192_)begin
+    if(_zz_190)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_187_)begin
-      if(_zz_188_)begin
+    if(_zz_185)begin
+      if(_zz_186)begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_193_)begin
+    if(_zz_191)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2972,21 +2597,21 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_191_)begin
+    if(_zz_189)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_192_)begin
+    if(_zz_190)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_191_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_189)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_192_)begin
-      case(_zz_194_)
+    if(_zz_190)begin
+      case(_zz_192)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -3017,14 +2642,13 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_52_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}}};
-  assign _zz_53_ = (_zz_52_ & (~ _zz_233_));
-  assign _zz_54_ = _zz_53_[3];
-  assign _zz_55_ = (_zz_53_[1] || _zz_54_);
-  assign _zz_56_ = (_zz_53_[2] || _zz_54_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_172_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,IBusCachedPlugin_predictionJumpInterface_valid}} != 3'b000);
+  assign _zz_51 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid}};
+  assign _zz_52 = (_zz_51 & (~ _zz_231));
+  assign _zz_53 = _zz_52[1];
+  assign _zz_54 = _zz_52[2];
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_171;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -3044,7 +2668,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_235_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_233);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -3084,44 +2708,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_57_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_57_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_57_);
+  assign _zz_55 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_55);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_55);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_58_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_58_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_58_);
+  assign _zz_56 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_56);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_56);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_48_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_59_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_59_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_59_);
+  assign _zz_57 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_57);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_57);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_60_;
-  assign _zz_60_ = ((1'b0 && (! _zz_61_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_61_ = _zz_62_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_61_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_58;
+  assign _zz_58 = ((1'b0 && (! _zz_59)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_59 = _zz_60;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_59;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_63_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_63_ = _zz_64_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_63_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_65_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_61)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_61 = _zz_62;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_61;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_63;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -3136,143 +2760,137 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @ (*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_150_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_148)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
       3'b011 : begin
         decode_arbitration_isValid = 1'b1;
       end
-      3'b100 : begin
-      end
       default : begin
       end
     endcase
   end
 
-  assign _zz_66_ = _zz_236_[11];
+  assign _zz_64 = _zz_234[11];
   always @ (*) begin
-    _zz_67_[18] = _zz_66_;
-    _zz_67_[17] = _zz_66_;
-    _zz_67_[16] = _zz_66_;
-    _zz_67_[15] = _zz_66_;
-    _zz_67_[14] = _zz_66_;
-    _zz_67_[13] = _zz_66_;
-    _zz_67_[12] = _zz_66_;
-    _zz_67_[11] = _zz_66_;
-    _zz_67_[10] = _zz_66_;
-    _zz_67_[9] = _zz_66_;
-    _zz_67_[8] = _zz_66_;
-    _zz_67_[7] = _zz_66_;
-    _zz_67_[6] = _zz_66_;
-    _zz_67_[5] = _zz_66_;
-    _zz_67_[4] = _zz_66_;
-    _zz_67_[3] = _zz_66_;
-    _zz_67_[2] = _zz_66_;
-    _zz_67_[1] = _zz_66_;
-    _zz_67_[0] = _zz_66_;
+    _zz_65[18] = _zz_64;
+    _zz_65[17] = _zz_64;
+    _zz_65[16] = _zz_64;
+    _zz_65[15] = _zz_64;
+    _zz_65[14] = _zz_64;
+    _zz_65[13] = _zz_64;
+    _zz_65[12] = _zz_64;
+    _zz_65[11] = _zz_64;
+    _zz_65[10] = _zz_64;
+    _zz_65[9] = _zz_64;
+    _zz_65[8] = _zz_64;
+    _zz_65[7] = _zz_64;
+    _zz_65[6] = _zz_64;
+    _zz_65[5] = _zz_64;
+    _zz_65[4] = _zz_64;
+    _zz_65[3] = _zz_64;
+    _zz_65[2] = _zz_64;
+    _zz_65[1] = _zz_64;
+    _zz_65[0] = _zz_64;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_237_[31]));
-    if(_zz_72_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_235[31]));
+    if(_zz_70)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_68_ = _zz_238_[19];
+  assign _zz_66 = _zz_236[19];
   always @ (*) begin
-    _zz_69_[10] = _zz_68_;
-    _zz_69_[9] = _zz_68_;
-    _zz_69_[8] = _zz_68_;
-    _zz_69_[7] = _zz_68_;
-    _zz_69_[6] = _zz_68_;
-    _zz_69_[5] = _zz_68_;
-    _zz_69_[4] = _zz_68_;
-    _zz_69_[3] = _zz_68_;
-    _zz_69_[2] = _zz_68_;
-    _zz_69_[1] = _zz_68_;
-    _zz_69_[0] = _zz_68_;
+    _zz_67[10] = _zz_66;
+    _zz_67[9] = _zz_66;
+    _zz_67[8] = _zz_66;
+    _zz_67[7] = _zz_66;
+    _zz_67[6] = _zz_66;
+    _zz_67[5] = _zz_66;
+    _zz_67[4] = _zz_66;
+    _zz_67[3] = _zz_66;
+    _zz_67[2] = _zz_66;
+    _zz_67[1] = _zz_66;
+    _zz_67[0] = _zz_66;
   end
 
-  assign _zz_70_ = _zz_239_[11];
+  assign _zz_68 = _zz_237[11];
   always @ (*) begin
-    _zz_71_[18] = _zz_70_;
-    _zz_71_[17] = _zz_70_;
-    _zz_71_[16] = _zz_70_;
-    _zz_71_[15] = _zz_70_;
-    _zz_71_[14] = _zz_70_;
-    _zz_71_[13] = _zz_70_;
-    _zz_71_[12] = _zz_70_;
-    _zz_71_[11] = _zz_70_;
-    _zz_71_[10] = _zz_70_;
-    _zz_71_[9] = _zz_70_;
-    _zz_71_[8] = _zz_70_;
-    _zz_71_[7] = _zz_70_;
-    _zz_71_[6] = _zz_70_;
-    _zz_71_[5] = _zz_70_;
-    _zz_71_[4] = _zz_70_;
-    _zz_71_[3] = _zz_70_;
-    _zz_71_[2] = _zz_70_;
-    _zz_71_[1] = _zz_70_;
-    _zz_71_[0] = _zz_70_;
+    _zz_69[18] = _zz_68;
+    _zz_69[17] = _zz_68;
+    _zz_69[16] = _zz_68;
+    _zz_69[15] = _zz_68;
+    _zz_69[14] = _zz_68;
+    _zz_69[13] = _zz_68;
+    _zz_69[12] = _zz_68;
+    _zz_69[11] = _zz_68;
+    _zz_69[10] = _zz_68;
+    _zz_69[9] = _zz_68;
+    _zz_69[8] = _zz_68;
+    _zz_69[7] = _zz_68;
+    _zz_69[6] = _zz_68;
+    _zz_69[5] = _zz_68;
+    _zz_69[4] = _zz_68;
+    _zz_69[3] = _zz_68;
+    _zz_69[2] = _zz_68;
+    _zz_69[1] = _zz_68;
+    _zz_69[0] = _zz_68;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_72_ = _zz_240_[1];
+        _zz_70 = _zz_238[1];
       end
       default : begin
-        _zz_72_ = _zz_241_[1];
+        _zz_70 = _zz_239[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_73_ = _zz_242_[19];
+  assign _zz_71 = _zz_240[19];
   always @ (*) begin
-    _zz_74_[10] = _zz_73_;
-    _zz_74_[9] = _zz_73_;
-    _zz_74_[8] = _zz_73_;
-    _zz_74_[7] = _zz_73_;
-    _zz_74_[6] = _zz_73_;
-    _zz_74_[5] = _zz_73_;
-    _zz_74_[4] = _zz_73_;
-    _zz_74_[3] = _zz_73_;
-    _zz_74_[2] = _zz_73_;
-    _zz_74_[1] = _zz_73_;
-    _zz_74_[0] = _zz_73_;
+    _zz_72[10] = _zz_71;
+    _zz_72[9] = _zz_71;
+    _zz_72[8] = _zz_71;
+    _zz_72[7] = _zz_71;
+    _zz_72[6] = _zz_71;
+    _zz_72[5] = _zz_71;
+    _zz_72[4] = _zz_71;
+    _zz_72[3] = _zz_71;
+    _zz_72[2] = _zz_71;
+    _zz_72[1] = _zz_71;
+    _zz_72[0] = _zz_71;
   end
 
-  assign _zz_75_ = _zz_243_[11];
+  assign _zz_73 = _zz_241[11];
   always @ (*) begin
-    _zz_76_[18] = _zz_75_;
-    _zz_76_[17] = _zz_75_;
-    _zz_76_[16] = _zz_75_;
-    _zz_76_[15] = _zz_75_;
-    _zz_76_[14] = _zz_75_;
-    _zz_76_[13] = _zz_75_;
-    _zz_76_[12] = _zz_75_;
-    _zz_76_[11] = _zz_75_;
-    _zz_76_[10] = _zz_75_;
-    _zz_76_[9] = _zz_75_;
-    _zz_76_[8] = _zz_75_;
-    _zz_76_[7] = _zz_75_;
-    _zz_76_[6] = _zz_75_;
-    _zz_76_[5] = _zz_75_;
-    _zz_76_[4] = _zz_75_;
-    _zz_76_[3] = _zz_75_;
-    _zz_76_[2] = _zz_75_;
-    _zz_76_[1] = _zz_75_;
-    _zz_76_[0] = _zz_75_;
+    _zz_74[18] = _zz_73;
+    _zz_74[17] = _zz_73;
+    _zz_74[16] = _zz_73;
+    _zz_74[15] = _zz_73;
+    _zz_74[14] = _zz_73;
+    _zz_74[13] = _zz_73;
+    _zz_74[12] = _zz_73;
+    _zz_74[11] = _zz_73;
+    _zz_74[10] = _zz_73;
+    _zz_74[9] = _zz_73;
+    _zz_74[8] = _zz_73;
+    _zz_74[7] = _zz_73;
+    _zz_74[6] = _zz_73;
+    _zz_74[5] = _zz_73;
+    _zz_74[4] = _zz_73;
+    _zz_74[3] = _zz_73;
+    _zz_74[2] = _zz_73;
+    _zz_74[1] = _zz_73;
+    _zz_74[0] = _zz_73;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_74_,{{{_zz_324_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_76_,{{{_zz_325_,_zz_326_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_72,{{{_zz_322,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_74,{{{_zz_323,_zz_324},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -3281,157 +2899,128 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_163_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_164_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_165_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_166_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_167_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_168_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_161 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_162 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_163 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_162;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_165 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_166 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_167 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_184_)begin
+    if(_zz_183)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_182_)begin
+    if(_zz_181)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_169_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_182_)begin
-      _zz_169_ = 1'b1;
+    _zz_168 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_181)begin
+      _zz_168 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_183_)begin
+    if(_zz_182)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_181_)begin
+    if(_zz_180)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_183_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_182)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_181_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_180)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_162_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign _zz_78_ = 1'b0;
+  assign _zz_160 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign _zz_76 = 1'b0;
   always @ (*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
     if(execute_ALIGNEMENT_FAULT)begin
       execute_DBusSimplePlugin_skipCmd = 1'b1;
     end
-    if((execute_MMU_FAULT || execute_MMU_RSP_refilling))begin
-      execute_DBusSimplePlugin_skipCmd = 1'b1;
-    end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_78_));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_76));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_79_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_77 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_79_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_77 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_79_ = execute_RS2[31 : 0];
+        _zz_77 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_79_;
+  assign dBus_cmd_payload_data = _zz_77;
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_80_ = (4'b0001);
+        _zz_78 = 4'b0001;
       end
       2'b01 : begin
-        _zz_80_ = (4'b0011);
+        _zz_78 = 4'b0011;
       end
       default : begin
-        _zz_80_ = (4'b1111);
+        _zz_78 = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_80_ <<< dBus_cmd_payload_address[1 : 0]);
-  assign DBusSimplePlugin_mmuBus_cmd_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign DBusSimplePlugin_mmuBus_cmd_virtualAddress = execute_SRC_ADD;
-  assign DBusSimplePlugin_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign DBusSimplePlugin_mmuBus_end = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
-  assign dBus_cmd_payload_address = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
+  assign execute_DBusSimplePlugin_formalMask = (_zz_78 <<< dBus_cmd_payload_address[1 : 0]);
+  assign dBus_cmd_payload_address = execute_SRC_ADD;
   always @ (*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(_zz_195_)begin
+    if(_zz_193)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(memory_MMU_RSP_refilling)begin
-      DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    end else begin
-      if(memory_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
-      end
-    end
-    if(_zz_196_)begin
+    if((! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers)))))begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @ (*) begin
-    DBusSimplePlugin_memoryExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_195_)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = (4'b0101);
+    DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_193)begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_244_};
-    end
-    if(! memory_MMU_RSP_refilling) begin
-      if(memory_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? (4'b1111) : (4'b1101));
-      end
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_242};
     end
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  always @ (*) begin
-    DBusSimplePlugin_redoBranch_valid = 1'b0;
-    if(memory_MMU_RSP_refilling)begin
-      DBusSimplePlugin_redoBranch_valid = 1'b1;
-    end
-    if(_zz_196_)begin
-      DBusSimplePlugin_redoBranch_valid = 1'b0;
-    end
-  end
-
-  assign DBusSimplePlugin_redoBranch_payload = memory_PC;
   always @ (*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -3449,63 +3038,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_81_ = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_79 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_82_[31] = _zz_81_;
-    _zz_82_[30] = _zz_81_;
-    _zz_82_[29] = _zz_81_;
-    _zz_82_[28] = _zz_81_;
-    _zz_82_[27] = _zz_81_;
-    _zz_82_[26] = _zz_81_;
-    _zz_82_[25] = _zz_81_;
-    _zz_82_[24] = _zz_81_;
-    _zz_82_[23] = _zz_81_;
-    _zz_82_[22] = _zz_81_;
-    _zz_82_[21] = _zz_81_;
-    _zz_82_[20] = _zz_81_;
-    _zz_82_[19] = _zz_81_;
-    _zz_82_[18] = _zz_81_;
-    _zz_82_[17] = _zz_81_;
-    _zz_82_[16] = _zz_81_;
-    _zz_82_[15] = _zz_81_;
-    _zz_82_[14] = _zz_81_;
-    _zz_82_[13] = _zz_81_;
-    _zz_82_[12] = _zz_81_;
-    _zz_82_[11] = _zz_81_;
-    _zz_82_[10] = _zz_81_;
-    _zz_82_[9] = _zz_81_;
-    _zz_82_[8] = _zz_81_;
-    _zz_82_[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+    _zz_80[31] = _zz_79;
+    _zz_80[30] = _zz_79;
+    _zz_80[29] = _zz_79;
+    _zz_80[28] = _zz_79;
+    _zz_80[27] = _zz_79;
+    _zz_80[26] = _zz_79;
+    _zz_80[25] = _zz_79;
+    _zz_80[24] = _zz_79;
+    _zz_80[23] = _zz_79;
+    _zz_80[22] = _zz_79;
+    _zz_80[21] = _zz_79;
+    _zz_80[20] = _zz_79;
+    _zz_80[19] = _zz_79;
+    _zz_80[18] = _zz_79;
+    _zz_80[17] = _zz_79;
+    _zz_80[16] = _zz_79;
+    _zz_80[15] = _zz_79;
+    _zz_80[14] = _zz_79;
+    _zz_80[13] = _zz_79;
+    _zz_80[12] = _zz_79;
+    _zz_80[11] = _zz_79;
+    _zz_80[10] = _zz_79;
+    _zz_80[9] = _zz_79;
+    _zz_80[8] = _zz_79;
+    _zz_80[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_83_ = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_81 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_84_[31] = _zz_83_;
-    _zz_84_[30] = _zz_83_;
-    _zz_84_[29] = _zz_83_;
-    _zz_84_[28] = _zz_83_;
-    _zz_84_[27] = _zz_83_;
-    _zz_84_[26] = _zz_83_;
-    _zz_84_[25] = _zz_83_;
-    _zz_84_[24] = _zz_83_;
-    _zz_84_[23] = _zz_83_;
-    _zz_84_[22] = _zz_83_;
-    _zz_84_[21] = _zz_83_;
-    _zz_84_[20] = _zz_83_;
-    _zz_84_[19] = _zz_83_;
-    _zz_84_[18] = _zz_83_;
-    _zz_84_[17] = _zz_83_;
-    _zz_84_[16] = _zz_83_;
-    _zz_84_[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+    _zz_82[31] = _zz_81;
+    _zz_82[30] = _zz_81;
+    _zz_82[29] = _zz_81;
+    _zz_82[28] = _zz_81;
+    _zz_82[27] = _zz_81;
+    _zz_82[26] = _zz_81;
+    _zz_82[25] = _zz_81;
+    _zz_82[24] = _zz_81;
+    _zz_82[23] = _zz_81;
+    _zz_82[22] = _zz_81;
+    _zz_82[21] = _zz_81;
+    _zz_82[20] = _zz_81;
+    _zz_82[19] = _zz_81;
+    _zz_82[18] = _zz_81;
+    _zz_82[17] = _zz_81;
+    _zz_82[16] = _zz_81;
+    _zz_82[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_214_)
+    case(_zz_212)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_82_;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_80;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_84_;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_82;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -3513,59 +3102,64 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
   assign IBusCachedPlugin_mmuBus_rsp_allowRead = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowWrite = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_allowExecute = 1'b1;
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusSimplePlugin_mmuBus_rsp_physicalAddress = DBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  assign DBusSimplePlugin_mmuBus_rsp_allowRead = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_allowWrite = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_allowExecute = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_isIoAccess = DBusSimplePlugin_mmuBus_rsp_physicalAddress[31];
-  assign DBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
-  assign DBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
-  assign DBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign _zz_86_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_87_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_88_ = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
-  assign _zz_89_ = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
-  assign _zz_90_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_91_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_85_ = {({_zz_91_,{_zz_327_,{_zz_328_,_zz_329_}}} != 6'h0),{({_zz_330_,_zz_331_} != (2'b00)),{({_zz_332_,_zz_333_} != (2'b00)),{(_zz_334_ != _zz_335_),{_zz_336_,{_zz_337_,_zz_338_}}}}}};
-  assign _zz_92_ = _zz_85_[3 : 2];
-  assign _zz_46_ = _zz_92_;
-  assign _zz_93_ = _zz_85_[6 : 5];
-  assign _zz_45_ = _zz_93_;
-  assign _zz_94_ = _zz_85_[9 : 8];
-  assign _zz_44_ = _zz_94_;
-  assign _zz_95_ = _zz_85_[11 : 10];
-  assign _zz_43_ = _zz_95_;
-  assign _zz_96_ = _zz_85_[25 : 24];
-  assign _zz_42_ = _zz_96_;
-  assign _zz_97_ = _zz_85_[27 : 26];
-  assign _zz_41_ = _zz_97_;
-  assign _zz_98_ = _zz_85_[29 : 28];
-  assign _zz_40_ = _zz_98_;
+  assign _zz_84 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_85 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_86 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_87 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_88 = ((decode_INSTRUCTION & 32'h00007000) == 32'h00001000);
+  assign _zz_89 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00004000);
+  assign _zz_83 = {(((decode_INSTRUCTION & _zz_325) == 32'h00100050) != 1'b0),{((_zz_326 == _zz_327) != 1'b0),{({_zz_328,_zz_329} != 2'b00),{(_zz_330 != _zz_331),{_zz_332,{_zz_333,_zz_334}}}}}};
+  assign _zz_90 = _zz_83[2 : 1];
+  assign _zz_46 = _zz_90;
+  assign _zz_91 = _zz_83[7 : 6];
+  assign _zz_45 = _zz_91;
+  assign _zz_92 = _zz_83[9 : 8];
+  assign _zz_44 = _zz_92;
+  assign _zz_93 = _zz_83[18 : 17];
+  assign _zz_43 = _zz_93;
+  assign _zz_94 = _zz_83[21 : 20];
+  assign _zz_42 = _zz_94;
+  assign _zz_95 = _zz_83[23 : 22];
+  assign _zz_41 = _zz_95;
+  assign _zz_96 = _zz_83[26 : 25];
+  assign _zz_40 = _zz_96;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_170_;
-  assign decode_RegFilePlugin_rs2Data = _zz_171_;
+  assign decode_RegFilePlugin_rs1Data = _zz_169;
+  assign decode_RegFilePlugin_rs2Data = _zz_170;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_38_ && writeBack_arbitration_isFiring);
-    if(_zz_99_)begin
+    lastStageRegFileWrite_valid = (_zz_38 && writeBack_arbitration_isFiring);
+    if(_zz_97)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_37_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_47_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_37[11 : 7];
+    if(_zz_97)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_47;
+    if(_zz_97)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -3583,13 +3177,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_100_ = execute_IntAluPlugin_bitwise;
+        _zz_98 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_100_ = {31'd0, _zz_245_};
+        _zz_98 = {31'd0, _zz_243};
       end
       default : begin
-        _zz_100_ = execute_SRC_ADD_SUB;
+        _zz_98 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -3597,87 +3191,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_101_ = execute_RS1;
+        _zz_99 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_101_ = {29'd0, _zz_246_};
+        _zz_99 = {29'd0, _zz_244};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_101_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_99 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_101_ = {27'd0, _zz_247_};
+        _zz_99 = {27'd0, _zz_245};
       end
     endcase
   end
 
-  assign _zz_102_ = _zz_248_[11];
+  assign _zz_100 = _zz_246[11];
   always @ (*) begin
-    _zz_103_[19] = _zz_102_;
-    _zz_103_[18] = _zz_102_;
-    _zz_103_[17] = _zz_102_;
-    _zz_103_[16] = _zz_102_;
-    _zz_103_[15] = _zz_102_;
-    _zz_103_[14] = _zz_102_;
-    _zz_103_[13] = _zz_102_;
-    _zz_103_[12] = _zz_102_;
-    _zz_103_[11] = _zz_102_;
-    _zz_103_[10] = _zz_102_;
-    _zz_103_[9] = _zz_102_;
-    _zz_103_[8] = _zz_102_;
-    _zz_103_[7] = _zz_102_;
-    _zz_103_[6] = _zz_102_;
-    _zz_103_[5] = _zz_102_;
-    _zz_103_[4] = _zz_102_;
-    _zz_103_[3] = _zz_102_;
-    _zz_103_[2] = _zz_102_;
-    _zz_103_[1] = _zz_102_;
-    _zz_103_[0] = _zz_102_;
+    _zz_101[19] = _zz_100;
+    _zz_101[18] = _zz_100;
+    _zz_101[17] = _zz_100;
+    _zz_101[16] = _zz_100;
+    _zz_101[15] = _zz_100;
+    _zz_101[14] = _zz_100;
+    _zz_101[13] = _zz_100;
+    _zz_101[12] = _zz_100;
+    _zz_101[11] = _zz_100;
+    _zz_101[10] = _zz_100;
+    _zz_101[9] = _zz_100;
+    _zz_101[8] = _zz_100;
+    _zz_101[7] = _zz_100;
+    _zz_101[6] = _zz_100;
+    _zz_101[5] = _zz_100;
+    _zz_101[4] = _zz_100;
+    _zz_101[3] = _zz_100;
+    _zz_101[2] = _zz_100;
+    _zz_101[1] = _zz_100;
+    _zz_101[0] = _zz_100;
   end
 
-  assign _zz_104_ = _zz_249_[11];
+  assign _zz_102 = _zz_247[11];
   always @ (*) begin
-    _zz_105_[19] = _zz_104_;
-    _zz_105_[18] = _zz_104_;
-    _zz_105_[17] = _zz_104_;
-    _zz_105_[16] = _zz_104_;
-    _zz_105_[15] = _zz_104_;
-    _zz_105_[14] = _zz_104_;
-    _zz_105_[13] = _zz_104_;
-    _zz_105_[12] = _zz_104_;
-    _zz_105_[11] = _zz_104_;
-    _zz_105_[10] = _zz_104_;
-    _zz_105_[9] = _zz_104_;
-    _zz_105_[8] = _zz_104_;
-    _zz_105_[7] = _zz_104_;
-    _zz_105_[6] = _zz_104_;
-    _zz_105_[5] = _zz_104_;
-    _zz_105_[4] = _zz_104_;
-    _zz_105_[3] = _zz_104_;
-    _zz_105_[2] = _zz_104_;
-    _zz_105_[1] = _zz_104_;
-    _zz_105_[0] = _zz_104_;
+    _zz_103[19] = _zz_102;
+    _zz_103[18] = _zz_102;
+    _zz_103[17] = _zz_102;
+    _zz_103[16] = _zz_102;
+    _zz_103[15] = _zz_102;
+    _zz_103[14] = _zz_102;
+    _zz_103[13] = _zz_102;
+    _zz_103[12] = _zz_102;
+    _zz_103[11] = _zz_102;
+    _zz_103[10] = _zz_102;
+    _zz_103[9] = _zz_102;
+    _zz_103[8] = _zz_102;
+    _zz_103[7] = _zz_102;
+    _zz_103[6] = _zz_102;
+    _zz_103[5] = _zz_102;
+    _zz_103[4] = _zz_102;
+    _zz_103[3] = _zz_102;
+    _zz_103[2] = _zz_102;
+    _zz_103[1] = _zz_102;
+    _zz_103[0] = _zz_102;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_106_ = execute_RS2;
+        _zz_104 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_106_ = {_zz_103_,execute_INSTRUCTION[31 : 20]};
+        _zz_104 = {_zz_101,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_106_ = {_zz_105_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_104 = {_zz_103,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_106_ = _zz_32_;
+        _zz_104 = _zz_32;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_250_;
+    execute_SrcPlugin_addSub = _zz_248;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -3687,188 +3281,188 @@ module VexRiscv (
   assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
-  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == (4'b0000));
+  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
   always @ (*) begin
     case(execute_SHIFT_CTRL)
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_107_ = (execute_LightShifterPlugin_shiftInput <<< 1);
+        _zz_105 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_107_ = _zz_257_;
+        _zz_105 = _zz_255;
       end
     endcase
   end
 
   always @ (*) begin
-    _zz_108_ = 1'b0;
-    if(_zz_197_)begin
-      if(_zz_198_)begin
-        if(_zz_113_)begin
-          _zz_108_ = 1'b1;
+    _zz_106 = 1'b0;
+    if(_zz_194)begin
+      if(_zz_195)begin
+        if(_zz_111)begin
+          _zz_106 = 1'b1;
         end
       end
     end
-    if(_zz_199_)begin
-      if(_zz_200_)begin
-        if(_zz_115_)begin
-          _zz_108_ = 1'b1;
+    if(_zz_196)begin
+      if(_zz_197)begin
+        if(_zz_113)begin
+          _zz_106 = 1'b1;
         end
       end
     end
-    if(_zz_201_)begin
-      if(_zz_202_)begin
-        if(_zz_117_)begin
-          _zz_108_ = 1'b1;
+    if(_zz_198)begin
+      if(_zz_199)begin
+        if(_zz_115)begin
+          _zz_106 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_108_ = 1'b0;
+      _zz_106 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_109_ = 1'b0;
-    if(_zz_197_)begin
-      if(_zz_198_)begin
-        if(_zz_114_)begin
-          _zz_109_ = 1'b1;
+    _zz_107 = 1'b0;
+    if(_zz_194)begin
+      if(_zz_195)begin
+        if(_zz_112)begin
+          _zz_107 = 1'b1;
         end
       end
     end
-    if(_zz_199_)begin
-      if(_zz_200_)begin
-        if(_zz_116_)begin
-          _zz_109_ = 1'b1;
+    if(_zz_196)begin
+      if(_zz_197)begin
+        if(_zz_114)begin
+          _zz_107 = 1'b1;
         end
       end
     end
-    if(_zz_201_)begin
-      if(_zz_202_)begin
-        if(_zz_118_)begin
-          _zz_109_ = 1'b1;
+    if(_zz_198)begin
+      if(_zz_199)begin
+        if(_zz_116)begin
+          _zz_107 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_109_ = 1'b0;
+      _zz_107 = 1'b0;
     end
   end
 
-  assign _zz_113_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_114_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_115_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_116_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_117_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_118_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_111 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_112 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_113 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_114 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_115 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_116 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_119_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_117 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_119_ == (3'b000))) begin
-        _zz_120_ = execute_BranchPlugin_eq;
-    end else if((_zz_119_ == (3'b001))) begin
-        _zz_120_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_119_ & (3'b101)) == (3'b101)))) begin
-        _zz_120_ = (! execute_SRC_LESS);
+    if((_zz_117 == 3'b000)) begin
+        _zz_118 = execute_BranchPlugin_eq;
+    end else if((_zz_117 == 3'b001)) begin
+        _zz_118 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_117 & 3'b101) == 3'b101))) begin
+        _zz_118 = (! execute_SRC_LESS);
     end else begin
-        _zz_120_ = execute_SRC_LESS;
+        _zz_118 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_121_ = 1'b0;
+        _zz_119 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_121_ = 1'b1;
+        _zz_119 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_121_ = 1'b1;
+        _zz_119 = 1'b1;
       end
       default : begin
-        _zz_121_ = _zz_120_;
+        _zz_119 = _zz_118;
       end
     endcase
   end
 
-  assign _zz_122_ = _zz_259_[11];
+  assign _zz_120 = _zz_257[11];
   always @ (*) begin
-    _zz_123_[19] = _zz_122_;
-    _zz_123_[18] = _zz_122_;
-    _zz_123_[17] = _zz_122_;
-    _zz_123_[16] = _zz_122_;
-    _zz_123_[15] = _zz_122_;
-    _zz_123_[14] = _zz_122_;
-    _zz_123_[13] = _zz_122_;
-    _zz_123_[12] = _zz_122_;
-    _zz_123_[11] = _zz_122_;
-    _zz_123_[10] = _zz_122_;
-    _zz_123_[9] = _zz_122_;
-    _zz_123_[8] = _zz_122_;
-    _zz_123_[7] = _zz_122_;
-    _zz_123_[6] = _zz_122_;
-    _zz_123_[5] = _zz_122_;
-    _zz_123_[4] = _zz_122_;
-    _zz_123_[3] = _zz_122_;
-    _zz_123_[2] = _zz_122_;
-    _zz_123_[1] = _zz_122_;
-    _zz_123_[0] = _zz_122_;
+    _zz_121[19] = _zz_120;
+    _zz_121[18] = _zz_120;
+    _zz_121[17] = _zz_120;
+    _zz_121[16] = _zz_120;
+    _zz_121[15] = _zz_120;
+    _zz_121[14] = _zz_120;
+    _zz_121[13] = _zz_120;
+    _zz_121[12] = _zz_120;
+    _zz_121[11] = _zz_120;
+    _zz_121[10] = _zz_120;
+    _zz_121[9] = _zz_120;
+    _zz_121[8] = _zz_120;
+    _zz_121[7] = _zz_120;
+    _zz_121[6] = _zz_120;
+    _zz_121[5] = _zz_120;
+    _zz_121[4] = _zz_120;
+    _zz_121[3] = _zz_120;
+    _zz_121[2] = _zz_120;
+    _zz_121[1] = _zz_120;
+    _zz_121[0] = _zz_120;
   end
 
-  assign _zz_124_ = _zz_260_[19];
+  assign _zz_122 = _zz_258[19];
   always @ (*) begin
-    _zz_125_[10] = _zz_124_;
-    _zz_125_[9] = _zz_124_;
-    _zz_125_[8] = _zz_124_;
-    _zz_125_[7] = _zz_124_;
-    _zz_125_[6] = _zz_124_;
-    _zz_125_[5] = _zz_124_;
-    _zz_125_[4] = _zz_124_;
-    _zz_125_[3] = _zz_124_;
-    _zz_125_[2] = _zz_124_;
-    _zz_125_[1] = _zz_124_;
-    _zz_125_[0] = _zz_124_;
+    _zz_123[10] = _zz_122;
+    _zz_123[9] = _zz_122;
+    _zz_123[8] = _zz_122;
+    _zz_123[7] = _zz_122;
+    _zz_123[6] = _zz_122;
+    _zz_123[5] = _zz_122;
+    _zz_123[4] = _zz_122;
+    _zz_123[3] = _zz_122;
+    _zz_123[2] = _zz_122;
+    _zz_123[1] = _zz_122;
+    _zz_123[0] = _zz_122;
   end
 
-  assign _zz_126_ = _zz_261_[11];
+  assign _zz_124 = _zz_259[11];
   always @ (*) begin
-    _zz_127_[18] = _zz_126_;
-    _zz_127_[17] = _zz_126_;
-    _zz_127_[16] = _zz_126_;
-    _zz_127_[15] = _zz_126_;
-    _zz_127_[14] = _zz_126_;
-    _zz_127_[13] = _zz_126_;
-    _zz_127_[12] = _zz_126_;
-    _zz_127_[11] = _zz_126_;
-    _zz_127_[10] = _zz_126_;
-    _zz_127_[9] = _zz_126_;
-    _zz_127_[8] = _zz_126_;
-    _zz_127_[7] = _zz_126_;
-    _zz_127_[6] = _zz_126_;
-    _zz_127_[5] = _zz_126_;
-    _zz_127_[4] = _zz_126_;
-    _zz_127_[3] = _zz_126_;
-    _zz_127_[2] = _zz_126_;
-    _zz_127_[1] = _zz_126_;
-    _zz_127_[0] = _zz_126_;
+    _zz_125[18] = _zz_124;
+    _zz_125[17] = _zz_124;
+    _zz_125[16] = _zz_124;
+    _zz_125[15] = _zz_124;
+    _zz_125[14] = _zz_124;
+    _zz_125[13] = _zz_124;
+    _zz_125[12] = _zz_124;
+    _zz_125[11] = _zz_124;
+    _zz_125[10] = _zz_124;
+    _zz_125[9] = _zz_124;
+    _zz_125[8] = _zz_124;
+    _zz_125[7] = _zz_124;
+    _zz_125[6] = _zz_124;
+    _zz_125[5] = _zz_124;
+    _zz_125[4] = _zz_124;
+    _zz_125[3] = _zz_124;
+    _zz_125[2] = _zz_124;
+    _zz_125[1] = _zz_124;
+    _zz_125[0] = _zz_124;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_128_ = (_zz_262_[1] ^ execute_RS1[1]);
+        _zz_126 = (_zz_260[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_128_ = _zz_263_[1];
+        _zz_126 = _zz_261[1];
       end
       default : begin
-        _zz_128_ = _zz_264_[1];
+        _zz_126 = _zz_262[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_128_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_126);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -3880,110 +3474,110 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_129_ = _zz_265_[11];
+  assign _zz_127 = _zz_263[11];
   always @ (*) begin
-    _zz_130_[19] = _zz_129_;
-    _zz_130_[18] = _zz_129_;
-    _zz_130_[17] = _zz_129_;
-    _zz_130_[16] = _zz_129_;
-    _zz_130_[15] = _zz_129_;
-    _zz_130_[14] = _zz_129_;
-    _zz_130_[13] = _zz_129_;
-    _zz_130_[12] = _zz_129_;
-    _zz_130_[11] = _zz_129_;
-    _zz_130_[10] = _zz_129_;
-    _zz_130_[9] = _zz_129_;
-    _zz_130_[8] = _zz_129_;
-    _zz_130_[7] = _zz_129_;
-    _zz_130_[6] = _zz_129_;
-    _zz_130_[5] = _zz_129_;
-    _zz_130_[4] = _zz_129_;
-    _zz_130_[3] = _zz_129_;
-    _zz_130_[2] = _zz_129_;
-    _zz_130_[1] = _zz_129_;
-    _zz_130_[0] = _zz_129_;
+    _zz_128[19] = _zz_127;
+    _zz_128[18] = _zz_127;
+    _zz_128[17] = _zz_127;
+    _zz_128[16] = _zz_127;
+    _zz_128[15] = _zz_127;
+    _zz_128[14] = _zz_127;
+    _zz_128[13] = _zz_127;
+    _zz_128[12] = _zz_127;
+    _zz_128[11] = _zz_127;
+    _zz_128[10] = _zz_127;
+    _zz_128[9] = _zz_127;
+    _zz_128[8] = _zz_127;
+    _zz_128[7] = _zz_127;
+    _zz_128[6] = _zz_127;
+    _zz_128[5] = _zz_127;
+    _zz_128[4] = _zz_127;
+    _zz_128[3] = _zz_127;
+    _zz_128[2] = _zz_127;
+    _zz_128[1] = _zz_127;
+    _zz_128[0] = _zz_127;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_130_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_128,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_132_,{{{_zz_472_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_134_,{{{_zz_473_,_zz_474_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_130,{{{_zz_475,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_132,{{{_zz_476,_zz_477},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_268_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_266};
         end
       end
     endcase
   end
 
-  assign _zz_131_ = _zz_266_[19];
+  assign _zz_129 = _zz_264[19];
   always @ (*) begin
-    _zz_132_[10] = _zz_131_;
-    _zz_132_[9] = _zz_131_;
-    _zz_132_[8] = _zz_131_;
-    _zz_132_[7] = _zz_131_;
-    _zz_132_[6] = _zz_131_;
-    _zz_132_[5] = _zz_131_;
-    _zz_132_[4] = _zz_131_;
-    _zz_132_[3] = _zz_131_;
-    _zz_132_[2] = _zz_131_;
-    _zz_132_[1] = _zz_131_;
-    _zz_132_[0] = _zz_131_;
+    _zz_130[10] = _zz_129;
+    _zz_130[9] = _zz_129;
+    _zz_130[8] = _zz_129;
+    _zz_130[7] = _zz_129;
+    _zz_130[6] = _zz_129;
+    _zz_130[5] = _zz_129;
+    _zz_130[4] = _zz_129;
+    _zz_130[3] = _zz_129;
+    _zz_130[2] = _zz_129;
+    _zz_130[1] = _zz_129;
+    _zz_130[0] = _zz_129;
   end
 
-  assign _zz_133_ = _zz_267_[11];
+  assign _zz_131 = _zz_265[11];
   always @ (*) begin
-    _zz_134_[18] = _zz_133_;
-    _zz_134_[17] = _zz_133_;
-    _zz_134_[16] = _zz_133_;
-    _zz_134_[15] = _zz_133_;
-    _zz_134_[14] = _zz_133_;
-    _zz_134_[13] = _zz_133_;
-    _zz_134_[12] = _zz_133_;
-    _zz_134_[11] = _zz_133_;
-    _zz_134_[10] = _zz_133_;
-    _zz_134_[9] = _zz_133_;
-    _zz_134_[8] = _zz_133_;
-    _zz_134_[7] = _zz_133_;
-    _zz_134_[6] = _zz_133_;
-    _zz_134_[5] = _zz_133_;
-    _zz_134_[4] = _zz_133_;
-    _zz_134_[3] = _zz_133_;
-    _zz_134_[2] = _zz_133_;
-    _zz_134_[1] = _zz_133_;
-    _zz_134_[0] = _zz_133_;
+    _zz_132[18] = _zz_131;
+    _zz_132[17] = _zz_131;
+    _zz_132[16] = _zz_131;
+    _zz_132[15] = _zz_131;
+    _zz_132[14] = _zz_131;
+    _zz_132[13] = _zz_131;
+    _zz_132[12] = _zz_131;
+    _zz_132[11] = _zz_131;
+    _zz_132[10] = _zz_131;
+    _zz_132[9] = _zz_131;
+    _zz_132[8] = _zz_131;
+    _zz_132[7] = _zz_131;
+    _zz_132[6] = _zz_131;
+    _zz_132[5] = _zz_131;
+    _zz_132[4] = _zz_131;
+    _zz_132[3] = _zz_131;
+    _zz_132[2] = _zz_131;
+    _zz_132[1] = _zz_131;
+    _zz_132[0] = _zz_131;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_135_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_136_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_137_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_133 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_134 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_135 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_138_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_139_ = _zz_269_[0];
-  assign _zz_140_ = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_141_ = _zz_271_[0];
+  assign _zz_136 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_137 = _zz_267[0];
+  assign _zz_138 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_139 = _zz_269[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_185_)begin
+    if(_zz_184)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -4003,7 +3597,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_190_)begin
+    if(_zz_188)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -4027,7 +3621,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -4051,7 +3645,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -4073,7 +3667,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768)begin
@@ -4111,7 +3705,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_203_)begin
+    if(_zz_200)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -4130,20 +3724,20 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_204_)begin
+    if(_zz_201)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_204_)begin
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_201)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -4152,14 +3746,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_203_)begin
+    if(_zz_200)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_203_)begin
+    if(_zz_200)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -4168,7 +3762,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_215_)
+    case(_zz_213)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -4182,8 +3776,8 @@ module VexRiscv (
   assign memory_MulDivIterativePlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b0;
-    if(_zz_173_)begin
-      if(_zz_189_)begin
+    if(_zz_172)begin
+      if(_zz_187)begin
         memory_MulDivIterativePlugin_mul_counter_willIncrement = 1'b1;
       end
     end
@@ -4202,7 +3796,7 @@ module VexRiscv (
     if(memory_MulDivIterativePlugin_mul_counter_willOverflow)begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_274_);
+      memory_MulDivIterativePlugin_mul_counter_valueNext = (memory_MulDivIterativePlugin_mul_counter_value + _zz_272);
     end
     if(memory_MulDivIterativePlugin_mul_counter_willClear)begin
       memory_MulDivIterativePlugin_mul_counter_valueNext = 6'h0;
@@ -4211,8 +3805,8 @@ module VexRiscv (
 
   always @ (*) begin
     memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_174_)begin
-      if(_zz_205_)begin
+    if(_zz_173)begin
+      if(_zz_202)begin
         memory_MulDivIterativePlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -4220,7 +3814,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_MulDivIterativePlugin_div_counter_willClear = 1'b0;
-    if(_zz_206_)begin
+    if(_zz_203)begin
       memory_MulDivIterativePlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -4231,35 +3825,33 @@ module VexRiscv (
     if(memory_MulDivIterativePlugin_div_counter_willOverflow)begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_282_);
+      memory_MulDivIterativePlugin_div_counter_valueNext = (memory_MulDivIterativePlugin_div_counter_value + _zz_280);
     end
     if(memory_MulDivIterativePlugin_div_counter_willClear)begin
       memory_MulDivIterativePlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_142_ = memory_MulDivIterativePlugin_rs1[31 : 0];
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_142_[31]};
-  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_283_);
-  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_284_ : _zz_285_);
-  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_286_[31:0];
-  assign _zz_143_ = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
-  assign _zz_144_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_145_ = ((execute_IS_MUL && _zz_144_) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_140 = memory_MulDivIterativePlugin_rs1[31 : 0];
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderShifted = {memory_MulDivIterativePlugin_accumulator[31 : 0],_zz_140[31]};
+  assign memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator = (memory_MulDivIterativePlugin_div_stage_0_remainderShifted - _zz_281);
+  assign memory_MulDivIterativePlugin_div_stage_0_outRemainder = ((! memory_MulDivIterativePlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_282 : _zz_283);
+  assign memory_MulDivIterativePlugin_div_stage_0_outNumerator = _zz_284[31:0];
+  assign _zz_141 = (memory_INSTRUCTION[13] ? memory_MulDivIterativePlugin_accumulator[31 : 0] : memory_MulDivIterativePlugin_rs1[31 : 0]);
+  assign _zz_142 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_143 = ((execute_IS_MUL && _zz_142) || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_146_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_146_[31 : 0] = execute_RS1;
+    _zz_144[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_144[31 : 0] = execute_RS1;
   end
 
-  assign _zz_148_ = (_zz_147_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_148_ != 32'h0);
+  assign _zz_146 = (_zz_145 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_146 != 32'h0);
   always @ (*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid)begin
-      case(_zz_207_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_204)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
@@ -4272,7 +3864,7 @@ module VexRiscv (
 
   always @ (*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_149_))begin
+    if((! _zz_147))begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -4284,10 +3876,8 @@ module VexRiscv (
   always @ (*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid)begin
-      case(_zz_207_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_204)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
@@ -4299,37 +3889,37 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == (2'b11));
+  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_24_ = decode_SRC1_CTRL;
-  assign _zz_22_ = _zz_42_;
-  assign _zz_34_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_21_ = decode_BRANCH_CTRL;
-  assign _zz_49_ = _zz_40_;
-  assign _zz_28_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_19_ = decode_SHIFT_CTRL;
-  assign _zz_17_ = _zz_45_;
-  assign _zz_31_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_16_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_14_ = _zz_46_;
-  assign _zz_36_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_13_ = decode_ALU_CTRL;
-  assign _zz_11_ = _zz_41_;
-  assign _zz_35_ = decode_to_execute_ALU_CTRL;
-  assign _zz_10_ = decode_ENV_CTRL;
-  assign _zz_7_ = execute_ENV_CTRL;
-  assign _zz_5_ = memory_ENV_CTRL;
-  assign _zz_8_ = _zz_43_;
-  assign _zz_26_ = decode_to_execute_ENV_CTRL;
-  assign _zz_25_ = execute_to_memory_ENV_CTRL;
-  assign _zz_27_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_3_ = decode_SRC2_CTRL;
-  assign _zz_1_ = _zz_44_;
-  assign _zz_33_ = decode_to_execute_SRC2_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_24 = decode_SRC1_CTRL;
+  assign _zz_22 = _zz_46;
+  assign _zz_34 = decode_to_execute_SRC1_CTRL;
+  assign _zz_21 = decode_ALU_CTRL;
+  assign _zz_19 = _zz_45;
+  assign _zz_35 = decode_to_execute_ALU_CTRL;
+  assign _zz_18 = decode_SRC2_CTRL;
+  assign _zz_16 = _zz_44;
+  assign _zz_33 = decode_to_execute_SRC2_CTRL;
+  assign _zz_15 = decode_ALU_BITWISE_CTRL;
+  assign _zz_13 = _zz_43;
+  assign _zz_36 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_12 = decode_SHIFT_CTRL;
+  assign _zz_10 = _zz_42;
+  assign _zz_31 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_48 = _zz_41;
+  assign _zz_28 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_40;
+  assign _zz_26 = decode_to_execute_ENV_CTRL;
+  assign _zz_25 = execute_to_memory_ENV_CTRL;
+  assign _zz_27 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -4348,15 +3938,7 @@ module VexRiscv (
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_150_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
-      3'b010 : begin
-      end
-      3'b011 : begin
-      end
+    case(_zz_148)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -4366,91 +3948,91 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_151_ = 32'h0;
+    _zz_149 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_151_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_151_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_151_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_149[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_149[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_149[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_152_ = 32'h0;
+    _zz_150 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_152_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_152_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_152_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_150[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_150[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_150[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_153_ = 32'h0;
+    _zz_151 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_153_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_153_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_153_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_151[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_151[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_151[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_154_ = 32'h0;
+    _zz_152 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_154_[31 : 0] = CsrPlugin_mepc;
+      _zz_152[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_155_ = 32'h0;
+    _zz_153 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_155_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_155_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_153[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_153[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_156_ = 32'h0;
+    _zz_154 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_156_[31 : 0] = CsrPlugin_mtval;
+      _zz_154[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_157_ = 32'h0;
+    _zz_155 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_157_[31 : 0] = _zz_147_;
+      _zz_155[31 : 0] = _zz_145;
     end
   end
 
   always @ (*) begin
-    _zz_158_ = 32'h0;
+    _zz_156 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_158_[31 : 0] = _zz_148_;
+      _zz_156[31 : 0] = _zz_146;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((_zz_151_ | _zz_152_) | (_zz_153_ | _zz_154_)) | ((_zz_155_ | _zz_156_) | (_zz_157_ | _zz_158_)));
-  assign iBusWishbone_ADR = {_zz_302_,_zz_159_};
-  assign iBusWishbone_CTI = ((_zz_159_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((_zz_149 | _zz_150) | (_zz_151 | _zz_152)) | ((_zz_153 | _zz_154) | (_zz_155 | _zz_156)));
+  assign iBusWishbone_ADR = {_zz_300,_zz_157};
+  assign iBusWishbone_CTI = ((_zz_157 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_208_)begin
+    if(_zz_205)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_208_)begin
+    if(_zz_205)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_160_;
+  assign iBus_rsp_valid = _zz_158;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
   assign dBus_cmd_halfPipe_valid = dBus_cmd_halfPipe_regs_valid;
@@ -4460,26 +4042,26 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_halfPipe_regs_payload_size;
   assign dBus_cmd_ready = dBus_cmd_halfPipe_regs_ready;
   assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
-  assign dBusWishbone_CTI = (3'b000);
-  assign dBusWishbone_BTE = (2'b00);
+  assign dBusWishbone_CTI = 3'b000;
+  assign dBusWishbone_BTE = 2'b00;
   always @ (*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_161_ = (4'b0001);
+        _zz_159 = 4'b0001;
       end
       2'b01 : begin
-        _zz_161_ = (4'b0011);
+        _zz_159 = 4'b0011;
       end
       default : begin
-        _zz_161_ = (4'b1111);
+        _zz_159 = 4'b1111;
       end
     endcase
   end
 
   always @ (*) begin
-    dBusWishbone_SEL = (_zz_161_ <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    dBusWishbone_SEL = (_zz_159 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
     if((! dBus_cmd_halfPipe_payload_wr))begin
-      dBusWishbone_SEL = (4'b1111);
+      dBusWishbone_SEL = 4'b1111;
     end
   end
 
@@ -4497,21 +4079,21 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_62_ <= 1'b0;
-      _zz_64_ <= 1'b0;
+      _zz_60 <= 1'b0;
+      _zz_62 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_77_;
+      IBusCachedPlugin_rspCounter <= _zz_75;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_99_ <= 1'b1;
+      _zz_97 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_110_ <= 1'b0;
+      _zz_108 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -4527,15 +4109,13 @@ module VexRiscv (
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_MulDivIterativePlugin_mul_counter_value <= 6'h0;
       memory_MulDivIterativePlugin_div_counter_value <= 6'h0;
-      _zz_147_ <= 32'h0;
+      _zz_145 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_150_ <= (3'b000);
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_159_ <= (3'b000);
-      _zz_160_ <= 1'b0;
+      _zz_148 <= 3'b000;
+      _zz_157 <= 3'b000;
+      _zz_158 <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
     end else begin
@@ -4559,16 +4139,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_62_ <= 1'b0;
+        _zz_60 <= 1'b0;
       end
-      if(_zz_60_)begin
-        _zz_62_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_58)begin
+        _zz_60 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_64_ <= 1'b0;
+        _zz_62 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_64_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_62 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -4615,9 +4195,29 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      _zz_99_ <= 1'b0;
-      if(_zz_179_)begin
-        if(_zz_186_)begin
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
+        `else
+          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
+        `else
+          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      _zz_97 <= 1'b0;
+      if(_zz_178)begin
+        if(_zz_206)begin
           execute_LightShifterPlugin_isActive <= 1'b1;
           if(execute_LightShifterPlugin_done)begin
             execute_LightShifterPlugin_isActive <= 1'b0;
@@ -4627,7 +4227,7 @@ module VexRiscv (
       if(execute_arbitration_removeIt)begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_110_ <= (_zz_38_ && writeBack_arbitration_isFiring);
+      _zz_108 <= (_zz_38 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -4649,14 +4249,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_209_)begin
-        if(_zz_210_)begin
+      if(_zz_207)begin
+        if(_zz_208)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_211_)begin
+        if(_zz_209)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_212_)begin
+        if(_zz_210)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -4680,7 +4280,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_191_)begin
+      if(_zz_189)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -4691,10 +4291,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_192_)begin
-        case(_zz_194_)
+      if(_zz_190)begin
+        case(_zz_192)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -4702,15 +4302,9 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_137_,{_zz_136_,_zz_135_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_135,{_zz_134,_zz_133}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_MulDivIterativePlugin_mul_counter_value <= memory_MulDivIterativePlugin_mul_counter_valueNext;
       memory_MulDivIterativePlugin_div_counter_value <= memory_MulDivIterativePlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_29_;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -4729,25 +4323,25 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_150_)
+      case(_zz_148)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_150_ <= (3'b001);
+            _zz_148 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_150_ <= (3'b010);
+          _zz_148 <= 3'b010;
         end
         3'b010 : begin
-          _zz_150_ <= (3'b011);
+          _zz_148 <= 3'b011;
         end
         3'b011 : begin
           if((! decode_arbitration_isStuck))begin
-            _zz_150_ <= (3'b100);
+            _zz_148 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_150_ <= (3'b000);
+          _zz_148 <= 3'b000;
         end
         default : begin
         end
@@ -4755,29 +4349,29 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_296_[0];
-          CsrPlugin_mstatus_MIE <= _zz_297_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_294[0];
+          CsrPlugin_mstatus_MIE <= _zz_295[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_299_[0];
-          CsrPlugin_mie_MTIE <= _zz_300_[0];
-          CsrPlugin_mie_MSIE <= _zz_301_[0];
+          CsrPlugin_mie_MEIE <= _zz_297[0];
+          CsrPlugin_mie_MTIE <= _zz_298[0];
+          CsrPlugin_mie_MSIE <= _zz_299[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_147_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_145 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_208_)begin
+      if(_zz_205)begin
         if(iBusWishbone_ACK)begin
-          _zz_159_ <= (_zz_159_ + (3'b001));
+          _zz_157 <= (_zz_157 + 3'b001);
         end
       end
-      _zz_160_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if(_zz_213_)begin
+      _zz_158 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if(_zz_211)begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -4789,7 +4383,7 @@ module VexRiscv (
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_65_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_63 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -4797,33 +4391,13 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)))
-      `else
-        if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
-          $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
-          $finish;
-        end
-      `endif
-    `endif
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)))
-      `else
-        if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
-          $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
-          $finish;
-        end
-      `endif
-    `endif
-    if(_zz_179_)begin
-      if(_zz_186_)begin
+    if(_zz_178)begin
+      if(_zz_206)begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_111_ <= _zz_37_[11 : 7];
-    _zz_112_ <= _zz_47_;
+    _zz_109 <= _zz_37[11 : 7];
+    _zz_110 <= _zz_47;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -4831,33 +4405,33 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_185_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_184)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_137 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_137 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_190_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_141_ ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_141_ ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
+    if(_zz_188)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_139 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_139 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(_zz_209_)begin
-      if(_zz_210_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_207)begin
+      if(_zz_208)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_211_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_209)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_212_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_210)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_191_)begin
+    if(_zz_189)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -4871,10 +4445,10 @@ module VexRiscv (
         end
       endcase
     end
-    if(_zz_173_)begin
-      if(_zz_189_)begin
+    if(_zz_172)begin
+      if(_zz_187)begin
         memory_MulDivIterativePlugin_rs2 <= (memory_MulDivIterativePlugin_rs2 >>> 1);
-        memory_MulDivIterativePlugin_accumulator <= ({_zz_275_,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
+        memory_MulDivIterativePlugin_accumulator <= ({_zz_273,memory_MulDivIterativePlugin_accumulator[31 : 0]} >>> 1);
       end
     end
     if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
@@ -4883,141 +4457,54 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_MulDivIterativePlugin_div_done <= 1'b0;
     end
-    if(_zz_174_)begin
-      if(_zz_205_)begin
+    if(_zz_173)begin
+      if(_zz_202)begin
         memory_MulDivIterativePlugin_rs1[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outNumerator;
         memory_MulDivIterativePlugin_accumulator[31 : 0] <= memory_MulDivIterativePlugin_div_stage_0_outRemainder;
         if((memory_MulDivIterativePlugin_div_counter_value == 6'h20))begin
-          memory_MulDivIterativePlugin_div_result <= _zz_287_[31:0];
+          memory_MulDivIterativePlugin_div_result <= _zz_285[31:0];
         end
       end
     end
-    if(_zz_206_)begin
+    if(_zz_203)begin
       memory_MulDivIterativePlugin_accumulator <= 65'h0;
-      memory_MulDivIterativePlugin_rs1 <= ((_zz_145_ ? (~ _zz_146_) : _zz_146_) + _zz_293_);
-      memory_MulDivIterativePlugin_rs2 <= ((_zz_144_ ? (~ execute_RS2) : execute_RS2) + _zz_295_);
-      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_145_ ^ (_zz_144_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_MulDivIterativePlugin_rs1 <= ((_zz_143 ? (~ _zz_144) : _zz_144) + _zz_291);
+      memory_MulDivIterativePlugin_rs2 <= ((_zz_142 ? (~ execute_RS2) : execute_RS2) + _zz_293);
+      memory_MulDivIterativePlugin_div_needRevert <= ((_zz_143 ^ (_zz_142 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_32_;
+      execute_to_memory_PC <= _zz_32;
     end
     if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
       memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_51_;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_50;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_50_;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_49;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+      decode_to_execute_SRC1_CTRL <= _zz_23;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_23_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_20_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_18_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_15_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MMU_RSP_physicalAddress <= execute_MMU_RSP_physicalAddress;
-      execute_to_memory_MMU_RSP_isIoAccess <= execute_MMU_RSP_isIoAccess;
-      execute_to_memory_MMU_RSP_allowRead <= execute_MMU_RSP_allowRead;
-      execute_to_memory_MMU_RSP_allowWrite <= execute_MMU_RSP_allowWrite;
-      execute_to_memory_MMU_RSP_allowExecute <= execute_MMU_RSP_allowExecute;
-      execute_to_memory_MMU_RSP_exception <= execute_MMU_RSP_exception;
-      execute_to_memory_MMU_RSP_refilling <= execute_MMU_RSP_refilling;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_12_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_9_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_6_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_4_;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -5029,28 +4516,73 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_ALU_CTRL <= _zz_20;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+      decode_to_execute_SRC2_CTRL <= _zz_17;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_2_;
+      decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MMU_FAULT <= execute_MMU_FAULT;
+      execute_to_memory_MEMORY_STORE <= execute_MEMORY_STORE;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_14;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_11;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
@@ -5059,13 +4591,49 @@ module VexRiscv (
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+      decode_to_execute_RS1 <= decode_RS1;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_29;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
@@ -5096,7 +4664,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_298_[0];
+        CsrPlugin_mip_MSIP <= _zz_296[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -5111,7 +4679,7 @@ module VexRiscv (
       end
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
-    if(_zz_213_)begin
+    if(_zz_211)begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
@@ -5125,12 +4693,12 @@ module VexRiscv (
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
-    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != (4'b0000)) || IBusCachedPlugin_incomingInstruction);
+    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
     if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_47_;
+      DebugPlugin_busReadDataReg <= _zz_47;
     end
-    _zz_149_ <= debug_bus_cmd_payload_address[2];
-    if(_zz_187_)begin
+    _zz_147 <= debug_bus_cmd_payload_address[2];
+    if(_zz_185)begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -5148,8 +4716,8 @@ module VexRiscv (
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid)begin
-        case(_zz_207_)
-          6'b000000 : begin
+        case(_zz_204)
+          6'h0 : begin
             if(debug_bus_cmd_payload_wr)begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
               if(debug_bus_cmd_payload_data[16])begin
@@ -5172,23 +4740,311 @@ module VexRiscv (
               end
             end
           end
-          6'b000001 : begin
-          end
           default : begin
           end
         endcase
       end
-      if(_zz_187_)begin
-        if(_zz_188_)begin
+      if(_zz_185)begin
+        if(_zz_186)begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_193_)begin
+      if(_zz_191)begin
         if(decode_arbitration_isValid)begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input      [2:0]    _zz_9,
+  input      [31:0]   _zz_10,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_11;
+  reg        [22:0]   _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire       [0:0]    _zz_15;
+  wire       [0:0]    _zz_16;
+  wire       [22:0]   _zz_17;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [6:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [5:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [20:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [8:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [8:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [5:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [20:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [22:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:511];
+  (* ram_style = "block" *) reg [22:0] ways_0_tags [0:63];
+
+  assign _zz_13 = (! lineLoader_flushCounter[6]);
+  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_15 = _zz_8[0 : 0];
+  assign _zz_16 = _zz_8[1 : 1];
+  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_11 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_12 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_13)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[6]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[6] ? lineLoader_address[10 : 5] : lineLoader_flushCounter[5 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[6];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 11];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[10 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[10 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[10 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_12;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[22 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 11]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_14)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_13)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 7'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[6];
+    if(_zz_14)begin
+      lineLoader_flushCounter <= 7'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
+    if((_zz_9 != 3'b000))begin
+      io_cpu_fetch_data_regNextWhen <= _zz_10;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Min.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Min.v
@@ -1,34 +1,12 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:38:26
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
-
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
-
-`define Src2CtrlEnum_defaultEncoding_type [1:0]
-`define Src2CtrlEnum_defaultEncoding_RS 2'b00
-`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
-`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
-`define Src2CtrlEnum_defaultEncoding_PC 2'b11
-
-`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
 `define EnvCtrlEnum_defaultEncoding_XRET 2'b01
 `define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
-
-`define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
 `define BranchCtrlEnum_defaultEncoding_type [1:0]
 `define BranchCtrlEnum_defaultEncoding_INC 2'b00
@@ -36,141 +14,34 @@
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
+`define ShiftCtrlEnum_defaultEncoding_type [1:0]
+`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
+
+`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+
+`define Src2CtrlEnum_defaultEncoding_type [1:0]
+`define Src2CtrlEnum_defaultEncoding_RS 2'b00
+`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
+`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
+`define Src2CtrlEnum_defaultEncoding_PC 2'b11
+
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
+
 `define Src1CtrlEnum_defaultEncoding_type [1:0]
 `define Src1CtrlEnum_defaultEncoding_RS 2'b00
 `define Src1CtrlEnum_defaultEncoding_IMU 2'b01
 `define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
 `define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-
-module StreamFifoLowLatency (
-  input               io_push_valid,
-  output              io_push_ready,
-  input               io_push_payload_error,
-  input      [31:0]   io_push_payload_inst,
-  output reg          io_pop_valid,
-  input               io_pop_ready,
-  output reg          io_pop_payload_error,
-  output reg [31:0]   io_pop_payload_inst,
-  input               io_flush,
-  output     [0:0]    io_occupancy,
-  input               clk,
-  input               reset 
-);
-  wire                _zz_4_;
-  wire       [0:0]    _zz_5_;
-  reg                 _zz_1_;
-  reg                 pushPtr_willIncrement;
-  reg                 pushPtr_willClear;
-  wire                pushPtr_willOverflowIfInc;
-  wire                pushPtr_willOverflow;
-  reg                 popPtr_willIncrement;
-  reg                 popPtr_willClear;
-  wire                popPtr_willOverflowIfInc;
-  wire                popPtr_willOverflow;
-  wire                ptrMatch;
-  reg                 risingOccupancy;
-  wire                empty;
-  wire                full;
-  wire                pushing;
-  wire                popping;
-  wire       [32:0]   _zz_2_;
-  reg        [32:0]   _zz_3_;
-
-  assign _zz_4_ = (! empty);
-  assign _zz_5_ = _zz_2_[0 : 0];
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(pushing)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    pushPtr_willIncrement = 1'b0;
-    if(pushing)begin
-      pushPtr_willIncrement = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    pushPtr_willClear = 1'b0;
-    if(io_flush)begin
-      pushPtr_willClear = 1'b1;
-    end
-  end
-
-  assign pushPtr_willOverflowIfInc = 1'b1;
-  assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
-  always @ (*) begin
-    popPtr_willIncrement = 1'b0;
-    if(popping)begin
-      popPtr_willIncrement = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    popPtr_willClear = 1'b0;
-    if(io_flush)begin
-      popPtr_willClear = 1'b1;
-    end
-  end
-
-  assign popPtr_willOverflowIfInc = 1'b1;
-  assign popPtr_willOverflow = (popPtr_willOverflowIfInc && popPtr_willIncrement);
-  assign ptrMatch = 1'b1;
-  assign empty = (ptrMatch && (! risingOccupancy));
-  assign full = (ptrMatch && risingOccupancy);
-  assign pushing = (io_push_valid && io_push_ready);
-  assign popping = (io_pop_valid && io_pop_ready);
-  assign io_push_ready = (! full);
-  always @ (*) begin
-    if(_zz_4_)begin
-      io_pop_valid = 1'b1;
-    end else begin
-      io_pop_valid = io_push_valid;
-    end
-  end
-
-  assign _zz_2_ = _zz_3_;
-  always @ (*) begin
-    if(_zz_4_)begin
-      io_pop_payload_error = _zz_5_[0];
-    end else begin
-      io_pop_payload_error = io_push_payload_error;
-    end
-  end
-
-  always @ (*) begin
-    if(_zz_4_)begin
-      io_pop_payload_inst = _zz_2_[32 : 1];
-    end else begin
-      io_pop_payload_inst = io_push_payload_inst;
-    end
-  end
-
-  assign io_occupancy = (risingOccupancy && ptrMatch);
-  always @ (posedge clk) begin
-    if(reset) begin
-      risingOccupancy <= 1'b0;
-    end else begin
-      if((pushing != popping))begin
-        risingOccupancy <= pushing;
-      end
-      if(io_flush)begin
-        risingOccupancy <= 1'b0;
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_)begin
-      _zz_3_ <= {io_push_payload_inst,io_push_payload_error};
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -186,8 +57,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -197,302 +68,293 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output reg [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset 
+  input               reset
 );
-  wire                _zz_124_;
-  wire                _zz_125_;
-  reg        [31:0]   _zz_126_;
-  reg        [31:0]   _zz_127_;
-  reg        [31:0]   _zz_128_;
+  wire                _zz_119;
+  wire                _zz_120;
+  reg        [31:0]   _zz_121;
+  reg        [31:0]   _zz_122;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
-  wire                _zz_129_;
-  wire                _zz_130_;
-  wire                _zz_131_;
-  wire                _zz_132_;
-  wire                _zz_133_;
-  wire                _zz_134_;
-  wire                _zz_135_;
-  wire       [1:0]    _zz_136_;
-  wire                _zz_137_;
-  wire                _zz_138_;
-  wire                _zz_139_;
-  wire                _zz_140_;
-  wire                _zz_141_;
-  wire                _zz_142_;
-  wire                _zz_143_;
-  wire                _zz_144_;
-  wire                _zz_145_;
-  wire                _zz_146_;
-  wire                _zz_147_;
-  wire                _zz_148_;
-  wire                _zz_149_;
-  wire                _zz_150_;
-  wire                _zz_151_;
-  wire                _zz_152_;
-  wire       [1:0]    _zz_153_;
-  wire                _zz_154_;
-  wire       [0:0]    _zz_155_;
-  wire       [0:0]    _zz_156_;
-  wire       [0:0]    _zz_157_;
-  wire       [0:0]    _zz_158_;
-  wire       [0:0]    _zz_159_;
-  wire       [0:0]    _zz_160_;
-  wire       [0:0]    _zz_161_;
-  wire       [0:0]    _zz_162_;
-  wire       [0:0]    _zz_163_;
-  wire       [0:0]    _zz_164_;
-  wire       [0:0]    _zz_165_;
-  wire       [2:0]    _zz_166_;
-  wire       [2:0]    _zz_167_;
-  wire       [31:0]   _zz_168_;
-  wire       [2:0]    _zz_169_;
-  wire       [0:0]    _zz_170_;
-  wire       [2:0]    _zz_171_;
-  wire       [0:0]    _zz_172_;
-  wire       [2:0]    _zz_173_;
-  wire       [0:0]    _zz_174_;
-  wire       [2:0]    _zz_175_;
-  wire       [0:0]    _zz_176_;
-  wire       [2:0]    _zz_177_;
-  wire       [2:0]    _zz_178_;
-  wire       [0:0]    _zz_179_;
-  wire       [2:0]    _zz_180_;
-  wire       [4:0]    _zz_181_;
-  wire       [11:0]   _zz_182_;
-  wire       [11:0]   _zz_183_;
-  wire       [31:0]   _zz_184_;
-  wire       [31:0]   _zz_185_;
-  wire       [31:0]   _zz_186_;
-  wire       [31:0]   _zz_187_;
-  wire       [31:0]   _zz_188_;
-  wire       [31:0]   _zz_189_;
-  wire       [31:0]   _zz_190_;
-  wire       [31:0]   _zz_191_;
-  wire       [32:0]   _zz_192_;
-  wire       [19:0]   _zz_193_;
-  wire       [11:0]   _zz_194_;
-  wire       [11:0]   _zz_195_;
-  wire       [1:0]    _zz_196_;
-  wire       [1:0]    _zz_197_;
-  wire       [1:0]    _zz_198_;
-  wire       [1:0]    _zz_199_;
-  wire       [0:0]    _zz_200_;
-  wire       [0:0]    _zz_201_;
-  wire       [0:0]    _zz_202_;
-  wire       [0:0]    _zz_203_;
-  wire       [0:0]    _zz_204_;
-  wire       [0:0]    _zz_205_;
-  wire                _zz_206_;
-  wire                _zz_207_;
-  wire       [1:0]    _zz_208_;
-  wire       [31:0]   _zz_209_;
-  wire       [31:0]   _zz_210_;
-  wire       [31:0]   _zz_211_;
-  wire                _zz_212_;
-  wire       [0:0]    _zz_213_;
-  wire       [12:0]   _zz_214_;
-  wire       [31:0]   _zz_215_;
-  wire       [31:0]   _zz_216_;
-  wire       [31:0]   _zz_217_;
-  wire                _zz_218_;
-  wire       [0:0]    _zz_219_;
-  wire       [6:0]    _zz_220_;
-  wire       [31:0]   _zz_221_;
-  wire       [31:0]   _zz_222_;
-  wire       [31:0]   _zz_223_;
-  wire                _zz_224_;
-  wire       [0:0]    _zz_225_;
-  wire       [0:0]    _zz_226_;
-  wire       [31:0]   _zz_227_;
-  wire                _zz_228_;
-  wire                _zz_229_;
-  wire       [0:0]    _zz_230_;
-  wire       [0:0]    _zz_231_;
-  wire       [3:0]    _zz_232_;
-  wire       [3:0]    _zz_233_;
-  wire                _zz_234_;
-  wire       [0:0]    _zz_235_;
-  wire       [19:0]   _zz_236_;
-  wire       [31:0]   _zz_237_;
-  wire       [31:0]   _zz_238_;
-  wire       [31:0]   _zz_239_;
-  wire       [31:0]   _zz_240_;
-  wire                _zz_241_;
-  wire       [0:0]    _zz_242_;
-  wire       [0:0]    _zz_243_;
-  wire                _zz_244_;
-  wire       [0:0]    _zz_245_;
-  wire       [0:0]    _zz_246_;
-  wire       [0:0]    _zz_247_;
-  wire       [0:0]    _zz_248_;
-  wire                _zz_249_;
-  wire       [0:0]    _zz_250_;
-  wire       [16:0]   _zz_251_;
-  wire       [31:0]   _zz_252_;
-  wire       [31:0]   _zz_253_;
-  wire       [31:0]   _zz_254_;
-  wire       [31:0]   _zz_255_;
-  wire       [31:0]   _zz_256_;
-  wire       [31:0]   _zz_257_;
-  wire       [0:0]    _zz_258_;
-  wire       [1:0]    _zz_259_;
-  wire       [0:0]    _zz_260_;
-  wire       [0:0]    _zz_261_;
-  wire                _zz_262_;
-  wire       [0:0]    _zz_263_;
-  wire       [13:0]   _zz_264_;
-  wire       [31:0]   _zz_265_;
-  wire       [31:0]   _zz_266_;
-  wire       [31:0]   _zz_267_;
-  wire       [31:0]   _zz_268_;
-  wire       [31:0]   _zz_269_;
-  wire       [31:0]   _zz_270_;
-  wire       [31:0]   _zz_271_;
-  wire       [31:0]   _zz_272_;
-  wire       [0:0]    _zz_273_;
-  wire       [0:0]    _zz_274_;
-  wire       [0:0]    _zz_275_;
-  wire       [0:0]    _zz_276_;
-  wire                _zz_277_;
-  wire       [0:0]    _zz_278_;
-  wire       [10:0]   _zz_279_;
-  wire       [31:0]   _zz_280_;
-  wire       [31:0]   _zz_281_;
-  wire       [31:0]   _zz_282_;
-  wire       [0:0]    _zz_283_;
-  wire       [1:0]    _zz_284_;
-  wire       [5:0]    _zz_285_;
-  wire       [5:0]    _zz_286_;
-  wire                _zz_287_;
-  wire       [0:0]    _zz_288_;
-  wire       [6:0]    _zz_289_;
-  wire       [31:0]   _zz_290_;
-  wire       [31:0]   _zz_291_;
-  wire       [31:0]   _zz_292_;
-  wire       [31:0]   _zz_293_;
-  wire       [31:0]   _zz_294_;
-  wire                _zz_295_;
-  wire       [0:0]    _zz_296_;
-  wire       [2:0]    _zz_297_;
-  wire                _zz_298_;
-  wire                _zz_299_;
-  wire                _zz_300_;
-  wire       [1:0]    _zz_301_;
-  wire       [1:0]    _zz_302_;
-  wire                _zz_303_;
-  wire       [0:0]    _zz_304_;
-  wire       [3:0]    _zz_305_;
-  wire       [31:0]   _zz_306_;
-  wire       [31:0]   _zz_307_;
-  wire       [31:0]   _zz_308_;
-  wire       [0:0]    _zz_309_;
-  wire       [0:0]    _zz_310_;
-  wire       [31:0]   _zz_311_;
-  wire       [31:0]   _zz_312_;
-  wire       [31:0]   _zz_313_;
-  wire                _zz_314_;
-  wire                _zz_315_;
-  wire       [0:0]    _zz_316_;
-  wire       [0:0]    _zz_317_;
-  wire       [0:0]    _zz_318_;
-  wire       [0:0]    _zz_319_;
-  wire                _zz_320_;
-  wire       [0:0]    _zz_321_;
-  wire       [1:0]    _zz_322_;
-  wire       [31:0]   _zz_323_;
-  wire       [31:0]   _zz_324_;
-  wire       [31:0]   _zz_325_;
-  wire       [31:0]   _zz_326_;
-  wire       [31:0]   _zz_327_;
-  wire       [31:0]   _zz_328_;
-  wire       [31:0]   _zz_329_;
-  wire       [31:0]   _zz_330_;
-  wire       [31:0]   _zz_331_;
-  wire       [31:0]   _zz_332_;
-  wire       [31:0]   _zz_333_;
-  wire       [31:0]   _zz_334_;
-  wire       [0:0]    _zz_335_;
-  wire       [0:0]    _zz_336_;
-  wire       [0:0]    _zz_337_;
-  wire       [0:0]    _zz_338_;
-  wire                _zz_339_;
-  wire                _zz_340_;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire                _zz_123;
+  wire                _zz_124;
+  wire                _zz_125;
+  wire                _zz_126;
+  wire                _zz_127;
+  wire       [1:0]    _zz_128;
+  wire                _zz_129;
+  wire                _zz_130;
+  wire                _zz_131;
+  wire                _zz_132;
+  wire                _zz_133;
+  wire                _zz_134;
+  wire                _zz_135;
+  wire                _zz_136;
+  wire                _zz_137;
+  wire                _zz_138;
+  wire                _zz_139;
+  wire                _zz_140;
+  wire                _zz_141;
+  wire                _zz_142;
+  wire                _zz_143;
+  wire       [1:0]    _zz_144;
+  wire                _zz_145;
+  wire       [0:0]    _zz_146;
+  wire       [0:0]    _zz_147;
+  wire       [0:0]    _zz_148;
+  wire       [0:0]    _zz_149;
+  wire       [0:0]    _zz_150;
+  wire       [0:0]    _zz_151;
+  wire       [0:0]    _zz_152;
+  wire       [0:0]    _zz_153;
+  wire       [0:0]    _zz_154;
+  wire       [0:0]    _zz_155;
+  wire       [0:0]    _zz_156;
+  wire       [1:0]    _zz_157;
+  wire       [1:0]    _zz_158;
+  wire       [2:0]    _zz_159;
+  wire       [31:0]   _zz_160;
+  wire       [2:0]    _zz_161;
+  wire       [0:0]    _zz_162;
+  wire       [2:0]    _zz_163;
+  wire       [0:0]    _zz_164;
+  wire       [2:0]    _zz_165;
+  wire       [0:0]    _zz_166;
+  wire       [2:0]    _zz_167;
+  wire       [0:0]    _zz_168;
+  wire       [2:0]    _zz_169;
+  wire       [2:0]    _zz_170;
+  wire       [0:0]    _zz_171;
+  wire       [2:0]    _zz_172;
+  wire       [4:0]    _zz_173;
+  wire       [11:0]   _zz_174;
+  wire       [11:0]   _zz_175;
+  wire       [31:0]   _zz_176;
+  wire       [31:0]   _zz_177;
+  wire       [31:0]   _zz_178;
+  wire       [31:0]   _zz_179;
+  wire       [31:0]   _zz_180;
+  wire       [31:0]   _zz_181;
+  wire       [31:0]   _zz_182;
+  wire       [31:0]   _zz_183;
+  wire       [32:0]   _zz_184;
+  wire       [19:0]   _zz_185;
+  wire       [11:0]   _zz_186;
+  wire       [11:0]   _zz_187;
+  wire       [1:0]    _zz_188;
+  wire       [1:0]    _zz_189;
+  wire       [0:0]    _zz_190;
+  wire       [0:0]    _zz_191;
+  wire       [0:0]    _zz_192;
+  wire       [0:0]    _zz_193;
+  wire       [0:0]    _zz_194;
+  wire       [0:0]    _zz_195;
+  wire                _zz_196;
+  wire                _zz_197;
+  wire       [31:0]   _zz_198;
+  wire       [31:0]   _zz_199;
+  wire       [31:0]   _zz_200;
+  wire                _zz_201;
+  wire       [0:0]    _zz_202;
+  wire       [12:0]   _zz_203;
+  wire       [31:0]   _zz_204;
+  wire       [31:0]   _zz_205;
+  wire       [31:0]   _zz_206;
+  wire                _zz_207;
+  wire       [0:0]    _zz_208;
+  wire       [6:0]    _zz_209;
+  wire       [31:0]   _zz_210;
+  wire       [31:0]   _zz_211;
+  wire       [31:0]   _zz_212;
+  wire                _zz_213;
+  wire       [0:0]    _zz_214;
+  wire       [0:0]    _zz_215;
+  wire       [31:0]   _zz_216;
+  wire       [31:0]   _zz_217;
+  wire       [31:0]   _zz_218;
+  wire       [0:0]    _zz_219;
+  wire       [0:0]    _zz_220;
+  wire       [1:0]    _zz_221;
+  wire       [1:0]    _zz_222;
+  wire                _zz_223;
+  wire       [0:0]    _zz_224;
+  wire       [19:0]   _zz_225;
+  wire       [31:0]   _zz_226;
+  wire       [31:0]   _zz_227;
+  wire       [31:0]   _zz_228;
+  wire       [31:0]   _zz_229;
+  wire       [31:0]   _zz_230;
+  wire       [31:0]   _zz_231;
+  wire                _zz_232;
+  wire       [1:0]    _zz_233;
+  wire       [1:0]    _zz_234;
+  wire                _zz_235;
+  wire       [0:0]    _zz_236;
+  wire       [16:0]   _zz_237;
+  wire       [31:0]   _zz_238;
+  wire       [31:0]   _zz_239;
+  wire       [31:0]   _zz_240;
+  wire       [31:0]   _zz_241;
+  wire                _zz_242;
+  wire                _zz_243;
+  wire                _zz_244;
+  wire       [0:0]    _zz_245;
+  wire       [0:0]    _zz_246;
+  wire                _zz_247;
+  wire       [0:0]    _zz_248;
+  wire       [13:0]   _zz_249;
+  wire       [31:0]   _zz_250;
+  wire                _zz_251;
+  wire                _zz_252;
+  wire       [0:0]    _zz_253;
+  wire       [0:0]    _zz_254;
+  wire       [2:0]    _zz_255;
+  wire       [2:0]    _zz_256;
+  wire                _zz_257;
+  wire       [0:0]    _zz_258;
+  wire       [10:0]   _zz_259;
+  wire       [31:0]   _zz_260;
+  wire       [31:0]   _zz_261;
+  wire       [31:0]   _zz_262;
+  wire       [31:0]   _zz_263;
+  wire                _zz_264;
+  wire                _zz_265;
+  wire       [31:0]   _zz_266;
+  wire       [31:0]   _zz_267;
+  wire                _zz_268;
+  wire       [0:0]    _zz_269;
+  wire       [0:0]    _zz_270;
+  wire                _zz_271;
+  wire       [0:0]    _zz_272;
+  wire       [7:0]    _zz_273;
+  wire       [0:0]    _zz_274;
+  wire       [3:0]    _zz_275;
+  wire       [0:0]    _zz_276;
+  wire       [0:0]    _zz_277;
+  wire       [1:0]    _zz_278;
+  wire       [1:0]    _zz_279;
+  wire                _zz_280;
+  wire       [0:0]    _zz_281;
+  wire       [4:0]    _zz_282;
+  wire       [31:0]   _zz_283;
+  wire       [31:0]   _zz_284;
+  wire       [31:0]   _zz_285;
+  wire       [0:0]    _zz_286;
+  wire       [0:0]    _zz_287;
+  wire       [31:0]   _zz_288;
+  wire       [31:0]   _zz_289;
+  wire       [31:0]   _zz_290;
+  wire                _zz_291;
+  wire                _zz_292;
+  wire                _zz_293;
+  wire       [3:0]    _zz_294;
+  wire       [3:0]    _zz_295;
+  wire                _zz_296;
+  wire       [0:0]    _zz_297;
+  wire       [1:0]    _zz_298;
+  wire       [31:0]   _zz_299;
+  wire       [31:0]   _zz_300;
+  wire       [31:0]   _zz_301;
+  wire       [31:0]   _zz_302;
+  wire       [31:0]   _zz_303;
+  wire       [31:0]   _zz_304;
+  wire       [31:0]   _zz_305;
+  wire                _zz_306;
+  wire       [0:0]    _zz_307;
+  wire       [1:0]    _zz_308;
+  wire                _zz_309;
+  wire       [2:0]    _zz_310;
+  wire       [2:0]    _zz_311;
+  wire                _zz_312;
+  wire                _zz_313;
+  wire       [31:0]   _zz_314;
+  wire       [31:0]   _zz_315;
+  wire       [31:0]   _zz_316;
+  wire       [31:0]   _zz_317;
+  wire       [31:0]   _zz_318;
+  wire       [31:0]   _zz_319;
+  wire       [31:0]   _zz_320;
+  wire                _zz_321;
+  wire                _zz_322;
+  wire                _zz_323;
+  wire                _zz_324;
+  wire       [31:0]   memory_MEMORY_READ_DATA;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire       [31:0]   decode_RS2;
+  wire       [31:0]   decode_RS1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_STORE;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_3_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire                decode_MEMORY_ENABLE;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire                decode_IS_CSR;
-  wire       [31:0]   memory_MEMORY_READ_DATA;
-  wire       [31:0]   decode_RS2;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_6_;
-  wire                execute_BRANCH_DO;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       [31:0]   decode_RS1;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                decode_CSR_READ_OPCODE;
-  wire                decode_MEMORY_STORE;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_22_;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25_;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire       [31:0]   memory_PC;
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_29;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -501,79 +363,61 @@ module VexRiscv (
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
-  reg        [31:0]   _zz_30_;
+  reg        [31:0]   _zz_30;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_32_;
+  wire       [31:0]   _zz_32;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_35_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_35;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36_;
-  wire       [31:0]   _zz_37_;
-  wire                _zz_38_;
-  reg                 _zz_39_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36;
+  wire       [31:0]   _zz_37;
+  wire                _zz_38;
+  reg                 _zz_39;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_40_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_41_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_42_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_40;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_41;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_47_;
+  reg        [31:0]   _zz_47;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
-  wire                memory_MMU_FAULT;
-  wire       [31:0]   memory_MMU_RSP_physicalAddress;
-  wire                memory_MMU_RSP_isIoAccess;
-  wire                memory_MMU_RSP_allowRead;
-  wire                memory_MMU_RSP_allowWrite;
-  wire                memory_MMU_RSP_allowExecute;
-  wire                memory_MMU_RSP_exception;
-  wire                memory_MMU_RSP_refilling;
-  wire       [31:0]   memory_PC;
   wire                memory_ALIGNEMENT_FAULT;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_STORE;
   wire                memory_MEMORY_ENABLE;
-  wire                execute_MMU_FAULT;
-  wire       [31:0]   execute_MMU_RSP_physicalAddress;
-  wire                execute_MMU_RSP_isIoAccess;
-  wire                execute_MMU_RSP_allowRead;
-  wire                execute_MMU_RSP_allowWrite;
-  wire                execute_MMU_RSP_allowExecute;
-  wire                execute_MMU_RSP_exception;
-  wire                execute_MMU_RSP_refilling;
   wire       [31:0]   execute_SRC_ADD;
   wire       [31:0]   execute_RS2;
   wire       [31:0]   execute_INSTRUCTION;
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
   wire                execute_ALIGNEMENT_FAULT;
-  wire                decode_MEMORY_ENABLE;
-  reg        [31:0]   _zz_48_;
+  reg        [31:0]   _zz_48;
   wire       [31:0]   decode_PC;
   wire       [31:0]   decode_INSTRUCTION;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
-  reg                 decode_arbitration_haltItself;
+  wire                decode_arbitration_haltItself;
   reg                 decode_arbitration_haltByOther;
   reg                 decode_arbitration_removeIt;
   wire                decode_arbitration_flushIt;
@@ -598,7 +442,7 @@ module VexRiscv (
   reg                 memory_arbitration_haltItself;
   wire                memory_arbitration_haltByOther;
   reg                 memory_arbitration_removeIt;
-  reg                 memory_arbitration_flushIt;
+  wire                memory_arbitration_flushIt;
   reg                 memory_arbitration_flushNext;
   reg                 memory_arbitration_isValid;
   wire                memory_arbitration_isStuck;
@@ -633,38 +477,9 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire                iBus_rsp_payload_error;
   wire       [31:0]   iBus_rsp_payload_inst;
-  wire                IBusSimplePlugin_decodeExceptionPort_valid;
-  reg        [3:0]    IBusSimplePlugin_decodeExceptionPort_payload_code;
-  wire       [31:0]   IBusSimplePlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusSimplePlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusSimplePlugin_mmuBus_cmd_bypassTranslation;
-  wire       [31:0]   IBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  wire                IBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  wire                IBusSimplePlugin_mmuBus_rsp_allowRead;
-  wire                IBusSimplePlugin_mmuBus_rsp_allowWrite;
-  wire                IBusSimplePlugin_mmuBus_rsp_allowExecute;
-  wire                IBusSimplePlugin_mmuBus_rsp_exception;
-  wire                IBusSimplePlugin_mmuBus_rsp_refilling;
-  wire                IBusSimplePlugin_mmuBus_end;
-  wire                IBusSimplePlugin_mmuBus_busy;
   reg                 DBusSimplePlugin_memoryExceptionPort_valid;
   reg        [3:0]    DBusSimplePlugin_memoryExceptionPort_payload_code;
   wire       [31:0]   DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
-  wire                DBusSimplePlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusSimplePlugin_mmuBus_cmd_bypassTranslation;
-  wire       [31:0]   DBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  wire                DBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowRead;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowWrite;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowExecute;
-  wire                DBusSimplePlugin_mmuBus_rsp_exception;
-  wire                DBusSimplePlugin_mmuBus_rsp_refilling;
-  wire                DBusSimplePlugin_mmuBus_end;
-  wire                DBusSimplePlugin_mmuBus_busy;
-  reg                 DBusSimplePlugin_redoBranch_valid;
-  wire       [31:0]   DBusSimplePlugin_redoBranch_payload;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -693,10 +508,7 @@ module VexRiscv (
   wire                IBusSimplePlugin_externalFlush;
   wire                IBusSimplePlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
-  wire       [2:0]    _zz_49_;
-  wire       [2:0]    _zz_50_;
-  wire                _zz_51_;
-  wire                _zz_52_;
+  wire       [1:0]    _zz_49;
   wire                IBusSimplePlugin_fetchPc_output_valid;
   wire                IBusSimplePlugin_fetchPc_output_ready;
   wire       [31:0]   IBusSimplePlugin_fetchPc_output_payload;
@@ -708,10 +520,8 @@ module VexRiscv (
   reg                 IBusSimplePlugin_fetchPc_booted;
   reg                 IBusSimplePlugin_fetchPc_inc;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
-  wire                IBusSimplePlugin_fetchPc_redo_valid;
-  wire       [31:0]   IBusSimplePlugin_fetchPc_redo_payload;
   reg                 IBusSimplePlugin_fetchPc_flushed;
-  reg                 IBusSimplePlugin_iBusRsp_redoFetch;
+  wire                IBusSimplePlugin_iBusRsp_redoFetch;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
   wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_0_input_payload;
@@ -726,12 +536,12 @@ module VexRiscv (
   wire                IBusSimplePlugin_iBusRsp_stages_1_output_ready;
   wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   wire                IBusSimplePlugin_iBusRsp_stages_1_halt;
-  wire                _zz_53_;
-  wire                _zz_54_;
+  wire                _zz_50;
+  wire                _zz_51;
   wire                IBusSimplePlugin_iBusRsp_flush;
-  wire                _zz_55_;
-  wire                _zz_56_;
-  reg                 _zz_57_;
+  wire                _zz_52;
+  wire                _zz_53;
+  reg                 _zz_54;
   reg                 IBusSimplePlugin_iBusRsp_readyForError;
   wire                IBusSimplePlugin_iBusRsp_output_valid;
   wire                IBusSimplePlugin_iBusRsp_output_ready;
@@ -745,18 +555,18 @@ module VexRiscv (
   wire                IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   wire       [31:0]   IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   wire                IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_58_;
-  reg        [31:0]   _zz_59_;
-  reg                 _zz_60_;
-  reg        [31:0]   _zz_61_;
-  reg                 _zz_62_;
+  reg                 _zz_55;
+  reg        [31:0]   _zz_56;
+  reg                 _zz_57;
+  reg        [31:0]   _zz_58;
+  reg                 _zz_59;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_4;
   reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
-  reg                 IBusSimplePlugin_cmd_valid;
+  wire                IBusSimplePlugin_cmd_valid;
   wire                IBusSimplePlugin_cmd_ready;
   wire       [31:0]   IBusSimplePlugin_cmd_payload_pc;
   wire                IBusSimplePlugin_pending_inc;
@@ -764,13 +574,6 @@ module VexRiscv (
   reg        [2:0]    IBusSimplePlugin_pending_value;
   wire       [2:0]    IBusSimplePlugin_pending_next;
   wire                IBusSimplePlugin_cmdFork_canEmit;
-  reg        [31:0]   IBusSimplePlugin_mmu_joinCtx_physicalAddress;
-  reg                 IBusSimplePlugin_mmu_joinCtx_isIoAccess;
-  reg                 IBusSimplePlugin_mmu_joinCtx_allowRead;
-  reg                 IBusSimplePlugin_mmu_joinCtx_allowWrite;
-  reg                 IBusSimplePlugin_mmu_joinCtx_allowExecute;
-  reg                 IBusSimplePlugin_mmu_joinCtx_exception;
-  reg                 IBusSimplePlugin_mmu_joinCtx_refilling;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -787,8 +590,8 @@ module VexRiscv (
   wire                IBusSimplePlugin_rspJoin_join_payload_rsp_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
   wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
-  reg                 IBusSimplePlugin_rspJoin_exceptionDetected;
-  wire                _zz_63_;
+  wire                IBusSimplePlugin_rspJoin_exceptionDetected;
+  wire                _zz_60;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -798,45 +601,45 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_64_;
+  wire                _zz_61;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_65_;
-  reg        [3:0]    _zz_66_;
+  reg        [31:0]   _zz_62;
+  reg        [3:0]    _zz_63;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_67_;
-  reg        [31:0]   _zz_68_;
-  wire                _zz_69_;
-  reg        [31:0]   _zz_70_;
+  wire                _zz_64;
+  reg        [31:0]   _zz_65;
+  wire                _zz_66;
+  reg        [31:0]   _zz_67;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [25:0]   _zz_71_;
-  wire                _zz_72_;
-  wire                _zz_73_;
-  wire                _zz_74_;
-  wire                _zz_75_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_76_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_77_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_78_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_79_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_80_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_81_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_82_;
+  wire       [25:0]   _zz_68;
+  wire                _zz_69;
+  wire                _zz_70;
+  wire                _zz_71;
+  wire                _zz_72;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_73;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_74;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_75;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_76;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_77;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_78;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_79;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_83_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_80;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_84_;
-  reg        [31:0]   _zz_85_;
-  wire                _zz_86_;
-  reg        [19:0]   _zz_87_;
-  wire                _zz_88_;
-  reg        [19:0]   _zz_89_;
-  reg        [31:0]   _zz_90_;
+  reg        [31:0]   _zz_81;
+  reg        [31:0]   _zz_82;
+  wire                _zz_83;
+  reg        [19:0]   _zz_84;
+  wire                _zz_85;
+  reg        [19:0]   _zz_86;
+  reg        [31:0]   _zz_87;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -845,23 +648,23 @@ module VexRiscv (
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_91_;
-  reg                 _zz_92_;
-  reg                 _zz_93_;
-  reg                 _zz_94_;
-  reg        [4:0]    _zz_95_;
+  reg        [31:0]   _zz_88;
+  reg                 _zz_89;
+  reg                 _zz_90;
+  reg                 _zz_91;
+  reg        [4:0]    _zz_92;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_96_;
-  reg                 _zz_97_;
-  reg                 _zz_98_;
+  wire       [2:0]    _zz_93;
+  reg                 _zz_94;
+  reg                 _zz_95;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_99_;
-  reg        [10:0]   _zz_100_;
-  wire                _zz_101_;
-  reg        [19:0]   _zz_102_;
-  wire                _zz_103_;
-  reg        [18:0]   _zz_104_;
-  reg        [31:0]   _zz_105_;
+  wire                _zz_96;
+  reg        [10:0]   _zz_97;
+  wire                _zz_98;
+  reg        [19:0]   _zz_99;
+  wire                _zz_100;
+  reg        [18:0]   _zz_101;
+  reg        [31:0]   _zz_102;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
@@ -883,9 +686,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_106_;
-  wire                _zz_107_;
-  wire                _zz_108_;
+  wire                _zz_103;
+  wire                _zz_104;
+  wire                _zz_105;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -898,10 +701,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_109_;
-  wire                _zz_110_;
-  wire       [1:0]    _zz_111_;
-  wire                _zz_112_;
+  wire       [1:0]    _zz_106;
+  wire                _zz_107;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -913,7 +714,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -931,62 +732,54 @@ module VexRiscv (
   reg        [31:0]   execute_CsrPlugin_writeData;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_113_;
-  wire       [31:0]   _zz_114_;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   _zz_108;
+  wire       [31:0]   _zz_109;
+  reg        [31:0]   decode_to_execute_PC;
+  reg        [31:0]   execute_to_memory_PC;
+  reg        [31:0]   memory_to_writeBack_PC;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
+  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
+  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
+  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   reg                 decode_to_execute_MEMORY_STORE;
   reg                 execute_to_memory_MEMORY_STORE;
   reg                 memory_to_writeBack_MEMORY_STORE;
-  reg        [31:0]   execute_to_memory_MMU_RSP_physicalAddress;
-  reg                 execute_to_memory_MMU_RSP_isIoAccess;
-  reg                 execute_to_memory_MMU_RSP_allowRead;
-  reg                 execute_to_memory_MMU_RSP_allowWrite;
-  reg                 execute_to_memory_MMU_RSP_allowExecute;
-  reg                 execute_to_memory_MMU_RSP_exception;
-  reg                 execute_to_memory_MMU_RSP_refilling;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 execute_to_memory_ALIGNEMENT_FAULT;
-  reg        [31:0]   decode_to_execute_RS1;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
-  reg        [31:0]   decode_to_execute_PC;
-  reg        [31:0]   execute_to_memory_PC;
-  reg        [31:0]   memory_to_writeBack_PC;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
   reg                 decode_to_execute_IS_CSR;
-  reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
-  reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg                 execute_to_memory_MMU_FAULT;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [31:0]   decode_to_execute_INSTRUCTION;
-  reg        [31:0]   execute_to_memory_INSTRUCTION;
-  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
   reg                 execute_CsrPlugin_csr_772;
@@ -996,14 +789,14 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_835;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_115_;
-  reg        [31:0]   _zz_116_;
-  reg        [31:0]   _zz_117_;
-  reg        [31:0]   _zz_118_;
-  reg        [31:0]   _zz_119_;
-  reg        [31:0]   _zz_120_;
-  reg        [31:0]   _zz_121_;
-  reg        [31:0]   _zz_122_;
+  reg        [31:0]   _zz_110;
+  reg        [31:0]   _zz_111;
+  reg        [31:0]   _zz_112;
+  reg        [31:0]   _zz_113;
+  reg        [31:0]   _zz_114;
+  reg        [31:0]   _zz_115;
+  reg        [31:0]   _zz_116;
+  reg        [31:0]   _zz_117;
   wire                iBus_cmd_m2sPipe_valid;
   wire                iBus_cmd_m2sPipe_ready;
   wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
@@ -1021,474 +814,350 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_123_;
+  reg        [3:0]    _zz_118;
   `ifndef SYNTHESIS
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_1__string;
-  reg [63:0] _zz_2__string;
-  reg [63:0] _zz_3__string;
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_4__string;
-  reg [23:0] _zz_5__string;
-  reg [23:0] _zz_6__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_7__string;
-  reg [39:0] _zz_8__string;
-  reg [39:0] _zz_9__string;
-  reg [39:0] _zz_10__string;
-  reg [39:0] _zz_11__string;
-  reg [39:0] _zz_12__string;
-  reg [39:0] _zz_13__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_14__string;
-  reg [39:0] _zz_15__string;
-  reg [39:0] _zz_16__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_17__string;
-  reg [71:0] _zz_18__string;
-  reg [71:0] _zz_19__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_20__string;
-  reg [31:0] _zz_21__string;
-  reg [31:0] _zz_22__string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [31:0] _zz_10_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_14_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_17_string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_20_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
   reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_23__string;
-  reg [95:0] _zz_24__string;
-  reg [95:0] _zz_25__string;
+  reg [95:0] _zz_23_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_26__string;
+  reg [39:0] _zz_26_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_29__string;
+  reg [31:0] _zz_29_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_31__string;
+  reg [71:0] _zz_31_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_33__string;
+  reg [23:0] _zz_33_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_34__string;
+  reg [95:0] _zz_34_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_35__string;
+  reg [63:0] _zz_35_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_36__string;
-  reg [71:0] _zz_40__string;
-  reg [23:0] _zz_41__string;
-  reg [39:0] _zz_42__string;
-  reg [31:0] _zz_43__string;
-  reg [39:0] _zz_44__string;
-  reg [63:0] _zz_45__string;
-  reg [95:0] _zz_46__string;
-  reg [95:0] _zz_76__string;
-  reg [63:0] _zz_77__string;
-  reg [39:0] _zz_78__string;
-  reg [31:0] _zz_79__string;
-  reg [39:0] _zz_80__string;
-  reg [23:0] _zz_81__string;
-  reg [71:0] _zz_82__string;
+  reg [39:0] _zz_36_string;
+  reg [39:0] _zz_40_string;
+  reg [31:0] _zz_41_string;
+  reg [71:0] _zz_42_string;
+  reg [39:0] _zz_43_string;
+  reg [23:0] _zz_44_string;
+  reg [63:0] _zz_45_string;
+  reg [95:0] _zz_46_string;
+  reg [95:0] _zz_73_string;
+  reg [63:0] _zz_74_string;
+  reg [23:0] _zz_75_string;
+  reg [39:0] _zz_76_string;
+  reg [71:0] _zz_77_string;
+  reg [31:0] _zz_78_string;
+  reg [39:0] _zz_79_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
+  reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
   reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
-  reg [63:0] decode_to_execute_ALU_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_129_ = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_130_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_131_ = ({decodeExceptionPort_valid,IBusSimplePlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_132_ = (! execute_arbitration_isStuckByOthers);
-  assign _zz_133_ = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != (2'b00));
-  assign _zz_134_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_135_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_136_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_137_ = ((IBusSimplePlugin_iBusRsp_stages_1_input_valid && (! IBusSimplePlugin_mmu_joinCtx_refilling)) && (IBusSimplePlugin_mmu_joinCtx_exception || (! IBusSimplePlugin_mmu_joinCtx_allowExecute)));
-  assign _zz_138_ = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign _zz_139_ = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
-  assign _zz_140_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_141_ = (1'b1 || (! 1'b1));
-  assign _zz_142_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_143_ = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_144_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_145_ = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_146_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_147_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_148_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_149_ = ((_zz_106_ && 1'b1) && (! 1'b0));
-  assign _zz_150_ = ((_zz_107_ && 1'b1) && (! 1'b0));
-  assign _zz_151_ = ((_zz_108_ && 1'b1) && (! 1'b0));
-  assign _zz_152_ = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_153_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_154_ = execute_INSTRUCTION[13];
-  assign _zz_155_ = _zz_71_[2 : 2];
-  assign _zz_156_ = _zz_71_[8 : 8];
-  assign _zz_157_ = _zz_71_[16 : 16];
-  assign _zz_158_ = _zz_71_[7 : 7];
-  assign _zz_159_ = _zz_71_[23 : 23];
-  assign _zz_160_ = _zz_71_[6 : 6];
-  assign _zz_161_ = _zz_71_[22 : 22];
-  assign _zz_162_ = _zz_71_[10 : 10];
-  assign _zz_163_ = _zz_71_[3 : 3];
-  assign _zz_164_ = _zz_71_[9 : 9];
-  assign _zz_165_ = _zz_71_[15 : 15];
-  assign _zz_166_ = (_zz_49_ - (3'b001));
-  assign _zz_167_ = {IBusSimplePlugin_fetchPc_inc,(2'b00)};
-  assign _zz_168_ = {29'd0, _zz_167_};
-  assign _zz_169_ = (IBusSimplePlugin_pending_value + _zz_171_);
-  assign _zz_170_ = IBusSimplePlugin_pending_inc;
-  assign _zz_171_ = {2'd0, _zz_170_};
-  assign _zz_172_ = IBusSimplePlugin_pending_dec;
-  assign _zz_173_ = {2'd0, _zz_172_};
-  assign _zz_174_ = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != (3'b000)));
-  assign _zz_175_ = {2'd0, _zz_174_};
-  assign _zz_176_ = IBusSimplePlugin_pending_dec;
-  assign _zz_177_ = {2'd0, _zz_176_};
-  assign _zz_178_ = (memory_MEMORY_STORE ? (3'b110) : (3'b100));
-  assign _zz_179_ = execute_SRC_LESS;
-  assign _zz_180_ = (3'b100);
-  assign _zz_181_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_182_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_183_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_184_ = ($signed(_zz_185_) + $signed(_zz_188_));
-  assign _zz_185_ = ($signed(_zz_186_) + $signed(_zz_187_));
-  assign _zz_186_ = execute_SRC1;
-  assign _zz_187_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_188_ = (execute_SRC_USE_SUB_LESS ? _zz_189_ : _zz_190_);
-  assign _zz_189_ = 32'h00000001;
-  assign _zz_190_ = 32'h0;
-  assign _zz_191_ = (_zz_192_ >>> 1);
-  assign _zz_192_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_193_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_194_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_195_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_196_ = (_zz_109_ & (~ _zz_197_));
-  assign _zz_197_ = (_zz_109_ - (2'b01));
-  assign _zz_198_ = (_zz_111_ & (~ _zz_199_));
-  assign _zz_199_ = (_zz_111_ - (2'b01));
-  assign _zz_200_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_201_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_202_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_203_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_204_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_205_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_206_ = 1'b1;
-  assign _zz_207_ = 1'b1;
-  assign _zz_208_ = {_zz_52_,_zz_51_};
-  assign _zz_209_ = 32'h0000107f;
-  assign _zz_210_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_211_ = 32'h00002073;
-  assign _zz_212_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_213_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_214_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_215_) == 32'h00000003),{(_zz_216_ == _zz_217_),{_zz_218_,{_zz_219_,_zz_220_}}}}}};
-  assign _zz_215_ = 32'h0000505f;
-  assign _zz_216_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_217_ = 32'h00000063;
-  assign _zz_218_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_219_ = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
-  assign _zz_220_ = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_221_) == 32'h00005033),{(_zz_222_ == _zz_223_),{_zz_224_,{_zz_225_,_zz_226_}}}}}};
-  assign _zz_221_ = 32'hbe00707f;
-  assign _zz_222_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_223_ = 32'h00000033;
-  assign _zz_224_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_225_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_226_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
-  assign _zz_227_ = 32'h00007054;
-  assign _zz_228_ = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_229_ = ((decode_INSTRUCTION & 32'h00007054) == 32'h00001010);
-  assign _zz_230_ = ((decode_INSTRUCTION & _zz_237_) == 32'h00002000);
-  assign _zz_231_ = ((decode_INSTRUCTION & _zz_238_) == 32'h00001000);
-  assign _zz_232_ = {(_zz_239_ == _zz_240_),{_zz_241_,{_zz_242_,_zz_243_}}};
-  assign _zz_233_ = (4'b0000);
-  assign _zz_234_ = ({_zz_75_,_zz_244_} != (2'b00));
-  assign _zz_235_ = ({_zz_245_,_zz_246_} != (2'b00));
-  assign _zz_236_ = {(_zz_247_ != _zz_248_),{_zz_249_,{_zz_250_,_zz_251_}}};
-  assign _zz_237_ = 32'h00002010;
-  assign _zz_238_ = 32'h00005000;
-  assign _zz_239_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_240_ = 32'h0;
-  assign _zz_241_ = ((decode_INSTRUCTION & 32'h00000018) == 32'h0);
-  assign _zz_242_ = ((decode_INSTRUCTION & _zz_252_) == 32'h00002000);
-  assign _zz_243_ = ((decode_INSTRUCTION & _zz_253_) == 32'h00001000);
-  assign _zz_244_ = ((decode_INSTRUCTION & 32'h00000070) == 32'h00000020);
-  assign _zz_245_ = _zz_75_;
-  assign _zz_246_ = ((decode_INSTRUCTION & _zz_254_) == 32'h0);
-  assign _zz_247_ = ((decode_INSTRUCTION & _zz_255_) == 32'h00000050);
-  assign _zz_248_ = (1'b0);
-  assign _zz_249_ = ((_zz_256_ == _zz_257_) != (1'b0));
-  assign _zz_250_ = ({_zz_258_,_zz_259_} != (3'b000));
-  assign _zz_251_ = {(_zz_260_ != _zz_261_),{_zz_262_,{_zz_263_,_zz_264_}}};
-  assign _zz_252_ = 32'h00006004;
-  assign _zz_253_ = 32'h00005004;
-  assign _zz_254_ = 32'h00000020;
-  assign _zz_255_ = 32'h10003050;
-  assign _zz_256_ = (decode_INSTRUCTION & 32'h10403050);
-  assign _zz_257_ = 32'h10000050;
-  assign _zz_258_ = ((decode_INSTRUCTION & _zz_265_) == 32'h00000040);
-  assign _zz_259_ = {(_zz_266_ == _zz_267_),(_zz_268_ == _zz_269_)};
-  assign _zz_260_ = ((decode_INSTRUCTION & _zz_270_) == 32'h00000020);
-  assign _zz_261_ = (1'b0);
-  assign _zz_262_ = ((_zz_271_ == _zz_272_) != (1'b0));
-  assign _zz_263_ = ({_zz_273_,_zz_274_} != (2'b00));
-  assign _zz_264_ = {(_zz_275_ != _zz_276_),{_zz_277_,{_zz_278_,_zz_279_}}};
-  assign _zz_265_ = 32'h00000050;
-  assign _zz_266_ = (decode_INSTRUCTION & 32'h00000038);
-  assign _zz_267_ = 32'h0;
-  assign _zz_268_ = (decode_INSTRUCTION & 32'h00403040);
-  assign _zz_269_ = 32'h00000040;
-  assign _zz_270_ = 32'h00000020;
-  assign _zz_271_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_272_ = 32'h0;
-  assign _zz_273_ = _zz_74_;
-  assign _zz_274_ = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_275_ = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
-  assign _zz_276_ = (1'b0);
-  assign _zz_277_ = (((decode_INSTRUCTION & _zz_280_) == 32'h00001000) != (1'b0));
-  assign _zz_278_ = ((_zz_281_ == _zz_282_) != (1'b0));
-  assign _zz_279_ = {({_zz_283_,_zz_284_} != (3'b000)),{(_zz_285_ != _zz_286_),{_zz_287_,{_zz_288_,_zz_289_}}}};
-  assign _zz_280_ = 32'h00001000;
-  assign _zz_281_ = (decode_INSTRUCTION & 32'h00003000);
-  assign _zz_282_ = 32'h00002000;
-  assign _zz_283_ = ((decode_INSTRUCTION & _zz_290_) == 32'h00000040);
-  assign _zz_284_ = {(_zz_291_ == _zz_292_),(_zz_293_ == _zz_294_)};
-  assign _zz_285_ = {_zz_74_,{_zz_295_,{_zz_296_,_zz_297_}}};
-  assign _zz_286_ = 6'h0;
-  assign _zz_287_ = ({_zz_298_,_zz_299_} != (2'b00));
-  assign _zz_288_ = (_zz_300_ != (1'b0));
-  assign _zz_289_ = {(_zz_301_ != _zz_302_),{_zz_303_,{_zz_304_,_zz_305_}}};
-  assign _zz_290_ = 32'h00000044;
-  assign _zz_291_ = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_292_ = 32'h00002010;
-  assign _zz_293_ = (decode_INSTRUCTION & 32'h40004034);
-  assign _zz_294_ = 32'h40000030;
-  assign _zz_295_ = ((decode_INSTRUCTION & _zz_306_) == 32'h00001010);
-  assign _zz_296_ = (_zz_307_ == _zz_308_);
-  assign _zz_297_ = {_zz_73_,{_zz_309_,_zz_310_}};
-  assign _zz_298_ = ((decode_INSTRUCTION & _zz_311_) == 32'h00001050);
-  assign _zz_299_ = ((decode_INSTRUCTION & _zz_312_) == 32'h00002050);
-  assign _zz_300_ = ((decode_INSTRUCTION & _zz_313_) == 32'h00000010);
-  assign _zz_301_ = {_zz_314_,_zz_315_};
-  assign _zz_302_ = (2'b00);
-  assign _zz_303_ = ({_zz_316_,_zz_317_} != (2'b00));
-  assign _zz_304_ = (_zz_318_ != _zz_319_);
-  assign _zz_305_ = {_zz_320_,{_zz_321_,_zz_322_}};
-  assign _zz_306_ = 32'h00001010;
-  assign _zz_307_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_308_ = 32'h00002010;
-  assign _zz_309_ = (_zz_323_ == _zz_324_);
-  assign _zz_310_ = (_zz_325_ == _zz_326_);
-  assign _zz_311_ = 32'h00001050;
-  assign _zz_312_ = 32'h00002050;
-  assign _zz_313_ = 32'h00000010;
-  assign _zz_314_ = ((decode_INSTRUCTION & _zz_327_) == 32'h00000020);
-  assign _zz_315_ = ((decode_INSTRUCTION & _zz_328_) == 32'h00000020);
-  assign _zz_316_ = (_zz_329_ == _zz_330_);
-  assign _zz_317_ = (_zz_331_ == _zz_332_);
-  assign _zz_318_ = (_zz_333_ == _zz_334_);
-  assign _zz_319_ = (1'b0);
-  assign _zz_320_ = ({_zz_335_,_zz_336_} != (2'b00));
-  assign _zz_321_ = (_zz_337_ != _zz_338_);
-  assign _zz_322_ = {_zz_339_,_zz_340_};
-  assign _zz_323_ = (decode_INSTRUCTION & 32'h0000000c);
-  assign _zz_324_ = 32'h00000004;
-  assign _zz_325_ = (decode_INSTRUCTION & 32'h00000028);
-  assign _zz_326_ = 32'h0;
-  assign _zz_327_ = 32'h00000034;
-  assign _zz_328_ = 32'h00000064;
-  assign _zz_329_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_330_ = 32'h00006010;
-  assign _zz_331_ = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz_332_ = 32'h00004010;
-  assign _zz_333_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_334_ = 32'h00002010;
-  assign _zz_335_ = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_336_ = ((decode_INSTRUCTION & 32'h00003054) == 32'h00001010);
-  assign _zz_337_ = _zz_73_;
-  assign _zz_338_ = (1'b0);
-  assign _zz_339_ = ({((decode_INSTRUCTION & 32'h00000014) == 32'h00000004),_zz_72_} != (2'b00));
-  assign _zz_340_ = ({((decode_INSTRUCTION & 32'h00000044) == 32'h00000004),_zz_72_} != (2'b00));
+  assign _zz_123 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign _zz_124 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_125 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz_126 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_127 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_128 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_129 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign _zz_130 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_131 = (1'b1 || (! 1'b1));
+  assign _zz_132 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_133 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_134 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_135 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_136 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_137 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_138 = (! execute_arbitration_isStuckByOthers);
+  assign _zz_139 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_140 = ((_zz_103 && 1'b1) && (! 1'b0));
+  assign _zz_141 = ((_zz_104 && 1'b1) && (! 1'b0));
+  assign _zz_142 = ((_zz_105 && 1'b1) && (! 1'b0));
+  assign _zz_143 = (! dBus_cmd_halfPipe_regs_valid);
+  assign _zz_144 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_145 = execute_INSTRUCTION[13];
+  assign _zz_146 = _zz_68[23 : 23];
+  assign _zz_147 = _zz_68[15 : 15];
+  assign _zz_148 = _zz_68[12 : 12];
+  assign _zz_149 = _zz_68[11 : 11];
+  assign _zz_150 = _zz_68[10 : 10];
+  assign _zz_151 = _zz_68[3 : 3];
+  assign _zz_152 = _zz_68[14 : 14];
+  assign _zz_153 = _zz_68[4 : 4];
+  assign _zz_154 = _zz_68[2 : 2];
+  assign _zz_155 = _zz_68[18 : 18];
+  assign _zz_156 = _zz_68[9 : 9];
+  assign _zz_157 = (_zz_49 & (~ _zz_158));
+  assign _zz_158 = (_zz_49 - 2'b01);
+  assign _zz_159 = {IBusSimplePlugin_fetchPc_inc,2'b00};
+  assign _zz_160 = {29'd0, _zz_159};
+  assign _zz_161 = (IBusSimplePlugin_pending_value + _zz_163);
+  assign _zz_162 = IBusSimplePlugin_pending_inc;
+  assign _zz_163 = {2'd0, _zz_162};
+  assign _zz_164 = IBusSimplePlugin_pending_dec;
+  assign _zz_165 = {2'd0, _zz_164};
+  assign _zz_166 = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000));
+  assign _zz_167 = {2'd0, _zz_166};
+  assign _zz_168 = IBusSimplePlugin_pending_dec;
+  assign _zz_169 = {2'd0, _zz_168};
+  assign _zz_170 = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz_171 = execute_SRC_LESS;
+  assign _zz_172 = 3'b100;
+  assign _zz_173 = execute_INSTRUCTION[19 : 15];
+  assign _zz_174 = execute_INSTRUCTION[31 : 20];
+  assign _zz_175 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_176 = ($signed(_zz_177) + $signed(_zz_180));
+  assign _zz_177 = ($signed(_zz_178) + $signed(_zz_179));
+  assign _zz_178 = execute_SRC1;
+  assign _zz_179 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_180 = (execute_SRC_USE_SUB_LESS ? _zz_181 : _zz_182);
+  assign _zz_181 = 32'h00000001;
+  assign _zz_182 = 32'h0;
+  assign _zz_183 = (_zz_184 >>> 1);
+  assign _zz_184 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz_185 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_186 = execute_INSTRUCTION[31 : 20];
+  assign _zz_187 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_188 = (_zz_106 & (~ _zz_189));
+  assign _zz_189 = (_zz_106 - 2'b01);
+  assign _zz_190 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_191 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_192 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_193 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_194 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_195 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_196 = 1'b1;
+  assign _zz_197 = 1'b1;
+  assign _zz_198 = 32'h0000107f;
+  assign _zz_199 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_200 = 32'h00002073;
+  assign _zz_201 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_202 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_203 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_204) == 32'h00000003),{(_zz_205 == _zz_206),{_zz_207,{_zz_208,_zz_209}}}}}};
+  assign _zz_204 = 32'h0000505f;
+  assign _zz_205 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_206 = 32'h00000063;
+  assign _zz_207 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_208 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
+  assign _zz_209 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_210) == 32'h00005033),{(_zz_211 == _zz_212),{_zz_213,{_zz_214,_zz_215}}}}}};
+  assign _zz_210 = 32'hbe00707f;
+  assign _zz_211 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_212 = 32'h00000033;
+  assign _zz_213 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_214 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_215 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073);
+  assign _zz_216 = 32'h10003050;
+  assign _zz_217 = (decode_INSTRUCTION & 32'h10403050);
+  assign _zz_218 = 32'h10000050;
+  assign _zz_219 = ((decode_INSTRUCTION & _zz_226) == 32'h00001050);
+  assign _zz_220 = ((decode_INSTRUCTION & _zz_227) == 32'h00002050);
+  assign _zz_221 = {_zz_72,(_zz_228 == _zz_229)};
+  assign _zz_222 = 2'b00;
+  assign _zz_223 = ((_zz_230 == _zz_231) != 1'b0);
+  assign _zz_224 = (_zz_232 != 1'b0);
+  assign _zz_225 = {(_zz_233 != _zz_234),{_zz_235,{_zz_236,_zz_237}}};
+  assign _zz_226 = 32'h00001050;
+  assign _zz_227 = 32'h00002050;
+  assign _zz_228 = (decode_INSTRUCTION & 32'h0000001c);
+  assign _zz_229 = 32'h00000004;
+  assign _zz_230 = (decode_INSTRUCTION & 32'h00000058);
+  assign _zz_231 = 32'h00000040;
+  assign _zz_232 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00005010);
+  assign _zz_233 = {(_zz_238 == _zz_239),(_zz_240 == _zz_241)};
+  assign _zz_234 = 2'b00;
+  assign _zz_235 = ({_zz_242,_zz_243} != 2'b00);
+  assign _zz_236 = (_zz_244 != 1'b0);
+  assign _zz_237 = {(_zz_245 != _zz_246),{_zz_247,{_zz_248,_zz_249}}};
+  assign _zz_238 = (decode_INSTRUCTION & 32'h40003054);
+  assign _zz_239 = 32'h40001010;
+  assign _zz_240 = (decode_INSTRUCTION & 32'h00007054);
+  assign _zz_241 = 32'h00001010;
+  assign _zz_242 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz_243 = ((decode_INSTRUCTION & 32'h00003054) == 32'h00001010);
+  assign _zz_244 = ((decode_INSTRUCTION & 32'h00001000) == 32'h00001000);
+  assign _zz_245 = ((decode_INSTRUCTION & _zz_250) == 32'h00002000);
+  assign _zz_246 = 1'b0;
+  assign _zz_247 = ({_zz_251,_zz_252} != 2'b00);
+  assign _zz_248 = ({_zz_253,_zz_254} != 2'b00);
+  assign _zz_249 = {(_zz_255 != _zz_256),{_zz_257,{_zz_258,_zz_259}}};
+  assign _zz_250 = 32'h00003000;
+  assign _zz_251 = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002000);
+  assign _zz_252 = ((decode_INSTRUCTION & 32'h00005000) == 32'h00001000);
+  assign _zz_253 = ((decode_INSTRUCTION & _zz_260) == 32'h00000020);
+  assign _zz_254 = ((decode_INSTRUCTION & _zz_261) == 32'h00000020);
+  assign _zz_255 = {(_zz_262 == _zz_263),{_zz_264,_zz_265}};
+  assign _zz_256 = 3'b000;
+  assign _zz_257 = ((_zz_266 == _zz_267) != 1'b0);
+  assign _zz_258 = (_zz_268 != 1'b0);
+  assign _zz_259 = {(_zz_269 != _zz_270),{_zz_271,{_zz_272,_zz_273}}};
+  assign _zz_260 = 32'h00000034;
+  assign _zz_261 = 32'h00000064;
+  assign _zz_262 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_263 = 32'h00000040;
+  assign _zz_264 = ((decode_INSTRUCTION & 32'h00000038) == 32'h0);
+  assign _zz_265 = ((decode_INSTRUCTION & 32'h00403040) == 32'h00000040);
+  assign _zz_266 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_267 = 32'h00000020;
+  assign _zz_268 = ((decode_INSTRUCTION & 32'h00000010) == 32'h00000010);
+  assign _zz_269 = _zz_71;
+  assign _zz_270 = 1'b0;
+  assign _zz_271 = ({_zz_72,{_zz_274,_zz_275}} != 6'h0);
+  assign _zz_272 = ({_zz_276,_zz_277} != 2'b00);
+  assign _zz_273 = {(_zz_278 != _zz_279),{_zz_280,{_zz_281,_zz_282}}};
+  assign _zz_274 = ((decode_INSTRUCTION & _zz_283) == 32'h00001010);
+  assign _zz_275 = {(_zz_284 == _zz_285),{_zz_71,{_zz_286,_zz_287}}};
+  assign _zz_276 = _zz_70;
+  assign _zz_277 = ((decode_INSTRUCTION & _zz_288) == 32'h00000020);
+  assign _zz_278 = {_zz_70,(_zz_289 == _zz_290)};
+  assign _zz_279 = 2'b00;
+  assign _zz_280 = ({_zz_291,_zz_292} != 2'b00);
+  assign _zz_281 = (_zz_293 != 1'b0);
+  assign _zz_282 = {(_zz_294 != _zz_295),{_zz_296,{_zz_297,_zz_298}}};
+  assign _zz_283 = 32'h00001010;
+  assign _zz_284 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_285 = 32'h00002010;
+  assign _zz_286 = (_zz_299 == _zz_300);
+  assign _zz_287 = (_zz_301 == _zz_302);
+  assign _zz_288 = 32'h00000070;
+  assign _zz_289 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_290 = 32'h0;
+  assign _zz_291 = ((decode_INSTRUCTION & _zz_303) == 32'h00006010);
+  assign _zz_292 = ((decode_INSTRUCTION & _zz_304) == 32'h00004010);
+  assign _zz_293 = ((decode_INSTRUCTION & _zz_305) == 32'h00002010);
+  assign _zz_294 = {_zz_306,{_zz_307,_zz_308}};
+  assign _zz_295 = 4'b0000;
+  assign _zz_296 = (_zz_309 != 1'b0);
+  assign _zz_297 = (_zz_310 != _zz_311);
+  assign _zz_298 = {_zz_312,_zz_313};
+  assign _zz_299 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz_300 = 32'h00000004;
+  assign _zz_301 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_302 = 32'h0;
+  assign _zz_303 = 32'h00006014;
+  assign _zz_304 = 32'h00005014;
+  assign _zz_305 = 32'h00006014;
+  assign _zz_306 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz_307 = ((decode_INSTRUCTION & _zz_314) == 32'h0);
+  assign _zz_308 = {(_zz_315 == _zz_316),(_zz_317 == _zz_318)};
+  assign _zz_309 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz_310 = {(_zz_319 == _zz_320),{_zz_321,_zz_322}};
+  assign _zz_311 = 3'b000;
+  assign _zz_312 = ({_zz_323,_zz_69} != 2'b00);
+  assign _zz_313 = ({_zz_324,_zz_69} != 2'b00);
+  assign _zz_314 = 32'h00000018;
+  assign _zz_315 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz_316 = 32'h00002000;
+  assign _zz_317 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz_318 = 32'h00001000;
+  assign _zz_319 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_320 = 32'h00000040;
+  assign _zz_321 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_322 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz_323 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz_324 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
   always @ (posedge clk) begin
-    if(_zz_206_) begin
-      _zz_126_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_196) begin
+      _zz_121 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_207_) begin
-      _zz_127_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_197) begin
+      _zz_122 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_39_) begin
+    if(_zz_39) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c ( 
+  StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c (
     .io_push_valid            (iBus_rsp_valid                                                  ), //i
     .io_push_ready            (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready              ), //o
     .io_push_payload_error    (iBus_rsp_payload_error                                          ), //i
     .io_push_payload_inst     (iBus_rsp_payload_inst[31:0]                                     ), //i
     .io_pop_valid             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid               ), //o
-    .io_pop_ready             (_zz_124_                                                        ), //i
+    .io_pop_ready             (_zz_119                                                         ), //i
     .io_pop_payload_error     (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error       ), //o
     .io_pop_payload_inst      (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]  ), //o
-    .io_flush                 (_zz_125_                                                        ), //i
+    .io_flush                 (_zz_120                                                         ), //i
     .io_occupancy             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy               ), //o
     .clk                      (clk                                                             ), //i
     .reset                    (reset                                                           )  //i
   );
-  always @(*) begin
-    case(_zz_208_)
-      2'b00 : begin
-        _zz_128_ = CsrPlugin_jumpInterface_payload;
-      end
-      2'b01 : begin
-        _zz_128_ = DBusSimplePlugin_redoBranch_payload;
-      end
-      default : begin
-        _zz_128_ = BranchPlugin_jumpInterface_payload;
-      end
-    endcase
-  end
-
   `ifndef SYNTHESIS
   always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_1_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_1__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_1__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_1__string = "BITWISE ";
-      default : _zz_1__string = "????????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_2__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_2__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_2__string = "BITWISE ";
-      default : _zz_2__string = "????????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_3__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_3__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_3__string = "BITWISE ";
-      default : _zz_3__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_4__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_4__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_4__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_4__string = "PC ";
-      default : _zz_4__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_5__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_5__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_5__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_5__string = "PC ";
-      default : _zz_5__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_6__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_6__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_6__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_6__string = "PC ";
-      default : _zz_6__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_7__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_7__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_7__string = "AND_1";
-      default : _zz_7__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_8__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_8__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_8__string = "AND_1";
-      default : _zz_8__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_9__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_9__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_9__string = "AND_1";
-      default : _zz_9__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10__string = "ECALL";
-      default : _zz_10__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_11_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_11__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_11__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_11__string = "ECALL";
-      default : _zz_11__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_12__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_12__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_12__string = "ECALL";
-      default : _zz_12__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_13__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_13__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_13__string = "ECALL";
-      default : _zz_13__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1500,63 +1169,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_14_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_14__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_14__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_14__string = "ECALL";
-      default : _zz_14__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_15_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_15__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_15__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_15__string = "ECALL";
-      default : _zz_15__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_16_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_16__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_16__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_16__string = "ECALL";
-      default : _zz_16__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_17__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_17__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_17__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_17__string = "SRA_1    ";
-      default : _zz_17__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_18__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_18__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_18__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_18__string = "SRA_1    ";
-      default : _zz_18__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_19__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_19__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_19__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_19__string = "SRA_1    ";
-      default : _zz_19__string = "?????????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1569,30 +1202,166 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_20_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_20__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_20__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_20__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_20__string = "JALR";
-      default : _zz_20__string = "????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_21__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_21__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_21__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_21__string = "JALR";
-      default : _zz_21__string = "????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_22__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_22__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_22__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_22__string = "JALR";
-      default : _zz_22__string = "????";
+    case(_zz_10)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_10_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_10_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_10_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_10_string = "JALR";
+      default : _zz_10_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
+      default : _zz_14_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_17_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_17_string = "PC ";
+      default : _zz_17_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
+      default : _zz_20_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1605,30 +1374,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_23__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23__string = "URS1        ";
-      default : _zz_23__string = "????????????";
+    case(_zz_23)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
+      default : _zz_23_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_24__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24__string = "URS1        ";
-      default : _zz_24__string = "????????????";
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_25__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25__string = "URS1        ";
-      default : _zz_25__string = "????????????";
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1640,11 +1409,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26__string = "ECALL";
-      default : _zz_26__string = "?????";
+    case(_zz_26)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26_string = "ECALL";
+      default : _zz_26_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1656,11 +1425,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1672,11 +1441,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1689,12 +1458,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_29__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_29__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_29__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_29__string = "JALR";
-      default : _zz_29__string = "????";
+    case(_zz_29)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_29_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_29_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_29_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_29_string = "JALR";
+      default : _zz_29_string = "????";
     endcase
   end
   always @(*) begin
@@ -1707,12 +1476,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_31_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31__string = "SRA_1    ";
-      default : _zz_31__string = "?????????";
+    case(_zz_31)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
+      default : _zz_31_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1725,12 +1494,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_33__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_33__string = "PC ";
-      default : _zz_33__string = "???";
+    case(_zz_33)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_33_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_33_string = "PC ";
+      default : _zz_33_string = "???";
     endcase
   end
   always @(*) begin
@@ -1743,12 +1512,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_34__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34__string = "URS1        ";
-      default : _zz_34__string = "????????????";
+    case(_zz_34)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34_string = "URS1        ";
+      default : _zz_34_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1760,11 +1529,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35__string = "BITWISE ";
-      default : _zz_35__string = "????????";
+    case(_zz_35)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35_string = "BITWISE ";
+      default : _zz_35_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1776,131 +1545,131 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36__string = "AND_1";
-      default : _zz_36__string = "?????";
+    case(_zz_36)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36_string = "AND_1";
+      default : _zz_36_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_40_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_40__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_40__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_40__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_40__string = "SRA_1    ";
-      default : _zz_40__string = "?????????";
+    case(_zz_40)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_40_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_40_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_40_string = "ECALL";
+      default : _zz_40_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_41_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_41__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_41__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_41__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_41__string = "PC ";
-      default : _zz_41__string = "???";
+    case(_zz_41)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_41_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_41_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41_string = "JALR";
+      default : _zz_41_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_42_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_42__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_42__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_42__string = "ECALL";
-      default : _zz_42__string = "?????";
+    case(_zz_42)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_42_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_42_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_42_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_42_string = "SRA_1    ";
+      default : _zz_42_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_43__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_43__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_43__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_43__string = "JALR";
-      default : _zz_43__string = "????";
+    case(_zz_43)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_44__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_44__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_44__string = "AND_1";
-      default : _zz_44__string = "?????";
+    case(_zz_44)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_44_string = "PC ";
+      default : _zz_44_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45__string = "BITWISE ";
-      default : _zz_45__string = "????????";
+    case(_zz_45)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
+      default : _zz_45_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_46__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46__string = "URS1        ";
-      default : _zz_46__string = "????????????";
+    case(_zz_46)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46_string = "URS1        ";
+      default : _zz_46_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_76_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_76__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_76__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_76__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_76__string = "URS1        ";
-      default : _zz_76__string = "????????????";
+    case(_zz_73)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_73_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_73_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_73_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_73_string = "URS1        ";
+      default : _zz_73_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_77_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_77__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_77__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_77__string = "BITWISE ";
-      default : _zz_77__string = "????????";
+    case(_zz_74)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_74_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_74_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_74_string = "BITWISE ";
+      default : _zz_74_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_78_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_78__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_78__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_78__string = "AND_1";
-      default : _zz_78__string = "?????";
+    case(_zz_75)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_75_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_75_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_75_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_75_string = "PC ";
+      default : _zz_75_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_79_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_79__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_79__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_79__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_79__string = "JALR";
-      default : _zz_79__string = "????";
+    case(_zz_76)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_76_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_76_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_76_string = "AND_1";
+      default : _zz_76_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_80_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_80__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_80__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_80__string = "ECALL";
-      default : _zz_80__string = "?????";
+    case(_zz_77)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_77_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_77_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_77_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_77_string = "SRA_1    ";
+      default : _zz_77_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_81_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_81__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_81__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_81__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_81__string = "PC ";
-      default : _zz_81__string = "???";
+    case(_zz_78)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_78_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_78_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_78_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_78_string = "JALR";
+      default : _zz_78_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_82_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_82__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_82__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_82__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_82__string = "SRA_1    ";
-      default : _zz_82__string = "?????????";
+    case(_zz_79)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_79_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_79_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_79_string = "ECALL";
+      default : _zz_79_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1913,12 +1682,28 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
-      default : decode_to_execute_BRANCH_CTRL_string = "????";
+    case(decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1928,6 +1713,15 @@ module VexRiscv (
       `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
       `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
       default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -1954,84 +1748,61 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
-      default : decode_to_execute_ALU_CTRL_string = "????????";
-    endcase
-  end
   `endif
 
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_155_[0];
+  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = _zz_95;
   assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_84_;
-  assign decode_ALU_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
+  assign execute_REGFILE_WRITE_DATA = _zz_81;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_RS2 = decode_RegFilePlugin_rs2Data;
+  assign decode_RS1 = decode_RegFilePlugin_rs1Data;
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_146[0];
+  assign decode_BRANCH_CTRL = _zz_8;
+  assign _zz_9 = _zz_10;
+  assign decode_SHIFT_CTRL = _zz_11;
+  assign _zz_12 = _zz_13;
+  assign decode_ALU_BITWISE_CTRL = _zz_14;
+  assign _zz_15 = _zz_16;
+  assign decode_SRC_LESS_UNSIGNED = _zz_147[0];
+  assign decode_MEMORY_STORE = _zz_148[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_149[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_150[0];
+  assign decode_SRC2_CTRL = _zz_17;
+  assign _zz_18 = _zz_19;
+  assign decode_ALU_CTRL = _zz_20;
+  assign _zz_21 = _zz_22;
+  assign decode_MEMORY_ENABLE = _zz_151[0];
+  assign decode_SRC1_CTRL = _zz_23;
+  assign _zz_24 = _zz_25;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign decode_IS_CSR = _zz_156_[0];
-  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
-  assign decode_RS2 = decode_RegFilePlugin_rs2Data;
-  assign decode_SRC2_CTRL = _zz_4_;
-  assign _zz_5_ = _zz_6_;
-  assign execute_BRANCH_DO = _zz_98_;
-  assign decode_ALU_BITWISE_CTRL = _zz_7_;
-  assign _zz_8_ = _zz_9_;
-  assign decode_RS1 = decode_RegFilePlugin_rs1Data;
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_MEMORY_STORE = _zz_157_[0];
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_158_[0];
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign _zz_10_ = _zz_11_;
-  assign _zz_12_ = _zz_13_;
-  assign decode_ENV_CTRL = _zz_14_;
-  assign _zz_15_ = _zz_16_;
-  assign decode_SHIFT_CTRL = _zz_17_;
-  assign _zz_18_ = _zz_19_;
-  assign decode_BRANCH_CTRL = _zz_20_;
-  assign _zz_21_ = _zz_22_;
-  assign decode_SRC_LESS_UNSIGNED = _zz_159_[0];
-  assign decode_SRC1_CTRL = _zz_23_;
-  assign _zz_24_ = _zz_25_;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
+  assign memory_PC = execute_to_memory_PC;
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_26_;
-  assign execute_ENV_CTRL = _zz_27_;
-  assign writeBack_ENV_CTRL = _zz_28_;
+  assign memory_ENV_CTRL = _zz_26;
+  assign execute_ENV_CTRL = _zz_27;
+  assign writeBack_ENV_CTRL = _zz_28;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_29_;
-  assign decode_RS2_USE = _zz_160_[0];
-  assign decode_RS1_USE = _zz_161_[0];
+  assign execute_BRANCH_CTRL = _zz_29;
+  assign decode_RS2_USE = _zz_152[0];
+  assign decode_RS1_USE = _zz_153[0];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
@@ -2039,94 +1810,73 @@ module VexRiscv (
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_30_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_129_)begin
-      _zz_30_ = _zz_91_;
+    _zz_30 = execute_REGFILE_WRITE_DATA;
+    if(_zz_123)begin
+      _zz_30 = _zz_88;
     end
-    if(_zz_130_)begin
-      _zz_30_ = execute_CsrPlugin_readData;
+    if(_zz_124)begin
+      _zz_30 = execute_CsrPlugin_readData;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_31_;
+  assign execute_SHIFT_CTRL = _zz_31;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_32_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_33_;
-  assign execute_SRC1_CTRL = _zz_34_;
-  assign decode_SRC_USE_SUB_LESS = _zz_162_[0];
-  assign decode_SRC_ADD_ZERO = _zz_163_[0];
+  assign _zz_32 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_33;
+  assign execute_SRC1_CTRL = _zz_34;
+  assign decode_SRC_USE_SUB_LESS = _zz_154[0];
+  assign decode_SRC_ADD_ZERO = _zz_155[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_35_;
-  assign execute_SRC2 = _zz_90_;
-  assign execute_SRC1 = _zz_85_;
-  assign execute_ALU_BITWISE_CTRL = _zz_36_;
-  assign _zz_37_ = writeBack_INSTRUCTION;
-  assign _zz_38_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_35;
+  assign execute_SRC2 = _zz_87;
+  assign execute_SRC1 = _zz_82;
+  assign execute_ALU_BITWISE_CTRL = _zz_36;
+  assign _zz_37 = writeBack_INSTRUCTION;
+  assign _zz_38 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_39_ = 1'b0;
+    _zz_39 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_39_ = 1'b1;
+      _zz_39 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_iBusRsp_output_payload_rsp_inst);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_164_[0];
+    decode_REGFILE_WRITE_VALID = _zz_156[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_209_) == 32'h00001073),{(_zz_210_ == _zz_211_),{_zz_212_,{_zz_213_,_zz_214_}}}}}}} != 20'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_198) == 32'h00001073),{(_zz_199 == _zz_200),{_zz_201,{_zz_202,_zz_203}}}}}}} != 20'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @ (*) begin
-    _zz_47_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_47 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_47_ = writeBack_DBusSimplePlugin_rspFormated;
+      _zz_47 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_READ_DATA = memory_to_writeBack_MEMORY_READ_DATA;
-  assign memory_MMU_FAULT = execute_to_memory_MMU_FAULT;
-  assign memory_MMU_RSP_physicalAddress = execute_to_memory_MMU_RSP_physicalAddress;
-  assign memory_MMU_RSP_isIoAccess = execute_to_memory_MMU_RSP_isIoAccess;
-  assign memory_MMU_RSP_allowRead = execute_to_memory_MMU_RSP_allowRead;
-  assign memory_MMU_RSP_allowWrite = execute_to_memory_MMU_RSP_allowWrite;
-  assign memory_MMU_RSP_allowExecute = execute_to_memory_MMU_RSP_allowExecute;
-  assign memory_MMU_RSP_exception = execute_to_memory_MMU_RSP_exception;
-  assign memory_MMU_RSP_refilling = execute_to_memory_MMU_RSP_refilling;
-  assign memory_PC = execute_to_memory_PC;
   assign memory_ALIGNEMENT_FAULT = execute_to_memory_ALIGNEMENT_FAULT;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_STORE = execute_to_memory_MEMORY_STORE;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
-  assign execute_MMU_FAULT = ((execute_MMU_RSP_exception || ((! execute_MMU_RSP_allowWrite) && execute_MEMORY_STORE)) || ((! execute_MMU_RSP_allowRead) && (! execute_MEMORY_STORE)));
-  assign execute_MMU_RSP_physicalAddress = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  assign execute_MMU_RSP_isIoAccess = DBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  assign execute_MMU_RSP_allowRead = DBusSimplePlugin_mmuBus_rsp_allowRead;
-  assign execute_MMU_RSP_allowWrite = DBusSimplePlugin_mmuBus_rsp_allowWrite;
-  assign execute_MMU_RSP_allowExecute = DBusSimplePlugin_mmuBus_rsp_allowExecute;
-  assign execute_MMU_RSP_exception = DBusSimplePlugin_mmuBus_rsp_exception;
-  assign execute_MMU_RSP_refilling = DBusSimplePlugin_mmuBus_rsp_refilling;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
-  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == (2'b10)) && (dBus_cmd_payload_address[1 : 0] != (2'b00))) || ((dBus_cmd_payload_size == (2'b01)) && (dBus_cmd_payload_address[0 : 0] != (1'b0))));
-  assign decode_MEMORY_ENABLE = _zz_165_[0];
+  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
   always @ (*) begin
-    _zz_48_ = memory_FORMAL_PC_NEXT;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      _zz_48_ = DBusSimplePlugin_redoBranch_payload;
-    end
+    _zz_48 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_48_ = BranchPlugin_jumpInterface_payload;
+      _zz_48 = BranchPlugin_jumpInterface_payload;
     end
   end
 
@@ -2134,29 +1884,23 @@ module VexRiscv (
   assign decode_INSTRUCTION = IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   assign writeBack_PC = memory_to_writeBack_PC;
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
-  always @ (*) begin
-    decode_arbitration_haltItself = 1'b0;
-    if(((DBusSimplePlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
-      decode_arbitration_haltItself = 1'b1;
-    end
-  end
-
+  assign decode_arbitration_haltItself = 1'b0;
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_92_ || _zz_93_)))begin
+    if((decode_arbitration_isValid && (_zz_89 || _zz_90)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_131_)begin
+    if(decodeExceptionPort_valid)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -2167,24 +1911,22 @@ module VexRiscv (
   assign decode_arbitration_flushIt = 1'b0;
   always @ (*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(_zz_131_)begin
+    if(decodeExceptionPort_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_64_)))begin
+    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_61)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_129_)begin
-      if(_zz_132_)begin
-        if(! execute_LightShifterPlugin_done) begin
-          execute_arbitration_haltItself = 1'b1;
-        end
+    if(_zz_123)begin
+      if((! execute_LightShifterPlugin_done))begin
+        execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_130_)begin
+    if(_zz_124)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2220,7 +1962,7 @@ module VexRiscv (
   assign memory_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_133_)begin
+    if(_zz_125)begin
       memory_arbitration_removeIt = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -2228,22 +1970,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
-    memory_arbitration_flushIt = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      memory_arbitration_flushIt = 1'b1;
-    end
-  end
-
+  assign memory_arbitration_flushIt = 1'b0;
   always @ (*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      memory_arbitration_flushNext = 1'b1;
-    end
     if(BranchPlugin_jumpInterface_valid)begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_133_)begin
+    if(_zz_125)begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
@@ -2260,10 +1993,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @ (*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_134_)begin
+    if(_zz_126)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_135_)begin
+    if(_zz_127)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2274,13 +2007,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusSimplePlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_134_)begin
+    if(_zz_126)begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_135_)begin
+    if(_zz_127)begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2299,21 +2032,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_134_)begin
+    if(_zz_126)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_135_)begin
+    if(_zz_127)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_134_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_126)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_135_)begin
-      case(_zz_136_)
+    if(_zz_127)begin
+      case(_zz_128)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2326,18 +2059,12 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusSimplePlugin_redoBranch_valid}} != (3'b000));
-  assign _zz_49_ = {BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}};
-  assign _zz_50_ = (_zz_49_ & (~ _zz_166_));
-  assign _zz_51_ = _zz_50_[1];
-  assign _zz_52_ = _zz_50_[2];
-  assign IBusSimplePlugin_jump_pcLoad_payload = _zz_128_;
+  assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,BranchPlugin_jumpInterface_valid} != 2'b00);
+  assign _zz_49 = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
+  assign IBusSimplePlugin_jump_pcLoad_payload = (_zz_157[0] ? CsrPlugin_jumpInterface_payload : BranchPlugin_jumpInterface_payload);
   always @ (*) begin
     IBusSimplePlugin_fetchPc_correction = 1'b0;
-    if(IBusSimplePlugin_fetchPc_redo_valid)begin
-      IBusSimplePlugin_fetchPc_correction = 1'b1;
-    end
     if(IBusSimplePlugin_jump_pcLoad_valid)begin
       IBusSimplePlugin_fetchPc_correction = 1'b1;
     end
@@ -2352,10 +2079,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_168_);
-    if(IBusSimplePlugin_fetchPc_redo_valid)begin
-      IBusSimplePlugin_fetchPc_pc = IBusSimplePlugin_fetchPc_redo_payload;
-    end
+    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_160);
     if(IBusSimplePlugin_jump_pcLoad_valid)begin
       IBusSimplePlugin_fetchPc_pc = IBusSimplePlugin_jump_pcLoad_payload;
     end
@@ -2365,9 +2089,6 @@ module VexRiscv (
 
   always @ (*) begin
     IBusSimplePlugin_fetchPc_flushed = 1'b0;
-    if(IBusSimplePlugin_fetchPc_redo_valid)begin
-      IBusSimplePlugin_fetchPc_flushed = 1'b1;
-    end
     if(IBusSimplePlugin_jump_pcLoad_valid)begin
       IBusSimplePlugin_fetchPc_flushed = 1'b1;
     end
@@ -2375,13 +2096,7 @@ module VexRiscv (
 
   assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
   assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
-  always @ (*) begin
-    IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
-    if((IBusSimplePlugin_iBusRsp_stages_1_input_valid && IBusSimplePlugin_mmu_joinCtx_refilling))begin
-      IBusSimplePlugin_iBusRsp_redoFetch = 1'b1;
-    end
-  end
-
+  assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
   assign IBusSimplePlugin_iBusRsp_stages_0_input_valid = IBusSimplePlugin_fetchPc_output_valid;
   assign IBusSimplePlugin_fetchPc_output_ready = IBusSimplePlugin_iBusRsp_stages_0_input_ready;
   assign IBusSimplePlugin_iBusRsp_stages_0_input_payload = IBusSimplePlugin_fetchPc_output_payload;
@@ -2390,32 +2105,22 @@ module VexRiscv (
     if((IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready))))begin
       IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
     end
-    if(IBusSimplePlugin_iBusRsp_stages_0_input_valid)begin
-      if(IBusSimplePlugin_mmuBus_rsp_refilling)begin
-        IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
-      end
-      if(IBusSimplePlugin_mmuBus_rsp_exception)begin
-        IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b0;
-      end
-    end
   end
 
-  assign _zz_53_ = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
-  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_53_);
-  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_53_);
+  assign _zz_50 = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_50);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_50);
   assign IBusSimplePlugin_iBusRsp_stages_0_output_payload = IBusSimplePlugin_iBusRsp_stages_0_input_payload;
   assign IBusSimplePlugin_iBusRsp_stages_1_halt = 1'b0;
-  assign _zz_54_ = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_54_);
-  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_54_);
+  assign _zz_51 = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_51);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_51);
   assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
-  assign IBusSimplePlugin_fetchPc_redo_valid = IBusSimplePlugin_iBusRsp_redoFetch;
-  assign IBusSimplePlugin_fetchPc_redo_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
   assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
-  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_55_;
-  assign _zz_55_ = ((1'b0 && (! _zz_56_)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_56_ = _zz_57_;
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_56_;
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_52;
+  assign _zz_52 = ((1'b0 && (! _zz_53)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_53 = _zz_54;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_53;
   assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
   always @ (*) begin
     IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
@@ -2428,11 +2133,11 @@ module VexRiscv (
   end
 
   assign IBusSimplePlugin_iBusRsp_output_ready = ((1'b0 && (! IBusSimplePlugin_injector_decodeInput_valid)) || IBusSimplePlugin_injector_decodeInput_ready);
-  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_58_;
-  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_59_;
-  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_60_;
-  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_61_;
-  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_62_;
+  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_55;
+  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_56;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_57;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_58;
+  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_59;
   assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
   assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
   assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
@@ -2442,32 +2147,17 @@ module VexRiscv (
   assign iBus_cmd_valid = IBusSimplePlugin_cmd_valid;
   assign IBusSimplePlugin_cmd_ready = iBus_cmd_ready;
   assign iBus_cmd_payload_pc = IBusSimplePlugin_cmd_payload_pc;
-  assign IBusSimplePlugin_pending_next = (_zz_169_ - _zz_173_);
-  assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != (3'b111)));
-  always @ (*) begin
-    IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
-    if(IBusSimplePlugin_iBusRsp_stages_0_input_valid)begin
-      if(IBusSimplePlugin_mmuBus_rsp_refilling)begin
-        IBusSimplePlugin_cmd_valid = 1'b0;
-      end
-      if(IBusSimplePlugin_mmuBus_rsp_exception)begin
-        IBusSimplePlugin_cmd_valid = 1'b0;
-      end
-    end
-  end
-
+  assign IBusSimplePlugin_pending_next = (_zz_161 - _zz_165);
+  assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != 3'b111));
+  assign IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
   assign IBusSimplePlugin_pending_inc = (IBusSimplePlugin_cmd_valid && IBusSimplePlugin_cmd_ready);
-  assign IBusSimplePlugin_mmuBus_cmd_isValid = IBusSimplePlugin_iBusRsp_stages_0_input_valid;
-  assign IBusSimplePlugin_mmuBus_cmd_virtualAddress = IBusSimplePlugin_iBusRsp_stages_0_input_payload;
-  assign IBusSimplePlugin_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign IBusSimplePlugin_mmuBus_end = ((IBusSimplePlugin_iBusRsp_stages_0_output_valid && IBusSimplePlugin_iBusRsp_stages_0_output_ready) || IBusSimplePlugin_externalFlush);
-  assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_mmuBus_rsp_physicalAddress[31 : 2],(2'b00)};
-  assign IBusSimplePlugin_rspJoin_rspBuffer_flush = ((IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != (3'b000)) || IBusSimplePlugin_iBusRsp_flush);
-  assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == (3'b000)));
+  assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_iBusRsp_stages_0_input_payload[31 : 2],2'b00};
+  assign IBusSimplePlugin_rspJoin_rspBuffer_flush = ((IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000) || IBusSimplePlugin_iBusRsp_flush);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == 3'b000));
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
-  assign _zz_124_ = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
-  assign IBusSimplePlugin_pending_dec = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && _zz_124_);
+  assign _zz_119 = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
+  assign IBusSimplePlugin_pending_dec = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && _zz_119);
   assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   always @ (*) begin
     IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -2477,13 +2167,7 @@ module VexRiscv (
   end
 
   assign IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
-  always @ (*) begin
-    IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
-    if(_zz_137_)begin
-      IBusSimplePlugin_rspJoin_exceptionDetected = 1'b1;
-    end
-  end
-
+  assign IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
   assign IBusSimplePlugin_rspJoin_join_valid = (IBusSimplePlugin_iBusRsp_stages_1_output_valid && IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
   assign IBusSimplePlugin_rspJoin_join_payload_pc = IBusSimplePlugin_rspJoin_fetchRsp_pc;
   assign IBusSimplePlugin_rspJoin_join_payload_rsp_error = IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
@@ -2491,118 +2175,79 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
   assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready) : IBusSimplePlugin_rspJoin_join_ready);
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
-  assign _zz_63_ = (! IBusSimplePlugin_rspJoin_exceptionDetected);
-  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_63_);
-  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_63_);
+  assign _zz_60 = (! IBusSimplePlugin_rspJoin_exceptionDetected);
+  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_60);
+  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_60);
   assign IBusSimplePlugin_iBusRsp_output_payload_pc = IBusSimplePlugin_rspJoin_join_payload_pc;
   assign IBusSimplePlugin_iBusRsp_output_payload_rsp_error = IBusSimplePlugin_rspJoin_join_payload_rsp_error;
   assign IBusSimplePlugin_iBusRsp_output_payload_rsp_inst = IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
   assign IBusSimplePlugin_iBusRsp_output_payload_isRvc = IBusSimplePlugin_rspJoin_join_payload_isRvc;
-  always @ (*) begin
-    IBusSimplePlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_137_)begin
-      IBusSimplePlugin_decodeExceptionPort_payload_code = (4'b1100);
-    end
-  end
-
-  assign IBusSimplePlugin_decodeExceptionPort_payload_badAddr = {IBusSimplePlugin_rspJoin_join_payload_pc[31 : 2],(2'b00)};
-  assign IBusSimplePlugin_decodeExceptionPort_valid = (IBusSimplePlugin_rspJoin_exceptionDetected && IBusSimplePlugin_iBusRsp_readyForError);
-  assign _zz_64_ = 1'b0;
+  assign _zz_61 = 1'b0;
   always @ (*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
     if(execute_ALIGNEMENT_FAULT)begin
       execute_DBusSimplePlugin_skipCmd = 1'b1;
     end
-    if((execute_MMU_FAULT || execute_MMU_RSP_refilling))begin
-      execute_DBusSimplePlugin_skipCmd = 1'b1;
-    end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_64_));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_61));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_65_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_62 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_65_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_62 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_65_ = execute_RS2[31 : 0];
+        _zz_62 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_65_;
+  assign dBus_cmd_payload_data = _zz_62;
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_66_ = (4'b0001);
+        _zz_63 = 4'b0001;
       end
       2'b01 : begin
-        _zz_66_ = (4'b0011);
+        _zz_63 = 4'b0011;
       end
       default : begin
-        _zz_66_ = (4'b1111);
+        _zz_63 = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_66_ <<< dBus_cmd_payload_address[1 : 0]);
-  assign DBusSimplePlugin_mmuBus_cmd_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign DBusSimplePlugin_mmuBus_cmd_virtualAddress = execute_SRC_ADD;
-  assign DBusSimplePlugin_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign DBusSimplePlugin_mmuBus_end = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
-  assign dBus_cmd_payload_address = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
+  assign execute_DBusSimplePlugin_formalMask = (_zz_63 <<< dBus_cmd_payload_address[1 : 0]);
+  assign dBus_cmd_payload_address = execute_SRC_ADD;
   always @ (*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(_zz_138_)begin
+    if(_zz_129)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(memory_MMU_RSP_refilling)begin
-      DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    end else begin
-      if(memory_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
-      end
-    end
-    if(_zz_139_)begin
+    if((! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers)))))begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @ (*) begin
-    DBusSimplePlugin_memoryExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_138_)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = (4'b0101);
+    DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_129)begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_178_};
-    end
-    if(! memory_MMU_RSP_refilling) begin
-      if(memory_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? (4'b1111) : (4'b1101));
-      end
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_170};
     end
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  always @ (*) begin
-    DBusSimplePlugin_redoBranch_valid = 1'b0;
-    if(memory_MMU_RSP_refilling)begin
-      DBusSimplePlugin_redoBranch_valid = 1'b1;
-    end
-    if(_zz_139_)begin
-      DBusSimplePlugin_redoBranch_valid = 1'b0;
-    end
-  end
-
-  assign DBusSimplePlugin_redoBranch_payload = memory_PC;
   always @ (*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2620,63 +2265,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_67_ = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_64 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_68_[31] = _zz_67_;
-    _zz_68_[30] = _zz_67_;
-    _zz_68_[29] = _zz_67_;
-    _zz_68_[28] = _zz_67_;
-    _zz_68_[27] = _zz_67_;
-    _zz_68_[26] = _zz_67_;
-    _zz_68_[25] = _zz_67_;
-    _zz_68_[24] = _zz_67_;
-    _zz_68_[23] = _zz_67_;
-    _zz_68_[22] = _zz_67_;
-    _zz_68_[21] = _zz_67_;
-    _zz_68_[20] = _zz_67_;
-    _zz_68_[19] = _zz_67_;
-    _zz_68_[18] = _zz_67_;
-    _zz_68_[17] = _zz_67_;
-    _zz_68_[16] = _zz_67_;
-    _zz_68_[15] = _zz_67_;
-    _zz_68_[14] = _zz_67_;
-    _zz_68_[13] = _zz_67_;
-    _zz_68_[12] = _zz_67_;
-    _zz_68_[11] = _zz_67_;
-    _zz_68_[10] = _zz_67_;
-    _zz_68_[9] = _zz_67_;
-    _zz_68_[8] = _zz_67_;
-    _zz_68_[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+    _zz_65[31] = _zz_64;
+    _zz_65[30] = _zz_64;
+    _zz_65[29] = _zz_64;
+    _zz_65[28] = _zz_64;
+    _zz_65[27] = _zz_64;
+    _zz_65[26] = _zz_64;
+    _zz_65[25] = _zz_64;
+    _zz_65[24] = _zz_64;
+    _zz_65[23] = _zz_64;
+    _zz_65[22] = _zz_64;
+    _zz_65[21] = _zz_64;
+    _zz_65[20] = _zz_64;
+    _zz_65[19] = _zz_64;
+    _zz_65[18] = _zz_64;
+    _zz_65[17] = _zz_64;
+    _zz_65[16] = _zz_64;
+    _zz_65[15] = _zz_64;
+    _zz_65[14] = _zz_64;
+    _zz_65[13] = _zz_64;
+    _zz_65[12] = _zz_64;
+    _zz_65[11] = _zz_64;
+    _zz_65[10] = _zz_64;
+    _zz_65[9] = _zz_64;
+    _zz_65[8] = _zz_64;
+    _zz_65[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_69_ = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_66 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_70_[31] = _zz_69_;
-    _zz_70_[30] = _zz_69_;
-    _zz_70_[29] = _zz_69_;
-    _zz_70_[28] = _zz_69_;
-    _zz_70_[27] = _zz_69_;
-    _zz_70_[26] = _zz_69_;
-    _zz_70_[25] = _zz_69_;
-    _zz_70_[24] = _zz_69_;
-    _zz_70_[23] = _zz_69_;
-    _zz_70_[22] = _zz_69_;
-    _zz_70_[21] = _zz_69_;
-    _zz_70_[20] = _zz_69_;
-    _zz_70_[19] = _zz_69_;
-    _zz_70_[18] = _zz_69_;
-    _zz_70_[17] = _zz_69_;
-    _zz_70_[16] = _zz_69_;
-    _zz_70_[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+    _zz_67[31] = _zz_66;
+    _zz_67[30] = _zz_66;
+    _zz_67[29] = _zz_66;
+    _zz_67[28] = _zz_66;
+    _zz_67[27] = _zz_66;
+    _zz_67[26] = _zz_66;
+    _zz_67[25] = _zz_66;
+    _zz_67[24] = _zz_66;
+    _zz_67[23] = _zz_66;
+    _zz_67[22] = _zz_66;
+    _zz_67[21] = _zz_66;
+    _zz_67[20] = _zz_66;
+    _zz_67[19] = _zz_66;
+    _zz_67[18] = _zz_66;
+    _zz_67[17] = _zz_66;
+    _zz_67[16] = _zz_66;
+    _zz_67[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_153_)
+    case(_zz_144)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_68_;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_65;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_70_;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_67;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -2684,57 +2329,53 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusSimplePlugin_mmuBus_rsp_physicalAddress = IBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  assign IBusSimplePlugin_mmuBus_rsp_allowRead = 1'b1;
-  assign IBusSimplePlugin_mmuBus_rsp_allowWrite = 1'b1;
-  assign IBusSimplePlugin_mmuBus_rsp_allowExecute = 1'b1;
-  assign IBusSimplePlugin_mmuBus_rsp_isIoAccess = IBusSimplePlugin_mmuBus_rsp_physicalAddress[31];
-  assign IBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
-  assign IBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
-  assign IBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign DBusSimplePlugin_mmuBus_rsp_physicalAddress = DBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  assign DBusSimplePlugin_mmuBus_rsp_allowRead = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_allowWrite = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_allowExecute = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_isIoAccess = DBusSimplePlugin_mmuBus_rsp_physicalAddress[31];
-  assign DBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
-  assign DBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
-  assign DBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign _zz_72_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_73_ = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_74_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_75_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_71_ = {(((decode_INSTRUCTION & _zz_227_) == 32'h00005010) != (1'b0)),{({_zz_228_,_zz_229_} != (2'b00)),{({_zz_230_,_zz_231_} != (2'b00)),{(_zz_232_ != _zz_233_),{_zz_234_,{_zz_235_,_zz_236_}}}}}};
-  assign _zz_76_ = _zz_71_[1 : 0];
-  assign _zz_46_ = _zz_76_;
-  assign _zz_77_ = _zz_71_[5 : 4];
-  assign _zz_45_ = _zz_77_;
-  assign _zz_78_ = _zz_71_[12 : 11];
-  assign _zz_44_ = _zz_78_;
-  assign _zz_79_ = _zz_71_[14 : 13];
-  assign _zz_43_ = _zz_79_;
-  assign _zz_80_ = _zz_71_[19 : 18];
-  assign _zz_42_ = _zz_80_;
-  assign _zz_81_ = _zz_71_[21 : 20];
-  assign _zz_41_ = _zz_81_;
-  assign _zz_82_ = _zz_71_[25 : 24];
-  assign _zz_40_ = _zz_82_;
+  assign _zz_69 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_70 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_71 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz_72 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_68 = {(((decode_INSTRUCTION & _zz_216) == 32'h00000050) != 1'b0),{((_zz_217 == _zz_218) != 1'b0),{({_zz_219,_zz_220} != 2'b00),{(_zz_221 != _zz_222),{_zz_223,{_zz_224,_zz_225}}}}}};
+  assign _zz_73 = _zz_68[1 : 0];
+  assign _zz_46 = _zz_73;
+  assign _zz_74 = _zz_68[6 : 5];
+  assign _zz_45 = _zz_74;
+  assign _zz_75 = _zz_68[8 : 7];
+  assign _zz_44 = _zz_75;
+  assign _zz_76 = _zz_68[17 : 16];
+  assign _zz_43 = _zz_76;
+  assign _zz_77 = _zz_68[20 : 19];
+  assign _zz_42 = _zz_77;
+  assign _zz_78 = _zz_68[22 : 21];
+  assign _zz_41 = _zz_78;
+  assign _zz_79 = _zz_68[25 : 24];
+  assign _zz_40 = _zz_79;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_126_;
-  assign decode_RegFilePlugin_rs2Data = _zz_127_;
+  assign decode_RegFilePlugin_rs1Data = _zz_121;
+  assign decode_RegFilePlugin_rs2Data = _zz_122;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_38_ && writeBack_arbitration_isFiring);
-    if(_zz_83_)begin
+    lastStageRegFileWrite_valid = (_zz_38 && writeBack_arbitration_isFiring);
+    if(_zz_80)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_37_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_47_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_37[11 : 7];
+    if(_zz_80)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_47;
+    if(_zz_80)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -2752,13 +2393,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_84_ = execute_IntAluPlugin_bitwise;
+        _zz_81 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_84_ = {31'd0, _zz_179_};
+        _zz_81 = {31'd0, _zz_171};
       end
       default : begin
-        _zz_84_ = execute_SRC_ADD_SUB;
+        _zz_81 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -2766,87 +2407,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_85_ = execute_RS1;
+        _zz_82 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_85_ = {29'd0, _zz_180_};
+        _zz_82 = {29'd0, _zz_172};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_85_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_82 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_85_ = {27'd0, _zz_181_};
+        _zz_82 = {27'd0, _zz_173};
       end
     endcase
   end
 
-  assign _zz_86_ = _zz_182_[11];
+  assign _zz_83 = _zz_174[11];
   always @ (*) begin
-    _zz_87_[19] = _zz_86_;
-    _zz_87_[18] = _zz_86_;
-    _zz_87_[17] = _zz_86_;
-    _zz_87_[16] = _zz_86_;
-    _zz_87_[15] = _zz_86_;
-    _zz_87_[14] = _zz_86_;
-    _zz_87_[13] = _zz_86_;
-    _zz_87_[12] = _zz_86_;
-    _zz_87_[11] = _zz_86_;
-    _zz_87_[10] = _zz_86_;
-    _zz_87_[9] = _zz_86_;
-    _zz_87_[8] = _zz_86_;
-    _zz_87_[7] = _zz_86_;
-    _zz_87_[6] = _zz_86_;
-    _zz_87_[5] = _zz_86_;
-    _zz_87_[4] = _zz_86_;
-    _zz_87_[3] = _zz_86_;
-    _zz_87_[2] = _zz_86_;
-    _zz_87_[1] = _zz_86_;
-    _zz_87_[0] = _zz_86_;
+    _zz_84[19] = _zz_83;
+    _zz_84[18] = _zz_83;
+    _zz_84[17] = _zz_83;
+    _zz_84[16] = _zz_83;
+    _zz_84[15] = _zz_83;
+    _zz_84[14] = _zz_83;
+    _zz_84[13] = _zz_83;
+    _zz_84[12] = _zz_83;
+    _zz_84[11] = _zz_83;
+    _zz_84[10] = _zz_83;
+    _zz_84[9] = _zz_83;
+    _zz_84[8] = _zz_83;
+    _zz_84[7] = _zz_83;
+    _zz_84[6] = _zz_83;
+    _zz_84[5] = _zz_83;
+    _zz_84[4] = _zz_83;
+    _zz_84[3] = _zz_83;
+    _zz_84[2] = _zz_83;
+    _zz_84[1] = _zz_83;
+    _zz_84[0] = _zz_83;
   end
 
-  assign _zz_88_ = _zz_183_[11];
+  assign _zz_85 = _zz_175[11];
   always @ (*) begin
-    _zz_89_[19] = _zz_88_;
-    _zz_89_[18] = _zz_88_;
-    _zz_89_[17] = _zz_88_;
-    _zz_89_[16] = _zz_88_;
-    _zz_89_[15] = _zz_88_;
-    _zz_89_[14] = _zz_88_;
-    _zz_89_[13] = _zz_88_;
-    _zz_89_[12] = _zz_88_;
-    _zz_89_[11] = _zz_88_;
-    _zz_89_[10] = _zz_88_;
-    _zz_89_[9] = _zz_88_;
-    _zz_89_[8] = _zz_88_;
-    _zz_89_[7] = _zz_88_;
-    _zz_89_[6] = _zz_88_;
-    _zz_89_[5] = _zz_88_;
-    _zz_89_[4] = _zz_88_;
-    _zz_89_[3] = _zz_88_;
-    _zz_89_[2] = _zz_88_;
-    _zz_89_[1] = _zz_88_;
-    _zz_89_[0] = _zz_88_;
+    _zz_86[19] = _zz_85;
+    _zz_86[18] = _zz_85;
+    _zz_86[17] = _zz_85;
+    _zz_86[16] = _zz_85;
+    _zz_86[15] = _zz_85;
+    _zz_86[14] = _zz_85;
+    _zz_86[13] = _zz_85;
+    _zz_86[12] = _zz_85;
+    _zz_86[11] = _zz_85;
+    _zz_86[10] = _zz_85;
+    _zz_86[9] = _zz_85;
+    _zz_86[8] = _zz_85;
+    _zz_86[7] = _zz_85;
+    _zz_86[6] = _zz_85;
+    _zz_86[5] = _zz_85;
+    _zz_86[4] = _zz_85;
+    _zz_86[3] = _zz_85;
+    _zz_86[2] = _zz_85;
+    _zz_86[1] = _zz_85;
+    _zz_86[0] = _zz_85;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_90_ = execute_RS2;
+        _zz_87 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_90_ = {_zz_87_,execute_INSTRUCTION[31 : 20]};
+        _zz_87 = {_zz_84,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_90_ = {_zz_89_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_87 = {_zz_86,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_90_ = _zz_32_;
+        _zz_87 = _zz_32;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_184_;
+    execute_SrcPlugin_addSub = _zz_176;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -2856,220 +2497,218 @@ module VexRiscv (
   assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
-  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == (4'b0000));
+  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
   always @ (*) begin
     case(execute_SHIFT_CTRL)
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_91_ = (execute_LightShifterPlugin_shiftInput <<< 1);
+        _zz_88 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_91_ = _zz_191_;
+        _zz_88 = _zz_183;
       end
     endcase
   end
 
   always @ (*) begin
-    _zz_92_ = 1'b0;
-    if(_zz_94_)begin
-      if((_zz_95_ == decode_INSTRUCTION[19 : 15]))begin
-        _zz_92_ = 1'b1;
+    _zz_89 = 1'b0;
+    if(_zz_91)begin
+      if((_zz_92 == decode_INSTRUCTION[19 : 15]))begin
+        _zz_89 = 1'b1;
       end
     end
-    if(_zz_140_)begin
-      if(_zz_141_)begin
+    if(_zz_130)begin
+      if(_zz_131)begin
         if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_92_ = 1'b1;
+          _zz_89 = 1'b1;
         end
       end
     end
-    if(_zz_142_)begin
-      if(_zz_143_)begin
+    if(_zz_132)begin
+      if(_zz_133)begin
         if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_92_ = 1'b1;
+          _zz_89 = 1'b1;
         end
       end
     end
-    if(_zz_144_)begin
-      if(_zz_145_)begin
+    if(_zz_134)begin
+      if(_zz_135)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_92_ = 1'b1;
+          _zz_89 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_92_ = 1'b0;
+      _zz_89 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_93_ = 1'b0;
-    if(_zz_94_)begin
-      if((_zz_95_ == decode_INSTRUCTION[24 : 20]))begin
-        _zz_93_ = 1'b1;
+    _zz_90 = 1'b0;
+    if(_zz_91)begin
+      if((_zz_92 == decode_INSTRUCTION[24 : 20]))begin
+        _zz_90 = 1'b1;
       end
     end
-    if(_zz_140_)begin
-      if(_zz_141_)begin
+    if(_zz_130)begin
+      if(_zz_131)begin
         if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_93_ = 1'b1;
+          _zz_90 = 1'b1;
         end
       end
     end
-    if(_zz_142_)begin
-      if(_zz_143_)begin
+    if(_zz_132)begin
+      if(_zz_133)begin
         if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_93_ = 1'b1;
+          _zz_90 = 1'b1;
         end
       end
     end
-    if(_zz_144_)begin
-      if(_zz_145_)begin
+    if(_zz_134)begin
+      if(_zz_135)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_93_ = 1'b1;
+          _zz_90 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_93_ = 1'b0;
+      _zz_90 = 1'b0;
     end
   end
 
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_96_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_93 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_96_ == (3'b000))) begin
-        _zz_97_ = execute_BranchPlugin_eq;
-    end else if((_zz_96_ == (3'b001))) begin
-        _zz_97_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_96_ & (3'b101)) == (3'b101)))) begin
-        _zz_97_ = (! execute_SRC_LESS);
+    if((_zz_93 == 3'b000)) begin
+        _zz_94 = execute_BranchPlugin_eq;
+    end else if((_zz_93 == 3'b001)) begin
+        _zz_94 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_93 & 3'b101) == 3'b101))) begin
+        _zz_94 = (! execute_SRC_LESS);
     end else begin
-        _zz_97_ = execute_SRC_LESS;
+        _zz_94 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_98_ = 1'b0;
+        _zz_95 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_98_ = 1'b1;
+        _zz_95 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_98_ = 1'b1;
+        _zz_95 = 1'b1;
       end
       default : begin
-        _zz_98_ = _zz_97_;
+        _zz_95 = _zz_94;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_99_ = _zz_193_[19];
+  assign _zz_96 = _zz_185[19];
   always @ (*) begin
-    _zz_100_[10] = _zz_99_;
-    _zz_100_[9] = _zz_99_;
-    _zz_100_[8] = _zz_99_;
-    _zz_100_[7] = _zz_99_;
-    _zz_100_[6] = _zz_99_;
-    _zz_100_[5] = _zz_99_;
-    _zz_100_[4] = _zz_99_;
-    _zz_100_[3] = _zz_99_;
-    _zz_100_[2] = _zz_99_;
-    _zz_100_[1] = _zz_99_;
-    _zz_100_[0] = _zz_99_;
+    _zz_97[10] = _zz_96;
+    _zz_97[9] = _zz_96;
+    _zz_97[8] = _zz_96;
+    _zz_97[7] = _zz_96;
+    _zz_97[6] = _zz_96;
+    _zz_97[5] = _zz_96;
+    _zz_97[4] = _zz_96;
+    _zz_97[3] = _zz_96;
+    _zz_97[2] = _zz_96;
+    _zz_97[1] = _zz_96;
+    _zz_97[0] = _zz_96;
   end
 
-  assign _zz_101_ = _zz_194_[11];
+  assign _zz_98 = _zz_186[11];
   always @ (*) begin
-    _zz_102_[19] = _zz_101_;
-    _zz_102_[18] = _zz_101_;
-    _zz_102_[17] = _zz_101_;
-    _zz_102_[16] = _zz_101_;
-    _zz_102_[15] = _zz_101_;
-    _zz_102_[14] = _zz_101_;
-    _zz_102_[13] = _zz_101_;
-    _zz_102_[12] = _zz_101_;
-    _zz_102_[11] = _zz_101_;
-    _zz_102_[10] = _zz_101_;
-    _zz_102_[9] = _zz_101_;
-    _zz_102_[8] = _zz_101_;
-    _zz_102_[7] = _zz_101_;
-    _zz_102_[6] = _zz_101_;
-    _zz_102_[5] = _zz_101_;
-    _zz_102_[4] = _zz_101_;
-    _zz_102_[3] = _zz_101_;
-    _zz_102_[2] = _zz_101_;
-    _zz_102_[1] = _zz_101_;
-    _zz_102_[0] = _zz_101_;
+    _zz_99[19] = _zz_98;
+    _zz_99[18] = _zz_98;
+    _zz_99[17] = _zz_98;
+    _zz_99[16] = _zz_98;
+    _zz_99[15] = _zz_98;
+    _zz_99[14] = _zz_98;
+    _zz_99[13] = _zz_98;
+    _zz_99[12] = _zz_98;
+    _zz_99[11] = _zz_98;
+    _zz_99[10] = _zz_98;
+    _zz_99[9] = _zz_98;
+    _zz_99[8] = _zz_98;
+    _zz_99[7] = _zz_98;
+    _zz_99[6] = _zz_98;
+    _zz_99[5] = _zz_98;
+    _zz_99[4] = _zz_98;
+    _zz_99[3] = _zz_98;
+    _zz_99[2] = _zz_98;
+    _zz_99[1] = _zz_98;
+    _zz_99[0] = _zz_98;
   end
 
-  assign _zz_103_ = _zz_195_[11];
+  assign _zz_100 = _zz_187[11];
   always @ (*) begin
-    _zz_104_[18] = _zz_103_;
-    _zz_104_[17] = _zz_103_;
-    _zz_104_[16] = _zz_103_;
-    _zz_104_[15] = _zz_103_;
-    _zz_104_[14] = _zz_103_;
-    _zz_104_[13] = _zz_103_;
-    _zz_104_[12] = _zz_103_;
-    _zz_104_[11] = _zz_103_;
-    _zz_104_[10] = _zz_103_;
-    _zz_104_[9] = _zz_103_;
-    _zz_104_[8] = _zz_103_;
-    _zz_104_[7] = _zz_103_;
-    _zz_104_[6] = _zz_103_;
-    _zz_104_[5] = _zz_103_;
-    _zz_104_[4] = _zz_103_;
-    _zz_104_[3] = _zz_103_;
-    _zz_104_[2] = _zz_103_;
-    _zz_104_[1] = _zz_103_;
-    _zz_104_[0] = _zz_103_;
+    _zz_101[18] = _zz_100;
+    _zz_101[17] = _zz_100;
+    _zz_101[16] = _zz_100;
+    _zz_101[15] = _zz_100;
+    _zz_101[14] = _zz_100;
+    _zz_101[13] = _zz_100;
+    _zz_101[12] = _zz_100;
+    _zz_101[11] = _zz_100;
+    _zz_101[10] = _zz_100;
+    _zz_101[9] = _zz_100;
+    _zz_101[8] = _zz_100;
+    _zz_101[7] = _zz_100;
+    _zz_101[6] = _zz_100;
+    _zz_101[5] = _zz_100;
+    _zz_101[4] = _zz_100;
+    _zz_101[3] = _zz_100;
+    _zz_101[2] = _zz_100;
+    _zz_101[1] = _zz_100;
+    _zz_101[0] = _zz_100;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_105_ = {{_zz_100_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_102 = {{_zz_97,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_105_ = {_zz_102_,execute_INSTRUCTION[31 : 20]};
+        _zz_102 = {_zz_99,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_105_ = {{_zz_104_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_102 = {{_zz_101,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_105_;
+  assign execute_BranchPlugin_branch_src2 = _zz_102;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && BranchPlugin_jumpInterface_payload[1]);
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = BranchPlugin_jumpInterface_payload;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_106_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_107_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_108_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_103 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_104 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_105 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_109_ = {decodeExceptionPort_valid,IBusSimplePlugin_decodeExceptionPort_valid};
-  assign _zz_110_ = _zz_196_[0];
-  assign _zz_111_ = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_112_ = _zz_198_[0];
+  assign _zz_106 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_107 = _zz_188[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_131_)begin
+    if(decodeExceptionPort_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3089,7 +2728,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_133_)begin
+    if(_zz_125)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -3113,7 +2752,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -3137,7 +2776,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -3159,7 +2798,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768)begin
@@ -3197,7 +2836,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_146_)begin
+    if(_zz_136)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -3216,20 +2855,20 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_147_)begin
+    if(_zz_137)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_147_)begin
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_137)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -3238,14 +2877,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_146_)begin
+    if(_zz_136)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_146_)begin
+    if(_zz_136)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3254,7 +2893,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_154_)
+    case(_zz_145)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -3265,37 +2904,37 @@ module VexRiscv (
   end
 
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign _zz_114_ = (_zz_113_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_114_ != 32'h0);
-  assign _zz_25_ = decode_SRC1_CTRL;
-  assign _zz_23_ = _zz_46_;
-  assign _zz_34_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_22_ = decode_BRANCH_CTRL;
-  assign _zz_20_ = _zz_43_;
-  assign _zz_29_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_19_ = decode_SHIFT_CTRL;
-  assign _zz_17_ = _zz_40_;
-  assign _zz_31_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_16_ = decode_ENV_CTRL;
-  assign _zz_13_ = execute_ENV_CTRL;
-  assign _zz_11_ = memory_ENV_CTRL;
-  assign _zz_14_ = _zz_42_;
-  assign _zz_27_ = decode_to_execute_ENV_CTRL;
-  assign _zz_26_ = execute_to_memory_ENV_CTRL;
-  assign _zz_28_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_9_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_7_ = _zz_44_;
-  assign _zz_36_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_6_ = decode_SRC2_CTRL;
-  assign _zz_4_ = _zz_41_;
-  assign _zz_33_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_3_ = decode_ALU_CTRL;
-  assign _zz_1_ = _zz_45_;
-  assign _zz_35_ = decode_to_execute_ALU_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_109 = (_zz_108 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_109 != 32'h0);
+  assign _zz_25 = decode_SRC1_CTRL;
+  assign _zz_23 = _zz_46;
+  assign _zz_34 = decode_to_execute_SRC1_CTRL;
+  assign _zz_22 = decode_ALU_CTRL;
+  assign _zz_20 = _zz_45;
+  assign _zz_35 = decode_to_execute_ALU_CTRL;
+  assign _zz_19 = decode_SRC2_CTRL;
+  assign _zz_17 = _zz_44;
+  assign _zz_33 = decode_to_execute_SRC2_CTRL;
+  assign _zz_16 = decode_ALU_BITWISE_CTRL;
+  assign _zz_14 = _zz_43;
+  assign _zz_36 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_13 = decode_SHIFT_CTRL;
+  assign _zz_11 = _zz_42;
+  assign _zz_31 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_10 = decode_BRANCH_CTRL;
+  assign _zz_8 = _zz_41;
+  assign _zz_29 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_40;
+  assign _zz_27 = decode_to_execute_ENV_CTRL;
+  assign _zz_26 = execute_to_memory_ENV_CTRL;
+  assign _zz_28 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -3313,76 +2952,76 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_115_ = 32'h0;
+    _zz_110 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_115_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_115_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_115_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_110[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_110[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_110[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_116_ = 32'h0;
+    _zz_111 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_116_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_116_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_116_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_111[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_111[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_111[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_117_ = 32'h0;
+    _zz_112 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_117_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_117_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_117_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_112[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_112[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_112[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_118_ = 32'h0;
+    _zz_113 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_118_[31 : 0] = CsrPlugin_mepc;
+      _zz_113[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_119_ = 32'h0;
+    _zz_114 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_119_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_119_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_114[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_114[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_120_ = 32'h0;
+    _zz_115 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_120_[31 : 0] = CsrPlugin_mtval;
+      _zz_115[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_121_ = 32'h0;
+    _zz_116 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_121_[31 : 0] = _zz_113_;
+      _zz_116[31 : 0] = _zz_108;
     end
   end
 
   always @ (*) begin
-    _zz_122_ = 32'h0;
+    _zz_117 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_122_[31 : 0] = _zz_114_;
+      _zz_117[31 : 0] = _zz_109;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((_zz_115_ | _zz_116_) | (_zz_117_ | _zz_118_)) | ((_zz_119_ | _zz_120_) | (_zz_121_ | _zz_122_)));
+  assign execute_CsrPlugin_readData = (((_zz_110 | _zz_111) | (_zz_112 | _zz_113)) | ((_zz_114 | _zz_115) | (_zz_116 | _zz_117)));
   assign iBus_cmd_ready = ((1'b1 && (! iBus_cmd_m2sPipe_valid)) || iBus_cmd_m2sPipe_ready);
   assign iBus_cmd_m2sPipe_valid = iBus_cmd_m2sPipe_rValid;
   assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_m2sPipe_rData_pc;
   assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
-  assign iBusWishbone_CTI = (3'b000);
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign iBusWishbone_CTI = 3'b000;
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   assign iBusWishbone_CYC = iBus_cmd_m2sPipe_valid;
@@ -3398,26 +3037,26 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_halfPipe_regs_payload_size;
   assign dBus_cmd_ready = dBus_cmd_halfPipe_regs_ready;
   assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
-  assign dBusWishbone_CTI = (3'b000);
-  assign dBusWishbone_BTE = (2'b00);
+  assign dBusWishbone_CTI = 3'b000;
+  assign dBusWishbone_BTE = 2'b00;
   always @ (*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_123_ = (4'b0001);
+        _zz_118 = 4'b0001;
       end
       2'b01 : begin
-        _zz_123_ = (4'b0011);
+        _zz_118 = 4'b0011;
       end
       default : begin
-        _zz_123_ = (4'b1111);
+        _zz_118 = 4'b1111;
       end
     endcase
   end
 
   always @ (*) begin
-    dBusWishbone_SEL = (_zz_123_ <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    dBusWishbone_SEL = (_zz_118 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
     if((! dBus_cmd_halfPipe_payload_wr))begin
-      dBusWishbone_SEL = (4'b1111);
+      dBusWishbone_SEL = 4'b1111;
     end
   end
 
@@ -3429,28 +3068,28 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
-  assign _zz_125_ = 1'b0;
+  assign _zz_120 = 1'b0;
   always @ (posedge clk) begin
     if(reset) begin
       IBusSimplePlugin_fetchPc_pcReg <= externalResetVector;
       IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       IBusSimplePlugin_fetchPc_booted <= 1'b0;
       IBusSimplePlugin_fetchPc_inc <= 1'b0;
-      _zz_57_ <= 1'b0;
-      _zz_58_ <= 1'b0;
+      _zz_54 <= 1'b0;
+      _zz_55 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusSimplePlugin_pending_value <= (3'b000);
-      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (3'b000);
-      _zz_83_ <= 1'b1;
+      IBusSimplePlugin_pending_value <= 3'b000;
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
+      _zz_80 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_94_ <= 1'b0;
+      _zz_91 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -3464,12 +3103,10 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      _zz_113_ <= 32'h0;
+      _zz_108 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
       iBus_cmd_m2sPipe_rValid <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
@@ -3494,16 +3131,16 @@ module VexRiscv (
         IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
       if(IBusSimplePlugin_iBusRsp_flush)begin
-        _zz_57_ <= 1'b0;
+        _zz_54 <= 1'b0;
       end
-      if(_zz_55_)begin
-        _zz_57_ <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_52)begin
+        _zz_54 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(decode_arbitration_removeIt)begin
-        _zz_58_ <= 1'b0;
+        _zz_55 <= 1'b0;
       end
       if(IBusSimplePlugin_iBusRsp_output_ready)begin
-        _zz_58_ <= (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_externalFlush));
+        _zz_55 <= (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_externalFlush));
       end
       if(IBusSimplePlugin_fetchPc_flushed)begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -3548,13 +3185,33 @@ module VexRiscv (
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
       IBusSimplePlugin_pending_value <= IBusSimplePlugin_pending_next;
-      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_175_);
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_167);
       if(IBusSimplePlugin_iBusRsp_flush)begin
-        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_177_);
+        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_169);
       end
-      _zz_83_ <= 1'b0;
-      if(_zz_129_)begin
-        if(_zz_132_)begin
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
+        `else
+          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
+        `else
+          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      _zz_80 <= 1'b0;
+      if(_zz_123)begin
+        if(_zz_138)begin
           execute_LightShifterPlugin_isActive <= 1'b1;
           if(execute_LightShifterPlugin_done)begin
             execute_LightShifterPlugin_isActive <= 1'b0;
@@ -3564,7 +3221,7 @@ module VexRiscv (
       if(execute_arbitration_removeIt)begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_94_ <= (_zz_38_ && writeBack_arbitration_isFiring);
+      _zz_91 <= (_zz_38 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -3586,14 +3243,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_148_)begin
-        if(_zz_149_)begin
+      if(_zz_139)begin
+        if(_zz_140)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_150_)begin
+        if(_zz_141)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_151_)begin
+        if(_zz_142)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -3617,7 +3274,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_134_)begin
+      if(_zz_126)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3628,10 +3285,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_135_)begin
-        case(_zz_136_)
+      if(_zz_127)begin
+        case(_zz_128)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -3639,13 +3296,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_108_,{_zz_107_,_zz_106_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= memory_REGFILE_WRITE_DATA;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
+      execute_CsrPlugin_wfiWake <= (({_zz_105,{_zz_104,_zz_103}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -3667,26 +3318,26 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_200_[0];
-          CsrPlugin_mstatus_MIE <= _zz_201_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_190[0];
+          CsrPlugin_mstatus_MIE <= _zz_191[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_203_[0];
-          CsrPlugin_mie_MTIE <= _zz_204_[0];
-          CsrPlugin_mie_MSIE <= _zz_205_[0];
+          CsrPlugin_mie_MEIE <= _zz_193[0];
+          CsrPlugin_mie_MTIE <= _zz_194[0];
+          CsrPlugin_mie_MSIE <= _zz_195[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_113_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_108 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
       if(iBus_cmd_ready)begin
         iBus_cmd_m2sPipe_rValid <= iBus_cmd_valid;
       end
-      if(_zz_152_)begin
+      if(_zz_143)begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -3698,49 +3349,20 @@ module VexRiscv (
 
   always @ (posedge clk) begin
     if(IBusSimplePlugin_iBusRsp_output_ready)begin
-      _zz_59_ <= IBusSimplePlugin_iBusRsp_output_payload_pc;
-      _zz_60_ <= IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
-      _zz_61_ <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
-      _zz_62_ <= IBusSimplePlugin_iBusRsp_output_payload_isRvc;
+      _zz_56 <= IBusSimplePlugin_iBusRsp_output_payload_pc;
+      _zz_57 <= IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
+      _zz_58 <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
+      _zz_59 <= IBusSimplePlugin_iBusRsp_output_payload_isRvc;
     end
     if(IBusSimplePlugin_injector_decodeInput_ready)begin
       IBusSimplePlugin_injector_formal_rawInDecode <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
     end
-    if(IBusSimplePlugin_iBusRsp_stages_1_output_ready)begin
-      IBusSimplePlugin_mmu_joinCtx_physicalAddress <= IBusSimplePlugin_mmuBus_rsp_physicalAddress;
-      IBusSimplePlugin_mmu_joinCtx_isIoAccess <= IBusSimplePlugin_mmuBus_rsp_isIoAccess;
-      IBusSimplePlugin_mmu_joinCtx_allowRead <= IBusSimplePlugin_mmuBus_rsp_allowRead;
-      IBusSimplePlugin_mmu_joinCtx_allowWrite <= IBusSimplePlugin_mmuBus_rsp_allowWrite;
-      IBusSimplePlugin_mmu_joinCtx_allowExecute <= IBusSimplePlugin_mmuBus_rsp_allowExecute;
-      IBusSimplePlugin_mmu_joinCtx_exception <= IBusSimplePlugin_mmuBus_rsp_exception;
-      IBusSimplePlugin_mmu_joinCtx_refilling <= IBusSimplePlugin_mmuBus_rsp_refilling;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)))
-      `else
-        if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
-          $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
-          $finish;
-        end
-      `endif
-    `endif
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)))
-      `else
-        if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
-          $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
-          $finish;
-        end
-      `endif
-    `endif
-    if(_zz_129_)begin
-      if(_zz_132_)begin
+    if(_zz_123)begin
+      if(_zz_138)begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_95_ <= _zz_37_[11 : 7];
+    _zz_92 <= _zz_37[11 : 7];
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -3748,33 +3370,33 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_131_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_110_ ? IBusSimplePlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_110_ ? IBusSimplePlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(decodeExceptionPort_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= decodeExceptionPort_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= decodeExceptionPort_payload_badAddr;
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_133_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_112_ ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_112_ ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
+    if(_zz_125)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_107 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_107 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(_zz_148_)begin
-      if(_zz_149_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_139)begin
+      if(_zz_140)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_150_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_141)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_151_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_142)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_134_)begin
+    if(_zz_126)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -3789,35 +3411,65 @@ module VexRiscv (
       endcase
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_24_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_21_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_18_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_15_;
+      decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_12_;
+      execute_to_memory_PC <= _zz_32;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_10_;
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_48;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC1_CTRL <= _zz_24;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_CTRL <= _zz_21;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_18;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
@@ -3834,104 +3486,68 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MMU_RSP_physicalAddress <= execute_MMU_RSP_physicalAddress;
-      execute_to_memory_MMU_RSP_isIoAccess <= execute_MMU_RSP_isIoAccess;
-      execute_to_memory_MMU_RSP_allowRead <= execute_MMU_RSP_allowRead;
-      execute_to_memory_MMU_RSP_allowWrite <= execute_MMU_RSP_allowWrite;
-      execute_to_memory_MMU_RSP_allowExecute <= execute_MMU_RSP_allowExecute;
-      execute_to_memory_MMU_RSP_exception <= execute_MMU_RSP_exception;
-      execute_to_memory_MMU_RSP_refilling <= execute_MMU_RSP_refilling;
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_15;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
+      decode_to_execute_SHIFT_CTRL <= _zz_12;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_8_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_5_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ENABLE <= execute_MEMORY_ENABLE;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_32_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
+      decode_to_execute_BRANCH_CTRL <= _zz_9;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_CSR <= decode_IS_CSR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
+      decode_to_execute_ENV_CTRL <= _zz_6;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+      execute_to_memory_ENV_CTRL <= _zz_3;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_48_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MMU_FAULT <= execute_MMU_FAULT;
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_2_;
-    end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30_;
+      decode_to_execute_RS1 <= decode_RS1;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+      decode_to_execute_RS2 <= decode_RS2;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= memory_REGFILE_WRITE_DATA;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
@@ -3962,7 +3578,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_202_[0];
+        CsrPlugin_mip_MSIP <= _zz_192[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -3979,11 +3595,140 @@ module VexRiscv (
     if(iBus_cmd_ready)begin
       iBus_cmd_m2sPipe_rData_pc <= iBus_cmd_payload_pc;
     end
-    if(_zz_152_)begin
+    if(_zz_143)begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
       dBus_cmd_halfPipe_regs_payload_size <= dBus_cmd_payload_size;
+    end
+  end
+
+
+endmodule
+
+module StreamFifoLowLatency (
+  input               io_push_valid,
+  output              io_push_ready,
+  input               io_push_payload_error,
+  input      [31:0]   io_push_payload_inst,
+  output reg          io_pop_valid,
+  input               io_pop_ready,
+  output reg          io_pop_payload_error,
+  output reg [31:0]   io_pop_payload_inst,
+  input               io_flush,
+  output     [0:0]    io_occupancy,
+  input               clk,
+  input               reset
+);
+  wire                _zz_4;
+  wire       [0:0]    _zz_5;
+  reg                 _zz_1;
+  reg                 pushPtr_willIncrement;
+  reg                 pushPtr_willClear;
+  wire                pushPtr_willOverflowIfInc;
+  wire                pushPtr_willOverflow;
+  reg                 popPtr_willIncrement;
+  reg                 popPtr_willClear;
+  wire                popPtr_willOverflowIfInc;
+  wire                popPtr_willOverflow;
+  wire                ptrMatch;
+  reg                 risingOccupancy;
+  wire                empty;
+  wire                full;
+  wire                pushing;
+  wire                popping;
+  wire       [32:0]   _zz_2;
+  reg        [32:0]   _zz_3;
+
+  assign _zz_4 = (! empty);
+  assign _zz_5 = _zz_2[0 : 0];
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(pushing)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    pushPtr_willIncrement = 1'b0;
+    if(pushing)begin
+      pushPtr_willIncrement = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    pushPtr_willClear = 1'b0;
+    if(io_flush)begin
+      pushPtr_willClear = 1'b1;
+    end
+  end
+
+  assign pushPtr_willOverflowIfInc = 1'b1;
+  assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
+  always @ (*) begin
+    popPtr_willIncrement = 1'b0;
+    if(popping)begin
+      popPtr_willIncrement = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    popPtr_willClear = 1'b0;
+    if(io_flush)begin
+      popPtr_willClear = 1'b1;
+    end
+  end
+
+  assign popPtr_willOverflowIfInc = 1'b1;
+  assign popPtr_willOverflow = (popPtr_willOverflowIfInc && popPtr_willIncrement);
+  assign ptrMatch = 1'b1;
+  assign empty = (ptrMatch && (! risingOccupancy));
+  assign full = (ptrMatch && risingOccupancy);
+  assign pushing = (io_push_valid && io_push_ready);
+  assign popping = (io_pop_valid && io_pop_ready);
+  assign io_push_ready = (! full);
+  always @ (*) begin
+    if(_zz_4)begin
+      io_pop_valid = 1'b1;
+    end else begin
+      io_pop_valid = io_push_valid;
+    end
+  end
+
+  assign _zz_2 = _zz_3;
+  always @ (*) begin
+    if(_zz_4)begin
+      io_pop_payload_error = _zz_5[0];
+    end else begin
+      io_pop_payload_error = io_push_payload_error;
+    end
+  end
+
+  always @ (*) begin
+    if(_zz_4)begin
+      io_pop_payload_inst = _zz_2[32 : 1];
+    end else begin
+      io_pop_payload_inst = io_push_payload_inst;
+    end
+  end
+
+  assign io_occupancy = (risingOccupancy && ptrMatch);
+  always @ (posedge clk) begin
+    if(reset) begin
+      risingOccupancy <= 1'b0;
+    end else begin
+      if((pushing != popping))begin
+        risingOccupancy <= pushing;
+      end
+      if(io_flush)begin
+        risingOccupancy <= 1'b0;
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_1)begin
+      _zz_3 <= {io_push_payload_inst,io_push_payload_error};
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_MinDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_MinDebug.v
@@ -1,13 +1,18 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 15:38:33
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
 
-`define Src2CtrlEnum_defaultEncoding_type [1:0]
-`define Src2CtrlEnum_defaultEncoding_RS 2'b00
-`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
-`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
-`define Src2CtrlEnum_defaultEncoding_PC 2'b11
+`define EnvCtrlEnum_defaultEncoding_type [1:0]
+`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
+`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
+`define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
+
+`define BranchCtrlEnum_defaultEncoding_type [1:0]
+`define BranchCtrlEnum_defaultEncoding_INC 2'b00
+`define BranchCtrlEnum_defaultEncoding_B 2'b01
+`define BranchCtrlEnum_defaultEncoding_JAL 2'b10
+`define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
 `define ShiftCtrlEnum_defaultEncoding_type [1:0]
 `define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
@@ -15,10 +20,16 @@
 `define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
 `define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
-`define EnvCtrlEnum_defaultEncoding_type [1:0]
-`define EnvCtrlEnum_defaultEncoding_NONE 2'b00
-`define EnvCtrlEnum_defaultEncoding_XRET 2'b01
-`define EnvCtrlEnum_defaultEncoding_ECALL 2'b10
+`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
+
+`define Src2CtrlEnum_defaultEncoding_type [1:0]
+`define Src2CtrlEnum_defaultEncoding_RS 2'b00
+`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
+`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
+`define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
 `define AluCtrlEnum_defaultEncoding_type [1:0]
 `define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
@@ -31,146 +42,6 @@
 `define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
 `define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
-
-`define BranchCtrlEnum_defaultEncoding_type [1:0]
-`define BranchCtrlEnum_defaultEncoding_INC 2'b00
-`define BranchCtrlEnum_defaultEncoding_B 2'b01
-`define BranchCtrlEnum_defaultEncoding_JAL 2'b10
-`define BranchCtrlEnum_defaultEncoding_JALR 2'b11
-
-
-module StreamFifoLowLatency (
-  input               io_push_valid,
-  output              io_push_ready,
-  input               io_push_payload_error,
-  input      [31:0]   io_push_payload_inst,
-  output reg          io_pop_valid,
-  input               io_pop_ready,
-  output reg          io_pop_payload_error,
-  output reg [31:0]   io_pop_payload_inst,
-  input               io_flush,
-  output     [0:0]    io_occupancy,
-  input               clk,
-  input               reset 
-);
-  wire                _zz_4_;
-  wire       [0:0]    _zz_5_;
-  reg                 _zz_1_;
-  reg                 pushPtr_willIncrement;
-  reg                 pushPtr_willClear;
-  wire                pushPtr_willOverflowIfInc;
-  wire                pushPtr_willOverflow;
-  reg                 popPtr_willIncrement;
-  reg                 popPtr_willClear;
-  wire                popPtr_willOverflowIfInc;
-  wire                popPtr_willOverflow;
-  wire                ptrMatch;
-  reg                 risingOccupancy;
-  wire                empty;
-  wire                full;
-  wire                pushing;
-  wire                popping;
-  wire       [32:0]   _zz_2_;
-  reg        [32:0]   _zz_3_;
-
-  assign _zz_4_ = (! empty);
-  assign _zz_5_ = _zz_2_[0 : 0];
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(pushing)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    pushPtr_willIncrement = 1'b0;
-    if(pushing)begin
-      pushPtr_willIncrement = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    pushPtr_willClear = 1'b0;
-    if(io_flush)begin
-      pushPtr_willClear = 1'b1;
-    end
-  end
-
-  assign pushPtr_willOverflowIfInc = 1'b1;
-  assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
-  always @ (*) begin
-    popPtr_willIncrement = 1'b0;
-    if(popping)begin
-      popPtr_willIncrement = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    popPtr_willClear = 1'b0;
-    if(io_flush)begin
-      popPtr_willClear = 1'b1;
-    end
-  end
-
-  assign popPtr_willOverflowIfInc = 1'b1;
-  assign popPtr_willOverflow = (popPtr_willOverflowIfInc && popPtr_willIncrement);
-  assign ptrMatch = 1'b1;
-  assign empty = (ptrMatch && (! risingOccupancy));
-  assign full = (ptrMatch && risingOccupancy);
-  assign pushing = (io_push_valid && io_push_ready);
-  assign popping = (io_pop_valid && io_pop_ready);
-  assign io_push_ready = (! full);
-  always @ (*) begin
-    if(_zz_4_)begin
-      io_pop_valid = 1'b1;
-    end else begin
-      io_pop_valid = io_push_valid;
-    end
-  end
-
-  assign _zz_2_ = _zz_3_;
-  always @ (*) begin
-    if(_zz_4_)begin
-      io_pop_payload_error = _zz_5_[0];
-    end else begin
-      io_pop_payload_error = io_push_payload_error;
-    end
-  end
-
-  always @ (*) begin
-    if(_zz_4_)begin
-      io_pop_payload_inst = _zz_2_[32 : 1];
-    end else begin
-      io_pop_payload_inst = io_push_payload_inst;
-    end
-  end
-
-  assign io_occupancy = (risingOccupancy && ptrMatch);
-  always @ (posedge clk) begin
-    if(reset) begin
-      risingOccupancy <= 1'b0;
-    end else begin
-      if((pushing != popping))begin
-        risingOccupancy <= pushing;
-      end
-      if(io_flush)begin
-        risingOccupancy <= 1'b0;
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_)begin
-      _zz_3_ <= {io_push_payload_inst,io_push_payload_error};
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -193,8 +64,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -204,305 +75,305 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output reg [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
   input               reset,
-  input               debugReset 
+  input               debugReset
 );
-  wire                _zz_126_;
-  wire                _zz_127_;
-  reg        [31:0]   _zz_128_;
-  reg        [31:0]   _zz_129_;
-  reg        [31:0]   _zz_130_;
+  wire                _zz_121;
+  wire                _zz_122;
+  reg        [31:0]   _zz_123;
+  reg        [31:0]   _zz_124;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
   wire       [0:0]    IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy;
-  wire                _zz_131_;
-  wire                _zz_132_;
-  wire                _zz_133_;
-  wire                _zz_134_;
-  wire                _zz_135_;
-  wire                _zz_136_;
-  wire                _zz_137_;
-  wire                _zz_138_;
-  wire                _zz_139_;
-  wire                _zz_140_;
-  wire       [1:0]    _zz_141_;
-  wire                _zz_142_;
-  wire                _zz_143_;
-  wire                _zz_144_;
-  wire                _zz_145_;
-  wire                _zz_146_;
-  wire                _zz_147_;
-  wire                _zz_148_;
-  wire                _zz_149_;
-  wire                _zz_150_;
-  wire                _zz_151_;
-  wire                _zz_152_;
-  wire       [5:0]    _zz_153_;
-  wire                _zz_154_;
-  wire                _zz_155_;
-  wire                _zz_156_;
-  wire                _zz_157_;
-  wire                _zz_158_;
-  wire       [1:0]    _zz_159_;
-  wire                _zz_160_;
-  wire       [0:0]    _zz_161_;
-  wire       [0:0]    _zz_162_;
-  wire       [0:0]    _zz_163_;
-  wire       [0:0]    _zz_164_;
-  wire       [0:0]    _zz_165_;
-  wire       [0:0]    _zz_166_;
-  wire       [0:0]    _zz_167_;
-  wire       [0:0]    _zz_168_;
-  wire       [0:0]    _zz_169_;
-  wire       [0:0]    _zz_170_;
-  wire       [0:0]    _zz_171_;
-  wire       [0:0]    _zz_172_;
-  wire       [2:0]    _zz_173_;
-  wire       [2:0]    _zz_174_;
-  wire       [31:0]   _zz_175_;
-  wire       [2:0]    _zz_176_;
-  wire       [0:0]    _zz_177_;
-  wire       [2:0]    _zz_178_;
-  wire       [0:0]    _zz_179_;
-  wire       [2:0]    _zz_180_;
-  wire       [0:0]    _zz_181_;
-  wire       [2:0]    _zz_182_;
-  wire       [0:0]    _zz_183_;
-  wire       [2:0]    _zz_184_;
-  wire       [2:0]    _zz_185_;
-  wire       [0:0]    _zz_186_;
-  wire       [2:0]    _zz_187_;
-  wire       [4:0]    _zz_188_;
-  wire       [11:0]   _zz_189_;
-  wire       [11:0]   _zz_190_;
-  wire       [31:0]   _zz_191_;
-  wire       [31:0]   _zz_192_;
-  wire       [31:0]   _zz_193_;
-  wire       [31:0]   _zz_194_;
-  wire       [31:0]   _zz_195_;
-  wire       [31:0]   _zz_196_;
-  wire       [31:0]   _zz_197_;
-  wire       [31:0]   _zz_198_;
-  wire       [32:0]   _zz_199_;
-  wire       [19:0]   _zz_200_;
-  wire       [11:0]   _zz_201_;
-  wire       [11:0]   _zz_202_;
-  wire       [1:0]    _zz_203_;
-  wire       [1:0]    _zz_204_;
-  wire       [1:0]    _zz_205_;
-  wire       [1:0]    _zz_206_;
-  wire       [0:0]    _zz_207_;
-  wire       [0:0]    _zz_208_;
-  wire       [0:0]    _zz_209_;
-  wire       [0:0]    _zz_210_;
-  wire       [0:0]    _zz_211_;
-  wire       [0:0]    _zz_212_;
-  wire                _zz_213_;
-  wire                _zz_214_;
-  wire       [1:0]    _zz_215_;
-  wire       [31:0]   _zz_216_;
-  wire       [31:0]   _zz_217_;
-  wire       [31:0]   _zz_218_;
-  wire                _zz_219_;
-  wire       [0:0]    _zz_220_;
-  wire       [12:0]   _zz_221_;
-  wire       [31:0]   _zz_222_;
-  wire       [31:0]   _zz_223_;
-  wire       [31:0]   _zz_224_;
-  wire                _zz_225_;
-  wire       [0:0]    _zz_226_;
-  wire       [6:0]    _zz_227_;
-  wire       [31:0]   _zz_228_;
-  wire       [31:0]   _zz_229_;
-  wire       [31:0]   _zz_230_;
-  wire                _zz_231_;
-  wire       [0:0]    _zz_232_;
-  wire       [0:0]    _zz_233_;
-  wire       [31:0]   _zz_234_;
-  wire                _zz_235_;
-  wire                _zz_236_;
-  wire       [0:0]    _zz_237_;
-  wire       [1:0]    _zz_238_;
-  wire       [1:0]    _zz_239_;
-  wire       [1:0]    _zz_240_;
-  wire                _zz_241_;
-  wire       [0:0]    _zz_242_;
-  wire       [20:0]   _zz_243_;
-  wire       [31:0]   _zz_244_;
-  wire       [31:0]   _zz_245_;
-  wire       [31:0]   _zz_246_;
-  wire       [31:0]   _zz_247_;
-  wire       [31:0]   _zz_248_;
-  wire       [31:0]   _zz_249_;
-  wire       [31:0]   _zz_250_;
-  wire                _zz_251_;
-  wire       [0:0]    _zz_252_;
-  wire       [0:0]    _zz_253_;
-  wire       [1:0]    _zz_254_;
-  wire       [1:0]    _zz_255_;
-  wire                _zz_256_;
-  wire       [0:0]    _zz_257_;
-  wire       [17:0]   _zz_258_;
-  wire       [31:0]   _zz_259_;
-  wire       [31:0]   _zz_260_;
-  wire       [31:0]   _zz_261_;
-  wire       [31:0]   _zz_262_;
-  wire       [31:0]   _zz_263_;
-  wire       [31:0]   _zz_264_;
-  wire       [31:0]   _zz_265_;
-  wire       [31:0]   _zz_266_;
-  wire                _zz_267_;
-  wire       [0:0]    _zz_268_;
-  wire       [0:0]    _zz_269_;
-  wire                _zz_270_;
-  wire       [0:0]    _zz_271_;
-  wire       [14:0]   _zz_272_;
-  wire       [31:0]   _zz_273_;
-  wire                _zz_274_;
-  wire       [0:0]    _zz_275_;
-  wire       [0:0]    _zz_276_;
-  wire       [0:0]    _zz_277_;
-  wire       [0:0]    _zz_278_;
-  wire       [0:0]    _zz_279_;
-  wire       [0:0]    _zz_280_;
-  wire                _zz_281_;
-  wire       [0:0]    _zz_282_;
-  wire       [11:0]   _zz_283_;
-  wire       [31:0]   _zz_284_;
-  wire       [31:0]   _zz_285_;
-  wire       [31:0]   _zz_286_;
-  wire       [31:0]   _zz_287_;
-  wire                _zz_288_;
-  wire       [0:0]    _zz_289_;
-  wire       [0:0]    _zz_290_;
-  wire                _zz_291_;
-  wire       [0:0]    _zz_292_;
-  wire       [8:0]    _zz_293_;
-  wire       [31:0]   _zz_294_;
-  wire       [31:0]   _zz_295_;
-  wire                _zz_296_;
-  wire       [0:0]    _zz_297_;
-  wire       [0:0]    _zz_298_;
-  wire       [31:0]   _zz_299_;
-  wire       [31:0]   _zz_300_;
-  wire       [0:0]    _zz_301_;
-  wire       [0:0]    _zz_302_;
-  wire       [1:0]    _zz_303_;
-  wire       [1:0]    _zz_304_;
-  wire                _zz_305_;
-  wire       [0:0]    _zz_306_;
-  wire       [4:0]    _zz_307_;
-  wire       [31:0]   _zz_308_;
-  wire       [31:0]   _zz_309_;
-  wire       [31:0]   _zz_310_;
-  wire       [31:0]   _zz_311_;
-  wire       [31:0]   _zz_312_;
-  wire       [31:0]   _zz_313_;
-  wire       [31:0]   _zz_314_;
-  wire       [31:0]   _zz_315_;
-  wire       [31:0]   _zz_316_;
-  wire                _zz_317_;
-  wire                _zz_318_;
-  wire                _zz_319_;
-  wire       [1:0]    _zz_320_;
-  wire       [1:0]    _zz_321_;
-  wire                _zz_322_;
-  wire       [0:0]    _zz_323_;
-  wire       [2:0]    _zz_324_;
-  wire       [31:0]   _zz_325_;
-  wire       [31:0]   _zz_326_;
-  wire       [31:0]   _zz_327_;
-  wire       [31:0]   _zz_328_;
-  wire       [31:0]   _zz_329_;
-  wire       [31:0]   _zz_330_;
-  wire       [0:0]    _zz_331_;
-  wire       [0:0]    _zz_332_;
-  wire       [1:0]    _zz_333_;
-  wire       [1:0]    _zz_334_;
-  wire                _zz_335_;
-  wire                _zz_336_;
-  wire       [31:0]   _zz_337_;
-  wire       [31:0]   _zz_338_;
-  wire                _zz_339_;
-  wire       [0:0]    _zz_340_;
-  wire       [1:0]    _zz_341_;
+  wire                _zz_125;
+  wire                _zz_126;
+  wire                _zz_127;
+  wire                _zz_128;
+  wire                _zz_129;
+  wire                _zz_130;
+  wire                _zz_131;
+  wire                _zz_132;
+  wire       [1:0]    _zz_133;
+  wire                _zz_134;
+  wire                _zz_135;
+  wire                _zz_136;
+  wire                _zz_137;
+  wire                _zz_138;
+  wire                _zz_139;
+  wire                _zz_140;
+  wire                _zz_141;
+  wire                _zz_142;
+  wire       [5:0]    _zz_143;
+  wire                _zz_144;
+  wire                _zz_145;
+  wire                _zz_146;
+  wire                _zz_147;
+  wire                _zz_148;
+  wire                _zz_149;
+  wire       [1:0]    _zz_150;
+  wire                _zz_151;
+  wire       [0:0]    _zz_152;
+  wire       [0:0]    _zz_153;
+  wire       [0:0]    _zz_154;
+  wire       [0:0]    _zz_155;
+  wire       [0:0]    _zz_156;
+  wire       [0:0]    _zz_157;
+  wire       [0:0]    _zz_158;
+  wire       [0:0]    _zz_159;
+  wire       [0:0]    _zz_160;
+  wire       [0:0]    _zz_161;
+  wire       [0:0]    _zz_162;
+  wire       [0:0]    _zz_163;
+  wire       [1:0]    _zz_164;
+  wire       [1:0]    _zz_165;
+  wire       [2:0]    _zz_166;
+  wire       [31:0]   _zz_167;
+  wire       [2:0]    _zz_168;
+  wire       [0:0]    _zz_169;
+  wire       [2:0]    _zz_170;
+  wire       [0:0]    _zz_171;
+  wire       [2:0]    _zz_172;
+  wire       [0:0]    _zz_173;
+  wire       [2:0]    _zz_174;
+  wire       [0:0]    _zz_175;
+  wire       [2:0]    _zz_176;
+  wire       [2:0]    _zz_177;
+  wire       [0:0]    _zz_178;
+  wire       [2:0]    _zz_179;
+  wire       [4:0]    _zz_180;
+  wire       [11:0]   _zz_181;
+  wire       [11:0]   _zz_182;
+  wire       [31:0]   _zz_183;
+  wire       [31:0]   _zz_184;
+  wire       [31:0]   _zz_185;
+  wire       [31:0]   _zz_186;
+  wire       [31:0]   _zz_187;
+  wire       [31:0]   _zz_188;
+  wire       [31:0]   _zz_189;
+  wire       [31:0]   _zz_190;
+  wire       [32:0]   _zz_191;
+  wire       [19:0]   _zz_192;
+  wire       [11:0]   _zz_193;
+  wire       [11:0]   _zz_194;
+  wire       [1:0]    _zz_195;
+  wire       [1:0]    _zz_196;
+  wire       [0:0]    _zz_197;
+  wire       [0:0]    _zz_198;
+  wire       [0:0]    _zz_199;
+  wire       [0:0]    _zz_200;
+  wire       [0:0]    _zz_201;
+  wire       [0:0]    _zz_202;
+  wire                _zz_203;
+  wire                _zz_204;
+  wire       [31:0]   _zz_205;
+  wire       [31:0]   _zz_206;
+  wire       [31:0]   _zz_207;
+  wire                _zz_208;
+  wire       [0:0]    _zz_209;
+  wire       [12:0]   _zz_210;
+  wire       [31:0]   _zz_211;
+  wire       [31:0]   _zz_212;
+  wire       [31:0]   _zz_213;
+  wire                _zz_214;
+  wire       [0:0]    _zz_215;
+  wire       [6:0]    _zz_216;
+  wire       [31:0]   _zz_217;
+  wire       [31:0]   _zz_218;
+  wire       [31:0]   _zz_219;
+  wire                _zz_220;
+  wire       [0:0]    _zz_221;
+  wire       [0:0]    _zz_222;
+  wire       [31:0]   _zz_223;
+  wire       [31:0]   _zz_224;
+  wire       [31:0]   _zz_225;
+  wire                _zz_226;
+  wire       [1:0]    _zz_227;
+  wire       [1:0]    _zz_228;
+  wire                _zz_229;
+  wire       [0:0]    _zz_230;
+  wire       [20:0]   _zz_231;
+  wire       [31:0]   _zz_232;
+  wire       [31:0]   _zz_233;
+  wire       [31:0]   _zz_234;
+  wire       [31:0]   _zz_235;
+  wire                _zz_236;
+  wire                _zz_237;
+  wire       [0:0]    _zz_238;
+  wire       [0:0]    _zz_239;
+  wire                _zz_240;
+  wire       [0:0]    _zz_241;
+  wire       [17:0]   _zz_242;
+  wire       [31:0]   _zz_243;
+  wire                _zz_244;
+  wire                _zz_245;
+  wire       [0:0]    _zz_246;
+  wire       [0:0]    _zz_247;
+  wire       [0:0]    _zz_248;
+  wire       [0:0]    _zz_249;
+  wire                _zz_250;
+  wire       [0:0]    _zz_251;
+  wire       [14:0]   _zz_252;
+  wire       [31:0]   _zz_253;
+  wire       [31:0]   _zz_254;
+  wire       [31:0]   _zz_255;
+  wire       [31:0]   _zz_256;
+  wire       [31:0]   _zz_257;
+  wire       [0:0]    _zz_258;
+  wire       [0:0]    _zz_259;
+  wire       [1:0]    _zz_260;
+  wire       [1:0]    _zz_261;
+  wire                _zz_262;
+  wire       [0:0]    _zz_263;
+  wire       [11:0]   _zz_264;
+  wire       [31:0]   _zz_265;
+  wire       [31:0]   _zz_266;
+  wire       [31:0]   _zz_267;
+  wire       [31:0]   _zz_268;
+  wire       [31:0]   _zz_269;
+  wire       [31:0]   _zz_270;
+  wire                _zz_271;
+  wire       [0:0]    _zz_272;
+  wire       [0:0]    _zz_273;
+  wire                _zz_274;
+  wire       [0:0]    _zz_275;
+  wire       [0:0]    _zz_276;
+  wire                _zz_277;
+  wire       [0:0]    _zz_278;
+  wire       [8:0]    _zz_279;
+  wire       [31:0]   _zz_280;
+  wire       [31:0]   _zz_281;
+  wire       [31:0]   _zz_282;
+  wire       [0:0]    _zz_283;
+  wire       [4:0]    _zz_284;
+  wire       [1:0]    _zz_285;
+  wire       [1:0]    _zz_286;
+  wire                _zz_287;
+  wire       [0:0]    _zz_288;
+  wire       [5:0]    _zz_289;
+  wire       [31:0]   _zz_290;
+  wire       [31:0]   _zz_291;
+  wire                _zz_292;
+  wire       [0:0]    _zz_293;
+  wire       [1:0]    _zz_294;
+  wire       [31:0]   _zz_295;
+  wire       [31:0]   _zz_296;
+  wire                _zz_297;
+  wire       [0:0]    _zz_298;
+  wire       [0:0]    _zz_299;
+  wire       [0:0]    _zz_300;
+  wire       [0:0]    _zz_301;
+  wire                _zz_302;
+  wire       [0:0]    _zz_303;
+  wire       [2:0]    _zz_304;
+  wire       [31:0]   _zz_305;
+  wire                _zz_306;
+  wire                _zz_307;
+  wire       [31:0]   _zz_308;
+  wire       [31:0]   _zz_309;
+  wire       [31:0]   _zz_310;
+  wire       [31:0]   _zz_311;
+  wire       [31:0]   _zz_312;
+  wire       [31:0]   _zz_313;
+  wire       [31:0]   _zz_314;
+  wire       [0:0]    _zz_315;
+  wire       [2:0]    _zz_316;
+  wire       [0:0]    _zz_317;
+  wire       [0:0]    _zz_318;
+  wire                _zz_319;
+  wire       [0:0]    _zz_320;
+  wire       [0:0]    _zz_321;
+  wire       [31:0]   _zz_322;
+  wire       [31:0]   _zz_323;
+  wire       [31:0]   _zz_324;
+  wire                _zz_325;
+  wire                _zz_326;
+  wire       [31:0]   _zz_327;
+  wire                _zz_328;
+  wire       [0:0]    _zz_329;
+  wire       [0:0]    _zz_330;
+  wire       [0:0]    _zz_331;
+  wire       [0:0]    _zz_332;
+  wire       [0:0]    _zz_333;
+  wire       [0:0]    _zz_334;
+  wire       [31:0]   memory_MEMORY_READ_DATA;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_DO_EBREAK;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire       [31:0]   decode_RS2;
+  wire       [31:0]   decode_RS1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_STORE;
   wire                execute_BYPASSABLE_MEMORY_STAGE;
   wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
   wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_3_;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_6_;
-  wire       [31:0]   decode_RS1;
-  wire                decode_SRC2_FORCE_ZERO;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_17;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire                decode_MEMORY_ENABLE;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire                decode_MEMORY_STORE;
-  wire                execute_BRANCH_DO;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_16_;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       [31:0]   memory_MEMORY_READ_DATA;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_19_;
-  wire                decode_IS_CSR;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire                decode_DO_EBREAK;
-  wire                decode_CSR_READ_OPCODE;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_22_;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire       [31:0]   decode_RS2;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_24_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_25_;
+  wire       [31:0]   memory_PC;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_CSR_READ_OPCODE;
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_26;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire       [31:0]   execute_RS1;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_29;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
   wire                execute_REGFILE_WRITE_VALID;
@@ -511,74 +382,56 @@ module VexRiscv (
   wire       [31:0]   memory_INSTRUCTION;
   wire                memory_BYPASSABLE_MEMORY_STAGE;
   wire                writeBack_REGFILE_WRITE_VALID;
-  reg        [31:0]   _zz_30_;
+  reg        [31:0]   _zz_30;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_31;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_32_;
+  wire       [31:0]   _zz_32;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_33;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_34;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_35_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_35;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36_;
-  wire       [31:0]   _zz_37_;
-  wire                _zz_38_;
-  reg                 _zz_39_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_36;
+  wire       [31:0]   _zz_37;
+  wire                _zz_38;
+  reg                 _zz_39;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_40_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_41_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_42_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_40;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_41;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_42;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_46;
   wire                writeBack_MEMORY_STORE;
-  reg        [31:0]   _zz_47_;
+  reg        [31:0]   _zz_47;
   wire                writeBack_MEMORY_ENABLE;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire       [31:0]   writeBack_MEMORY_READ_DATA;
-  wire                memory_MMU_FAULT;
-  wire       [31:0]   memory_MMU_RSP_physicalAddress;
-  wire                memory_MMU_RSP_isIoAccess;
-  wire                memory_MMU_RSP_allowRead;
-  wire                memory_MMU_RSP_allowWrite;
-  wire                memory_MMU_RSP_allowExecute;
-  wire                memory_MMU_RSP_exception;
-  wire                memory_MMU_RSP_refilling;
-  wire       [31:0]   memory_PC;
   wire                memory_ALIGNEMENT_FAULT;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_STORE;
   wire                memory_MEMORY_ENABLE;
-  wire                execute_MMU_FAULT;
-  wire       [31:0]   execute_MMU_RSP_physicalAddress;
-  wire                execute_MMU_RSP_isIoAccess;
-  wire                execute_MMU_RSP_allowRead;
-  wire                execute_MMU_RSP_allowWrite;
-  wire                execute_MMU_RSP_allowExecute;
-  wire                execute_MMU_RSP_exception;
-  wire                execute_MMU_RSP_refilling;
   wire       [31:0]   execute_SRC_ADD;
   wire       [31:0]   execute_RS2;
   wire       [31:0]   execute_INSTRUCTION;
   wire                execute_MEMORY_STORE;
   wire                execute_MEMORY_ENABLE;
   wire                execute_ALIGNEMENT_FAULT;
-  wire                decode_MEMORY_ENABLE;
-  reg        [31:0]   _zz_48_;
+  reg        [31:0]   _zz_48;
   wire       [31:0]   decode_PC;
   wire       [31:0]   decode_INSTRUCTION;
   wire       [31:0]   writeBack_PC;
@@ -608,7 +461,7 @@ module VexRiscv (
   reg                 memory_arbitration_haltItself;
   wire                memory_arbitration_haltByOther;
   reg                 memory_arbitration_removeIt;
-  reg                 memory_arbitration_flushIt;
+  wire                memory_arbitration_flushIt;
   reg                 memory_arbitration_flushNext;
   reg                 memory_arbitration_isValid;
   wire                memory_arbitration_isStuck;
@@ -643,38 +496,9 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire                iBus_rsp_payload_error;
   wire       [31:0]   iBus_rsp_payload_inst;
-  wire                IBusSimplePlugin_decodeExceptionPort_valid;
-  reg        [3:0]    IBusSimplePlugin_decodeExceptionPort_payload_code;
-  wire       [31:0]   IBusSimplePlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusSimplePlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusSimplePlugin_mmuBus_cmd_bypassTranslation;
-  wire       [31:0]   IBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  wire                IBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  wire                IBusSimplePlugin_mmuBus_rsp_allowRead;
-  wire                IBusSimplePlugin_mmuBus_rsp_allowWrite;
-  wire                IBusSimplePlugin_mmuBus_rsp_allowExecute;
-  wire                IBusSimplePlugin_mmuBus_rsp_exception;
-  wire                IBusSimplePlugin_mmuBus_rsp_refilling;
-  wire                IBusSimplePlugin_mmuBus_end;
-  wire                IBusSimplePlugin_mmuBus_busy;
   reg                 DBusSimplePlugin_memoryExceptionPort_valid;
   reg        [3:0]    DBusSimplePlugin_memoryExceptionPort_payload_code;
   wire       [31:0]   DBusSimplePlugin_memoryExceptionPort_payload_badAddr;
-  wire                DBusSimplePlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusSimplePlugin_mmuBus_cmd_bypassTranslation;
-  wire       [31:0]   DBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  wire                DBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowRead;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowWrite;
-  wire                DBusSimplePlugin_mmuBus_rsp_allowExecute;
-  wire                DBusSimplePlugin_mmuBus_rsp_exception;
-  wire                DBusSimplePlugin_mmuBus_rsp_refilling;
-  wire                DBusSimplePlugin_mmuBus_end;
-  wire                DBusSimplePlugin_mmuBus_busy;
-  reg                 DBusSimplePlugin_redoBranch_valid;
-  wire       [31:0]   DBusSimplePlugin_redoBranch_payload;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -706,10 +530,7 @@ module VexRiscv (
   wire                IBusSimplePlugin_externalFlush;
   wire                IBusSimplePlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusSimplePlugin_jump_pcLoad_payload;
-  wire       [2:0]    _zz_49_;
-  wire       [2:0]    _zz_50_;
-  wire                _zz_51_;
-  wire                _zz_52_;
+  wire       [1:0]    _zz_49;
   wire                IBusSimplePlugin_fetchPc_output_valid;
   wire                IBusSimplePlugin_fetchPc_output_ready;
   wire       [31:0]   IBusSimplePlugin_fetchPc_output_payload;
@@ -721,10 +542,8 @@ module VexRiscv (
   reg                 IBusSimplePlugin_fetchPc_booted;
   reg                 IBusSimplePlugin_fetchPc_inc;
   reg        [31:0]   IBusSimplePlugin_fetchPc_pc;
-  wire                IBusSimplePlugin_fetchPc_redo_valid;
-  wire       [31:0]   IBusSimplePlugin_fetchPc_redo_payload;
   reg                 IBusSimplePlugin_fetchPc_flushed;
-  reg                 IBusSimplePlugin_iBusRsp_redoFetch;
+  wire                IBusSimplePlugin_iBusRsp_redoFetch;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_valid;
   wire                IBusSimplePlugin_iBusRsp_stages_0_input_ready;
   wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_0_input_payload;
@@ -739,12 +558,12 @@ module VexRiscv (
   wire                IBusSimplePlugin_iBusRsp_stages_1_output_ready;
   wire       [31:0]   IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   wire                IBusSimplePlugin_iBusRsp_stages_1_halt;
-  wire                _zz_53_;
-  wire                _zz_54_;
+  wire                _zz_50;
+  wire                _zz_51;
   wire                IBusSimplePlugin_iBusRsp_flush;
-  wire                _zz_55_;
-  wire                _zz_56_;
-  reg                 _zz_57_;
+  wire                _zz_52;
+  wire                _zz_53;
+  reg                 _zz_54;
   reg                 IBusSimplePlugin_iBusRsp_readyForError;
   wire                IBusSimplePlugin_iBusRsp_output_valid;
   wire                IBusSimplePlugin_iBusRsp_output_ready;
@@ -758,18 +577,18 @@ module VexRiscv (
   wire                IBusSimplePlugin_injector_decodeInput_payload_rsp_error;
   wire       [31:0]   IBusSimplePlugin_injector_decodeInput_payload_rsp_inst;
   wire                IBusSimplePlugin_injector_decodeInput_payload_isRvc;
-  reg                 _zz_58_;
-  reg        [31:0]   _zz_59_;
-  reg                 _zz_60_;
-  reg        [31:0]   _zz_61_;
-  reg                 _zz_62_;
+  reg                 _zz_55;
+  reg        [31:0]   _zz_56;
+  reg                 _zz_57;
+  reg        [31:0]   _zz_58;
+  reg                 _zz_59;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_0;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_1;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_2;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_3;
   reg                 IBusSimplePlugin_injector_nextPcCalc_valids_4;
   reg        [31:0]   IBusSimplePlugin_injector_formal_rawInDecode;
-  reg                 IBusSimplePlugin_cmd_valid;
+  wire                IBusSimplePlugin_cmd_valid;
   wire                IBusSimplePlugin_cmd_ready;
   wire       [31:0]   IBusSimplePlugin_cmd_payload_pc;
   wire                IBusSimplePlugin_pending_inc;
@@ -777,13 +596,6 @@ module VexRiscv (
   reg        [2:0]    IBusSimplePlugin_pending_value;
   wire       [2:0]    IBusSimplePlugin_pending_next;
   wire                IBusSimplePlugin_cmdFork_canEmit;
-  reg        [31:0]   IBusSimplePlugin_mmu_joinCtx_physicalAddress;
-  reg                 IBusSimplePlugin_mmu_joinCtx_isIoAccess;
-  reg                 IBusSimplePlugin_mmu_joinCtx_allowRead;
-  reg                 IBusSimplePlugin_mmu_joinCtx_allowWrite;
-  reg                 IBusSimplePlugin_mmu_joinCtx_allowExecute;
-  reg                 IBusSimplePlugin_mmu_joinCtx_exception;
-  reg                 IBusSimplePlugin_mmu_joinCtx_refilling;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_valid;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_ready;
   wire                IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -800,8 +612,8 @@ module VexRiscv (
   wire                IBusSimplePlugin_rspJoin_join_payload_rsp_error;
   wire       [31:0]   IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
   wire                IBusSimplePlugin_rspJoin_join_payload_isRvc;
-  reg                 IBusSimplePlugin_rspJoin_exceptionDetected;
-  wire                _zz_63_;
+  wire                IBusSimplePlugin_rspJoin_exceptionDetected;
+  wire                _zz_60;
   wire                dBus_cmd_valid;
   wire                dBus_cmd_ready;
   wire                dBus_cmd_payload_wr;
@@ -811,45 +623,45 @@ module VexRiscv (
   wire                dBus_rsp_ready;
   wire                dBus_rsp_error;
   wire       [31:0]   dBus_rsp_data;
-  wire                _zz_64_;
+  wire                _zz_61;
   reg                 execute_DBusSimplePlugin_skipCmd;
-  reg        [31:0]   _zz_65_;
-  reg        [3:0]    _zz_66_;
+  reg        [31:0]   _zz_62;
+  reg        [3:0]    _zz_63;
   wire       [3:0]    execute_DBusSimplePlugin_formalMask;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspShifted;
-  wire                _zz_67_;
-  reg        [31:0]   _zz_68_;
-  wire                _zz_69_;
-  reg        [31:0]   _zz_70_;
+  wire                _zz_64;
+  reg        [31:0]   _zz_65;
+  wire                _zz_66;
+  reg        [31:0]   _zz_67;
   reg        [31:0]   writeBack_DBusSimplePlugin_rspFormated;
-  wire       [26:0]   _zz_71_;
-  wire                _zz_72_;
-  wire                _zz_73_;
-  wire                _zz_74_;
-  wire                _zz_75_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_76_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_77_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_78_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_79_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_80_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_81_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_82_;
+  wire       [26:0]   _zz_68;
+  wire                _zz_69;
+  wire                _zz_70;
+  wire                _zz_71;
+  wire                _zz_72;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_73;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_74;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_75;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_76;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_77;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_78;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_79;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_83_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_80;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_84_;
-  reg        [31:0]   _zz_85_;
-  wire                _zz_86_;
-  reg        [19:0]   _zz_87_;
-  wire                _zz_88_;
-  reg        [19:0]   _zz_89_;
-  reg        [31:0]   _zz_90_;
+  reg        [31:0]   _zz_81;
+  reg        [31:0]   _zz_82;
+  wire                _zz_83;
+  reg        [19:0]   _zz_84;
+  wire                _zz_85;
+  reg        [19:0]   _zz_86;
+  reg        [31:0]   _zz_87;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   reg                 execute_LightShifterPlugin_isActive;
@@ -858,23 +670,23 @@ module VexRiscv (
   wire       [4:0]    execute_LightShifterPlugin_amplitude;
   wire       [31:0]   execute_LightShifterPlugin_shiftInput;
   wire                execute_LightShifterPlugin_done;
-  reg        [31:0]   _zz_91_;
-  reg                 _zz_92_;
-  reg                 _zz_93_;
-  reg                 _zz_94_;
-  reg        [4:0]    _zz_95_;
+  reg        [31:0]   _zz_88;
+  reg                 _zz_89;
+  reg                 _zz_90;
+  reg                 _zz_91;
+  reg        [4:0]    _zz_92;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_96_;
-  reg                 _zz_97_;
-  reg                 _zz_98_;
+  wire       [2:0]    _zz_93;
+  reg                 _zz_94;
+  reg                 _zz_95;
   wire       [31:0]   execute_BranchPlugin_branch_src1;
-  wire                _zz_99_;
-  reg        [10:0]   _zz_100_;
-  wire                _zz_101_;
-  reg        [19:0]   _zz_102_;
-  wire                _zz_103_;
-  reg        [18:0]   _zz_104_;
-  reg        [31:0]   _zz_105_;
+  wire                _zz_96;
+  reg        [10:0]   _zz_97;
+  wire                _zz_98;
+  reg        [19:0]   _zz_99;
+  wire                _zz_100;
+  reg        [18:0]   _zz_101;
+  reg        [31:0]   _zz_102;
   wire       [31:0]   execute_BranchPlugin_branch_src2;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
   wire       [1:0]    CsrPlugin_misa_base;
@@ -896,9 +708,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_106_;
-  wire                _zz_107_;
-  wire                _zz_108_;
+  wire                _zz_103;
+  wire                _zz_104;
+  wire                _zz_105;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -911,10 +723,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_109_;
-  wire                _zz_110_;
-  wire       [1:0]    _zz_111_;
-  wire                _zz_112_;
+  wire       [1:0]    _zz_106;
+  wire                _zz_107;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -926,7 +736,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -944,8 +754,8 @@ module VexRiscv (
   reg        [31:0]   execute_CsrPlugin_writeData;
   wire       [11:0]   execute_CsrPlugin_csrAddress;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_113_;
-  wire       [31:0]   _zz_114_;
+  reg        [31:0]   _zz_108;
+  wire       [31:0]   _zz_109;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -955,65 +765,57 @@ module VexRiscv (
   reg                 DebugPlugin_godmode;
   reg                 DebugPlugin_haltedByBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_115_;
+  reg                 _zz_110;
   wire                DebugPlugin_allowEBreak;
   reg                 DebugPlugin_resetIt_regNext;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg        [31:0]   decode_to_execute_INSTRUCTION;
-  reg        [31:0]   execute_to_memory_INSTRUCTION;
-  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [31:0]   execute_to_memory_MMU_RSP_physicalAddress;
-  reg                 execute_to_memory_MMU_RSP_isIoAccess;
-  reg                 execute_to_memory_MMU_RSP_allowRead;
-  reg                 execute_to_memory_MMU_RSP_allowWrite;
-  reg                 execute_to_memory_MMU_RSP_allowExecute;
-  reg                 execute_to_memory_MMU_RSP_exception;
-  reg                 execute_to_memory_MMU_RSP_refilling;
-  reg                 decode_to_execute_DO_EBREAK;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 execute_to_memory_MMU_FAULT;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg                 decode_to_execute_IS_CSR;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg                 execute_to_memory_ALIGNEMENT_FAULT;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg                 decode_to_execute_MEMORY_ENABLE;
-  reg                 execute_to_memory_MEMORY_ENABLE;
-  reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg                 decode_to_execute_MEMORY_STORE;
-  reg                 execute_to_memory_MEMORY_STORE;
-  reg                 memory_to_writeBack_MEMORY_STORE;
+  reg        [31:0]   decode_to_execute_INSTRUCTION;
+  reg        [31:0]   execute_to_memory_INSTRUCTION;
+  reg        [31:0]   memory_to_writeBack_INSTRUCTION;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg                 decode_to_execute_MEMORY_ENABLE;
+  reg                 execute_to_memory_MEMORY_ENABLE;
+  reg                 memory_to_writeBack_MEMORY_ENABLE;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
   reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg        [2:0]    _zz_116_;
+  reg                 decode_to_execute_MEMORY_STORE;
+  reg                 execute_to_memory_MEMORY_STORE;
+  reg                 memory_to_writeBack_MEMORY_STORE;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_DO_EBREAK;
+  reg                 execute_to_memory_ALIGNEMENT_FAULT;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   memory_to_writeBack_MEMORY_READ_DATA;
+  reg        [2:0]    _zz_111;
   reg                 execute_CsrPlugin_csr_768;
   reg                 execute_CsrPlugin_csr_836;
   reg                 execute_CsrPlugin_csr_772;
@@ -1023,14 +825,14 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_835;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_117_;
-  reg        [31:0]   _zz_118_;
-  reg        [31:0]   _zz_119_;
-  reg        [31:0]   _zz_120_;
-  reg        [31:0]   _zz_121_;
-  reg        [31:0]   _zz_122_;
-  reg        [31:0]   _zz_123_;
-  reg        [31:0]   _zz_124_;
+  reg        [31:0]   _zz_112;
+  reg        [31:0]   _zz_113;
+  reg        [31:0]   _zz_114;
+  reg        [31:0]   _zz_115;
+  reg        [31:0]   _zz_116;
+  reg        [31:0]   _zz_117;
+  reg        [31:0]   _zz_118;
+  reg        [31:0]   _zz_119;
   wire                iBus_cmd_m2sPipe_valid;
   wire                iBus_cmd_m2sPipe_ready;
   wire       [31:0]   iBus_cmd_m2sPipe_payload_pc;
@@ -1048,445 +850,358 @@ module VexRiscv (
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_address;
   reg        [31:0]   dBus_cmd_halfPipe_regs_payload_data;
   reg        [1:0]    dBus_cmd_halfPipe_regs_payload_size;
-  reg        [3:0]    _zz_125_;
+  reg        [3:0]    _zz_120;
   `ifndef SYNTHESIS
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_1__string;
-  reg [23:0] _zz_2__string;
-  reg [23:0] _zz_3__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_4__string;
-  reg [71:0] _zz_5__string;
-  reg [71:0] _zz_6__string;
-  reg [39:0] _zz_7__string;
-  reg [39:0] _zz_8__string;
-  reg [39:0] _zz_9__string;
-  reg [39:0] _zz_10__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_11__string;
-  reg [39:0] _zz_12__string;
-  reg [39:0] _zz_13__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_14__string;
-  reg [63:0] _zz_15__string;
-  reg [63:0] _zz_16__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_17__string;
-  reg [95:0] _zz_18__string;
-  reg [95:0] _zz_19__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_20__string;
-  reg [39:0] _zz_21__string;
-  reg [39:0] _zz_22__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_23__string;
-  reg [31:0] _zz_24__string;
-  reg [31:0] _zz_25__string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [31:0] _zz_10_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_14_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_17_string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_20_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_23_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_26__string;
+  reg [39:0] _zz_26_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_29__string;
+  reg [31:0] _zz_29_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_31__string;
+  reg [71:0] _zz_31_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_33__string;
+  reg [23:0] _zz_33_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_34__string;
+  reg [95:0] _zz_34_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_35__string;
+  reg [63:0] _zz_35_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_36__string;
-  reg [23:0] _zz_40__string;
-  reg [39:0] _zz_41__string;
-  reg [31:0] _zz_42__string;
-  reg [39:0] _zz_43__string;
-  reg [71:0] _zz_44__string;
-  reg [63:0] _zz_45__string;
-  reg [95:0] _zz_46__string;
-  reg [95:0] _zz_76__string;
-  reg [63:0] _zz_77__string;
-  reg [71:0] _zz_78__string;
-  reg [39:0] _zz_79__string;
-  reg [31:0] _zz_80__string;
-  reg [39:0] _zz_81__string;
-  reg [23:0] _zz_82__string;
-  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_36_string;
+  reg [39:0] _zz_40_string;
+  reg [31:0] _zz_41_string;
+  reg [71:0] _zz_42_string;
+  reg [39:0] _zz_43_string;
+  reg [23:0] _zz_44_string;
+  reg [63:0] _zz_45_string;
+  reg [95:0] _zz_46_string;
+  reg [95:0] _zz_73_string;
+  reg [63:0] _zz_74_string;
+  reg [23:0] _zz_75_string;
+  reg [39:0] _zz_76_string;
+  reg [71:0] _zz_77_string;
+  reg [31:0] _zz_78_string;
+  reg [39:0] _zz_79_string;
   reg [95:0] decode_to_execute_SRC1_CTRL_string;
   reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_131_ = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
-  assign _zz_132_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_133_ = ({decodeExceptionPort_valid,IBusSimplePlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_134_ = (! execute_arbitration_isStuckByOthers);
-  assign _zz_135_ = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_136_ = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00)) == 1'b0);
-  assign _zz_137_ = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != (2'b00));
-  assign _zz_138_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_139_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_140_ = (DebugPlugin_stepIt && IBusSimplePlugin_incomingInstruction);
-  assign _zz_141_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_142_ = ((IBusSimplePlugin_iBusRsp_stages_1_input_valid && (! IBusSimplePlugin_mmu_joinCtx_refilling)) && (IBusSimplePlugin_mmu_joinCtx_exception || (! IBusSimplePlugin_mmu_joinCtx_allowExecute)));
-  assign _zz_143_ = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
-  assign _zz_144_ = (! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers))));
-  assign _zz_145_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_146_ = (1'b1 || (! 1'b1));
-  assign _zz_147_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_148_ = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_149_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_150_ = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_151_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_152_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_153_ = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_154_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_155_ = ((_zz_106_ && 1'b1) && (! 1'b0));
-  assign _zz_156_ = ((_zz_107_ && 1'b1) && (! 1'b0));
-  assign _zz_157_ = ((_zz_108_ && 1'b1) && (! 1'b0));
-  assign _zz_158_ = (! dBus_cmd_halfPipe_regs_valid);
-  assign _zz_159_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_160_ = execute_INSTRUCTION[13];
-  assign _zz_161_ = _zz_71_[26 : 26];
-  assign _zz_162_ = _zz_71_[0 : 0];
-  assign _zz_163_ = _zz_71_[13 : 13];
-  assign _zz_164_ = _zz_71_[25 : 25];
-  assign _zz_165_ = _zz_71_[21 : 21];
-  assign _zz_166_ = _zz_71_[17 : 17];
-  assign _zz_167_ = _zz_71_[7 : 7];
-  assign _zz_168_ = _zz_71_[10 : 10];
-  assign _zz_169_ = _zz_71_[24 : 24];
-  assign _zz_170_ = _zz_71_[20 : 20];
-  assign _zz_171_ = _zz_71_[1 : 1];
-  assign _zz_172_ = _zz_71_[6 : 6];
-  assign _zz_173_ = (_zz_49_ - (3'b001));
-  assign _zz_174_ = {IBusSimplePlugin_fetchPc_inc,(2'b00)};
-  assign _zz_175_ = {29'd0, _zz_174_};
-  assign _zz_176_ = (IBusSimplePlugin_pending_value + _zz_178_);
-  assign _zz_177_ = IBusSimplePlugin_pending_inc;
-  assign _zz_178_ = {2'd0, _zz_177_};
-  assign _zz_179_ = IBusSimplePlugin_pending_dec;
-  assign _zz_180_ = {2'd0, _zz_179_};
-  assign _zz_181_ = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != (3'b000)));
-  assign _zz_182_ = {2'd0, _zz_181_};
-  assign _zz_183_ = IBusSimplePlugin_pending_dec;
-  assign _zz_184_ = {2'd0, _zz_183_};
-  assign _zz_185_ = (memory_MEMORY_STORE ? (3'b110) : (3'b100));
-  assign _zz_186_ = execute_SRC_LESS;
-  assign _zz_187_ = (3'b100);
-  assign _zz_188_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_189_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_190_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_191_ = ($signed(_zz_192_) + $signed(_zz_195_));
-  assign _zz_192_ = ($signed(_zz_193_) + $signed(_zz_194_));
-  assign _zz_193_ = execute_SRC1;
-  assign _zz_194_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_195_ = (execute_SRC_USE_SUB_LESS ? _zz_196_ : _zz_197_);
-  assign _zz_196_ = 32'h00000001;
-  assign _zz_197_ = 32'h0;
-  assign _zz_198_ = (_zz_199_ >>> 1);
-  assign _zz_199_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
-  assign _zz_200_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_201_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_202_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_203_ = (_zz_109_ & (~ _zz_204_));
-  assign _zz_204_ = (_zz_109_ - (2'b01));
-  assign _zz_205_ = (_zz_111_ & (~ _zz_206_));
-  assign _zz_206_ = (_zz_111_ - (2'b01));
-  assign _zz_207_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_208_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_209_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_210_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_211_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_212_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_213_ = 1'b1;
-  assign _zz_214_ = 1'b1;
-  assign _zz_215_ = {_zz_52_,_zz_51_};
-  assign _zz_216_ = 32'h0000107f;
-  assign _zz_217_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_218_ = 32'h00002073;
-  assign _zz_219_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_220_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_221_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_222_) == 32'h00000003),{(_zz_223_ == _zz_224_),{_zz_225_,{_zz_226_,_zz_227_}}}}}};
-  assign _zz_222_ = 32'h0000505f;
-  assign _zz_223_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_224_ = 32'h00000063;
-  assign _zz_225_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_226_ = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
-  assign _zz_227_ = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_228_) == 32'h00005033),{(_zz_229_ == _zz_230_),{_zz_231_,{_zz_232_,_zz_233_}}}}}};
-  assign _zz_228_ = 32'hbe00707f;
-  assign _zz_229_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_230_ = 32'h00000033;
-  assign _zz_231_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_232_ = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
-  assign _zz_233_ = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
-  assign _zz_234_ = 32'h00000010;
-  assign _zz_235_ = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
-  assign _zz_236_ = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
-  assign _zz_237_ = ((decode_INSTRUCTION & _zz_244_) == 32'h00000040);
-  assign _zz_238_ = {(_zz_245_ == _zz_246_),(_zz_247_ == _zz_248_)};
-  assign _zz_239_ = {_zz_75_,(_zz_249_ == _zz_250_)};
-  assign _zz_240_ = (2'b00);
-  assign _zz_241_ = ({_zz_75_,_zz_251_} != (2'b00));
-  assign _zz_242_ = ({_zz_252_,_zz_253_} != (2'b00));
-  assign _zz_243_ = {(_zz_254_ != _zz_255_),{_zz_256_,{_zz_257_,_zz_258_}}};
-  assign _zz_244_ = 32'h00000044;
-  assign _zz_245_ = (decode_INSTRUCTION & 32'h00002014);
-  assign _zz_246_ = 32'h00002010;
-  assign _zz_247_ = (decode_INSTRUCTION & 32'h40004034);
-  assign _zz_248_ = 32'h40000030;
-  assign _zz_249_ = (decode_INSTRUCTION & 32'h00000070);
-  assign _zz_250_ = 32'h00000020;
-  assign _zz_251_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h0);
-  assign _zz_252_ = ((decode_INSTRUCTION & _zz_259_) == 32'h00002000);
-  assign _zz_253_ = ((decode_INSTRUCTION & _zz_260_) == 32'h00001000);
-  assign _zz_254_ = {(_zz_261_ == _zz_262_),(_zz_263_ == _zz_264_)};
-  assign _zz_255_ = (2'b00);
-  assign _zz_256_ = ((_zz_265_ == _zz_266_) != (1'b0));
-  assign _zz_257_ = (_zz_267_ != (1'b0));
-  assign _zz_258_ = {(_zz_268_ != _zz_269_),{_zz_270_,{_zz_271_,_zz_272_}}};
-  assign _zz_259_ = 32'h00002010;
-  assign _zz_260_ = 32'h00005000;
-  assign _zz_261_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_262_ = 32'h00000024;
-  assign _zz_263_ = (decode_INSTRUCTION & 32'h00003054);
-  assign _zz_264_ = 32'h00001010;
-  assign _zz_265_ = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_266_ = 32'h00001000;
-  assign _zz_267_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_268_ = ((decode_INSTRUCTION & _zz_273_) == 32'h00100050);
-  assign _zz_269_ = (1'b0);
-  assign _zz_270_ = ({_zz_274_,{_zz_275_,_zz_276_}} != (3'b000));
-  assign _zz_271_ = ({_zz_277_,_zz_278_} != (2'b00));
-  assign _zz_272_ = {(_zz_279_ != _zz_280_),{_zz_281_,{_zz_282_,_zz_283_}}};
-  assign _zz_273_ = 32'h10103050;
-  assign _zz_274_ = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
-  assign _zz_275_ = ((decode_INSTRUCTION & _zz_284_) == 32'h0);
-  assign _zz_276_ = ((decode_INSTRUCTION & _zz_285_) == 32'h00000040);
-  assign _zz_277_ = _zz_73_;
-  assign _zz_278_ = ((decode_INSTRUCTION & _zz_286_) == 32'h00000004);
-  assign _zz_279_ = ((decode_INSTRUCTION & _zz_287_) == 32'h00000040);
-  assign _zz_280_ = (1'b0);
-  assign _zz_281_ = (_zz_72_ != (1'b0));
-  assign _zz_282_ = (_zz_288_ != (1'b0));
-  assign _zz_283_ = {(_zz_289_ != _zz_290_),{_zz_291_,{_zz_292_,_zz_293_}}};
-  assign _zz_284_ = 32'h00000038;
-  assign _zz_285_ = 32'h00103040;
-  assign _zz_286_ = 32'h0000001c;
-  assign _zz_287_ = 32'h00000058;
-  assign _zz_288_ = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
-  assign _zz_289_ = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
-  assign _zz_290_ = (1'b0);
-  assign _zz_291_ = ({(_zz_294_ == _zz_295_),{_zz_296_,{_zz_297_,_zz_298_}}} != (4'b0000));
-  assign _zz_292_ = ((_zz_299_ == _zz_300_) != (1'b0));
-  assign _zz_293_ = {({_zz_301_,_zz_302_} != (2'b00)),{(_zz_303_ != _zz_304_),{_zz_305_,{_zz_306_,_zz_307_}}}};
-  assign _zz_294_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_295_ = 32'h0;
-  assign _zz_296_ = ((decode_INSTRUCTION & _zz_308_) == 32'h0);
-  assign _zz_297_ = (_zz_309_ == _zz_310_);
-  assign _zz_298_ = (_zz_311_ == _zz_312_);
-  assign _zz_299_ = (decode_INSTRUCTION & 32'h00007054);
-  assign _zz_300_ = 32'h00005010;
-  assign _zz_301_ = (_zz_313_ == _zz_314_);
-  assign _zz_302_ = (_zz_315_ == _zz_316_);
-  assign _zz_303_ = {_zz_317_,_zz_318_};
-  assign _zz_304_ = (2'b00);
-  assign _zz_305_ = (_zz_319_ != (1'b0));
-  assign _zz_306_ = (_zz_320_ != _zz_321_);
-  assign _zz_307_ = {_zz_322_,{_zz_323_,_zz_324_}};
-  assign _zz_308_ = 32'h00000018;
-  assign _zz_309_ = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_310_ = 32'h00002000;
-  assign _zz_311_ = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_312_ = 32'h00001000;
-  assign _zz_313_ = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_314_ = 32'h40001010;
-  assign _zz_315_ = (decode_INSTRUCTION & 32'h00007054);
-  assign _zz_316_ = 32'h00001010;
-  assign _zz_317_ = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
-  assign _zz_318_ = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
-  assign _zz_319_ = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz_320_ = {(_zz_325_ == _zz_326_),(_zz_327_ == _zz_328_)};
-  assign _zz_321_ = (2'b00);
-  assign _zz_322_ = ((_zz_329_ == _zz_330_) != (1'b0));
-  assign _zz_323_ = ({_zz_331_,_zz_332_} != (2'b00));
-  assign _zz_324_ = {(_zz_333_ != _zz_334_),{_zz_335_,_zz_336_}};
-  assign _zz_325_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_326_ = 32'h00006010;
-  assign _zz_327_ = (decode_INSTRUCTION & 32'h00005014);
-  assign _zz_328_ = 32'h00004010;
-  assign _zz_329_ = (decode_INSTRUCTION & 32'h00006014);
-  assign _zz_330_ = 32'h00002010;
-  assign _zz_331_ = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_332_ = _zz_74_;
-  assign _zz_333_ = {((decode_INSTRUCTION & 32'h00000044) == 32'h00000004),_zz_74_};
-  assign _zz_334_ = (2'b00);
-  assign _zz_335_ = ({_zz_73_,{(_zz_337_ == _zz_338_),{_zz_339_,{_zz_340_,_zz_341_}}}} != 6'h0);
-  assign _zz_336_ = (((decode_INSTRUCTION & 32'h00000020) == 32'h00000020) != (1'b0));
-  assign _zz_337_ = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_338_ = 32'h00001010;
-  assign _zz_339_ = ((decode_INSTRUCTION & 32'h00002010) == 32'h00002010);
-  assign _zz_340_ = _zz_72_;
-  assign _zz_341_ = {((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004),((decode_INSTRUCTION & 32'h00000028) == 32'h0)};
+  assign _zz_125 = ((execute_arbitration_isValid && execute_LightShifterPlugin_isShift) && (execute_SRC2[4 : 0] != 5'h0));
+  assign _zz_126 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_127 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign _zz_128 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign _zz_129 = ({BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid} != 2'b00);
+  assign _zz_130 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_131 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_132 = (DebugPlugin_stepIt && IBusSimplePlugin_incomingInstruction);
+  assign _zz_133 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_134 = ((dBus_rsp_ready && dBus_rsp_error) && (! memory_MEMORY_STORE));
+  assign _zz_135 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_136 = (1'b1 || (! 1'b1));
+  assign _zz_137 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_138 = (1'b1 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_139 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_140 = (1'b1 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_141 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_142 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_143 = debug_bus_cmd_payload_address[7 : 2];
+  assign _zz_144 = (! execute_arbitration_isStuckByOthers);
+  assign _zz_145 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_146 = ((_zz_103 && 1'b1) && (! 1'b0));
+  assign _zz_147 = ((_zz_104 && 1'b1) && (! 1'b0));
+  assign _zz_148 = ((_zz_105 && 1'b1) && (! 1'b0));
+  assign _zz_149 = (! dBus_cmd_halfPipe_regs_valid);
+  assign _zz_150 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_151 = execute_INSTRUCTION[13];
+  assign _zz_152 = _zz_68[23 : 23];
+  assign _zz_153 = _zz_68[15 : 15];
+  assign _zz_154 = _zz_68[12 : 12];
+  assign _zz_155 = _zz_68[11 : 11];
+  assign _zz_156 = _zz_68[10 : 10];
+  assign _zz_157 = _zz_68[3 : 3];
+  assign _zz_158 = _zz_68[26 : 26];
+  assign _zz_159 = _zz_68[14 : 14];
+  assign _zz_160 = _zz_68[4 : 4];
+  assign _zz_161 = _zz_68[2 : 2];
+  assign _zz_162 = _zz_68[18 : 18];
+  assign _zz_163 = _zz_68[9 : 9];
+  assign _zz_164 = (_zz_49 & (~ _zz_165));
+  assign _zz_165 = (_zz_49 - 2'b01);
+  assign _zz_166 = {IBusSimplePlugin_fetchPc_inc,2'b00};
+  assign _zz_167 = {29'd0, _zz_166};
+  assign _zz_168 = (IBusSimplePlugin_pending_value + _zz_170);
+  assign _zz_169 = IBusSimplePlugin_pending_inc;
+  assign _zz_170 = {2'd0, _zz_169};
+  assign _zz_171 = IBusSimplePlugin_pending_dec;
+  assign _zz_172 = {2'd0, _zz_171};
+  assign _zz_173 = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000));
+  assign _zz_174 = {2'd0, _zz_173};
+  assign _zz_175 = IBusSimplePlugin_pending_dec;
+  assign _zz_176 = {2'd0, _zz_175};
+  assign _zz_177 = (memory_MEMORY_STORE ? 3'b110 : 3'b100);
+  assign _zz_178 = execute_SRC_LESS;
+  assign _zz_179 = 3'b100;
+  assign _zz_180 = execute_INSTRUCTION[19 : 15];
+  assign _zz_181 = execute_INSTRUCTION[31 : 20];
+  assign _zz_182 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_183 = ($signed(_zz_184) + $signed(_zz_187));
+  assign _zz_184 = ($signed(_zz_185) + $signed(_zz_186));
+  assign _zz_185 = execute_SRC1;
+  assign _zz_186 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_187 = (execute_SRC_USE_SUB_LESS ? _zz_188 : _zz_189);
+  assign _zz_188 = 32'h00000001;
+  assign _zz_189 = 32'h0;
+  assign _zz_190 = (_zz_191 >>> 1);
+  assign _zz_191 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_LightShifterPlugin_shiftInput[31]),execute_LightShifterPlugin_shiftInput};
+  assign _zz_192 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_193 = execute_INSTRUCTION[31 : 20];
+  assign _zz_194 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_195 = (_zz_106 & (~ _zz_196));
+  assign _zz_196 = (_zz_106 - 2'b01);
+  assign _zz_197 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_198 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_199 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_200 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_201 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_202 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_203 = 1'b1;
+  assign _zz_204 = 1'b1;
+  assign _zz_205 = 32'h0000107f;
+  assign _zz_206 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_207 = 32'h00002073;
+  assign _zz_208 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_209 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_210 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_211) == 32'h00000003),{(_zz_212 == _zz_213),{_zz_214,{_zz_215,_zz_216}}}}}};
+  assign _zz_211 = 32'h0000505f;
+  assign _zz_212 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_213 = 32'h00000063;
+  assign _zz_214 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_215 = ((decode_INSTRUCTION & 32'hfe00007f) == 32'h00000033);
+  assign _zz_216 = {((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & 32'hfc00307f) == 32'h00001013),{((decode_INSTRUCTION & _zz_217) == 32'h00005033),{(_zz_218 == _zz_219),{_zz_220,{_zz_221,_zz_222}}}}}};
+  assign _zz_217 = 32'hbe00707f;
+  assign _zz_218 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_219 = 32'h00000033;
+  assign _zz_220 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_221 = ((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073);
+  assign _zz_222 = ((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073);
+  assign _zz_223 = 32'h10103050;
+  assign _zz_224 = (decode_INSTRUCTION & 32'h10103050);
+  assign _zz_225 = 32'h00000050;
+  assign _zz_226 = ((decode_INSTRUCTION & 32'h10403050) == 32'h10000050);
+  assign _zz_227 = {(_zz_232 == _zz_233),(_zz_234 == _zz_235)};
+  assign _zz_228 = 2'b00;
+  assign _zz_229 = ({_zz_72,_zz_236} != 2'b00);
+  assign _zz_230 = (_zz_237 != 1'b0);
+  assign _zz_231 = {(_zz_238 != _zz_239),{_zz_240,{_zz_241,_zz_242}}};
+  assign _zz_232 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_233 = 32'h00001050;
+  assign _zz_234 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_235 = 32'h00002050;
+  assign _zz_236 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_237 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_238 = ((decode_INSTRUCTION & _zz_243) == 32'h00005010);
+  assign _zz_239 = 1'b0;
+  assign _zz_240 = ({_zz_244,_zz_245} != 2'b00);
+  assign _zz_241 = ({_zz_246,_zz_247} != 2'b00);
+  assign _zz_242 = {(_zz_248 != _zz_249),{_zz_250,{_zz_251,_zz_252}}};
+  assign _zz_243 = 32'h00007054;
+  assign _zz_244 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz_245 = ((decode_INSTRUCTION & 32'h00007054) == 32'h00001010);
+  assign _zz_246 = ((decode_INSTRUCTION & _zz_253) == 32'h00000024);
+  assign _zz_247 = ((decode_INSTRUCTION & _zz_254) == 32'h00001010);
+  assign _zz_248 = ((decode_INSTRUCTION & _zz_255) == 32'h00001000);
+  assign _zz_249 = 1'b0;
+  assign _zz_250 = ((_zz_256 == _zz_257) != 1'b0);
+  assign _zz_251 = ({_zz_258,_zz_259} != 2'b00);
+  assign _zz_252 = {(_zz_260 != _zz_261),{_zz_262,{_zz_263,_zz_264}}};
+  assign _zz_253 = 32'h00000064;
+  assign _zz_254 = 32'h00003054;
+  assign _zz_255 = 32'h00001000;
+  assign _zz_256 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz_257 = 32'h00002000;
+  assign _zz_258 = ((decode_INSTRUCTION & _zz_265) == 32'h00002000);
+  assign _zz_259 = ((decode_INSTRUCTION & _zz_266) == 32'h00001000);
+  assign _zz_260 = {(_zz_267 == _zz_268),(_zz_269 == _zz_270)};
+  assign _zz_261 = 2'b00;
+  assign _zz_262 = ({_zz_271,{_zz_272,_zz_273}} != 3'b000);
+  assign _zz_263 = (_zz_274 != 1'b0);
+  assign _zz_264 = {(_zz_275 != _zz_276),{_zz_277,{_zz_278,_zz_279}}};
+  assign _zz_265 = 32'h00002010;
+  assign _zz_266 = 32'h00005000;
+  assign _zz_267 = (decode_INSTRUCTION & 32'h00000034);
+  assign _zz_268 = 32'h00000020;
+  assign _zz_269 = (decode_INSTRUCTION & 32'h00000064);
+  assign _zz_270 = 32'h00000020;
+  assign _zz_271 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000040);
+  assign _zz_272 = ((decode_INSTRUCTION & _zz_280) == 32'h0);
+  assign _zz_273 = ((decode_INSTRUCTION & _zz_281) == 32'h00000040);
+  assign _zz_274 = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
+  assign _zz_275 = ((decode_INSTRUCTION & _zz_282) == 32'h00000010);
+  assign _zz_276 = 1'b0;
+  assign _zz_277 = (_zz_71 != 1'b0);
+  assign _zz_278 = ({_zz_283,_zz_284} != 6'h0);
+  assign _zz_279 = {(_zz_285 != _zz_286),{_zz_287,{_zz_288,_zz_289}}};
+  assign _zz_280 = 32'h00000038;
+  assign _zz_281 = 32'h00103040;
+  assign _zz_282 = 32'h00000010;
+  assign _zz_283 = _zz_72;
+  assign _zz_284 = {(_zz_290 == _zz_291),{_zz_292,{_zz_293,_zz_294}}};
+  assign _zz_285 = {_zz_70,(_zz_295 == _zz_296)};
+  assign _zz_286 = 2'b00;
+  assign _zz_287 = ({_zz_70,_zz_297} != 2'b00);
+  assign _zz_288 = ({_zz_298,_zz_299} != 2'b00);
+  assign _zz_289 = {(_zz_300 != _zz_301),{_zz_302,{_zz_303,_zz_304}}};
+  assign _zz_290 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_291 = 32'h00001010;
+  assign _zz_292 = ((decode_INSTRUCTION & _zz_305) == 32'h00002010);
+  assign _zz_293 = _zz_71;
+  assign _zz_294 = {_zz_306,_zz_307};
+  assign _zz_295 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_296 = 32'h00000020;
+  assign _zz_297 = ((decode_INSTRUCTION & _zz_308) == 32'h0);
+  assign _zz_298 = (_zz_309 == _zz_310);
+  assign _zz_299 = (_zz_311 == _zz_312);
+  assign _zz_300 = (_zz_313 == _zz_314);
+  assign _zz_301 = 1'b0;
+  assign _zz_302 = ({_zz_315,_zz_316} != 4'b0000);
+  assign _zz_303 = (_zz_317 != _zz_318);
+  assign _zz_304 = {_zz_319,{_zz_320,_zz_321}};
+  assign _zz_305 = 32'h00002010;
+  assign _zz_306 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_307 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz_308 = 32'h00000020;
+  assign _zz_309 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_310 = 32'h00006010;
+  assign _zz_311 = (decode_INSTRUCTION & 32'h00005014);
+  assign _zz_312 = 32'h00004010;
+  assign _zz_313 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_314 = 32'h00002010;
+  assign _zz_315 = ((decode_INSTRUCTION & _zz_322) == 32'h0);
+  assign _zz_316 = {(_zz_323 == _zz_324),{_zz_325,_zz_326}};
+  assign _zz_317 = ((decode_INSTRUCTION & _zz_327) == 32'h0);
+  assign _zz_318 = 1'b0;
+  assign _zz_319 = ({_zz_328,{_zz_329,_zz_330}} != 3'b000);
+  assign _zz_320 = ({_zz_331,_zz_332} != 2'b00);
+  assign _zz_321 = ({_zz_333,_zz_334} != 2'b00);
+  assign _zz_322 = 32'h00000044;
+  assign _zz_323 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_324 = 32'h0;
+  assign _zz_325 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_326 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz_327 = 32'h00000058;
+  assign _zz_328 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_329 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_330 = ((decode_INSTRUCTION & 32'h40004034) == 32'h40000030);
+  assign _zz_331 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz_332 = _zz_69;
+  assign _zz_333 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_334 = _zz_69;
   always @ (posedge clk) begin
-    if(_zz_213_) begin
-      _zz_128_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_203) begin
+      _zz_123 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_214_) begin
-      _zz_129_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_204) begin
+      _zz_124 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_39_) begin
+    if(_zz_39) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c ( 
+  StreamFifoLowLatency IBusSimplePlugin_rspJoin_rspBuffer_c (
     .io_push_valid            (iBus_rsp_valid                                                  ), //i
     .io_push_ready            (IBusSimplePlugin_rspJoin_rspBuffer_c_io_push_ready              ), //o
     .io_push_payload_error    (iBus_rsp_payload_error                                          ), //i
     .io_push_payload_inst     (iBus_rsp_payload_inst[31:0]                                     ), //i
     .io_pop_valid             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid               ), //o
-    .io_pop_ready             (_zz_126_                                                        ), //i
+    .io_pop_ready             (_zz_121                                                         ), //i
     .io_pop_payload_error     (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error       ), //o
     .io_pop_payload_inst      (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst[31:0]  ), //o
-    .io_flush                 (_zz_127_                                                        ), //i
+    .io_flush                 (_zz_122                                                         ), //i
     .io_occupancy             (IBusSimplePlugin_rspJoin_rspBuffer_c_io_occupancy               ), //o
     .clk                      (clk                                                             ), //i
     .reset                    (reset                                                           )  //i
   );
-  always @(*) begin
-    case(_zz_215_)
-      2'b00 : begin
-        _zz_130_ = CsrPlugin_jumpInterface_payload;
-      end
-      2'b01 : begin
-        _zz_130_ = DBusSimplePlugin_redoBranch_payload;
-      end
-      default : begin
-        _zz_130_ = BranchPlugin_jumpInterface_payload;
-      end
-    endcase
-  end
-
   `ifndef SYNTHESIS
   always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_1_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_1__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_1__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_1__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_1__string = "PC ";
-      default : _zz_1__string = "???";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_2__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_2__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_2__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_2__string = "PC ";
-      default : _zz_2__string = "???";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_3__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_3__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_3__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_3__string = "PC ";
-      default : _zz_3__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_4__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_4__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_4__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_4__string = "SRA_1    ";
-      default : _zz_4__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_5__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_5__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_5__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_5__string = "SRA_1    ";
-      default : _zz_5__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_6__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_6__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_6__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_6__string = "SRA_1    ";
-      default : _zz_6__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7__string = "ECALL";
-      default : _zz_7__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_8__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_8__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_8__string = "ECALL";
-      default : _zz_8__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9__string = "ECALL";
-      default : _zz_9__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10__string = "ECALL";
-      default : _zz_10__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1498,127 +1213,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_11_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_11__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_11__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_11__string = "ECALL";
-      default : _zz_11__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_12_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_12__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_12__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_12__string = "ECALL";
-      default : _zz_12__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_13_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_13__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_13__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_13__string = "ECALL";
-      default : _zz_13__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_14__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_14__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_14__string = "BITWISE ";
-      default : _zz_14__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_15__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_15__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_15__string = "BITWISE ";
-      default : _zz_15__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_16__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_16__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_16__string = "BITWISE ";
-      default : _zz_16__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_17__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_17__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_17__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_17__string = "URS1        ";
-      default : _zz_17__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_18__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_18__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_18__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_18__string = "URS1        ";
-      default : _zz_18__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_19__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_19__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_19__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_19__string = "URS1        ";
-      default : _zz_19__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_20__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_20__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_20__string = "AND_1";
-      default : _zz_20__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_21_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_21__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_21__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_21__string = "AND_1";
-      default : _zz_21__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_22_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_22__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_22__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_22__string = "AND_1";
-      default : _zz_22__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1631,30 +1246,202 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_23__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_23__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_23__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_23__string = "JALR";
-      default : _zz_23__string = "????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_24__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_24__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_24__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_24__string = "JALR";
-      default : _zz_24__string = "????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_25__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_25__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_25__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_25__string = "JALR";
-      default : _zz_25__string = "????";
+    case(_zz_10)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_10_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_10_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_10_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_10_string = "JALR";
+      default : _zz_10_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_14_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_14_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_14_string = "AND_1";
+      default : _zz_14_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_17_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_17_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_17_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_17_string = "PC ";
+      default : _zz_17_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_20_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_20_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_20_string = "BITWISE ";
+      default : _zz_20_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_23_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_23_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_23_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_23_string = "URS1        ";
+      default : _zz_23_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1666,11 +1453,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26__string = "ECALL";
-      default : _zz_26__string = "?????";
+    case(_zz_26)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_26_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_26_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_26_string = "ECALL";
+      default : _zz_26_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1682,11 +1469,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1698,11 +1485,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1715,12 +1502,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_29__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_29__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_29__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_29__string = "JALR";
-      default : _zz_29__string = "????";
+    case(_zz_29)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_29_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_29_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_29_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_29_string = "JALR";
+      default : _zz_29_string = "????";
     endcase
   end
   always @(*) begin
@@ -1733,12 +1520,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_31_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31__string = "SRA_1    ";
-      default : _zz_31__string = "?????????";
+    case(_zz_31)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_31_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_31_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_31_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_31_string = "SRA_1    ";
+      default : _zz_31_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -1751,12 +1538,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_33__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_33__string = "PC ";
-      default : _zz_33__string = "???";
+    case(_zz_33)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_33_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_33_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_33_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_33_string = "PC ";
+      default : _zz_33_string = "???";
     endcase
   end
   always @(*) begin
@@ -1769,12 +1556,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_34__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34__string = "URS1        ";
-      default : _zz_34__string = "????????????";
+    case(_zz_34)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_34_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_34_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_34_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_34_string = "URS1        ";
+      default : _zz_34_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -1786,11 +1573,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_35_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35__string = "BITWISE ";
-      default : _zz_35__string = "????????";
+    case(_zz_35)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_35_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_35_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_35_string = "BITWISE ";
+      default : _zz_35_string = "????????";
     endcase
   end
   always @(*) begin
@@ -1802,148 +1589,131 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36__string = "AND_1";
-      default : _zz_36__string = "?????";
+    case(_zz_36)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_36_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_36_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_36_string = "AND_1";
+      default : _zz_36_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_40_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_40__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_40__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_40__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_40__string = "PC ";
-      default : _zz_40__string = "???";
+    case(_zz_40)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_40_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_40_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_40_string = "ECALL";
+      default : _zz_40_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_41_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_41__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_41__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_41__string = "AND_1";
-      default : _zz_41__string = "?????";
+    case(_zz_41)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_41_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_41_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_41_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_41_string = "JALR";
+      default : _zz_41_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_42_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_42__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_42__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_42__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_42__string = "JALR";
-      default : _zz_42__string = "????";
+    case(_zz_42)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_42_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_42_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_42_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_42_string = "SRA_1    ";
+      default : _zz_42_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43__string = "ECALL";
-      default : _zz_43__string = "?????";
+    case(_zz_43)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_43_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_43_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_43_string = "AND_1";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_44__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_44__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_44__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_44__string = "SRA_1    ";
-      default : _zz_44__string = "?????????";
+    case(_zz_44)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_44_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_44_string = "PC ";
+      default : _zz_44_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45__string = "BITWISE ";
-      default : _zz_45__string = "????????";
+    case(_zz_45)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45_string = "BITWISE ";
+      default : _zz_45_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_46__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46__string = "URS1        ";
-      default : _zz_46__string = "????????????";
+    case(_zz_46)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_46_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_46_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_46_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_46_string = "URS1        ";
+      default : _zz_46_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_76_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_76__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_76__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_76__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_76__string = "URS1        ";
-      default : _zz_76__string = "????????????";
+    case(_zz_73)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_73_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_73_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_73_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_73_string = "URS1        ";
+      default : _zz_73_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_77_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_77__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_77__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_77__string = "BITWISE ";
-      default : _zz_77__string = "????????";
+    case(_zz_74)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_74_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_74_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_74_string = "BITWISE ";
+      default : _zz_74_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_78_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_78__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_78__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_78__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_78__string = "SRA_1    ";
-      default : _zz_78__string = "?????????";
+    case(_zz_75)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_75_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_75_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_75_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_75_string = "PC ";
+      default : _zz_75_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_79_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_79__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_79__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_79__string = "ECALL";
-      default : _zz_79__string = "?????";
+    case(_zz_76)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_76_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_76_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_76_string = "AND_1";
+      default : _zz_76_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_80_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_80__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_80__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_80__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_80__string = "JALR";
-      default : _zz_80__string = "????";
+    case(_zz_77)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_77_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_77_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_77_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_77_string = "SRA_1    ";
+      default : _zz_77_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_81_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_81__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_81__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_81__string = "AND_1";
-      default : _zz_81__string = "?????";
+    case(_zz_78)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_78_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_78_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_78_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_78_string = "JALR";
+      default : _zz_78_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_82_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_82__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_82__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_82__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_82__string = "PC ";
-      default : _zz_82__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
-      default : decode_to_execute_BRANCH_CTRL_string = "????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    case(_zz_79)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_79_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_79_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_79_string = "ECALL";
+      default : _zz_79_string = "?????";
     endcase
   end
   always @(*) begin
@@ -1961,6 +1731,41 @@ module VexRiscv (
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
       `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
       default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -1987,80 +1792,64 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
   `endif
 
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_161_[0];
-  assign decode_SRC2_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_SHIFT_CTRL = _zz_4_;
-  assign _zz_5_ = _zz_6_;
-  assign decode_RS1 = decode_RegFilePlugin_rs1Data;
+  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = _zz_95;
+  assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
+  assign execute_REGFILE_WRITE_DATA = _zz_81;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
+  assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_RS2 = decode_RegFilePlugin_rs2Data;
+  assign decode_RS1 = decode_RegFilePlugin_rs1Data;
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_152[0];
+  assign decode_BRANCH_CTRL = _zz_8;
+  assign _zz_9 = _zz_10;
+  assign decode_SHIFT_CTRL = _zz_11;
+  assign _zz_12 = _zz_13;
+  assign decode_ALU_BITWISE_CTRL = _zz_14;
+  assign _zz_15 = _zz_16;
+  assign decode_SRC_LESS_UNSIGNED = _zz_153[0];
+  assign decode_MEMORY_STORE = _zz_154[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_155[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_156[0];
+  assign decode_SRC2_CTRL = _zz_17;
+  assign _zz_18 = _zz_19;
+  assign decode_ALU_CTRL = _zz_20;
+  assign _zz_21 = _zz_22;
+  assign decode_MEMORY_ENABLE = _zz_157[0];
+  assign decode_SRC1_CTRL = _zz_23;
+  assign _zz_24 = _zz_25;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign decode_MEMORY_STORE = _zz_162_[0];
-  assign execute_BRANCH_DO = _zz_98_;
-  assign _zz_7_ = _zz_8_;
-  assign _zz_9_ = _zz_10_;
-  assign decode_ENV_CTRL = _zz_11_;
-  assign _zz_12_ = _zz_13_;
-  assign decode_ALU_CTRL = _zz_14_;
-  assign _zz_15_ = _zz_16_;
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_163_[0];
-  assign memory_MEMORY_READ_DATA = dBus_rsp_data;
-  assign decode_SRC1_CTRL = _zz_17_;
-  assign _zz_18_ = _zz_19_;
-  assign decode_IS_CSR = _zz_164_[0];
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
-  assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign decode_ALU_BITWISE_CTRL = _zz_20_;
-  assign _zz_21_ = _zz_22_;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = dBus_cmd_payload_address[1 : 0];
-  assign writeBack_REGFILE_WRITE_DATA = memory_to_writeBack_REGFILE_WRITE_DATA;
-  assign execute_REGFILE_WRITE_DATA = _zz_84_;
-  assign decode_RS2 = decode_RegFilePlugin_rs2Data;
-  assign decode_SRC_LESS_UNSIGNED = _zz_165_[0];
-  assign decode_BRANCH_CTRL = _zz_23_;
-  assign _zz_24_ = _zz_25_;
+  assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_166_[0];
+  assign decode_IS_EBREAK = _zz_158[0];
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_26_;
-  assign execute_ENV_CTRL = _zz_27_;
-  assign writeBack_ENV_CTRL = _zz_28_;
+  assign memory_ENV_CTRL = _zz_26;
+  assign execute_ENV_CTRL = _zz_27;
+  assign writeBack_ENV_CTRL = _zz_28;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_CTRL = _zz_29_;
-  assign decode_RS2_USE = _zz_167_[0];
-  assign decode_RS1_USE = _zz_168_[0];
+  assign execute_BRANCH_CTRL = _zz_29;
+  assign decode_RS2_USE = _zz_159[0];
+  assign decode_RS1_USE = _zz_160[0];
   assign execute_REGFILE_WRITE_VALID = decode_to_execute_REGFILE_WRITE_VALID;
   assign execute_BYPASSABLE_EXECUTE_STAGE = decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   assign memory_REGFILE_WRITE_VALID = execute_to_memory_REGFILE_WRITE_VALID;
@@ -2068,94 +1857,73 @@ module VexRiscv (
   assign memory_BYPASSABLE_MEMORY_STAGE = execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_30_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_131_)begin
-      _zz_30_ = _zz_91_;
+    _zz_30 = execute_REGFILE_WRITE_DATA;
+    if(_zz_125)begin
+      _zz_30 = _zz_88;
     end
-    if(_zz_132_)begin
-      _zz_30_ = execute_CsrPlugin_readData;
+    if(_zz_126)begin
+      _zz_30 = execute_CsrPlugin_readData;
     end
   end
 
-  assign execute_SHIFT_CTRL = _zz_31_;
+  assign execute_SHIFT_CTRL = _zz_31;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_32_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_33_;
-  assign execute_SRC1_CTRL = _zz_34_;
-  assign decode_SRC_USE_SUB_LESS = _zz_169_[0];
-  assign decode_SRC_ADD_ZERO = _zz_170_[0];
+  assign _zz_32 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_33;
+  assign execute_SRC1_CTRL = _zz_34;
+  assign decode_SRC_USE_SUB_LESS = _zz_161[0];
+  assign decode_SRC_ADD_ZERO = _zz_162[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_35_;
-  assign execute_SRC2 = _zz_90_;
-  assign execute_SRC1 = _zz_85_;
-  assign execute_ALU_BITWISE_CTRL = _zz_36_;
-  assign _zz_37_ = writeBack_INSTRUCTION;
-  assign _zz_38_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_35;
+  assign execute_SRC2 = _zz_87;
+  assign execute_SRC1 = _zz_82;
+  assign execute_ALU_BITWISE_CTRL = _zz_36;
+  assign _zz_37 = writeBack_INSTRUCTION;
+  assign _zz_38 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_39_ = 1'b0;
+    _zz_39 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_39_ = 1'b1;
+      _zz_39 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusSimplePlugin_iBusRsp_output_payload_rsp_inst);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_171_[0];
+    decode_REGFILE_WRITE_VALID = _zz_163[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_216_) == 32'h00001073),{(_zz_217_ == _zz_218_),{_zz_219_,{_zz_220_,_zz_221_}}}}}}} != 20'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_205) == 32'h00001073),{(_zz_206 == _zz_207),{_zz_208,{_zz_209,_zz_210}}}}}}} != 20'h0);
   assign writeBack_MEMORY_STORE = memory_to_writeBack_MEMORY_STORE;
   always @ (*) begin
-    _zz_47_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_47 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_47_ = writeBack_DBusSimplePlugin_rspFormated;
+      _zz_47 = writeBack_DBusSimplePlugin_rspFormated;
     end
   end
 
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign writeBack_MEMORY_ADDRESS_LOW = memory_to_writeBack_MEMORY_ADDRESS_LOW;
   assign writeBack_MEMORY_READ_DATA = memory_to_writeBack_MEMORY_READ_DATA;
-  assign memory_MMU_FAULT = execute_to_memory_MMU_FAULT;
-  assign memory_MMU_RSP_physicalAddress = execute_to_memory_MMU_RSP_physicalAddress;
-  assign memory_MMU_RSP_isIoAccess = execute_to_memory_MMU_RSP_isIoAccess;
-  assign memory_MMU_RSP_allowRead = execute_to_memory_MMU_RSP_allowRead;
-  assign memory_MMU_RSP_allowWrite = execute_to_memory_MMU_RSP_allowWrite;
-  assign memory_MMU_RSP_allowExecute = execute_to_memory_MMU_RSP_allowExecute;
-  assign memory_MMU_RSP_exception = execute_to_memory_MMU_RSP_exception;
-  assign memory_MMU_RSP_refilling = execute_to_memory_MMU_RSP_refilling;
-  assign memory_PC = execute_to_memory_PC;
   assign memory_ALIGNEMENT_FAULT = execute_to_memory_ALIGNEMENT_FAULT;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_STORE = execute_to_memory_MEMORY_STORE;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
-  assign execute_MMU_FAULT = ((execute_MMU_RSP_exception || ((! execute_MMU_RSP_allowWrite) && execute_MEMORY_STORE)) || ((! execute_MMU_RSP_allowRead) && (! execute_MEMORY_STORE)));
-  assign execute_MMU_RSP_physicalAddress = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
-  assign execute_MMU_RSP_isIoAccess = DBusSimplePlugin_mmuBus_rsp_isIoAccess;
-  assign execute_MMU_RSP_allowRead = DBusSimplePlugin_mmuBus_rsp_allowRead;
-  assign execute_MMU_RSP_allowWrite = DBusSimplePlugin_mmuBus_rsp_allowWrite;
-  assign execute_MMU_RSP_allowExecute = DBusSimplePlugin_mmuBus_rsp_allowExecute;
-  assign execute_MMU_RSP_exception = DBusSimplePlugin_mmuBus_rsp_exception;
-  assign execute_MMU_RSP_refilling = DBusSimplePlugin_mmuBus_rsp_refilling;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
   assign execute_MEMORY_STORE = decode_to_execute_MEMORY_STORE;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
-  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == (2'b10)) && (dBus_cmd_payload_address[1 : 0] != (2'b00))) || ((dBus_cmd_payload_size == (2'b01)) && (dBus_cmd_payload_address[0 : 0] != (1'b0))));
-  assign decode_MEMORY_ENABLE = _zz_172_[0];
+  assign execute_ALIGNEMENT_FAULT = (((dBus_cmd_payload_size == 2'b10) && (dBus_cmd_payload_address[1 : 0] != 2'b00)) || ((dBus_cmd_payload_size == 2'b01) && (dBus_cmd_payload_address[0 : 0] != 1'b0)));
   always @ (*) begin
-    _zz_48_ = memory_FORMAL_PC_NEXT;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      _zz_48_ = DBusSimplePlugin_redoBranch_payload;
-    end
+    _zz_48 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_48_ = BranchPlugin_jumpInterface_payload;
+      _zz_48 = BranchPlugin_jumpInterface_payload;
     end
   end
 
@@ -2165,20 +1933,9 @@ module VexRiscv (
   assign writeBack_INSTRUCTION = memory_to_writeBack_INSTRUCTION;
   always @ (*) begin
     decode_arbitration_haltItself = 1'b0;
-    if(((DBusSimplePlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
-      decode_arbitration_haltItself = 1'b1;
-    end
-    case(_zz_116_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_111)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
-      end
-      3'b011 : begin
-      end
-      3'b100 : begin
       end
       default : begin
       end
@@ -2187,20 +1944,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_92_ || _zz_93_)))begin
+    if((decode_arbitration_isValid && (_zz_89 || _zz_90)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_133_)begin
+    if(decodeExceptionPort_valid)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -2211,24 +1968,22 @@ module VexRiscv (
   assign decode_arbitration_flushIt = 1'b0;
   always @ (*) begin
     decode_arbitration_flushNext = 1'b0;
-    if(_zz_133_)begin
+    if(decodeExceptionPort_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_64_)))begin
+    if(((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! dBus_cmd_ready)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_61)))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(_zz_131_)begin
-      if(_zz_134_)begin
-        if(! execute_LightShifterPlugin_done) begin
-          execute_arbitration_haltItself = 1'b1;
-        end
+    if(_zz_125)begin
+      if((! execute_LightShifterPlugin_done))begin
+        execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_132_)begin
+    if(_zz_126)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -2237,7 +1992,7 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(_zz_135_)begin
+    if(_zz_127)begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -2254,8 +2009,8 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_135_)begin
-      if(_zz_136_)begin
+    if(_zz_127)begin
+      if(_zz_128)begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -2266,8 +2021,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_135_)begin
-      if(_zz_136_)begin
+    if(_zz_127)begin
+      if(_zz_128)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -2283,7 +2038,7 @@ module VexRiscv (
   assign memory_arbitration_haltByOther = 1'b0;
   always @ (*) begin
     memory_arbitration_removeIt = 1'b0;
-    if(_zz_137_)begin
+    if(_zz_129)begin
       memory_arbitration_removeIt = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -2291,22 +2046,13 @@ module VexRiscv (
     end
   end
 
-  always @ (*) begin
-    memory_arbitration_flushIt = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      memory_arbitration_flushIt = 1'b1;
-    end
-  end
-
+  assign memory_arbitration_flushIt = 1'b0;
   always @ (*) begin
     memory_arbitration_flushNext = 1'b0;
-    if(DBusSimplePlugin_redoBranch_valid)begin
-      memory_arbitration_flushNext = 1'b1;
-    end
     if(BranchPlugin_jumpInterface_valid)begin
       memory_arbitration_flushNext = 1'b1;
     end
-    if(_zz_137_)begin
+    if(_zz_129)begin
       memory_arbitration_flushNext = 1'b1;
     end
   end
@@ -2323,10 +2069,10 @@ module VexRiscv (
   assign writeBack_arbitration_flushIt = 1'b0;
   always @ (*) begin
     writeBack_arbitration_flushNext = 1'b0;
-    if(_zz_138_)begin
+    if(_zz_130)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_139_)begin
+    if(_zz_131)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -2337,24 +2083,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusSimplePlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_138_)begin
+    if(_zz_130)begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_139_)begin
+    if(_zz_131)begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_135_)begin
-      if(_zz_136_)begin
+    if(_zz_127)begin
+      if(_zz_128)begin
         IBusSimplePlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt)begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_140_)begin
+    if(_zz_132)begin
       IBusSimplePlugin_fetcherHalt = 1'b1;
     end
   end
@@ -2379,21 +2125,21 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_138_)begin
+    if(_zz_130)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_139_)begin
+    if(_zz_131)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_138_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_130)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_139_)begin
-      case(_zz_141_)
+    if(_zz_131)begin
+      case(_zz_133)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -2424,18 +2170,12 @@ module VexRiscv (
     end
   end
 
-  assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,DBusSimplePlugin_redoBranch_valid}} != (3'b000));
-  assign _zz_49_ = {BranchPlugin_jumpInterface_valid,{DBusSimplePlugin_redoBranch_valid,CsrPlugin_jumpInterface_valid}};
-  assign _zz_50_ = (_zz_49_ & (~ _zz_173_));
-  assign _zz_51_ = _zz_50_[1];
-  assign _zz_52_ = _zz_50_[2];
-  assign IBusSimplePlugin_jump_pcLoad_payload = _zz_130_;
+  assign IBusSimplePlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusSimplePlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,BranchPlugin_jumpInterface_valid} != 2'b00);
+  assign _zz_49 = {BranchPlugin_jumpInterface_valid,CsrPlugin_jumpInterface_valid};
+  assign IBusSimplePlugin_jump_pcLoad_payload = (_zz_164[0] ? CsrPlugin_jumpInterface_payload : BranchPlugin_jumpInterface_payload);
   always @ (*) begin
     IBusSimplePlugin_fetchPc_correction = 1'b0;
-    if(IBusSimplePlugin_fetchPc_redo_valid)begin
-      IBusSimplePlugin_fetchPc_correction = 1'b1;
-    end
     if(IBusSimplePlugin_jump_pcLoad_valid)begin
       IBusSimplePlugin_fetchPc_correction = 1'b1;
     end
@@ -2450,10 +2190,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_175_);
-    if(IBusSimplePlugin_fetchPc_redo_valid)begin
-      IBusSimplePlugin_fetchPc_pc = IBusSimplePlugin_fetchPc_redo_payload;
-    end
+    IBusSimplePlugin_fetchPc_pc = (IBusSimplePlugin_fetchPc_pcReg + _zz_167);
     if(IBusSimplePlugin_jump_pcLoad_valid)begin
       IBusSimplePlugin_fetchPc_pc = IBusSimplePlugin_jump_pcLoad_payload;
     end
@@ -2463,9 +2200,6 @@ module VexRiscv (
 
   always @ (*) begin
     IBusSimplePlugin_fetchPc_flushed = 1'b0;
-    if(IBusSimplePlugin_fetchPc_redo_valid)begin
-      IBusSimplePlugin_fetchPc_flushed = 1'b1;
-    end
     if(IBusSimplePlugin_jump_pcLoad_valid)begin
       IBusSimplePlugin_fetchPc_flushed = 1'b1;
     end
@@ -2473,13 +2207,7 @@ module VexRiscv (
 
   assign IBusSimplePlugin_fetchPc_output_valid = ((! IBusSimplePlugin_fetcherHalt) && IBusSimplePlugin_fetchPc_booted);
   assign IBusSimplePlugin_fetchPc_output_payload = IBusSimplePlugin_fetchPc_pc;
-  always @ (*) begin
-    IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
-    if((IBusSimplePlugin_iBusRsp_stages_1_input_valid && IBusSimplePlugin_mmu_joinCtx_refilling))begin
-      IBusSimplePlugin_iBusRsp_redoFetch = 1'b1;
-    end
-  end
-
+  assign IBusSimplePlugin_iBusRsp_redoFetch = 1'b0;
   assign IBusSimplePlugin_iBusRsp_stages_0_input_valid = IBusSimplePlugin_fetchPc_output_valid;
   assign IBusSimplePlugin_fetchPc_output_ready = IBusSimplePlugin_iBusRsp_stages_0_input_ready;
   assign IBusSimplePlugin_iBusRsp_stages_0_input_payload = IBusSimplePlugin_fetchPc_output_payload;
@@ -2488,32 +2216,22 @@ module VexRiscv (
     if((IBusSimplePlugin_iBusRsp_stages_0_input_valid && ((! IBusSimplePlugin_cmdFork_canEmit) || (! IBusSimplePlugin_cmd_ready))))begin
       IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
     end
-    if(IBusSimplePlugin_iBusRsp_stages_0_input_valid)begin
-      if(IBusSimplePlugin_mmuBus_rsp_refilling)begin
-        IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b1;
-      end
-      if(IBusSimplePlugin_mmuBus_rsp_exception)begin
-        IBusSimplePlugin_iBusRsp_stages_0_halt = 1'b0;
-      end
-    end
   end
 
-  assign _zz_53_ = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
-  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_53_);
-  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_53_);
+  assign _zz_50 = (! IBusSimplePlugin_iBusRsp_stages_0_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_0_input_ready = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && _zz_50);
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && _zz_50);
   assign IBusSimplePlugin_iBusRsp_stages_0_output_payload = IBusSimplePlugin_iBusRsp_stages_0_input_payload;
   assign IBusSimplePlugin_iBusRsp_stages_1_halt = 1'b0;
-  assign _zz_54_ = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_54_);
-  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_54_);
+  assign _zz_51 = (! IBusSimplePlugin_iBusRsp_stages_1_halt);
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_ready && _zz_51);
+  assign IBusSimplePlugin_iBusRsp_stages_1_output_valid = (IBusSimplePlugin_iBusRsp_stages_1_input_valid && _zz_51);
   assign IBusSimplePlugin_iBusRsp_stages_1_output_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
-  assign IBusSimplePlugin_fetchPc_redo_valid = IBusSimplePlugin_iBusRsp_redoFetch;
-  assign IBusSimplePlugin_fetchPc_redo_payload = IBusSimplePlugin_iBusRsp_stages_1_input_payload;
   assign IBusSimplePlugin_iBusRsp_flush = (IBusSimplePlugin_externalFlush || IBusSimplePlugin_iBusRsp_redoFetch);
-  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_55_;
-  assign _zz_55_ = ((1'b0 && (! _zz_56_)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_56_ = _zz_57_;
-  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_56_;
+  assign IBusSimplePlugin_iBusRsp_stages_0_output_ready = _zz_52;
+  assign _zz_52 = ((1'b0 && (! _zz_53)) || IBusSimplePlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_53 = _zz_54;
+  assign IBusSimplePlugin_iBusRsp_stages_1_input_valid = _zz_53;
   assign IBusSimplePlugin_iBusRsp_stages_1_input_payload = IBusSimplePlugin_fetchPc_pcReg;
   always @ (*) begin
     IBusSimplePlugin_iBusRsp_readyForError = 1'b1;
@@ -2526,11 +2244,11 @@ module VexRiscv (
   end
 
   assign IBusSimplePlugin_iBusRsp_output_ready = ((1'b0 && (! IBusSimplePlugin_injector_decodeInput_valid)) || IBusSimplePlugin_injector_decodeInput_ready);
-  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_58_;
-  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_59_;
-  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_60_;
-  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_61_;
-  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_62_;
+  assign IBusSimplePlugin_injector_decodeInput_valid = _zz_55;
+  assign IBusSimplePlugin_injector_decodeInput_payload_pc = _zz_56;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_error = _zz_57;
+  assign IBusSimplePlugin_injector_decodeInput_payload_rsp_inst = _zz_58;
+  assign IBusSimplePlugin_injector_decodeInput_payload_isRvc = _zz_59;
   assign IBusSimplePlugin_pcValids_0 = IBusSimplePlugin_injector_nextPcCalc_valids_1;
   assign IBusSimplePlugin_pcValids_1 = IBusSimplePlugin_injector_nextPcCalc_valids_2;
   assign IBusSimplePlugin_pcValids_2 = IBusSimplePlugin_injector_nextPcCalc_valids_3;
@@ -2538,18 +2256,12 @@ module VexRiscv (
   assign IBusSimplePlugin_injector_decodeInput_ready = (! decode_arbitration_isStuck);
   always @ (*) begin
     decode_arbitration_isValid = IBusSimplePlugin_injector_decodeInput_valid;
-    case(_zz_116_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_111)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
       3'b011 : begin
         decode_arbitration_isValid = 1'b1;
-      end
-      3'b100 : begin
       end
       default : begin
       end
@@ -2559,32 +2271,17 @@ module VexRiscv (
   assign iBus_cmd_valid = IBusSimplePlugin_cmd_valid;
   assign IBusSimplePlugin_cmd_ready = iBus_cmd_ready;
   assign iBus_cmd_payload_pc = IBusSimplePlugin_cmd_payload_pc;
-  assign IBusSimplePlugin_pending_next = (_zz_176_ - _zz_180_);
-  assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != (3'b111)));
-  always @ (*) begin
-    IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
-    if(IBusSimplePlugin_iBusRsp_stages_0_input_valid)begin
-      if(IBusSimplePlugin_mmuBus_rsp_refilling)begin
-        IBusSimplePlugin_cmd_valid = 1'b0;
-      end
-      if(IBusSimplePlugin_mmuBus_rsp_exception)begin
-        IBusSimplePlugin_cmd_valid = 1'b0;
-      end
-    end
-  end
-
+  assign IBusSimplePlugin_pending_next = (_zz_168 - _zz_172);
+  assign IBusSimplePlugin_cmdFork_canEmit = (IBusSimplePlugin_iBusRsp_stages_0_output_ready && (IBusSimplePlugin_pending_value != 3'b111));
+  assign IBusSimplePlugin_cmd_valid = (IBusSimplePlugin_iBusRsp_stages_0_input_valid && IBusSimplePlugin_cmdFork_canEmit);
   assign IBusSimplePlugin_pending_inc = (IBusSimplePlugin_cmd_valid && IBusSimplePlugin_cmd_ready);
-  assign IBusSimplePlugin_mmuBus_cmd_isValid = IBusSimplePlugin_iBusRsp_stages_0_input_valid;
-  assign IBusSimplePlugin_mmuBus_cmd_virtualAddress = IBusSimplePlugin_iBusRsp_stages_0_input_payload;
-  assign IBusSimplePlugin_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign IBusSimplePlugin_mmuBus_end = ((IBusSimplePlugin_iBusRsp_stages_0_output_valid && IBusSimplePlugin_iBusRsp_stages_0_output_ready) || IBusSimplePlugin_externalFlush);
-  assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_mmuBus_rsp_physicalAddress[31 : 2],(2'b00)};
-  assign IBusSimplePlugin_rspJoin_rspBuffer_flush = ((IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != (3'b000)) || IBusSimplePlugin_iBusRsp_flush);
-  assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == (3'b000)));
+  assign IBusSimplePlugin_cmd_payload_pc = {IBusSimplePlugin_iBusRsp_stages_0_input_payload[31 : 2],2'b00};
+  assign IBusSimplePlugin_rspJoin_rspBuffer_flush = ((IBusSimplePlugin_rspJoin_rspBuffer_discardCounter != 3'b000) || IBusSimplePlugin_iBusRsp_flush);
+  assign IBusSimplePlugin_rspJoin_rspBuffer_output_valid = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter == 3'b000));
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_error;
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst = IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_payload_inst;
-  assign _zz_126_ = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
-  assign IBusSimplePlugin_pending_dec = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && _zz_126_);
+  assign _zz_121 = (IBusSimplePlugin_rspJoin_rspBuffer_output_ready || IBusSimplePlugin_rspJoin_rspBuffer_flush);
+  assign IBusSimplePlugin_pending_dec = (IBusSimplePlugin_rspJoin_rspBuffer_c_io_pop_valid && _zz_121);
   assign IBusSimplePlugin_rspJoin_fetchRsp_pc = IBusSimplePlugin_iBusRsp_stages_1_output_payload;
   always @ (*) begin
     IBusSimplePlugin_rspJoin_fetchRsp_rsp_error = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_error;
@@ -2594,13 +2291,7 @@ module VexRiscv (
   end
 
   assign IBusSimplePlugin_rspJoin_fetchRsp_rsp_inst = IBusSimplePlugin_rspJoin_rspBuffer_output_payload_inst;
-  always @ (*) begin
-    IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
-    if(_zz_142_)begin
-      IBusSimplePlugin_rspJoin_exceptionDetected = 1'b1;
-    end
-  end
-
+  assign IBusSimplePlugin_rspJoin_exceptionDetected = 1'b0;
   assign IBusSimplePlugin_rspJoin_join_valid = (IBusSimplePlugin_iBusRsp_stages_1_output_valid && IBusSimplePlugin_rspJoin_rspBuffer_output_valid);
   assign IBusSimplePlugin_rspJoin_join_payload_pc = IBusSimplePlugin_rspJoin_fetchRsp_pc;
   assign IBusSimplePlugin_rspJoin_join_payload_rsp_error = IBusSimplePlugin_rspJoin_fetchRsp_rsp_error;
@@ -2608,118 +2299,79 @@ module VexRiscv (
   assign IBusSimplePlugin_rspJoin_join_payload_isRvc = IBusSimplePlugin_rspJoin_fetchRsp_isRvc;
   assign IBusSimplePlugin_iBusRsp_stages_1_output_ready = (IBusSimplePlugin_iBusRsp_stages_1_output_valid ? (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready) : IBusSimplePlugin_rspJoin_join_ready);
   assign IBusSimplePlugin_rspJoin_rspBuffer_output_ready = (IBusSimplePlugin_rspJoin_join_valid && IBusSimplePlugin_rspJoin_join_ready);
-  assign _zz_63_ = (! IBusSimplePlugin_rspJoin_exceptionDetected);
-  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_63_);
-  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_63_);
+  assign _zz_60 = (! IBusSimplePlugin_rspJoin_exceptionDetected);
+  assign IBusSimplePlugin_rspJoin_join_ready = (IBusSimplePlugin_iBusRsp_output_ready && _zz_60);
+  assign IBusSimplePlugin_iBusRsp_output_valid = (IBusSimplePlugin_rspJoin_join_valid && _zz_60);
   assign IBusSimplePlugin_iBusRsp_output_payload_pc = IBusSimplePlugin_rspJoin_join_payload_pc;
   assign IBusSimplePlugin_iBusRsp_output_payload_rsp_error = IBusSimplePlugin_rspJoin_join_payload_rsp_error;
   assign IBusSimplePlugin_iBusRsp_output_payload_rsp_inst = IBusSimplePlugin_rspJoin_join_payload_rsp_inst;
   assign IBusSimplePlugin_iBusRsp_output_payload_isRvc = IBusSimplePlugin_rspJoin_join_payload_isRvc;
-  always @ (*) begin
-    IBusSimplePlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_142_)begin
-      IBusSimplePlugin_decodeExceptionPort_payload_code = (4'b1100);
-    end
-  end
-
-  assign IBusSimplePlugin_decodeExceptionPort_payload_badAddr = {IBusSimplePlugin_rspJoin_join_payload_pc[31 : 2],(2'b00)};
-  assign IBusSimplePlugin_decodeExceptionPort_valid = (IBusSimplePlugin_rspJoin_exceptionDetected && IBusSimplePlugin_iBusRsp_readyForError);
-  assign _zz_64_ = 1'b0;
+  assign _zz_61 = 1'b0;
   always @ (*) begin
     execute_DBusSimplePlugin_skipCmd = 1'b0;
     if(execute_ALIGNEMENT_FAULT)begin
       execute_DBusSimplePlugin_skipCmd = 1'b1;
     end
-    if((execute_MMU_FAULT || execute_MMU_RSP_refilling))begin
-      execute_DBusSimplePlugin_skipCmd = 1'b1;
-    end
   end
 
-  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_64_));
+  assign dBus_cmd_valid = (((((execute_arbitration_isValid && execute_MEMORY_ENABLE) && (! execute_arbitration_isStuckByOthers)) && (! execute_arbitration_isFlushed)) && (! execute_DBusSimplePlugin_skipCmd)) && (! _zz_61));
   assign dBus_cmd_payload_wr = execute_MEMORY_STORE;
   assign dBus_cmd_payload_size = execute_INSTRUCTION[13 : 12];
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_65_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_62 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_65_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_62 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_65_ = execute_RS2[31 : 0];
+        _zz_62 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign dBus_cmd_payload_data = _zz_65_;
+  assign dBus_cmd_payload_data = _zz_62;
   always @ (*) begin
     case(dBus_cmd_payload_size)
       2'b00 : begin
-        _zz_66_ = (4'b0001);
+        _zz_63 = 4'b0001;
       end
       2'b01 : begin
-        _zz_66_ = (4'b0011);
+        _zz_63 = 4'b0011;
       end
       default : begin
-        _zz_66_ = (4'b1111);
+        _zz_63 = 4'b1111;
       end
     endcase
   end
 
-  assign execute_DBusSimplePlugin_formalMask = (_zz_66_ <<< dBus_cmd_payload_address[1 : 0]);
-  assign DBusSimplePlugin_mmuBus_cmd_isValid = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign DBusSimplePlugin_mmuBus_cmd_virtualAddress = execute_SRC_ADD;
-  assign DBusSimplePlugin_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign DBusSimplePlugin_mmuBus_end = ((! execute_arbitration_isStuck) || execute_arbitration_removeIt);
-  assign dBus_cmd_payload_address = DBusSimplePlugin_mmuBus_rsp_physicalAddress;
+  assign execute_DBusSimplePlugin_formalMask = (_zz_63 <<< dBus_cmd_payload_address[1 : 0]);
+  assign dBus_cmd_payload_address = execute_SRC_ADD;
   always @ (*) begin
     DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    if(_zz_143_)begin
+    if(_zz_134)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
     if(memory_ALIGNEMENT_FAULT)begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
     end
-    if(memory_MMU_RSP_refilling)begin
-      DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
-    end else begin
-      if(memory_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_valid = 1'b1;
-      end
-    end
-    if(_zz_144_)begin
+    if((! ((memory_arbitration_isValid && memory_MEMORY_ENABLE) && (1'b1 || (! memory_arbitration_isStuckByOthers)))))begin
       DBusSimplePlugin_memoryExceptionPort_valid = 1'b0;
     end
   end
 
   always @ (*) begin
-    DBusSimplePlugin_memoryExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_143_)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = (4'b0101);
+    DBusSimplePlugin_memoryExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_134)begin
+      DBusSimplePlugin_memoryExceptionPort_payload_code = 4'b0101;
     end
     if(memory_ALIGNEMENT_FAULT)begin
-      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_185_};
-    end
-    if(! memory_MMU_RSP_refilling) begin
-      if(memory_MMU_FAULT)begin
-        DBusSimplePlugin_memoryExceptionPort_payload_code = (memory_MEMORY_STORE ? (4'b1111) : (4'b1101));
-      end
+      DBusSimplePlugin_memoryExceptionPort_payload_code = {1'd0, _zz_177};
     end
   end
 
   assign DBusSimplePlugin_memoryExceptionPort_payload_badAddr = memory_REGFILE_WRITE_DATA;
-  always @ (*) begin
-    DBusSimplePlugin_redoBranch_valid = 1'b0;
-    if(memory_MMU_RSP_refilling)begin
-      DBusSimplePlugin_redoBranch_valid = 1'b1;
-    end
-    if(_zz_144_)begin
-      DBusSimplePlugin_redoBranch_valid = 1'b0;
-    end
-  end
-
-  assign DBusSimplePlugin_redoBranch_payload = memory_PC;
   always @ (*) begin
     writeBack_DBusSimplePlugin_rspShifted = writeBack_MEMORY_READ_DATA;
     case(writeBack_MEMORY_ADDRESS_LOW)
@@ -2737,63 +2389,63 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_67_ = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_64 = (writeBack_DBusSimplePlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_68_[31] = _zz_67_;
-    _zz_68_[30] = _zz_67_;
-    _zz_68_[29] = _zz_67_;
-    _zz_68_[28] = _zz_67_;
-    _zz_68_[27] = _zz_67_;
-    _zz_68_[26] = _zz_67_;
-    _zz_68_[25] = _zz_67_;
-    _zz_68_[24] = _zz_67_;
-    _zz_68_[23] = _zz_67_;
-    _zz_68_[22] = _zz_67_;
-    _zz_68_[21] = _zz_67_;
-    _zz_68_[20] = _zz_67_;
-    _zz_68_[19] = _zz_67_;
-    _zz_68_[18] = _zz_67_;
-    _zz_68_[17] = _zz_67_;
-    _zz_68_[16] = _zz_67_;
-    _zz_68_[15] = _zz_67_;
-    _zz_68_[14] = _zz_67_;
-    _zz_68_[13] = _zz_67_;
-    _zz_68_[12] = _zz_67_;
-    _zz_68_[11] = _zz_67_;
-    _zz_68_[10] = _zz_67_;
-    _zz_68_[9] = _zz_67_;
-    _zz_68_[8] = _zz_67_;
-    _zz_68_[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
+    _zz_65[31] = _zz_64;
+    _zz_65[30] = _zz_64;
+    _zz_65[29] = _zz_64;
+    _zz_65[28] = _zz_64;
+    _zz_65[27] = _zz_64;
+    _zz_65[26] = _zz_64;
+    _zz_65[25] = _zz_64;
+    _zz_65[24] = _zz_64;
+    _zz_65[23] = _zz_64;
+    _zz_65[22] = _zz_64;
+    _zz_65[21] = _zz_64;
+    _zz_65[20] = _zz_64;
+    _zz_65[19] = _zz_64;
+    _zz_65[18] = _zz_64;
+    _zz_65[17] = _zz_64;
+    _zz_65[16] = _zz_64;
+    _zz_65[15] = _zz_64;
+    _zz_65[14] = _zz_64;
+    _zz_65[13] = _zz_64;
+    _zz_65[12] = _zz_64;
+    _zz_65[11] = _zz_64;
+    _zz_65[10] = _zz_64;
+    _zz_65[9] = _zz_64;
+    _zz_65[8] = _zz_64;
+    _zz_65[7 : 0] = writeBack_DBusSimplePlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_69_ = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_66 = (writeBack_DBusSimplePlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_70_[31] = _zz_69_;
-    _zz_70_[30] = _zz_69_;
-    _zz_70_[29] = _zz_69_;
-    _zz_70_[28] = _zz_69_;
-    _zz_70_[27] = _zz_69_;
-    _zz_70_[26] = _zz_69_;
-    _zz_70_[25] = _zz_69_;
-    _zz_70_[24] = _zz_69_;
-    _zz_70_[23] = _zz_69_;
-    _zz_70_[22] = _zz_69_;
-    _zz_70_[21] = _zz_69_;
-    _zz_70_[20] = _zz_69_;
-    _zz_70_[19] = _zz_69_;
-    _zz_70_[18] = _zz_69_;
-    _zz_70_[17] = _zz_69_;
-    _zz_70_[16] = _zz_69_;
-    _zz_70_[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
+    _zz_67[31] = _zz_66;
+    _zz_67[30] = _zz_66;
+    _zz_67[29] = _zz_66;
+    _zz_67[28] = _zz_66;
+    _zz_67[27] = _zz_66;
+    _zz_67[26] = _zz_66;
+    _zz_67[25] = _zz_66;
+    _zz_67[24] = _zz_66;
+    _zz_67[23] = _zz_66;
+    _zz_67[22] = _zz_66;
+    _zz_67[21] = _zz_66;
+    _zz_67[20] = _zz_66;
+    _zz_67[19] = _zz_66;
+    _zz_67[18] = _zz_66;
+    _zz_67[17] = _zz_66;
+    _zz_67[16] = _zz_66;
+    _zz_67[15 : 0] = writeBack_DBusSimplePlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_159_)
+    case(_zz_150)
       2'b00 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_68_;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_65;
       end
       2'b01 : begin
-        writeBack_DBusSimplePlugin_rspFormated = _zz_70_;
+        writeBack_DBusSimplePlugin_rspFormated = _zz_67;
       end
       default : begin
         writeBack_DBusSimplePlugin_rspFormated = writeBack_DBusSimplePlugin_rspShifted;
@@ -2801,57 +2453,53 @@ module VexRiscv (
     endcase
   end
 
-  assign IBusSimplePlugin_mmuBus_rsp_physicalAddress = IBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  assign IBusSimplePlugin_mmuBus_rsp_allowRead = 1'b1;
-  assign IBusSimplePlugin_mmuBus_rsp_allowWrite = 1'b1;
-  assign IBusSimplePlugin_mmuBus_rsp_allowExecute = 1'b1;
-  assign IBusSimplePlugin_mmuBus_rsp_isIoAccess = IBusSimplePlugin_mmuBus_rsp_physicalAddress[31];
-  assign IBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
-  assign IBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
-  assign IBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign DBusSimplePlugin_mmuBus_rsp_physicalAddress = DBusSimplePlugin_mmuBus_cmd_virtualAddress;
-  assign DBusSimplePlugin_mmuBus_rsp_allowRead = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_allowWrite = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_allowExecute = 1'b1;
-  assign DBusSimplePlugin_mmuBus_rsp_isIoAccess = DBusSimplePlugin_mmuBus_rsp_physicalAddress[31];
-  assign DBusSimplePlugin_mmuBus_rsp_exception = 1'b0;
-  assign DBusSimplePlugin_mmuBus_rsp_refilling = 1'b0;
-  assign DBusSimplePlugin_mmuBus_busy = 1'b0;
-  assign _zz_72_ = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_73_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_74_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_75_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_71_ = {(((decode_INSTRUCTION & _zz_234_) == 32'h00000010) != (1'b0)),{({_zz_235_,_zz_236_} != (2'b00)),{({_zz_237_,_zz_238_} != (3'b000)),{(_zz_239_ != _zz_240_),{_zz_241_,{_zz_242_,_zz_243_}}}}}};
-  assign _zz_76_ = _zz_71_[3 : 2];
-  assign _zz_46_ = _zz_76_;
-  assign _zz_77_ = _zz_71_[5 : 4];
-  assign _zz_45_ = _zz_77_;
-  assign _zz_78_ = _zz_71_[9 : 8];
-  assign _zz_44_ = _zz_78_;
-  assign _zz_79_ = _zz_71_[12 : 11];
-  assign _zz_43_ = _zz_79_;
-  assign _zz_80_ = _zz_71_[15 : 14];
-  assign _zz_42_ = _zz_80_;
-  assign _zz_81_ = _zz_71_[19 : 18];
-  assign _zz_41_ = _zz_81_;
-  assign _zz_82_ = _zz_71_[23 : 22];
-  assign _zz_40_ = _zz_82_;
+  assign _zz_69 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_70 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_71 = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
+  assign _zz_72 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_68 = {(((decode_INSTRUCTION & _zz_223) == 32'h00100050) != 1'b0),{((_zz_224 == _zz_225) != 1'b0),{(_zz_226 != 1'b0),{(_zz_227 != _zz_228),{_zz_229,{_zz_230,_zz_231}}}}}};
+  assign _zz_73 = _zz_68[1 : 0];
+  assign _zz_46 = _zz_73;
+  assign _zz_74 = _zz_68[6 : 5];
+  assign _zz_45 = _zz_74;
+  assign _zz_75 = _zz_68[8 : 7];
+  assign _zz_44 = _zz_75;
+  assign _zz_76 = _zz_68[17 : 16];
+  assign _zz_43 = _zz_76;
+  assign _zz_77 = _zz_68[20 : 19];
+  assign _zz_42 = _zz_77;
+  assign _zz_78 = _zz_68[22 : 21];
+  assign _zz_41 = _zz_78;
+  assign _zz_79 = _zz_68[25 : 24];
+  assign _zz_40 = _zz_79;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_128_;
-  assign decode_RegFilePlugin_rs2Data = _zz_129_;
+  assign decode_RegFilePlugin_rs1Data = _zz_123;
+  assign decode_RegFilePlugin_rs2Data = _zz_124;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_38_ && writeBack_arbitration_isFiring);
-    if(_zz_83_)begin
+    lastStageRegFileWrite_valid = (_zz_38 && writeBack_arbitration_isFiring);
+    if(_zz_80)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_37_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_47_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_37[11 : 7];
+    if(_zz_80)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_47;
+    if(_zz_80)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -2869,13 +2517,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_84_ = execute_IntAluPlugin_bitwise;
+        _zz_81 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_84_ = {31'd0, _zz_186_};
+        _zz_81 = {31'd0, _zz_178};
       end
       default : begin
-        _zz_84_ = execute_SRC_ADD_SUB;
+        _zz_81 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -2883,87 +2531,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_85_ = execute_RS1;
+        _zz_82 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_85_ = {29'd0, _zz_187_};
+        _zz_82 = {29'd0, _zz_179};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_85_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_82 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_85_ = {27'd0, _zz_188_};
+        _zz_82 = {27'd0, _zz_180};
       end
     endcase
   end
 
-  assign _zz_86_ = _zz_189_[11];
+  assign _zz_83 = _zz_181[11];
   always @ (*) begin
-    _zz_87_[19] = _zz_86_;
-    _zz_87_[18] = _zz_86_;
-    _zz_87_[17] = _zz_86_;
-    _zz_87_[16] = _zz_86_;
-    _zz_87_[15] = _zz_86_;
-    _zz_87_[14] = _zz_86_;
-    _zz_87_[13] = _zz_86_;
-    _zz_87_[12] = _zz_86_;
-    _zz_87_[11] = _zz_86_;
-    _zz_87_[10] = _zz_86_;
-    _zz_87_[9] = _zz_86_;
-    _zz_87_[8] = _zz_86_;
-    _zz_87_[7] = _zz_86_;
-    _zz_87_[6] = _zz_86_;
-    _zz_87_[5] = _zz_86_;
-    _zz_87_[4] = _zz_86_;
-    _zz_87_[3] = _zz_86_;
-    _zz_87_[2] = _zz_86_;
-    _zz_87_[1] = _zz_86_;
-    _zz_87_[0] = _zz_86_;
+    _zz_84[19] = _zz_83;
+    _zz_84[18] = _zz_83;
+    _zz_84[17] = _zz_83;
+    _zz_84[16] = _zz_83;
+    _zz_84[15] = _zz_83;
+    _zz_84[14] = _zz_83;
+    _zz_84[13] = _zz_83;
+    _zz_84[12] = _zz_83;
+    _zz_84[11] = _zz_83;
+    _zz_84[10] = _zz_83;
+    _zz_84[9] = _zz_83;
+    _zz_84[8] = _zz_83;
+    _zz_84[7] = _zz_83;
+    _zz_84[6] = _zz_83;
+    _zz_84[5] = _zz_83;
+    _zz_84[4] = _zz_83;
+    _zz_84[3] = _zz_83;
+    _zz_84[2] = _zz_83;
+    _zz_84[1] = _zz_83;
+    _zz_84[0] = _zz_83;
   end
 
-  assign _zz_88_ = _zz_190_[11];
+  assign _zz_85 = _zz_182[11];
   always @ (*) begin
-    _zz_89_[19] = _zz_88_;
-    _zz_89_[18] = _zz_88_;
-    _zz_89_[17] = _zz_88_;
-    _zz_89_[16] = _zz_88_;
-    _zz_89_[15] = _zz_88_;
-    _zz_89_[14] = _zz_88_;
-    _zz_89_[13] = _zz_88_;
-    _zz_89_[12] = _zz_88_;
-    _zz_89_[11] = _zz_88_;
-    _zz_89_[10] = _zz_88_;
-    _zz_89_[9] = _zz_88_;
-    _zz_89_[8] = _zz_88_;
-    _zz_89_[7] = _zz_88_;
-    _zz_89_[6] = _zz_88_;
-    _zz_89_[5] = _zz_88_;
-    _zz_89_[4] = _zz_88_;
-    _zz_89_[3] = _zz_88_;
-    _zz_89_[2] = _zz_88_;
-    _zz_89_[1] = _zz_88_;
-    _zz_89_[0] = _zz_88_;
+    _zz_86[19] = _zz_85;
+    _zz_86[18] = _zz_85;
+    _zz_86[17] = _zz_85;
+    _zz_86[16] = _zz_85;
+    _zz_86[15] = _zz_85;
+    _zz_86[14] = _zz_85;
+    _zz_86[13] = _zz_85;
+    _zz_86[12] = _zz_85;
+    _zz_86[11] = _zz_85;
+    _zz_86[10] = _zz_85;
+    _zz_86[9] = _zz_85;
+    _zz_86[8] = _zz_85;
+    _zz_86[7] = _zz_85;
+    _zz_86[6] = _zz_85;
+    _zz_86[5] = _zz_85;
+    _zz_86[4] = _zz_85;
+    _zz_86[3] = _zz_85;
+    _zz_86[2] = _zz_85;
+    _zz_86[1] = _zz_85;
+    _zz_86[0] = _zz_85;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_90_ = execute_RS2;
+        _zz_87 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_90_ = {_zz_87_,execute_INSTRUCTION[31 : 20]};
+        _zz_87 = {_zz_84,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_90_ = {_zz_89_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_87 = {_zz_86,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_90_ = _zz_32_;
+        _zz_87 = _zz_32;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_191_;
+    execute_SrcPlugin_addSub = _zz_183;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -2973,220 +2621,218 @@ module VexRiscv (
   assign execute_LightShifterPlugin_isShift = (execute_SHIFT_CTRL != `ShiftCtrlEnum_defaultEncoding_DISABLE_1);
   assign execute_LightShifterPlugin_amplitude = (execute_LightShifterPlugin_isActive ? execute_LightShifterPlugin_amplitudeReg : execute_SRC2[4 : 0]);
   assign execute_LightShifterPlugin_shiftInput = (execute_LightShifterPlugin_isActive ? memory_REGFILE_WRITE_DATA : execute_SRC1);
-  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == (4'b0000));
+  assign execute_LightShifterPlugin_done = (execute_LightShifterPlugin_amplitude[4 : 1] == 4'b0000);
   always @ (*) begin
     case(execute_SHIFT_CTRL)
       `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-        _zz_91_ = (execute_LightShifterPlugin_shiftInput <<< 1);
+        _zz_88 = (execute_LightShifterPlugin_shiftInput <<< 1);
       end
       default : begin
-        _zz_91_ = _zz_198_;
+        _zz_88 = _zz_190;
       end
     endcase
   end
 
   always @ (*) begin
-    _zz_92_ = 1'b0;
-    if(_zz_94_)begin
-      if((_zz_95_ == decode_INSTRUCTION[19 : 15]))begin
-        _zz_92_ = 1'b1;
+    _zz_89 = 1'b0;
+    if(_zz_91)begin
+      if((_zz_92 == decode_INSTRUCTION[19 : 15]))begin
+        _zz_89 = 1'b1;
       end
     end
-    if(_zz_145_)begin
-      if(_zz_146_)begin
+    if(_zz_135)begin
+      if(_zz_136)begin
         if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_92_ = 1'b1;
+          _zz_89 = 1'b1;
         end
       end
     end
-    if(_zz_147_)begin
-      if(_zz_148_)begin
+    if(_zz_137)begin
+      if(_zz_138)begin
         if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_92_ = 1'b1;
+          _zz_89 = 1'b1;
         end
       end
     end
-    if(_zz_149_)begin
-      if(_zz_150_)begin
+    if(_zz_139)begin
+      if(_zz_140)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]))begin
-          _zz_92_ = 1'b1;
+          _zz_89 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_92_ = 1'b0;
+      _zz_89 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_93_ = 1'b0;
-    if(_zz_94_)begin
-      if((_zz_95_ == decode_INSTRUCTION[24 : 20]))begin
-        _zz_93_ = 1'b1;
+    _zz_90 = 1'b0;
+    if(_zz_91)begin
+      if((_zz_92 == decode_INSTRUCTION[24 : 20]))begin
+        _zz_90 = 1'b1;
       end
     end
-    if(_zz_145_)begin
-      if(_zz_146_)begin
+    if(_zz_135)begin
+      if(_zz_136)begin
         if((writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_93_ = 1'b1;
+          _zz_90 = 1'b1;
         end
       end
     end
-    if(_zz_147_)begin
-      if(_zz_148_)begin
+    if(_zz_137)begin
+      if(_zz_138)begin
         if((memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_93_ = 1'b1;
+          _zz_90 = 1'b1;
         end
       end
     end
-    if(_zz_149_)begin
-      if(_zz_150_)begin
+    if(_zz_139)begin
+      if(_zz_140)begin
         if((execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]))begin
-          _zz_93_ = 1'b1;
+          _zz_90 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_93_ = 1'b0;
+      _zz_90 = 1'b0;
     end
   end
 
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_96_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_93 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_96_ == (3'b000))) begin
-        _zz_97_ = execute_BranchPlugin_eq;
-    end else if((_zz_96_ == (3'b001))) begin
-        _zz_97_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_96_ & (3'b101)) == (3'b101)))) begin
-        _zz_97_ = (! execute_SRC_LESS);
+    if((_zz_93 == 3'b000)) begin
+        _zz_94 = execute_BranchPlugin_eq;
+    end else if((_zz_93 == 3'b001)) begin
+        _zz_94 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_93 & 3'b101) == 3'b101))) begin
+        _zz_94 = (! execute_SRC_LESS);
     end else begin
-        _zz_97_ = execute_SRC_LESS;
+        _zz_94 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_98_ = 1'b0;
+        _zz_95 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_98_ = 1'b1;
+        _zz_95 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_98_ = 1'b1;
+        _zz_95 = 1'b1;
       end
       default : begin
-        _zz_98_ = _zz_97_;
+        _zz_95 = _zz_94;
       end
     endcase
   end
 
   assign execute_BranchPlugin_branch_src1 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JALR) ? execute_RS1 : execute_PC);
-  assign _zz_99_ = _zz_200_[19];
+  assign _zz_96 = _zz_192[19];
   always @ (*) begin
-    _zz_100_[10] = _zz_99_;
-    _zz_100_[9] = _zz_99_;
-    _zz_100_[8] = _zz_99_;
-    _zz_100_[7] = _zz_99_;
-    _zz_100_[6] = _zz_99_;
-    _zz_100_[5] = _zz_99_;
-    _zz_100_[4] = _zz_99_;
-    _zz_100_[3] = _zz_99_;
-    _zz_100_[2] = _zz_99_;
-    _zz_100_[1] = _zz_99_;
-    _zz_100_[0] = _zz_99_;
+    _zz_97[10] = _zz_96;
+    _zz_97[9] = _zz_96;
+    _zz_97[8] = _zz_96;
+    _zz_97[7] = _zz_96;
+    _zz_97[6] = _zz_96;
+    _zz_97[5] = _zz_96;
+    _zz_97[4] = _zz_96;
+    _zz_97[3] = _zz_96;
+    _zz_97[2] = _zz_96;
+    _zz_97[1] = _zz_96;
+    _zz_97[0] = _zz_96;
   end
 
-  assign _zz_101_ = _zz_201_[11];
+  assign _zz_98 = _zz_193[11];
   always @ (*) begin
-    _zz_102_[19] = _zz_101_;
-    _zz_102_[18] = _zz_101_;
-    _zz_102_[17] = _zz_101_;
-    _zz_102_[16] = _zz_101_;
-    _zz_102_[15] = _zz_101_;
-    _zz_102_[14] = _zz_101_;
-    _zz_102_[13] = _zz_101_;
-    _zz_102_[12] = _zz_101_;
-    _zz_102_[11] = _zz_101_;
-    _zz_102_[10] = _zz_101_;
-    _zz_102_[9] = _zz_101_;
-    _zz_102_[8] = _zz_101_;
-    _zz_102_[7] = _zz_101_;
-    _zz_102_[6] = _zz_101_;
-    _zz_102_[5] = _zz_101_;
-    _zz_102_[4] = _zz_101_;
-    _zz_102_[3] = _zz_101_;
-    _zz_102_[2] = _zz_101_;
-    _zz_102_[1] = _zz_101_;
-    _zz_102_[0] = _zz_101_;
+    _zz_99[19] = _zz_98;
+    _zz_99[18] = _zz_98;
+    _zz_99[17] = _zz_98;
+    _zz_99[16] = _zz_98;
+    _zz_99[15] = _zz_98;
+    _zz_99[14] = _zz_98;
+    _zz_99[13] = _zz_98;
+    _zz_99[12] = _zz_98;
+    _zz_99[11] = _zz_98;
+    _zz_99[10] = _zz_98;
+    _zz_99[9] = _zz_98;
+    _zz_99[8] = _zz_98;
+    _zz_99[7] = _zz_98;
+    _zz_99[6] = _zz_98;
+    _zz_99[5] = _zz_98;
+    _zz_99[4] = _zz_98;
+    _zz_99[3] = _zz_98;
+    _zz_99[2] = _zz_98;
+    _zz_99[1] = _zz_98;
+    _zz_99[0] = _zz_98;
   end
 
-  assign _zz_103_ = _zz_202_[11];
+  assign _zz_100 = _zz_194[11];
   always @ (*) begin
-    _zz_104_[18] = _zz_103_;
-    _zz_104_[17] = _zz_103_;
-    _zz_104_[16] = _zz_103_;
-    _zz_104_[15] = _zz_103_;
-    _zz_104_[14] = _zz_103_;
-    _zz_104_[13] = _zz_103_;
-    _zz_104_[12] = _zz_103_;
-    _zz_104_[11] = _zz_103_;
-    _zz_104_[10] = _zz_103_;
-    _zz_104_[9] = _zz_103_;
-    _zz_104_[8] = _zz_103_;
-    _zz_104_[7] = _zz_103_;
-    _zz_104_[6] = _zz_103_;
-    _zz_104_[5] = _zz_103_;
-    _zz_104_[4] = _zz_103_;
-    _zz_104_[3] = _zz_103_;
-    _zz_104_[2] = _zz_103_;
-    _zz_104_[1] = _zz_103_;
-    _zz_104_[0] = _zz_103_;
+    _zz_101[18] = _zz_100;
+    _zz_101[17] = _zz_100;
+    _zz_101[16] = _zz_100;
+    _zz_101[15] = _zz_100;
+    _zz_101[14] = _zz_100;
+    _zz_101[13] = _zz_100;
+    _zz_101[12] = _zz_100;
+    _zz_101[11] = _zz_100;
+    _zz_101[10] = _zz_100;
+    _zz_101[9] = _zz_100;
+    _zz_101[8] = _zz_100;
+    _zz_101[7] = _zz_100;
+    _zz_101[6] = _zz_100;
+    _zz_101[5] = _zz_100;
+    _zz_101[4] = _zz_100;
+    _zz_101[3] = _zz_100;
+    _zz_101[2] = _zz_100;
+    _zz_101[1] = _zz_100;
+    _zz_101[0] = _zz_100;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_105_ = {{_zz_100_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+        _zz_102 = {{_zz_97,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_105_ = {_zz_102_,execute_INSTRUCTION[31 : 20]};
+        _zz_102 = {_zz_99,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        _zz_105_ = {{_zz_104_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+        _zz_102 = {{_zz_101,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
       end
     endcase
   end
 
-  assign execute_BranchPlugin_branch_src2 = _zz_105_;
+  assign execute_BranchPlugin_branch_src2 = _zz_102;
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && BranchPlugin_jumpInterface_payload[1]);
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = BranchPlugin_jumpInterface_payload;
   always @ (*) begin
-    CsrPlugin_privilege = (2'b11);
+    CsrPlugin_privilege = 2'b11;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign CsrPlugin_misa_base = (2'b01);
+  assign CsrPlugin_misa_base = 2'b01;
   assign CsrPlugin_misa_extensions = 26'h0000042;
-  assign _zz_106_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_107_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_108_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_103 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_104 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_105 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_109_ = {decodeExceptionPort_valid,IBusSimplePlugin_decodeExceptionPort_valid};
-  assign _zz_110_ = _zz_203_[0];
-  assign _zz_111_ = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
-  assign _zz_112_ = _zz_205_[0];
+  assign _zz_106 = {BranchPlugin_branchExceptionPort_valid,DBusSimplePlugin_memoryExceptionPort_valid};
+  assign _zz_107 = _zz_195[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_133_)begin
+    if(decodeExceptionPort_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -3206,7 +2852,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_memory = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory;
-    if(_zz_137_)begin
+    if(_zz_129)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_memory = 1'b1;
     end
     if(memory_arbitration_isFlushed)begin
@@ -3230,7 +2876,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -3254,7 +2900,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -3276,7 +2922,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_768)begin
@@ -3314,7 +2960,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_151_)begin
+    if(_zz_141)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -3333,20 +2979,20 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_152_)begin
+    if(_zz_142)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_152_)begin
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_142)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -3355,14 +3001,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_151_)begin
+    if(_zz_141)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_151_)begin
+    if(_zz_141)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -3371,7 +3017,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_160_)
+    case(_zz_151)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -3382,15 +3028,13 @@ module VexRiscv (
   end
 
   assign execute_CsrPlugin_csrAddress = execute_INSTRUCTION[31 : 20];
-  assign _zz_114_ = (_zz_113_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_114_ != 32'h0);
+  assign _zz_109 = (_zz_108 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_109 != 32'h0);
   always @ (*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid)begin
-      case(_zz_153_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_143)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             debug_bus_cmd_ready = IBusSimplePlugin_injectionPort_ready;
           end
@@ -3403,7 +3047,7 @@ module VexRiscv (
 
   always @ (*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_115_))begin
+    if((! _zz_110))begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -3415,10 +3059,8 @@ module VexRiscv (
   always @ (*) begin
     IBusSimplePlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid)begin
-      case(_zz_153_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_143)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             IBusSimplePlugin_injectionPort_valid = 1'b1;
           end
@@ -3430,37 +3072,37 @@ module VexRiscv (
   end
 
   assign IBusSimplePlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == (2'b11));
+  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_25_ = decode_BRANCH_CTRL;
-  assign _zz_23_ = _zz_42_;
-  assign _zz_29_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_22_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_20_ = _zz_41_;
-  assign _zz_36_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_19_ = decode_SRC1_CTRL;
-  assign _zz_17_ = _zz_46_;
-  assign _zz_34_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_16_ = decode_ALU_CTRL;
-  assign _zz_14_ = _zz_45_;
-  assign _zz_35_ = decode_to_execute_ALU_CTRL;
-  assign _zz_13_ = decode_ENV_CTRL;
-  assign _zz_10_ = execute_ENV_CTRL;
-  assign _zz_8_ = memory_ENV_CTRL;
-  assign _zz_11_ = _zz_43_;
-  assign _zz_27_ = decode_to_execute_ENV_CTRL;
-  assign _zz_26_ = execute_to_memory_ENV_CTRL;
-  assign _zz_28_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_6_ = decode_SHIFT_CTRL;
-  assign _zz_4_ = _zz_44_;
-  assign _zz_31_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_3_ = decode_SRC2_CTRL;
-  assign _zz_1_ = _zz_40_;
-  assign _zz_33_ = decode_to_execute_SRC2_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_25 = decode_SRC1_CTRL;
+  assign _zz_23 = _zz_46;
+  assign _zz_34 = decode_to_execute_SRC1_CTRL;
+  assign _zz_22 = decode_ALU_CTRL;
+  assign _zz_20 = _zz_45;
+  assign _zz_35 = decode_to_execute_ALU_CTRL;
+  assign _zz_19 = decode_SRC2_CTRL;
+  assign _zz_17 = _zz_44;
+  assign _zz_33 = decode_to_execute_SRC2_CTRL;
+  assign _zz_16 = decode_ALU_BITWISE_CTRL;
+  assign _zz_14 = _zz_43;
+  assign _zz_36 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_13 = decode_SHIFT_CTRL;
+  assign _zz_11 = _zz_42;
+  assign _zz_31 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_10 = decode_BRANCH_CTRL;
+  assign _zz_8 = _zz_41;
+  assign _zz_29 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_40;
+  assign _zz_27 = decode_to_execute_ENV_CTRL;
+  assign _zz_26 = execute_to_memory_ENV_CTRL;
+  assign _zz_28 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -3479,15 +3121,7 @@ module VexRiscv (
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
     IBusSimplePlugin_injectionPort_ready = 1'b0;
-    case(_zz_116_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
-      3'b010 : begin
-      end
-      3'b011 : begin
-      end
+    case(_zz_111)
       3'b100 : begin
         IBusSimplePlugin_injectionPort_ready = 1'b1;
       end
@@ -3497,76 +3131,76 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_117_ = 32'h0;
+    _zz_112 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_117_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_117_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_117_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_112[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_112[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_112[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_118_ = 32'h0;
+    _zz_113 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_118_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_118_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_118_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_113[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_113[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_113[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_119_ = 32'h0;
+    _zz_114 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_119_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_119_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_119_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_114[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_114[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_114[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_120_ = 32'h0;
+    _zz_115 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_120_[31 : 0] = CsrPlugin_mepc;
+      _zz_115[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_121_ = 32'h0;
+    _zz_116 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_121_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_121_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_116[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_116[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_122_ = 32'h0;
+    _zz_117 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_122_[31 : 0] = CsrPlugin_mtval;
+      _zz_117[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_123_ = 32'h0;
+    _zz_118 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_123_[31 : 0] = _zz_113_;
+      _zz_118[31 : 0] = _zz_108;
     end
   end
 
   always @ (*) begin
-    _zz_124_ = 32'h0;
+    _zz_119 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_124_[31 : 0] = _zz_114_;
+      _zz_119[31 : 0] = _zz_109;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((_zz_117_ | _zz_118_) | (_zz_119_ | _zz_120_)) | ((_zz_121_ | _zz_122_) | (_zz_123_ | _zz_124_)));
+  assign execute_CsrPlugin_readData = (((_zz_112 | _zz_113) | (_zz_114 | _zz_115)) | ((_zz_116 | _zz_117) | (_zz_118 | _zz_119)));
   assign iBus_cmd_ready = ((1'b1 && (! iBus_cmd_m2sPipe_valid)) || iBus_cmd_m2sPipe_ready);
   assign iBus_cmd_m2sPipe_valid = iBus_cmd_m2sPipe_rValid;
   assign iBus_cmd_m2sPipe_payload_pc = iBus_cmd_m2sPipe_rData_pc;
   assign iBusWishbone_ADR = (iBus_cmd_m2sPipe_payload_pc >>> 2);
-  assign iBusWishbone_CTI = (3'b000);
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign iBusWishbone_CTI = 3'b000;
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   assign iBusWishbone_CYC = iBus_cmd_m2sPipe_valid;
@@ -3582,26 +3216,26 @@ module VexRiscv (
   assign dBus_cmd_halfPipe_payload_size = dBus_cmd_halfPipe_regs_payload_size;
   assign dBus_cmd_ready = dBus_cmd_halfPipe_regs_ready;
   assign dBusWishbone_ADR = (dBus_cmd_halfPipe_payload_address >>> 2);
-  assign dBusWishbone_CTI = (3'b000);
-  assign dBusWishbone_BTE = (2'b00);
+  assign dBusWishbone_CTI = 3'b000;
+  assign dBusWishbone_BTE = 2'b00;
   always @ (*) begin
     case(dBus_cmd_halfPipe_payload_size)
       2'b00 : begin
-        _zz_125_ = (4'b0001);
+        _zz_120 = 4'b0001;
       end
       2'b01 : begin
-        _zz_125_ = (4'b0011);
+        _zz_120 = 4'b0011;
       end
       default : begin
-        _zz_125_ = (4'b1111);
+        _zz_120 = 4'b1111;
       end
     endcase
   end
 
   always @ (*) begin
-    dBusWishbone_SEL = (_zz_125_ <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
+    dBusWishbone_SEL = (_zz_120 <<< dBus_cmd_halfPipe_payload_address[1 : 0]);
     if((! dBus_cmd_halfPipe_payload_wr))begin
-      dBusWishbone_SEL = (4'b1111);
+      dBusWishbone_SEL = 4'b1111;
     end
   end
 
@@ -3613,28 +3247,28 @@ module VexRiscv (
   assign dBus_rsp_ready = ((dBus_cmd_halfPipe_valid && (! dBusWishbone_WE)) && dBusWishbone_ACK);
   assign dBus_rsp_data = dBusWishbone_DAT_MISO;
   assign dBus_rsp_error = 1'b0;
-  assign _zz_127_ = 1'b0;
+  assign _zz_122 = 1'b0;
   always @ (posedge clk) begin
     if(reset) begin
       IBusSimplePlugin_fetchPc_pcReg <= externalResetVector;
       IBusSimplePlugin_fetchPc_correctionReg <= 1'b0;
       IBusSimplePlugin_fetchPc_booted <= 1'b0;
       IBusSimplePlugin_fetchPc_inc <= 1'b0;
-      _zz_57_ <= 1'b0;
-      _zz_58_ <= 1'b0;
+      _zz_54 <= 1'b0;
+      _zz_55 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusSimplePlugin_pending_value <= (3'b000);
-      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (3'b000);
-      _zz_83_ <= 1'b1;
+      IBusSimplePlugin_pending_value <= 3'b000;
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= 3'b000;
+      _zz_80 <= 1'b1;
       execute_LightShifterPlugin_isActive <= 1'b0;
-      _zz_94_ <= 1'b0;
+      _zz_91 <= 1'b0;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -3648,13 +3282,11 @@ module VexRiscv (
       CsrPlugin_pipelineLiberator_pcValids_2 <= 1'b0;
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
-      _zz_113_ <= 32'h0;
+      _zz_108 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_116_ <= (3'b000);
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
+      _zz_111 <= 3'b000;
       iBus_cmd_m2sPipe_rValid <= 1'b0;
       dBus_cmd_halfPipe_regs_valid <= 1'b0;
       dBus_cmd_halfPipe_regs_ready <= 1'b1;
@@ -3679,16 +3311,16 @@ module VexRiscv (
         IBusSimplePlugin_fetchPc_pcReg <= IBusSimplePlugin_fetchPc_pc;
       end
       if(IBusSimplePlugin_iBusRsp_flush)begin
-        _zz_57_ <= 1'b0;
+        _zz_54 <= 1'b0;
       end
-      if(_zz_55_)begin
-        _zz_57_ <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_52)begin
+        _zz_54 <= (IBusSimplePlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(decode_arbitration_removeIt)begin
-        _zz_58_ <= 1'b0;
+        _zz_55 <= 1'b0;
       end
       if(IBusSimplePlugin_iBusRsp_output_ready)begin
-        _zz_58_ <= (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_externalFlush));
+        _zz_55 <= (IBusSimplePlugin_iBusRsp_output_valid && (! IBusSimplePlugin_externalFlush));
       end
       if(IBusSimplePlugin_fetchPc_flushed)begin
         IBusSimplePlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -3733,13 +3365,33 @@ module VexRiscv (
         IBusSimplePlugin_injector_nextPcCalc_valids_4 <= 1'b0;
       end
       IBusSimplePlugin_pending_value <= IBusSimplePlugin_pending_next;
-      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_182_);
+      IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_rspJoin_rspBuffer_discardCounter - _zz_174);
       if(IBusSimplePlugin_iBusRsp_flush)begin
-        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_184_);
+        IBusSimplePlugin_rspJoin_rspBuffer_discardCounter <= (IBusSimplePlugin_pending_value - _zz_176);
       end
-      _zz_83_ <= 1'b0;
-      if(_zz_131_)begin
-        if(_zz_134_)begin
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)));
+        `else
+          if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)));
+        `else
+          if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
+            $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
+            $finish;
+          end
+        `endif
+      `endif
+      _zz_80 <= 1'b0;
+      if(_zz_125)begin
+        if(_zz_144)begin
           execute_LightShifterPlugin_isActive <= 1'b1;
           if(execute_LightShifterPlugin_done)begin
             execute_LightShifterPlugin_isActive <= 1'b0;
@@ -3749,7 +3401,7 @@ module VexRiscv (
       if(execute_arbitration_removeIt)begin
         execute_LightShifterPlugin_isActive <= 1'b0;
       end
-      _zz_94_ <= (_zz_38_ && writeBack_arbitration_isFiring);
+      _zz_91 <= (_zz_38 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -3771,14 +3423,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_154_)begin
-        if(_zz_155_)begin
+      if(_zz_145)begin
+        if(_zz_146)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_156_)begin
+        if(_zz_147)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_157_)begin
+        if(_zz_148)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -3802,7 +3454,7 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_138_)begin
+      if(_zz_130)begin
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -3813,10 +3465,10 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_139_)begin
-        case(_zz_141_)
+      if(_zz_131)begin
+        case(_zz_133)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
           end
@@ -3824,13 +3476,7 @@ module VexRiscv (
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_108_,{_zz_107_,_zz_106_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= memory_REGFILE_WRITE_DATA;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
+      execute_CsrPlugin_wfiWake <= (({_zz_105,{_zz_104,_zz_103}} != 3'b000) || CsrPlugin_thirdPartyWake);
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -3849,25 +3495,25 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_116_)
+      case(_zz_111)
         3'b000 : begin
           if(IBusSimplePlugin_injectionPort_valid)begin
-            _zz_116_ <= (3'b001);
+            _zz_111 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_116_ <= (3'b010);
+          _zz_111 <= 3'b010;
         end
         3'b010 : begin
-          _zz_116_ <= (3'b011);
+          _zz_111 <= 3'b011;
         end
         3'b011 : begin
           if((! decode_arbitration_isStuck))begin
-            _zz_116_ <= (3'b100);
+            _zz_111 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_116_ <= (3'b000);
+          _zz_111 <= 3'b000;
         end
         default : begin
         end
@@ -3875,26 +3521,26 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_207_[0];
-          CsrPlugin_mstatus_MIE <= _zz_208_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_197[0];
+          CsrPlugin_mstatus_MIE <= _zz_198[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_210_[0];
-          CsrPlugin_mie_MTIE <= _zz_211_[0];
-          CsrPlugin_mie_MSIE <= _zz_212_[0];
+          CsrPlugin_mie_MEIE <= _zz_200[0];
+          CsrPlugin_mie_MTIE <= _zz_201[0];
+          CsrPlugin_mie_MSIE <= _zz_202[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_113_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_108 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
       if(iBus_cmd_ready)begin
         iBus_cmd_m2sPipe_rValid <= iBus_cmd_valid;
       end
-      if(_zz_158_)begin
+      if(_zz_149)begin
         dBus_cmd_halfPipe_regs_valid <= dBus_cmd_valid;
         dBus_cmd_halfPipe_regs_ready <= (! dBus_cmd_valid);
       end else begin
@@ -3906,49 +3552,20 @@ module VexRiscv (
 
   always @ (posedge clk) begin
     if(IBusSimplePlugin_iBusRsp_output_ready)begin
-      _zz_59_ <= IBusSimplePlugin_iBusRsp_output_payload_pc;
-      _zz_60_ <= IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
-      _zz_61_ <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
-      _zz_62_ <= IBusSimplePlugin_iBusRsp_output_payload_isRvc;
+      _zz_56 <= IBusSimplePlugin_iBusRsp_output_payload_pc;
+      _zz_57 <= IBusSimplePlugin_iBusRsp_output_payload_rsp_error;
+      _zz_58 <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
+      _zz_59 <= IBusSimplePlugin_iBusRsp_output_payload_isRvc;
     end
     if(IBusSimplePlugin_injector_decodeInput_ready)begin
       IBusSimplePlugin_injector_formal_rawInDecode <= IBusSimplePlugin_iBusRsp_output_payload_rsp_inst;
     end
-    if(IBusSimplePlugin_iBusRsp_stages_1_output_ready)begin
-      IBusSimplePlugin_mmu_joinCtx_physicalAddress <= IBusSimplePlugin_mmuBus_rsp_physicalAddress;
-      IBusSimplePlugin_mmu_joinCtx_isIoAccess <= IBusSimplePlugin_mmuBus_rsp_isIoAccess;
-      IBusSimplePlugin_mmu_joinCtx_allowRead <= IBusSimplePlugin_mmuBus_rsp_allowRead;
-      IBusSimplePlugin_mmu_joinCtx_allowWrite <= IBusSimplePlugin_mmuBus_rsp_allowWrite;
-      IBusSimplePlugin_mmu_joinCtx_allowExecute <= IBusSimplePlugin_mmuBus_rsp_allowExecute;
-      IBusSimplePlugin_mmu_joinCtx_exception <= IBusSimplePlugin_mmuBus_rsp_exception;
-      IBusSimplePlugin_mmu_joinCtx_refilling <= IBusSimplePlugin_mmuBus_rsp_refilling;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck)))
-      `else
-        if(!(! (((dBus_rsp_ready && memory_MEMORY_ENABLE) && memory_arbitration_isValid) && memory_arbitration_isStuck))) begin
-          $display("FAILURE DBusSimplePlugin doesn't allow memory stage stall when read happend");
-          $finish;
-        end
-      `endif
-    `endif
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck)))
-      `else
-        if(!(! (((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE) && (! writeBack_MEMORY_STORE)) && writeBack_arbitration_isStuck))) begin
-          $display("FAILURE DBusSimplePlugin doesn't allow writeback stage stall when read happend");
-          $finish;
-        end
-      `endif
-    `endif
-    if(_zz_131_)begin
-      if(_zz_134_)begin
+    if(_zz_125)begin
+      if(_zz_144)begin
         execute_LightShifterPlugin_amplitudeReg <= (execute_LightShifterPlugin_amplitude - 5'h01);
       end
     end
-    _zz_95_ <= _zz_37_[11 : 7];
+    _zz_92 <= _zz_37[11 : 7];
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -3956,33 +3573,33 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_133_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_110_ ? IBusSimplePlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_110_ ? IBusSimplePlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(decodeExceptionPort_valid)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= decodeExceptionPort_payload_code;
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= decodeExceptionPort_payload_badAddr;
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= CsrPlugin_selfException_payload_badAddr;
     end
-    if(_zz_137_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_112_ ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_112_ ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
+    if(_zz_129)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_107 ? DBusSimplePlugin_memoryExceptionPort_payload_code : BranchPlugin_branchExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_107 ? DBusSimplePlugin_memoryExceptionPort_payload_badAddr : BranchPlugin_branchExceptionPort_payload_badAddr);
     end
-    if(_zz_154_)begin
-      if(_zz_155_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_145)begin
+      if(_zz_146)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_156_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_147)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_157_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_148)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_138_)begin
+    if(_zz_130)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -3998,34 +3615,13 @@ module VexRiscv (
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_24_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+      decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+      execute_to_memory_PC <= _zz_32;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
-    end
-    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_21_;
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
@@ -4033,65 +3629,23 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+      decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MMU_RSP_physicalAddress <= execute_MMU_RSP_physicalAddress;
-      execute_to_memory_MMU_RSP_isIoAccess <= execute_MMU_RSP_isIoAccess;
-      execute_to_memory_MMU_RSP_allowRead <= execute_MMU_RSP_allowRead;
-      execute_to_memory_MMU_RSP_allowWrite <= execute_MMU_RSP_allowWrite;
-      execute_to_memory_MMU_RSP_allowExecute <= execute_MMU_RSP_allowExecute;
-      execute_to_memory_MMU_RSP_exception <= execute_MMU_RSP_exception;
-      execute_to_memory_MMU_RSP_refilling <= execute_MMU_RSP_refilling;
+      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_48;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+      decode_to_execute_SRC1_CTRL <= _zz_24;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MMU_FAULT <= execute_MMU_FAULT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_18_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_15_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_12_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_9_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_7_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_32_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -4102,8 +3656,29 @@ module VexRiscv (
     if((! writeBack_arbitration_isStuck))begin
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_CTRL <= _zz_21;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_18;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
+    end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_STORE <= decode_MEMORY_STORE;
@@ -4115,37 +3690,73 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_STORE <= memory_MEMORY_STORE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= decode_FORMAL_PC_NEXT;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_48_;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_15;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_12;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_9;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_RS1 <= decode_RS1;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_5_;
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ALIGNEMENT_FAULT <= execute_ALIGNEMENT_FAULT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if(((! memory_arbitration_isStuck) && (! execute_arbitration_isStuckByOthers)))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_30;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= memory_REGFILE_WRITE_DATA;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_2_;
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_READ_DATA <= memory_MEMORY_READ_DATA;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((_zz_116_ != (3'b000)))begin
-      _zz_61_ <= IBusSimplePlugin_injectionPort_payload;
+    if((_zz_111 != 3'b000))begin
+      _zz_58 <= IBusSimplePlugin_injectionPort_payload;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_768 <= (decode_INSTRUCTION[31 : 20] == 12'h300);
@@ -4176,7 +3787,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_209_[0];
+        CsrPlugin_mip_MSIP <= _zz_199[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -4193,7 +3804,7 @@ module VexRiscv (
     if(iBus_cmd_ready)begin
       iBus_cmd_m2sPipe_rData_pc <= iBus_cmd_payload_pc;
     end
-    if(_zz_158_)begin
+    if(_zz_149)begin
       dBus_cmd_halfPipe_regs_payload_wr <= dBus_cmd_payload_wr;
       dBus_cmd_halfPipe_regs_payload_address <= dBus_cmd_payload_address;
       dBus_cmd_halfPipe_regs_payload_data <= dBus_cmd_payload_data;
@@ -4207,12 +3818,12 @@ module VexRiscv (
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
-    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != (4'b0000)) || IBusSimplePlugin_incomingInstruction);
+    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusSimplePlugin_incomingInstruction);
     if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_47_;
+      DebugPlugin_busReadDataReg <= _zz_47;
     end
-    _zz_115_ <= debug_bus_cmd_payload_address[2];
-    if(_zz_135_)begin
+    _zz_110 <= debug_bus_cmd_payload_address[2];
+    if(_zz_127)begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -4230,8 +3841,8 @@ module VexRiscv (
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid)begin
-        case(_zz_153_)
-          6'b000000 : begin
+        case(_zz_143)
+          6'h0 : begin
             if(debug_bus_cmd_payload_wr)begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
               if(debug_bus_cmd_payload_data[16])begin
@@ -4254,23 +3865,150 @@ module VexRiscv (
               end
             end
           end
-          6'b000001 : begin
-          end
           default : begin
           end
         endcase
       end
-      if(_zz_135_)begin
-        if(_zz_136_)begin
+      if(_zz_127)begin
+        if(_zz_128)begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_140_)begin
+      if(_zz_132)begin
         if(decode_arbitration_isValid)begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
+    end
+  end
+
+
+endmodule
+
+module StreamFifoLowLatency (
+  input               io_push_valid,
+  output              io_push_ready,
+  input               io_push_payload_error,
+  input      [31:0]   io_push_payload_inst,
+  output reg          io_pop_valid,
+  input               io_pop_ready,
+  output reg          io_pop_payload_error,
+  output reg [31:0]   io_pop_payload_inst,
+  input               io_flush,
+  output     [0:0]    io_occupancy,
+  input               clk,
+  input               reset
+);
+  wire                _zz_4;
+  wire       [0:0]    _zz_5;
+  reg                 _zz_1;
+  reg                 pushPtr_willIncrement;
+  reg                 pushPtr_willClear;
+  wire                pushPtr_willOverflowIfInc;
+  wire                pushPtr_willOverflow;
+  reg                 popPtr_willIncrement;
+  reg                 popPtr_willClear;
+  wire                popPtr_willOverflowIfInc;
+  wire                popPtr_willOverflow;
+  wire                ptrMatch;
+  reg                 risingOccupancy;
+  wire                empty;
+  wire                full;
+  wire                pushing;
+  wire                popping;
+  wire       [32:0]   _zz_2;
+  reg        [32:0]   _zz_3;
+
+  assign _zz_4 = (! empty);
+  assign _zz_5 = _zz_2[0 : 0];
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(pushing)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    pushPtr_willIncrement = 1'b0;
+    if(pushing)begin
+      pushPtr_willIncrement = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    pushPtr_willClear = 1'b0;
+    if(io_flush)begin
+      pushPtr_willClear = 1'b1;
+    end
+  end
+
+  assign pushPtr_willOverflowIfInc = 1'b1;
+  assign pushPtr_willOverflow = (pushPtr_willOverflowIfInc && pushPtr_willIncrement);
+  always @ (*) begin
+    popPtr_willIncrement = 1'b0;
+    if(popping)begin
+      popPtr_willIncrement = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    popPtr_willClear = 1'b0;
+    if(io_flush)begin
+      popPtr_willClear = 1'b1;
+    end
+  end
+
+  assign popPtr_willOverflowIfInc = 1'b1;
+  assign popPtr_willOverflow = (popPtr_willOverflowIfInc && popPtr_willIncrement);
+  assign ptrMatch = 1'b1;
+  assign empty = (ptrMatch && (! risingOccupancy));
+  assign full = (ptrMatch && risingOccupancy);
+  assign pushing = (io_push_valid && io_push_ready);
+  assign popping = (io_pop_valid && io_pop_ready);
+  assign io_push_ready = (! full);
+  always @ (*) begin
+    if(_zz_4)begin
+      io_pop_valid = 1'b1;
+    end else begin
+      io_pop_valid = io_push_valid;
+    end
+  end
+
+  assign _zz_2 = _zz_3;
+  always @ (*) begin
+    if(_zz_4)begin
+      io_pop_payload_error = _zz_5[0];
+    end else begin
+      io_pop_payload_error = io_push_payload_error;
+    end
+  end
+
+  always @ (*) begin
+    if(_zz_4)begin
+      io_pop_payload_inst = _zz_2[32 : 1];
+    end else begin
+      io_pop_payload_inst = io_push_payload_inst;
+    end
+  end
+
+  assign io_occupancy = (risingOccupancy && ptrMatch);
+  always @ (posedge clk) begin
+    if(reset) begin
+      risingOccupancy <= 1'b0;
+    end else begin
+      if((pushing != popping))begin
+        risingOccupancy <= pushing;
+      end
+      if(io_flush)begin
+        risingOccupancy <= 1'b0;
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_1)begin
+      _zz_3 <= {io_push_payload_inst,io_push_payload_error};
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_Secure.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_Secure.v
@@ -1,35 +1,7 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 16:40:40
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
-
-`define Src2CtrlEnum_defaultEncoding_type [1:0]
-`define Src2CtrlEnum_defaultEncoding_RS 2'b00
-`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
-`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
-`define Src2CtrlEnum_defaultEncoding_PC 2'b11
-
-`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
-`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
-`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
-`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
-
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
-
-`define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
-
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
@@ -43,1013 +15,34 @@
 `define BranchCtrlEnum_defaultEncoding_JAL 2'b10
 `define BranchCtrlEnum_defaultEncoding_JALR 2'b11
 
+`define ShiftCtrlEnum_defaultEncoding_type [1:0]
+`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire       [0:0]    _zz_14_;
-  wire       [0:0]    _zz_15_;
-  wire       [21:0]   _zz_16_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* syn_keep , keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* syn_keep , keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
+`define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
+`define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
+`define AluBitwiseCtrlEnum_defaultEncoding_OR_1 2'b01
+`define AluBitwiseCtrlEnum_defaultEncoding_AND_1 2'b10
 
-  assign _zz_12_ = (! lineLoader_flushCounter[7]);
-  assign _zz_13_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_14_ = _zz_7_[0 : 0];
-  assign _zz_15_ = _zz_7_[1 : 1];
-  assign _zz_16_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_16_;
-    end
-  end
+`define Src2CtrlEnum_defaultEncoding_type [1:0]
+`define Src2CtrlEnum_defaultEncoding_RS 2'b00
+`define Src2CtrlEnum_defaultEncoding_IMI 2'b01
+`define Src2CtrlEnum_defaultEncoding_IMS 2'b10
+`define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_10_ <= ways_0_tags[_zz_5_];
-    end
-  end
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_11_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_12_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_10_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_14_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_15_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_11_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_13_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_12_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_13_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [0:0]    _zz_18_;
-  wire       [0:0]    _zz_19_;
-  wire       [2:0]    _zz_20_;
-  wire       [1:0]    _zz_21_;
-  wire       [21:0]   _zz_22_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  wire       [31:0]   stageB_requestDataBypass;
-  wire                stageB_isAmo;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_23_;
-  reg [7:0] _zz_24_;
-  reg [7:0] _zz_25_;
-  reg [7:0] _zz_26_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmo)));
-  assign _zz_15_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_16_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_17_ = _zz_4_[0 : 0];
-  assign _zz_18_ = _zz_4_[1 : 1];
-  assign _zz_19_ = loader_counter_willIncrement;
-  assign _zz_20_ = {2'd0, _zz_19_};
-  assign _zz_21_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_22_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_22_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_26_, _zz_25_, _zz_24_, _zz_23_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_23_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_24_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_25_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_26_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_17_[0];
-  assign ways_0_tagsReadRsp_error = _zz_18_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  assign stageB_requestDataBypass = stageB_request_data;
-  assign stageB_isAmo = 1'b0;
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((((! stageB_request_wr) || stageB_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0))))begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_15_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_20_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_16_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_16_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_15_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_21_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1065,8 +58,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1076,46 +69,63 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
-  input               reset 
+  input               reset
 );
-  wire                _zz_561_;
-  wire                _zz_562_;
-  wire                _zz_563_;
-  wire                _zz_564_;
-  wire                _zz_565_;
-  wire                _zz_566_;
-  wire                _zz_567_;
-  reg                 _zz_568_;
-  wire                _zz_569_;
-  wire       [31:0]   _zz_570_;
-  wire                _zz_571_;
-  wire       [31:0]   _zz_572_;
-  reg                 _zz_573_;
-  wire                _zz_574_;
-  wire                _zz_575_;
-  wire       [31:0]   _zz_576_;
-  wire                _zz_577_;
-  wire                _zz_578_;
-  reg        [31:0]   _zz_579_;
-  reg        [31:0]   _zz_580_;
-  reg        [31:0]   _zz_581_;
-  reg                 _zz_582_;
-  reg                 _zz_583_;
-  reg                 _zz_584_;
-  reg                 _zz_585_;
-  reg                 _zz_586_;
-  reg                 _zz_587_;
+  wire                _zz_622;
+  wire                _zz_623;
+  wire                _zz_624;
+  wire                _zz_625;
+  wire                _zz_626;
+  wire                _zz_627;
+  wire                _zz_628;
+  wire                _zz_629;
+  reg                 _zz_630;
+  wire                _zz_631;
+  wire       [31:0]   _zz_632;
+  wire                _zz_633;
+  wire       [31:0]   _zz_634;
+  reg                 _zz_635;
+  wire                _zz_636;
+  wire                _zz_637;
+  wire       [31:0]   _zz_638;
+  wire                _zz_639;
+  wire                _zz_640;
+  wire                _zz_641;
+  wire                _zz_642;
+  wire                _zz_643;
+  wire                _zz_644;
+  wire                _zz_645;
+  wire                _zz_646;
+  wire       [3:0]    _zz_647;
+  wire                _zz_648;
+  wire                _zz_649;
+  reg        [31:0]   _zz_650;
+  reg        [31:0]   _zz_651;
+  reg        [31:0]   _zz_652;
+  reg        [4:0]    _zz_653;
+  reg        [4:0]    _zz_654;
+  reg        [4:0]    _zz_655;
+  reg        [4:0]    _zz_656;
+  reg        [4:0]    _zz_657;
+  reg        [4:0]    _zz_658;
+  reg                 _zz_659;
+  reg                 _zz_660;
+  reg                 _zz_661;
+  reg        [4:0]    _zz_662;
+  reg        [4:0]    _zz_663;
+  reg        [4:0]    _zz_664;
+  reg        [4:0]    _zz_665;
+  reg        [4:0]    _zz_666;
+  reg        [4:0]    _zz_667;
+  reg                 _zz_668;
+  reg                 _zz_669;
+  reg                 _zz_670;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -1125,583 +135,610 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_588_;
-  wire                _zz_589_;
-  wire                _zz_590_;
-  wire                _zz_591_;
-  wire                _zz_592_;
-  wire                _zz_593_;
-  wire                _zz_594_;
-  wire                _zz_595_;
-  wire                _zz_596_;
-  wire                _zz_597_;
-  wire                _zz_598_;
-  wire                _zz_599_;
-  wire                _zz_600_;
-  wire                _zz_601_;
-  wire       [1:0]    _zz_602_;
-  wire                _zz_603_;
-  wire                _zz_604_;
-  wire                _zz_605_;
-  wire                _zz_606_;
-  wire                _zz_607_;
-  wire                _zz_608_;
-  wire                _zz_609_;
-  wire                _zz_610_;
-  wire                _zz_611_;
-  wire                _zz_612_;
-  wire                _zz_613_;
-  wire                _zz_614_;
-  wire       [1:0]    _zz_615_;
-  wire                _zz_616_;
-  wire                _zz_617_;
-  wire                _zz_618_;
-  wire                _zz_619_;
-  wire                _zz_620_;
-  wire                _zz_621_;
-  wire                _zz_622_;
-  wire                _zz_623_;
-  wire                _zz_624_;
-  wire                _zz_625_;
-  wire                _zz_626_;
-  wire                _zz_627_;
-  wire                _zz_628_;
-  wire                _zz_629_;
-  wire                _zz_630_;
-  wire                _zz_631_;
-  wire                _zz_632_;
-  wire                _zz_633_;
-  wire                _zz_634_;
-  wire                _zz_635_;
-  wire                _zz_636_;
-  wire                _zz_637_;
-  wire                _zz_638_;
-  wire                _zz_639_;
-  wire       [1:0]    _zz_640_;
-  wire                _zz_641_;
-  wire       [1:0]    _zz_642_;
-  wire       [0:0]    _zz_643_;
-  wire       [51:0]   _zz_644_;
-  wire       [51:0]   _zz_645_;
-  wire       [51:0]   _zz_646_;
-  wire       [32:0]   _zz_647_;
-  wire       [51:0]   _zz_648_;
-  wire       [49:0]   _zz_649_;
-  wire       [51:0]   _zz_650_;
-  wire       [49:0]   _zz_651_;
-  wire       [51:0]   _zz_652_;
-  wire       [0:0]    _zz_653_;
-  wire       [0:0]    _zz_654_;
-  wire       [32:0]   _zz_655_;
-  wire       [31:0]   _zz_656_;
-  wire       [32:0]   _zz_657_;
-  wire       [0:0]    _zz_658_;
-  wire       [0:0]    _zz_659_;
-  wire       [0:0]    _zz_660_;
-  wire       [0:0]    _zz_661_;
-  wire       [0:0]    _zz_662_;
-  wire       [0:0]    _zz_663_;
-  wire       [0:0]    _zz_664_;
-  wire       [0:0]    _zz_665_;
-  wire       [0:0]    _zz_666_;
-  wire       [0:0]    _zz_667_;
-  wire       [0:0]    _zz_668_;
-  wire       [0:0]    _zz_669_;
-  wire       [0:0]    _zz_670_;
-  wire       [0:0]    _zz_671_;
-  wire       [3:0]    _zz_672_;
-  wire       [2:0]    _zz_673_;
-  wire       [31:0]   _zz_674_;
-  wire       [11:0]   _zz_675_;
-  wire       [31:0]   _zz_676_;
-  wire       [19:0]   _zz_677_;
-  wire       [11:0]   _zz_678_;
-  wire       [31:0]   _zz_679_;
-  wire       [31:0]   _zz_680_;
-  wire       [19:0]   _zz_681_;
-  wire       [11:0]   _zz_682_;
-  wire       [2:0]    _zz_683_;
-  wire       [2:0]    _zz_684_;
-  wire       [31:0]   _zz_685_;
-  wire       [31:0]   _zz_686_;
-  wire       [31:0]   _zz_687_;
-  wire       [31:0]   _zz_688_;
-  wire       [31:0]   _zz_689_;
-  wire       [31:0]   _zz_690_;
-  wire       [31:0]   _zz_691_;
-  wire       [31:0]   _zz_692_;
-  wire       [31:0]   _zz_693_;
-  wire       [31:0]   _zz_694_;
-  wire       [31:0]   _zz_695_;
-  wire       [31:0]   _zz_696_;
-  wire       [31:0]   _zz_697_;
-  wire       [31:0]   _zz_698_;
-  wire       [31:0]   _zz_699_;
-  wire       [31:0]   _zz_700_;
-  wire       [31:0]   _zz_701_;
-  wire       [31:0]   _zz_702_;
-  wire       [31:0]   _zz_703_;
-  wire       [31:0]   _zz_704_;
-  wire       [31:0]   _zz_705_;
-  wire       [31:0]   _zz_706_;
-  wire       [31:0]   _zz_707_;
-  wire       [31:0]   _zz_708_;
-  wire       [31:0]   _zz_709_;
-  wire       [31:0]   _zz_710_;
-  wire       [31:0]   _zz_711_;
-  wire       [31:0]   _zz_712_;
-  wire       [31:0]   _zz_713_;
-  wire       [31:0]   _zz_714_;
-  wire       [31:0]   _zz_715_;
-  wire       [31:0]   _zz_716_;
-  wire       [31:0]   _zz_717_;
-  wire       [31:0]   _zz_718_;
-  wire       [31:0]   _zz_719_;
-  wire       [31:0]   _zz_720_;
-  wire       [31:0]   _zz_721_;
-  wire       [31:0]   _zz_722_;
-  wire       [31:0]   _zz_723_;
-  wire       [31:0]   _zz_724_;
-  wire       [31:0]   _zz_725_;
-  wire       [31:0]   _zz_726_;
-  wire       [31:0]   _zz_727_;
-  wire       [31:0]   _zz_728_;
-  wire       [31:0]   _zz_729_;
-  wire       [31:0]   _zz_730_;
-  wire       [31:0]   _zz_731_;
-  wire       [31:0]   _zz_732_;
-  wire       [15:0]   _zz_733_;
-  wire       [15:0]   _zz_734_;
-  wire       [15:0]   _zz_735_;
-  wire       [15:0]   _zz_736_;
-  wire       [15:0]   _zz_737_;
-  wire       [15:0]   _zz_738_;
-  wire       [0:0]    _zz_739_;
-  wire       [2:0]    _zz_740_;
-  wire       [4:0]    _zz_741_;
-  wire       [11:0]   _zz_742_;
-  wire       [11:0]   _zz_743_;
-  wire       [31:0]   _zz_744_;
-  wire       [31:0]   _zz_745_;
-  wire       [31:0]   _zz_746_;
-  wire       [31:0]   _zz_747_;
-  wire       [31:0]   _zz_748_;
-  wire       [31:0]   _zz_749_;
-  wire       [31:0]   _zz_750_;
-  wire       [11:0]   _zz_751_;
-  wire       [19:0]   _zz_752_;
-  wire       [11:0]   _zz_753_;
-  wire       [31:0]   _zz_754_;
-  wire       [31:0]   _zz_755_;
-  wire       [31:0]   _zz_756_;
-  wire       [11:0]   _zz_757_;
-  wire       [19:0]   _zz_758_;
-  wire       [11:0]   _zz_759_;
-  wire       [2:0]    _zz_760_;
-  wire       [1:0]    _zz_761_;
-  wire       [1:0]    _zz_762_;
-  wire       [65:0]   _zz_763_;
-  wire       [65:0]   _zz_764_;
-  wire       [31:0]   _zz_765_;
-  wire       [31:0]   _zz_766_;
-  wire       [0:0]    _zz_767_;
-  wire       [5:0]    _zz_768_;
-  wire       [32:0]   _zz_769_;
-  wire       [31:0]   _zz_770_;
-  wire       [31:0]   _zz_771_;
-  wire       [32:0]   _zz_772_;
-  wire       [32:0]   _zz_773_;
-  wire       [32:0]   _zz_774_;
-  wire       [32:0]   _zz_775_;
-  wire       [0:0]    _zz_776_;
-  wire       [32:0]   _zz_777_;
-  wire       [0:0]    _zz_778_;
-  wire       [32:0]   _zz_779_;
-  wire       [0:0]    _zz_780_;
-  wire       [31:0]   _zz_781_;
-  wire       [0:0]    _zz_782_;
-  wire       [0:0]    _zz_783_;
-  wire       [0:0]    _zz_784_;
-  wire       [0:0]    _zz_785_;
-  wire       [0:0]    _zz_786_;
-  wire       [0:0]    _zz_787_;
-  wire       [0:0]    _zz_788_;
-  wire       [0:0]    _zz_789_;
-  wire       [0:0]    _zz_790_;
-  wire       [0:0]    _zz_791_;
-  wire       [0:0]    _zz_792_;
-  wire       [0:0]    _zz_793_;
-  wire       [0:0]    _zz_794_;
-  wire       [0:0]    _zz_795_;
-  wire       [0:0]    _zz_796_;
-  wire       [0:0]    _zz_797_;
-  wire       [0:0]    _zz_798_;
-  wire       [0:0]    _zz_799_;
-  wire       [0:0]    _zz_800_;
-  wire       [0:0]    _zz_801_;
-  wire       [0:0]    _zz_802_;
-  wire       [0:0]    _zz_803_;
-  wire       [0:0]    _zz_804_;
-  wire       [0:0]    _zz_805_;
-  wire       [0:0]    _zz_806_;
-  wire       [0:0]    _zz_807_;
-  wire       [0:0]    _zz_808_;
-  wire       [0:0]    _zz_809_;
-  wire       [0:0]    _zz_810_;
-  wire       [0:0]    _zz_811_;
-  wire       [0:0]    _zz_812_;
-  wire       [0:0]    _zz_813_;
-  wire       [0:0]    _zz_814_;
-  wire       [0:0]    _zz_815_;
-  wire       [0:0]    _zz_816_;
-  wire       [0:0]    _zz_817_;
-  wire       [0:0]    _zz_818_;
-  wire       [0:0]    _zz_819_;
-  wire       [0:0]    _zz_820_;
-  wire       [0:0]    _zz_821_;
-  wire       [0:0]    _zz_822_;
-  wire       [0:0]    _zz_823_;
-  wire       [0:0]    _zz_824_;
-  wire       [0:0]    _zz_825_;
-  wire       [0:0]    _zz_826_;
-  wire       [0:0]    _zz_827_;
-  wire       [0:0]    _zz_828_;
-  wire       [0:0]    _zz_829_;
-  wire       [0:0]    _zz_830_;
-  wire       [0:0]    _zz_831_;
-  wire       [0:0]    _zz_832_;
-  wire       [0:0]    _zz_833_;
-  wire       [0:0]    _zz_834_;
-  wire       [0:0]    _zz_835_;
-  wire       [0:0]    _zz_836_;
-  wire       [0:0]    _zz_837_;
-  wire       [0:0]    _zz_838_;
-  wire       [0:0]    _zz_839_;
-  wire       [0:0]    _zz_840_;
-  wire       [0:0]    _zz_841_;
-  wire       [0:0]    _zz_842_;
-  wire       [0:0]    _zz_843_;
-  wire       [0:0]    _zz_844_;
-  wire       [0:0]    _zz_845_;
-  wire       [0:0]    _zz_846_;
-  wire       [0:0]    _zz_847_;
-  wire       [0:0]    _zz_848_;
-  wire       [0:0]    _zz_849_;
-  wire       [0:0]    _zz_850_;
-  wire       [0:0]    _zz_851_;
-  wire       [0:0]    _zz_852_;
-  wire       [26:0]   _zz_853_;
-  wire                _zz_854_;
-  wire                _zz_855_;
-  wire       [1:0]    _zz_856_;
-  wire       [3:0]    _zz_857_;
-  wire       [3:0]    _zz_858_;
-  wire       [3:0]    _zz_859_;
-  wire       [3:0]    _zz_860_;
-  wire       [3:0]    _zz_861_;
-  wire       [3:0]    _zz_862_;
-  wire       [31:0]   _zz_863_;
-  wire       [31:0]   _zz_864_;
-  wire       [31:0]   _zz_865_;
-  wire                _zz_866_;
-  wire       [0:0]    _zz_867_;
-  wire       [13:0]   _zz_868_;
-  wire       [31:0]   _zz_869_;
-  wire       [31:0]   _zz_870_;
-  wire       [31:0]   _zz_871_;
-  wire                _zz_872_;
-  wire       [0:0]    _zz_873_;
-  wire       [7:0]    _zz_874_;
-  wire       [31:0]   _zz_875_;
-  wire       [31:0]   _zz_876_;
-  wire       [31:0]   _zz_877_;
-  wire                _zz_878_;
-  wire       [0:0]    _zz_879_;
-  wire       [1:0]    _zz_880_;
-  wire                _zz_881_;
-  wire                _zz_882_;
-  wire                _zz_883_;
-  wire       [0:0]    _zz_884_;
-  wire       [4:0]    _zz_885_;
-  wire       [0:0]    _zz_886_;
-  wire       [4:0]    _zz_887_;
-  wire       [0:0]    _zz_888_;
-  wire       [4:0]    _zz_889_;
-  wire       [0:0]    _zz_890_;
-  wire       [4:0]    _zz_891_;
-  wire       [0:0]    _zz_892_;
-  wire       [4:0]    _zz_893_;
-  wire       [0:0]    _zz_894_;
-  wire       [4:0]    _zz_895_;
-  wire       [31:0]   _zz_896_;
-  wire       [31:0]   _zz_897_;
-  wire       [31:0]   _zz_898_;
-  wire       [31:0]   _zz_899_;
-  wire                _zz_900_;
-  wire       [4:0]    _zz_901_;
-  wire       [4:0]    _zz_902_;
-  wire                _zz_903_;
-  wire       [0:0]    _zz_904_;
-  wire       [25:0]   _zz_905_;
-  wire       [31:0]   _zz_906_;
-  wire       [31:0]   _zz_907_;
-  wire       [0:0]    _zz_908_;
-  wire       [1:0]    _zz_909_;
-  wire       [0:0]    _zz_910_;
-  wire       [3:0]    _zz_911_;
-  wire       [0:0]    _zz_912_;
-  wire       [1:0]    _zz_913_;
-  wire       [0:0]    _zz_914_;
-  wire       [0:0]    _zz_915_;
-  wire                _zz_916_;
-  wire       [0:0]    _zz_917_;
-  wire       [22:0]   _zz_918_;
-  wire       [31:0]   _zz_919_;
-  wire       [31:0]   _zz_920_;
-  wire                _zz_921_;
-  wire                _zz_922_;
-  wire       [31:0]   _zz_923_;
-  wire       [31:0]   _zz_924_;
-  wire                _zz_925_;
-  wire       [0:0]    _zz_926_;
-  wire       [1:0]    _zz_927_;
-  wire       [31:0]   _zz_928_;
-  wire       [31:0]   _zz_929_;
-  wire                _zz_930_;
-  wire                _zz_931_;
-  wire       [31:0]   _zz_932_;
-  wire       [31:0]   _zz_933_;
-  wire                _zz_934_;
-  wire       [0:0]    _zz_935_;
-  wire       [0:0]    _zz_936_;
-  wire                _zz_937_;
-  wire       [0:0]    _zz_938_;
-  wire       [20:0]   _zz_939_;
-  wire       [31:0]   _zz_940_;
-  wire       [31:0]   _zz_941_;
-  wire       [31:0]   _zz_942_;
-  wire       [31:0]   _zz_943_;
-  wire       [31:0]   _zz_944_;
-  wire                _zz_945_;
-  wire                _zz_946_;
-  wire       [31:0]   _zz_947_;
-  wire       [31:0]   _zz_948_;
-  wire       [31:0]   _zz_949_;
-  wire       [31:0]   _zz_950_;
-  wire       [31:0]   _zz_951_;
-  wire                _zz_952_;
-  wire       [4:0]    _zz_953_;
-  wire       [4:0]    _zz_954_;
-  wire                _zz_955_;
-  wire       [0:0]    _zz_956_;
-  wire       [18:0]   _zz_957_;
-  wire       [31:0]   _zz_958_;
-  wire       [31:0]   _zz_959_;
-  wire                _zz_960_;
-  wire       [0:0]    _zz_961_;
-  wire       [1:0]    _zz_962_;
-  wire                _zz_963_;
-  wire                _zz_964_;
-  wire       [0:0]    _zz_965_;
-  wire       [1:0]    _zz_966_;
-  wire       [3:0]    _zz_967_;
-  wire       [3:0]    _zz_968_;
-  wire                _zz_969_;
-  wire       [0:0]    _zz_970_;
-  wire       [15:0]   _zz_971_;
-  wire       [31:0]   _zz_972_;
-  wire       [31:0]   _zz_973_;
-  wire       [31:0]   _zz_974_;
-  wire                _zz_975_;
-  wire                _zz_976_;
-  wire       [31:0]   _zz_977_;
-  wire       [31:0]   _zz_978_;
-  wire       [31:0]   _zz_979_;
-  wire       [31:0]   _zz_980_;
-  wire                _zz_981_;
-  wire                _zz_982_;
-  wire                _zz_983_;
-  wire       [0:0]    _zz_984_;
-  wire       [1:0]    _zz_985_;
-  wire                _zz_986_;
-  wire       [0:0]    _zz_987_;
-  wire       [0:0]    _zz_988_;
-  wire                _zz_989_;
-  wire       [0:0]    _zz_990_;
-  wire       [13:0]   _zz_991_;
-  wire       [31:0]   _zz_992_;
-  wire       [31:0]   _zz_993_;
-  wire       [31:0]   _zz_994_;
-  wire       [31:0]   _zz_995_;
-  wire       [31:0]   _zz_996_;
-  wire       [31:0]   _zz_997_;
-  wire       [31:0]   _zz_998_;
-  wire                _zz_999_;
-  wire                _zz_1000_;
-  wire       [31:0]   _zz_1001_;
-  wire       [31:0]   _zz_1002_;
-  wire       [31:0]   _zz_1003_;
-  wire                _zz_1004_;
-  wire       [4:0]    _zz_1005_;
-  wire       [4:0]    _zz_1006_;
-  wire                _zz_1007_;
-  wire       [0:0]    _zz_1008_;
-  wire       [11:0]   _zz_1009_;
-  wire                _zz_1010_;
-  wire       [0:0]    _zz_1011_;
-  wire       [1:0]    _zz_1012_;
-  wire                _zz_1013_;
-  wire                _zz_1014_;
-  wire                _zz_1015_;
-  wire       [0:0]    _zz_1016_;
-  wire       [0:0]    _zz_1017_;
-  wire                _zz_1018_;
-  wire       [0:0]    _zz_1019_;
-  wire       [8:0]    _zz_1020_;
-  wire       [31:0]   _zz_1021_;
-  wire       [31:0]   _zz_1022_;
-  wire       [31:0]   _zz_1023_;
-  wire                _zz_1024_;
-  wire                _zz_1025_;
-  wire       [31:0]   _zz_1026_;
-  wire       [31:0]   _zz_1027_;
-  wire       [31:0]   _zz_1028_;
-  wire       [0:0]    _zz_1029_;
-  wire       [0:0]    _zz_1030_;
-  wire       [0:0]    _zz_1031_;
-  wire       [0:0]    _zz_1032_;
-  wire                _zz_1033_;
-  wire       [0:0]    _zz_1034_;
-  wire       [6:0]    _zz_1035_;
-  wire       [31:0]   _zz_1036_;
-  wire       [31:0]   _zz_1037_;
-  wire       [31:0]   _zz_1038_;
-  wire       [31:0]   _zz_1039_;
-  wire       [31:0]   _zz_1040_;
-  wire                _zz_1041_;
-  wire       [1:0]    _zz_1042_;
-  wire       [1:0]    _zz_1043_;
-  wire                _zz_1044_;
-  wire       [0:0]    _zz_1045_;
-  wire       [3:0]    _zz_1046_;
-  wire       [31:0]   _zz_1047_;
-  wire       [31:0]   _zz_1048_;
-  wire       [31:0]   _zz_1049_;
-  wire       [31:0]   _zz_1050_;
-  wire       [31:0]   _zz_1051_;
-  wire       [0:0]    _zz_1052_;
-  wire       [0:0]    _zz_1053_;
-  wire       [1:0]    _zz_1054_;
-  wire       [1:0]    _zz_1055_;
-  wire                _zz_1056_;
-  wire                _zz_1057_;
-  wire                _zz_1058_;
-  wire                _zz_1059_;
-  wire                _zz_1060_;
-  wire       [31:0]   _zz_1061_;
-  wire       [31:0]   _zz_1062_;
-  wire       [31:0]   _zz_1063_;
-  wire       [31:0]   _zz_1064_;
-  wire       [31:0]   _zz_1065_;
-  wire       [31:0]   _zz_1066_;
-  wire       [31:0]   _zz_1067_;
-  wire       [31:0]   _zz_1068_;
-  wire       [31:0]   _zz_1069_;
-  wire       [31:0]   _zz_1070_;
-  wire       [31:0]   _zz_1071_;
-  wire       [31:0]   _zz_1072_;
-  wire       [31:0]   _zz_1073_;
-  wire       [31:0]   _zz_1074_;
-  wire       [31:0]   _zz_1075_;
-  wire       [31:0]   _zz_1076_;
-  wire       [31:0]   _zz_1077_;
-  wire                decode_CSR_READ_OPCODE;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire                execute_BRANCH_DO;
-  wire                decode_IS_DIV;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_3_;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_671;
+  wire                _zz_672;
+  wire                _zz_673;
+  wire                _zz_674;
+  wire                _zz_675;
+  wire                _zz_676;
+  wire                _zz_677;
+  wire                _zz_678;
+  wire                _zz_679;
+  wire                _zz_680;
+  wire                _zz_681;
+  wire                _zz_682;
+  wire                _zz_683;
+  wire                _zz_684;
+  wire       [1:0]    _zz_685;
+  wire                _zz_686;
+  wire                _zz_687;
+  wire                _zz_688;
+  wire                _zz_689;
+  wire                _zz_690;
+  wire                _zz_691;
+  wire                _zz_692;
+  wire                _zz_693;
+  wire                _zz_694;
+  wire                _zz_695;
+  wire                _zz_696;
+  wire                _zz_697;
+  wire       [1:0]    _zz_698;
+  wire                _zz_699;
+  wire                _zz_700;
+  wire                _zz_701;
+  wire                _zz_702;
+  wire                _zz_703;
+  wire                _zz_704;
+  wire                _zz_705;
+  wire                _zz_706;
+  wire                _zz_707;
+  wire                _zz_708;
+  wire                _zz_709;
+  wire                _zz_710;
+  wire                _zz_711;
+  wire                _zz_712;
+  wire                _zz_713;
+  wire                _zz_714;
+  wire                _zz_715;
+  wire                _zz_716;
+  wire                _zz_717;
+  wire                _zz_718;
+  wire                _zz_719;
+  wire                _zz_720;
+  wire                _zz_721;
+  wire                _zz_722;
+  wire       [1:0]    _zz_723;
+  wire                _zz_724;
+  wire       [1:0]    _zz_725;
+  wire       [51:0]   _zz_726;
+  wire       [51:0]   _zz_727;
+  wire       [51:0]   _zz_728;
+  wire       [32:0]   _zz_729;
+  wire       [51:0]   _zz_730;
+  wire       [49:0]   _zz_731;
+  wire       [51:0]   _zz_732;
+  wire       [49:0]   _zz_733;
+  wire       [51:0]   _zz_734;
+  wire       [32:0]   _zz_735;
+  wire       [31:0]   _zz_736;
+  wire       [32:0]   _zz_737;
+  wire       [0:0]    _zz_738;
+  wire       [0:0]    _zz_739;
+  wire       [0:0]    _zz_740;
+  wire       [0:0]    _zz_741;
+  wire       [0:0]    _zz_742;
+  wire       [0:0]    _zz_743;
+  wire       [0:0]    _zz_744;
+  wire       [0:0]    _zz_745;
+  wire       [0:0]    _zz_746;
+  wire       [0:0]    _zz_747;
+  wire       [0:0]    _zz_748;
+  wire       [0:0]    _zz_749;
+  wire       [0:0]    _zz_750;
+  wire       [0:0]    _zz_751;
+  wire       [0:0]    _zz_752;
+  wire       [0:0]    _zz_753;
+  wire       [0:0]    _zz_754;
+  wire       [3:0]    _zz_755;
+  wire       [2:0]    _zz_756;
+  wire       [31:0]   _zz_757;
+  wire       [11:0]   _zz_758;
+  wire       [31:0]   _zz_759;
+  wire       [19:0]   _zz_760;
+  wire       [11:0]   _zz_761;
+  wire       [31:0]   _zz_762;
+  wire       [31:0]   _zz_763;
+  wire       [19:0]   _zz_764;
+  wire       [11:0]   _zz_765;
+  wire       [2:0]    _zz_766;
+  wire       [2:0]    _zz_767;
+  wire       [31:0]   _zz_768;
+  wire       [31:0]   _zz_769;
+  wire       [31:0]   _zz_770;
+  wire       [31:0]   _zz_771;
+  wire       [31:0]   _zz_772;
+  wire       [31:0]   _zz_773;
+  wire       [31:0]   _zz_774;
+  wire       [31:0]   _zz_775;
+  wire       [31:0]   _zz_776;
+  wire       [31:0]   _zz_777;
+  wire       [31:0]   _zz_778;
+  wire       [31:0]   _zz_779;
+  wire       [31:0]   _zz_780;
+  wire       [31:0]   _zz_781;
+  wire       [31:0]   _zz_782;
+  wire       [31:0]   _zz_783;
+  wire       [31:0]   _zz_784;
+  wire       [31:0]   _zz_785;
+  wire       [31:0]   _zz_786;
+  wire       [31:0]   _zz_787;
+  wire       [31:0]   _zz_788;
+  wire       [31:0]   _zz_789;
+  wire       [31:0]   _zz_790;
+  wire       [31:0]   _zz_791;
+  wire       [31:0]   _zz_792;
+  wire       [31:0]   _zz_793;
+  wire       [31:0]   _zz_794;
+  wire       [31:0]   _zz_795;
+  wire       [31:0]   _zz_796;
+  wire       [31:0]   _zz_797;
+  wire       [31:0]   _zz_798;
+  wire       [31:0]   _zz_799;
+  wire       [31:0]   _zz_800;
+  wire       [31:0]   _zz_801;
+  wire       [31:0]   _zz_802;
+  wire       [31:0]   _zz_803;
+  wire       [31:0]   _zz_804;
+  wire       [31:0]   _zz_805;
+  wire       [31:0]   _zz_806;
+  wire       [31:0]   _zz_807;
+  wire       [31:0]   _zz_808;
+  wire       [31:0]   _zz_809;
+  wire       [31:0]   _zz_810;
+  wire       [31:0]   _zz_811;
+  wire       [31:0]   _zz_812;
+  wire       [31:0]   _zz_813;
+  wire       [31:0]   _zz_814;
+  wire       [31:0]   _zz_815;
+  wire       [4:0]    _zz_816;
+  wire       [4:0]    _zz_817;
+  wire       [4:0]    _zz_818;
+  wire       [4:0]    _zz_819;
+  wire       [4:0]    _zz_820;
+  wire       [0:0]    _zz_821;
+  wire       [2:0]    _zz_822;
+  wire       [15:0]   _zz_823;
+  wire       [15:0]   _zz_824;
+  wire       [15:0]   _zz_825;
+  wire       [4:0]    _zz_826;
+  wire       [4:0]    _zz_827;
+  wire       [4:0]    _zz_828;
+  wire       [4:0]    _zz_829;
+  wire       [4:0]    _zz_830;
+  wire       [0:0]    _zz_831;
+  wire       [2:0]    _zz_832;
+  wire       [15:0]   _zz_833;
+  wire       [15:0]   _zz_834;
+  wire       [15:0]   _zz_835;
+  wire       [0:0]    _zz_836;
+  wire       [2:0]    _zz_837;
+  wire       [4:0]    _zz_838;
+  wire       [11:0]   _zz_839;
+  wire       [11:0]   _zz_840;
+  wire       [31:0]   _zz_841;
+  wire       [31:0]   _zz_842;
+  wire       [31:0]   _zz_843;
+  wire       [31:0]   _zz_844;
+  wire       [31:0]   _zz_845;
+  wire       [31:0]   _zz_846;
+  wire       [31:0]   _zz_847;
+  wire       [11:0]   _zz_848;
+  wire       [19:0]   _zz_849;
+  wire       [11:0]   _zz_850;
+  wire       [31:0]   _zz_851;
+  wire       [31:0]   _zz_852;
+  wire       [31:0]   _zz_853;
+  wire       [11:0]   _zz_854;
+  wire       [19:0]   _zz_855;
+  wire       [11:0]   _zz_856;
+  wire       [2:0]    _zz_857;
+  wire       [1:0]    _zz_858;
+  wire       [1:0]    _zz_859;
+  wire       [65:0]   _zz_860;
+  wire       [65:0]   _zz_861;
+  wire       [31:0]   _zz_862;
+  wire       [31:0]   _zz_863;
+  wire       [0:0]    _zz_864;
+  wire       [5:0]    _zz_865;
+  wire       [32:0]   _zz_866;
+  wire       [31:0]   _zz_867;
+  wire       [31:0]   _zz_868;
+  wire       [32:0]   _zz_869;
+  wire       [32:0]   _zz_870;
+  wire       [32:0]   _zz_871;
+  wire       [32:0]   _zz_872;
+  wire       [0:0]    _zz_873;
+  wire       [32:0]   _zz_874;
+  wire       [0:0]    _zz_875;
+  wire       [32:0]   _zz_876;
+  wire       [0:0]    _zz_877;
+  wire       [31:0]   _zz_878;
+  wire       [0:0]    _zz_879;
+  wire       [0:0]    _zz_880;
+  wire       [0:0]    _zz_881;
+  wire       [0:0]    _zz_882;
+  wire       [0:0]    _zz_883;
+  wire       [0:0]    _zz_884;
+  wire       [0:0]    _zz_885;
+  wire       [0:0]    _zz_886;
+  wire       [0:0]    _zz_887;
+  wire       [0:0]    _zz_888;
+  wire       [0:0]    _zz_889;
+  wire       [0:0]    _zz_890;
+  wire       [0:0]    _zz_891;
+  wire       [0:0]    _zz_892;
+  wire       [0:0]    _zz_893;
+  wire       [0:0]    _zz_894;
+  wire       [0:0]    _zz_895;
+  wire       [0:0]    _zz_896;
+  wire       [0:0]    _zz_897;
+  wire       [0:0]    _zz_898;
+  wire       [0:0]    _zz_899;
+  wire       [0:0]    _zz_900;
+  wire       [0:0]    _zz_901;
+  wire       [0:0]    _zz_902;
+  wire       [0:0]    _zz_903;
+  wire       [0:0]    _zz_904;
+  wire       [0:0]    _zz_905;
+  wire       [0:0]    _zz_906;
+  wire       [0:0]    _zz_907;
+  wire       [0:0]    _zz_908;
+  wire       [0:0]    _zz_909;
+  wire       [0:0]    _zz_910;
+  wire       [0:0]    _zz_911;
+  wire       [0:0]    _zz_912;
+  wire       [0:0]    _zz_913;
+  wire       [0:0]    _zz_914;
+  wire       [0:0]    _zz_915;
+  wire       [0:0]    _zz_916;
+  wire       [0:0]    _zz_917;
+  wire       [0:0]    _zz_918;
+  wire       [0:0]    _zz_919;
+  wire       [0:0]    _zz_920;
+  wire       [0:0]    _zz_921;
+  wire       [0:0]    _zz_922;
+  wire       [0:0]    _zz_923;
+  wire       [0:0]    _zz_924;
+  wire       [0:0]    _zz_925;
+  wire       [0:0]    _zz_926;
+  wire       [0:0]    _zz_927;
+  wire       [0:0]    _zz_928;
+  wire       [0:0]    _zz_929;
+  wire       [0:0]    _zz_930;
+  wire       [0:0]    _zz_931;
+  wire       [0:0]    _zz_932;
+  wire       [0:0]    _zz_933;
+  wire       [0:0]    _zz_934;
+  wire       [0:0]    _zz_935;
+  wire       [0:0]    _zz_936;
+  wire       [0:0]    _zz_937;
+  wire       [0:0]    _zz_938;
+  wire       [0:0]    _zz_939;
+  wire       [0:0]    _zz_940;
+  wire       [0:0]    _zz_941;
+  wire       [0:0]    _zz_942;
+  wire       [0:0]    _zz_943;
+  wire       [0:0]    _zz_944;
+  wire       [0:0]    _zz_945;
+  wire       [0:0]    _zz_946;
+  wire       [0:0]    _zz_947;
+  wire       [0:0]    _zz_948;
+  wire       [0:0]    _zz_949;
+  wire       [26:0]   _zz_950;
+  wire                _zz_951;
+  wire                _zz_952;
+  wire       [1:0]    _zz_953;
+  wire       [2:0]    _zz_954;
+  wire       [2:0]    _zz_955;
+  wire       [2:0]    _zz_956;
+  wire       [2:0]    _zz_957;
+  wire       [2:0]    _zz_958;
+  wire       [3:0]    _zz_959;
+  wire       [3:0]    _zz_960;
+  wire       [3:0]    _zz_961;
+  wire       [2:0]    _zz_962;
+  wire       [2:0]    _zz_963;
+  wire       [2:0]    _zz_964;
+  wire       [2:0]    _zz_965;
+  wire       [2:0]    _zz_966;
+  wire       [3:0]    _zz_967;
+  wire       [3:0]    _zz_968;
+  wire       [3:0]    _zz_969;
+  wire       [31:0]   _zz_970;
+  wire       [31:0]   _zz_971;
+  wire       [31:0]   _zz_972;
+  wire                _zz_973;
+  wire       [0:0]    _zz_974;
+  wire       [13:0]   _zz_975;
+  wire       [31:0]   _zz_976;
+  wire       [31:0]   _zz_977;
+  wire       [31:0]   _zz_978;
+  wire                _zz_979;
+  wire       [0:0]    _zz_980;
+  wire       [7:0]    _zz_981;
+  wire       [31:0]   _zz_982;
+  wire       [31:0]   _zz_983;
+  wire       [31:0]   _zz_984;
+  wire                _zz_985;
+  wire       [0:0]    _zz_986;
+  wire       [1:0]    _zz_987;
+  wire                _zz_988;
+  wire                _zz_989;
+  wire                _zz_990;
+  wire       [0:0]    _zz_991;
+  wire       [4:0]    _zz_992;
+  wire       [0:0]    _zz_993;
+  wire       [4:0]    _zz_994;
+  wire       [0:0]    _zz_995;
+  wire       [4:0]    _zz_996;
+  wire       [0:0]    _zz_997;
+  wire       [4:0]    _zz_998;
+  wire       [0:0]    _zz_999;
+  wire       [4:0]    _zz_1000;
+  wire       [0:0]    _zz_1001;
+  wire       [4:0]    _zz_1002;
+  wire       [31:0]   _zz_1003;
+  wire       [31:0]   _zz_1004;
+  wire                _zz_1005;
+  wire       [0:0]    _zz_1006;
+  wire       [0:0]    _zz_1007;
+  wire                _zz_1008;
+  wire       [0:0]    _zz_1009;
+  wire       [24:0]   _zz_1010;
+  wire       [31:0]   _zz_1011;
+  wire                _zz_1012;
+  wire                _zz_1013;
+  wire       [0:0]    _zz_1014;
+  wire       [0:0]    _zz_1015;
+  wire       [0:0]    _zz_1016;
+  wire       [0:0]    _zz_1017;
+  wire                _zz_1018;
+  wire       [0:0]    _zz_1019;
+  wire       [20:0]   _zz_1020;
+  wire       [31:0]   _zz_1021;
+  wire       [31:0]   _zz_1022;
+  wire                _zz_1023;
+  wire                _zz_1024;
+  wire       [0:0]    _zz_1025;
+  wire       [1:0]    _zz_1026;
+  wire       [0:0]    _zz_1027;
+  wire       [0:0]    _zz_1028;
+  wire                _zz_1029;
+  wire       [0:0]    _zz_1030;
+  wire       [17:0]   _zz_1031;
+  wire       [31:0]   _zz_1032;
+  wire       [31:0]   _zz_1033;
+  wire       [31:0]   _zz_1034;
+  wire       [31:0]   _zz_1035;
+  wire       [31:0]   _zz_1036;
+  wire       [31:0]   _zz_1037;
+  wire       [31:0]   _zz_1038;
+  wire       [31:0]   _zz_1039;
+  wire                _zz_1040;
+  wire       [1:0]    _zz_1041;
+  wire       [1:0]    _zz_1042;
+  wire                _zz_1043;
+  wire       [0:0]    _zz_1044;
+  wire       [14:0]   _zz_1045;
+  wire       [31:0]   _zz_1046;
+  wire       [31:0]   _zz_1047;
+  wire       [31:0]   _zz_1048;
+  wire       [31:0]   _zz_1049;
+  wire       [31:0]   _zz_1050;
+  wire       [31:0]   _zz_1051;
+  wire       [0:0]    _zz_1052;
+  wire       [0:0]    _zz_1053;
+  wire       [4:0]    _zz_1054;
+  wire       [4:0]    _zz_1055;
+  wire                _zz_1056;
+  wire       [0:0]    _zz_1057;
+  wire       [11:0]   _zz_1058;
+  wire       [31:0]   _zz_1059;
+  wire       [31:0]   _zz_1060;
+  wire       [31:0]   _zz_1061;
+  wire       [31:0]   _zz_1062;
+  wire                _zz_1063;
+  wire       [0:0]    _zz_1064;
+  wire       [1:0]    _zz_1065;
+  wire       [31:0]   _zz_1066;
+  wire       [31:0]   _zz_1067;
+  wire       [0:0]    _zz_1068;
+  wire       [3:0]    _zz_1069;
+  wire       [4:0]    _zz_1070;
+  wire       [4:0]    _zz_1071;
+  wire                _zz_1072;
+  wire       [0:0]    _zz_1073;
+  wire       [8:0]    _zz_1074;
+  wire       [31:0]   _zz_1075;
+  wire       [31:0]   _zz_1076;
+  wire       [31:0]   _zz_1077;
+  wire                _zz_1078;
+  wire                _zz_1079;
+  wire       [31:0]   _zz_1080;
+  wire       [31:0]   _zz_1081;
+  wire       [0:0]    _zz_1082;
+  wire       [1:0]    _zz_1083;
+  wire       [0:0]    _zz_1084;
+  wire       [2:0]    _zz_1085;
+  wire       [0:0]    _zz_1086;
+  wire       [4:0]    _zz_1087;
+  wire       [1:0]    _zz_1088;
+  wire       [1:0]    _zz_1089;
+  wire                _zz_1090;
+  wire       [0:0]    _zz_1091;
+  wire       [6:0]    _zz_1092;
+  wire       [31:0]   _zz_1093;
+  wire       [31:0]   _zz_1094;
+  wire       [31:0]   _zz_1095;
+  wire       [31:0]   _zz_1096;
+  wire                _zz_1097;
+  wire                _zz_1098;
+  wire       [31:0]   _zz_1099;
+  wire       [31:0]   _zz_1100;
+  wire                _zz_1101;
+  wire       [0:0]    _zz_1102;
+  wire       [0:0]    _zz_1103;
+  wire                _zz_1104;
+  wire       [0:0]    _zz_1105;
+  wire       [2:0]    _zz_1106;
+  wire                _zz_1107;
+  wire       [0:0]    _zz_1108;
+  wire       [0:0]    _zz_1109;
+  wire       [0:0]    _zz_1110;
+  wire       [0:0]    _zz_1111;
+  wire                _zz_1112;
+  wire       [0:0]    _zz_1113;
+  wire       [4:0]    _zz_1114;
+  wire       [31:0]   _zz_1115;
+  wire       [31:0]   _zz_1116;
+  wire       [31:0]   _zz_1117;
+  wire       [31:0]   _zz_1118;
+  wire       [31:0]   _zz_1119;
+  wire       [31:0]   _zz_1120;
+  wire       [31:0]   _zz_1121;
+  wire       [31:0]   _zz_1122;
+  wire       [31:0]   _zz_1123;
+  wire       [31:0]   _zz_1124;
+  wire                _zz_1125;
+  wire       [0:0]    _zz_1126;
+  wire       [0:0]    _zz_1127;
+  wire       [31:0]   _zz_1128;
+  wire       [31:0]   _zz_1129;
+  wire       [31:0]   _zz_1130;
+  wire       [31:0]   _zz_1131;
+  wire       [31:0]   _zz_1132;
+  wire                _zz_1133;
+  wire       [3:0]    _zz_1134;
+  wire       [3:0]    _zz_1135;
+  wire                _zz_1136;
+  wire       [0:0]    _zz_1137;
+  wire       [2:0]    _zz_1138;
+  wire       [31:0]   _zz_1139;
+  wire       [31:0]   _zz_1140;
+  wire       [31:0]   _zz_1141;
+  wire       [31:0]   _zz_1142;
+  wire       [31:0]   _zz_1143;
+  wire       [31:0]   _zz_1144;
+  wire                _zz_1145;
+  wire       [0:0]    _zz_1146;
+  wire       [1:0]    _zz_1147;
+  wire                _zz_1148;
+  wire       [2:0]    _zz_1149;
+  wire       [2:0]    _zz_1150;
+  wire                _zz_1151;
+  wire       [0:0]    _zz_1152;
+  wire       [0:0]    _zz_1153;
+  wire       [31:0]   _zz_1154;
+  wire       [31:0]   _zz_1155;
+  wire       [31:0]   _zz_1156;
+  wire       [31:0]   _zz_1157;
+  wire       [31:0]   _zz_1158;
+  wire       [31:0]   _zz_1159;
+  wire       [31:0]   _zz_1160;
+  wire                _zz_1161;
+  wire                _zz_1162;
+  wire                _zz_1163;
+  wire       [0:0]    _zz_1164;
+  wire       [0:0]    _zz_1165;
+  wire                _zz_1166;
+  wire                _zz_1167;
+  wire                _zz_1168;
+  wire                _zz_1169;
+  wire       [31:0]   _zz_1170;
+  wire       [31:0]   _zz_1171;
+  wire       [31:0]   _zz_1172;
+  wire       [31:0]   _zz_1173;
+  wire       [31:0]   _zz_1174;
+  wire       [31:0]   _zz_1175;
+  wire       [31:0]   _zz_1176;
+  wire       [31:0]   _zz_1177;
+  wire       [31:0]   _zz_1178;
+  wire       [31:0]   _zz_1179;
+  wire       [31:0]   _zz_1180;
+  wire       [31:0]   _zz_1181;
+  wire       [31:0]   _zz_1182;
+  wire       [31:0]   _zz_1183;
+  wire       [31:0]   _zz_1184;
+  wire       [31:0]   _zz_1185;
+  wire       [31:0]   _zz_1186;
   wire       [51:0]   memory_MUL_LOW;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_6_;
-  wire                memory_MEMORY_WR;
-  wire                decode_MEMORY_WR;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
   wire       [33:0]   execute_MUL_LH;
   wire       [31:0]   execute_MUL_LL;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_8_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_9_;
-  wire                decode_IS_CSR;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
   wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
+  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
+  wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_MANAGMENT;
+  wire                memory_MEMORY_WR;
+  wire                decode_MEMORY_WR;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
+  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14_;
-  wire                decode_SRC_LESS_UNSIGNED;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire       [33:0]   execute_MUL_HL;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_15_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_18_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_21_;
-  wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_24_;
-  wire                decode_IS_RS1_SIGNED;
-  wire                memory_IS_MUL;
-  wire                execute_IS_MUL;
-  wire                decode_IS_MUL;
-  wire       [33:0]   memory_MUL_HH;
-  wire       [33:0]   execute_MUL_HH;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_26_;
   wire       [31:0]   memory_PC;
-  wire                decode_MEMORY_MANAGMENT;
-  wire                decode_IS_RS2_SIGNED;
   wire                execute_IS_RS1_SIGNED;
   wire                execute_IS_DIV;
   wire                execute_IS_RS2_SIGNED;
@@ -1716,22 +753,22 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* syn_keep , keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1741,98 +778,67 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49_;
-  reg        [4:0]    _zz_50_;
-  reg        [4:0]    _zz_50__14;
-  reg        [4:0]    _zz_50__13;
-  reg        [4:0]    _zz_50__12;
-  reg        [4:0]    _zz_50__11;
-  reg        [4:0]    _zz_50__10;
-  reg        [4:0]    _zz_50__9;
-  reg        [4:0]    _zz_50__8;
-  reg        [4:0]    _zz_50__7;
-  reg        [4:0]    _zz_50__6;
-  reg        [4:0]    _zz_50__5;
-  reg        [4:0]    _zz_50__4;
-  reg        [4:0]    _zz_50__3;
-  reg        [4:0]    _zz_50__2;
-  reg        [4:0]    _zz_50__1;
-  reg        [4:0]    _zz_50__0;
-  reg        [4:0]    _zz_51_;
-  reg        [4:0]    _zz_51__14;
-  reg        [4:0]    _zz_51__13;
-  reg        [4:0]    _zz_51__12;
-  reg        [4:0]    _zz_51__11;
-  reg        [4:0]    _zz_51__10;
-  reg        [4:0]    _zz_51__9;
-  reg        [4:0]    _zz_51__8;
-  reg        [4:0]    _zz_51__7;
-  reg        [4:0]    _zz_51__6;
-  reg        [4:0]    _zz_51__5;
-  reg        [4:0]    _zz_51__4;
-  reg        [4:0]    _zz_51__3;
-  reg        [4:0]    _zz_51__2;
-  reg        [4:0]    _zz_51__1;
-  reg        [4:0]    _zz_51__0;
-  reg        [31:0]   _zz_52_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
-  (* syn_keep , keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_53_;
-  reg                 _zz_53__2;
-  reg                 _zz_53__1;
-  reg                 _zz_53__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_54_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_55_;
-  reg        [31:0]   _zz_56_;
+  reg        [31:0]   _zz_52;
+  reg        [31:0]   _zz_53;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -1848,7 +854,7 @@ module VexRiscv (
   wire                decode_arbitration_isMoving;
   wire                decode_arbitration_isFiring;
   reg                 execute_arbitration_haltItself;
-  wire                execute_arbitration_haltByOther;
+  reg                 execute_arbitration_haltByOther;
   reg                 execute_arbitration_removeIt;
   wire                execute_arbitration_flushIt;
   reg                 execute_arbitration_flushNext;
@@ -1887,7 +893,7 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetcherHalt;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
-  (* syn_keep , keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
   reg                 IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   wire                IBusCachedPlugin_decodePrediction_rsp_wasWrong;
   wire                IBusCachedPlugin_pcValids_0;
@@ -1897,28 +903,47 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -1954,11 +979,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_57_;
-  wire       [3:0]    _zz_58_;
-  wire                _zz_59_;
-  wire                _zz_60_;
-  wire                _zz_61_;
+  wire       [3:0]    _zz_54;
+  wire       [3:0]    _zz_55;
+  wire                _zz_56;
+  wire                _zz_57;
+  wire                _zz_58;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -1995,16 +1020,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_62_;
-  wire                _zz_63_;
-  wire                _zz_64_;
+  wire                _zz_59;
+  wire                _zz_60;
+  wire                _zz_61;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_65_;
-  wire                _zz_66_;
-  reg                 _zz_67_;
-  wire                _zz_68_;
-  reg                 _zz_69_;
-  reg        [31:0]   _zz_70_;
+  wire                _zz_62;
+  wire                _zz_63;
+  reg                 _zz_64;
+  wire                _zz_65;
+  reg                 _zz_66;
+  reg        [31:0]   _zz_67;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -2017,17 +1042,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_71_;
-  reg        [18:0]   _zz_72_;
-  wire                _zz_73_;
-  reg        [10:0]   _zz_74_;
-  wire                _zz_75_;
-  reg        [18:0]   _zz_76_;
-  reg                 _zz_77_;
-  wire                _zz_78_;
-  reg        [10:0]   _zz_79_;
-  wire                _zz_80_;
-  reg        [18:0]   _zz_81_;
+  wire                _zz_68;
+  reg        [18:0]   _zz_69;
+  wire                _zz_70;
+  reg        [10:0]   _zz_71;
+  wire                _zz_72;
+  reg        [18:0]   _zz_73;
+  reg                 _zz_74;
+  wire                _zz_75;
+  reg        [10:0]   _zz_76;
+  wire                _zz_77;
+  reg        [18:0]   _zz_78;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -2035,7 +1060,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_82_;
+  wire       [31:0]   _zz_79;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -2043,313 +1068,354 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_83_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_80;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_84_;
+  reg        [31:0]   _zz_81;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_85_;
-  reg        [31:0]   _zz_86_;
-  wire                _zz_87_;
-  reg        [31:0]   _zz_88_;
+  wire                _zz_82;
+  reg        [31:0]   _zz_83;
+  wire                _zz_84;
+  reg        [31:0]   _zz_85;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  reg                 _zz_89_;
-  reg                 _zz_90_;
-  reg                 _zz_91_;
-  reg                 _zz_92_;
-  reg        [1:0]    _zz_93_;
-  reg        [31:0]   _zz_94_;
-  reg                 _zz_95_;
-  reg                 _zz_96_;
-  reg                 _zz_97_;
-  reg                 _zz_98_;
-  reg                 _zz_99_;
-  reg        [31:0]   _zz_100_;
-  reg        [31:0]   _zz_101_;
-  wire       [31:0]   _zz_102_;
-  wire       [31:0]   _zz_103_;
-  wire       [31:0]   _zz_104_;
-  reg                 _zz_105_;
-  reg                 _zz_106_;
-  reg                 _zz_107_;
-  reg                 _zz_108_;
-  reg        [1:0]    _zz_109_;
-  reg        [31:0]   _zz_110_;
-  reg                 _zz_111_;
-  reg                 _zz_112_;
-  reg                 _zz_113_;
-  reg                 _zz_114_;
-  reg                 _zz_115_;
-  reg        [31:0]   _zz_116_;
-  reg        [31:0]   _zz_117_;
-  wire       [31:0]   _zz_118_;
-  wire       [31:0]   _zz_119_;
-  wire       [31:0]   _zz_120_;
-  reg                 _zz_121_;
-  reg                 _zz_122_;
-  reg                 _zz_123_;
-  reg                 _zz_124_;
-  reg        [1:0]    _zz_125_;
-  reg        [31:0]   _zz_126_;
-  reg                 _zz_127_;
-  reg                 _zz_128_;
-  reg                 _zz_129_;
-  reg                 _zz_130_;
-  reg                 _zz_131_;
-  reg        [31:0]   _zz_132_;
-  reg        [31:0]   _zz_133_;
-  wire       [31:0]   _zz_134_;
-  wire       [31:0]   _zz_135_;
-  wire       [31:0]   _zz_136_;
-  reg                 _zz_137_;
-  reg                 _zz_138_;
-  reg                 _zz_139_;
-  reg                 _zz_140_;
-  reg        [1:0]    _zz_141_;
-  reg        [31:0]   _zz_142_;
-  reg                 _zz_143_;
-  reg                 _zz_144_;
-  reg                 _zz_145_;
-  reg                 _zz_146_;
-  reg                 _zz_147_;
-  reg        [31:0]   _zz_148_;
-  reg        [31:0]   _zz_149_;
-  wire       [31:0]   _zz_150_;
-  wire       [31:0]   _zz_151_;
-  wire       [31:0]   _zz_152_;
-  reg                 _zz_153_;
-  reg                 _zz_154_;
-  reg                 _zz_155_;
-  reg                 _zz_156_;
-  reg        [1:0]    _zz_157_;
-  reg        [31:0]   _zz_158_;
-  reg                 _zz_159_;
-  reg                 _zz_160_;
-  reg                 _zz_161_;
-  reg                 _zz_162_;
-  reg                 _zz_163_;
-  reg        [31:0]   _zz_164_;
-  reg        [31:0]   _zz_165_;
-  wire       [31:0]   _zz_166_;
-  wire       [31:0]   _zz_167_;
-  wire       [31:0]   _zz_168_;
-  reg                 _zz_169_;
-  reg                 _zz_170_;
-  reg                 _zz_171_;
-  reg                 _zz_172_;
-  reg        [1:0]    _zz_173_;
-  reg        [31:0]   _zz_174_;
-  reg                 _zz_175_;
-  reg                 _zz_176_;
-  reg                 _zz_177_;
-  reg                 _zz_178_;
-  reg                 _zz_179_;
-  reg        [31:0]   _zz_180_;
-  reg        [31:0]   _zz_181_;
-  wire       [31:0]   _zz_182_;
-  wire       [31:0]   _zz_183_;
-  wire       [31:0]   _zz_184_;
-  reg                 _zz_185_;
-  reg                 _zz_186_;
-  reg                 _zz_187_;
-  reg                 _zz_188_;
-  reg        [1:0]    _zz_189_;
-  reg        [31:0]   _zz_190_;
-  reg                 _zz_191_;
-  reg                 _zz_192_;
-  reg                 _zz_193_;
-  reg                 _zz_194_;
-  reg                 _zz_195_;
-  reg        [31:0]   _zz_196_;
-  reg        [31:0]   _zz_197_;
-  wire       [31:0]   _zz_198_;
-  wire       [31:0]   _zz_199_;
-  wire       [31:0]   _zz_200_;
-  reg                 _zz_201_;
-  reg                 _zz_202_;
-  reg                 _zz_203_;
-  reg                 _zz_204_;
-  reg        [1:0]    _zz_205_;
-  reg        [31:0]   _zz_206_;
-  reg                 _zz_207_;
-  reg                 _zz_208_;
-  reg                 _zz_209_;
-  reg                 _zz_210_;
-  reg                 _zz_211_;
-  reg        [31:0]   _zz_212_;
-  reg        [31:0]   _zz_213_;
-  wire       [31:0]   _zz_214_;
-  wire       [31:0]   _zz_215_;
-  wire       [31:0]   _zz_216_;
-  reg                 _zz_217_;
-  reg                 _zz_218_;
-  reg                 _zz_219_;
-  reg                 _zz_220_;
-  reg        [1:0]    _zz_221_;
-  reg        [31:0]   _zz_222_;
-  reg                 _zz_223_;
-  reg                 _zz_224_;
-  reg                 _zz_225_;
-  reg                 _zz_226_;
-  reg                 _zz_227_;
-  reg        [31:0]   _zz_228_;
-  reg        [31:0]   _zz_229_;
-  wire       [31:0]   _zz_230_;
-  wire       [31:0]   _zz_231_;
-  wire       [31:0]   _zz_232_;
-  reg                 _zz_233_;
-  reg                 _zz_234_;
-  reg                 _zz_235_;
-  reg                 _zz_236_;
-  reg        [1:0]    _zz_237_;
-  reg        [31:0]   _zz_238_;
-  reg                 _zz_239_;
-  reg                 _zz_240_;
-  reg                 _zz_241_;
-  reg                 _zz_242_;
-  reg                 _zz_243_;
-  reg        [31:0]   _zz_244_;
-  reg        [31:0]   _zz_245_;
-  wire       [31:0]   _zz_246_;
-  wire       [31:0]   _zz_247_;
-  wire       [31:0]   _zz_248_;
-  reg                 _zz_249_;
-  reg                 _zz_250_;
-  reg                 _zz_251_;
-  reg                 _zz_252_;
-  reg        [1:0]    _zz_253_;
-  reg        [31:0]   _zz_254_;
-  reg                 _zz_255_;
-  reg                 _zz_256_;
-  reg                 _zz_257_;
-  reg                 _zz_258_;
-  reg                 _zz_259_;
-  reg        [31:0]   _zz_260_;
-  reg        [31:0]   _zz_261_;
-  wire       [31:0]   _zz_262_;
-  wire       [31:0]   _zz_263_;
-  wire       [31:0]   _zz_264_;
-  reg                 _zz_265_;
-  reg                 _zz_266_;
-  reg                 _zz_267_;
-  reg                 _zz_268_;
-  reg        [1:0]    _zz_269_;
-  reg        [31:0]   _zz_270_;
-  reg                 _zz_271_;
-  reg                 _zz_272_;
-  reg                 _zz_273_;
-  reg                 _zz_274_;
-  reg                 _zz_275_;
-  reg        [31:0]   _zz_276_;
-  reg        [31:0]   _zz_277_;
-  wire       [31:0]   _zz_278_;
-  wire       [31:0]   _zz_279_;
-  wire       [31:0]   _zz_280_;
-  reg                 _zz_281_;
-  reg                 _zz_282_;
-  reg                 _zz_283_;
-  reg                 _zz_284_;
-  reg        [1:0]    _zz_285_;
-  reg        [31:0]   _zz_286_;
-  reg                 _zz_287_;
-  reg                 _zz_288_;
-  reg                 _zz_289_;
-  reg                 _zz_290_;
-  reg                 _zz_291_;
-  reg        [31:0]   _zz_292_;
-  reg        [31:0]   _zz_293_;
-  wire       [31:0]   _zz_294_;
-  wire       [31:0]   _zz_295_;
-  wire       [31:0]   _zz_296_;
-  reg                 _zz_297_;
-  reg                 _zz_298_;
-  reg                 _zz_299_;
-  reg                 _zz_300_;
-  reg        [1:0]    _zz_301_;
-  reg        [31:0]   _zz_302_;
-  reg                 _zz_303_;
-  reg                 _zz_304_;
-  reg                 _zz_305_;
-  reg                 _zz_306_;
-  reg                 _zz_307_;
-  reg        [31:0]   _zz_308_;
-  reg        [31:0]   _zz_309_;
-  wire       [31:0]   _zz_310_;
-  wire       [31:0]   _zz_311_;
-  wire       [31:0]   _zz_312_;
-  reg                 _zz_313_;
-  reg                 _zz_314_;
-  reg                 _zz_315_;
-  reg                 _zz_316_;
-  reg        [1:0]    _zz_317_;
-  reg        [31:0]   _zz_318_;
-  reg                 _zz_319_;
-  reg                 _zz_320_;
-  reg                 _zz_321_;
-  reg                 _zz_322_;
-  reg                 _zz_323_;
-  reg        [31:0]   _zz_324_;
-  reg        [31:0]   _zz_325_;
-  wire       [31:0]   _zz_326_;
-  wire       [31:0]   _zz_327_;
-  wire       [31:0]   _zz_328_;
-  reg                 _zz_329_;
-  reg                 _zz_330_;
-  reg                 _zz_331_;
-  reg                 _zz_332_;
-  reg        [1:0]    _zz_333_;
-  reg        [31:0]   _zz_334_;
-  reg                 _zz_335_;
-  reg                 _zz_336_;
-  reg                 _zz_337_;
-  reg                 _zz_338_;
-  reg                 _zz_339_;
-  reg        [31:0]   _zz_340_;
-  reg        [31:0]   _zz_341_;
-  wire       [31:0]   _zz_342_;
-  wire       [31:0]   _zz_343_;
-  wire       [31:0]   _zz_344_;
+  reg                 _zz_86;
+  reg                 _zz_87;
+  reg                 _zz_88;
+  reg                 _zz_89;
+  reg        [1:0]    _zz_90;
+  reg        [31:0]   _zz_91;
+  reg                 _zz_92;
+  reg                 _zz_93;
+  reg                 _zz_94;
+  reg                 _zz_95;
+  reg        [1:0]    _zz_96;
+  reg        [31:0]   _zz_97;
+  reg                 _zz_98;
+  wire                _zz_99;
+  reg        [31:0]   _zz_100;
+  reg        [31:0]   _zz_101;
+  wire       [31:0]   _zz_102;
+  wire       [31:0]   _zz_103;
+  wire       [31:0]   _zz_104;
+  reg                 _zz_105;
+  reg                 _zz_106;
+  reg                 _zz_107;
+  reg                 _zz_108;
+  reg        [1:0]    _zz_109;
+  reg        [31:0]   _zz_110;
+  reg                 _zz_111;
+  reg                 _zz_112;
+  reg                 _zz_113;
+  reg                 _zz_114;
+  reg        [1:0]    _zz_115;
+  reg        [31:0]   _zz_116;
+  reg                 _zz_117;
+  wire                _zz_118;
+  reg        [31:0]   _zz_119;
+  reg        [31:0]   _zz_120;
+  wire       [31:0]   _zz_121;
+  wire       [31:0]   _zz_122;
+  wire       [31:0]   _zz_123;
+  reg                 _zz_124;
+  reg                 _zz_125;
+  reg                 _zz_126;
+  reg                 _zz_127;
+  reg        [1:0]    _zz_128;
+  reg        [31:0]   _zz_129;
+  reg                 _zz_130;
+  reg                 _zz_131;
+  reg                 _zz_132;
+  reg                 _zz_133;
+  reg        [1:0]    _zz_134;
+  reg        [31:0]   _zz_135;
+  reg                 _zz_136;
+  wire                _zz_137;
+  reg        [31:0]   _zz_138;
+  reg        [31:0]   _zz_139;
+  wire       [31:0]   _zz_140;
+  wire       [31:0]   _zz_141;
+  wire       [31:0]   _zz_142;
+  reg                 _zz_143;
+  reg                 _zz_144;
+  reg                 _zz_145;
+  reg                 _zz_146;
+  reg        [1:0]    _zz_147;
+  reg        [31:0]   _zz_148;
+  reg                 _zz_149;
+  reg                 _zz_150;
+  reg                 _zz_151;
+  reg                 _zz_152;
+  reg        [1:0]    _zz_153;
+  reg        [31:0]   _zz_154;
+  reg                 _zz_155;
+  wire                _zz_156;
+  reg        [31:0]   _zz_157;
+  reg        [31:0]   _zz_158;
+  wire       [31:0]   _zz_159;
+  wire       [31:0]   _zz_160;
+  wire       [31:0]   _zz_161;
+  reg                 _zz_162;
+  reg                 _zz_163;
+  reg                 _zz_164;
+  reg                 _zz_165;
+  reg        [1:0]    _zz_166;
+  reg        [31:0]   _zz_167;
+  reg                 _zz_168;
+  reg                 _zz_169;
+  reg                 _zz_170;
+  reg                 _zz_171;
+  reg        [1:0]    _zz_172;
+  reg        [31:0]   _zz_173;
+  reg                 _zz_174;
+  wire                _zz_175;
+  reg        [31:0]   _zz_176;
+  reg        [31:0]   _zz_177;
+  wire       [31:0]   _zz_178;
+  wire       [31:0]   _zz_179;
+  wire       [31:0]   _zz_180;
+  reg                 _zz_181;
+  reg                 _zz_182;
+  reg                 _zz_183;
+  reg                 _zz_184;
+  reg        [1:0]    _zz_185;
+  reg        [31:0]   _zz_186;
+  reg                 _zz_187;
+  reg                 _zz_188;
+  reg                 _zz_189;
+  reg                 _zz_190;
+  reg        [1:0]    _zz_191;
+  reg        [31:0]   _zz_192;
+  reg                 _zz_193;
+  wire                _zz_194;
+  reg        [31:0]   _zz_195;
+  reg        [31:0]   _zz_196;
+  wire       [31:0]   _zz_197;
+  wire       [31:0]   _zz_198;
+  wire       [31:0]   _zz_199;
+  reg                 _zz_200;
+  reg                 _zz_201;
+  reg                 _zz_202;
+  reg                 _zz_203;
+  reg        [1:0]    _zz_204;
+  reg        [31:0]   _zz_205;
+  reg                 _zz_206;
+  reg                 _zz_207;
+  reg                 _zz_208;
+  reg                 _zz_209;
+  reg        [1:0]    _zz_210;
+  reg        [31:0]   _zz_211;
+  reg                 _zz_212;
+  wire                _zz_213;
+  reg        [31:0]   _zz_214;
+  reg        [31:0]   _zz_215;
+  wire       [31:0]   _zz_216;
+  wire       [31:0]   _zz_217;
+  wire       [31:0]   _zz_218;
+  reg                 _zz_219;
+  reg                 _zz_220;
+  reg                 _zz_221;
+  reg                 _zz_222;
+  reg        [1:0]    _zz_223;
+  reg        [31:0]   _zz_224;
+  reg                 _zz_225;
+  reg                 _zz_226;
+  reg                 _zz_227;
+  reg                 _zz_228;
+  reg        [1:0]    _zz_229;
+  reg        [31:0]   _zz_230;
+  reg                 _zz_231;
+  wire                _zz_232;
+  reg        [31:0]   _zz_233;
+  reg        [31:0]   _zz_234;
+  wire       [31:0]   _zz_235;
+  wire       [31:0]   _zz_236;
+  wire       [31:0]   _zz_237;
+  reg                 _zz_238;
+  reg                 _zz_239;
+  reg                 _zz_240;
+  reg                 _zz_241;
+  reg        [1:0]    _zz_242;
+  reg        [31:0]   _zz_243;
+  reg                 _zz_244;
+  reg                 _zz_245;
+  reg                 _zz_246;
+  reg                 _zz_247;
+  reg        [1:0]    _zz_248;
+  reg        [31:0]   _zz_249;
+  reg                 _zz_250;
+  wire                _zz_251;
+  reg        [31:0]   _zz_252;
+  reg        [31:0]   _zz_253;
+  wire       [31:0]   _zz_254;
+  wire       [31:0]   _zz_255;
+  wire       [31:0]   _zz_256;
+  reg                 _zz_257;
+  reg                 _zz_258;
+  reg                 _zz_259;
+  reg                 _zz_260;
+  reg        [1:0]    _zz_261;
+  reg        [31:0]   _zz_262;
+  reg                 _zz_263;
+  reg                 _zz_264;
+  reg                 _zz_265;
+  reg                 _zz_266;
+  reg        [1:0]    _zz_267;
+  reg        [31:0]   _zz_268;
+  reg                 _zz_269;
+  wire                _zz_270;
+  reg        [31:0]   _zz_271;
+  reg        [31:0]   _zz_272;
+  wire       [31:0]   _zz_273;
+  wire       [31:0]   _zz_274;
+  wire       [31:0]   _zz_275;
+  reg                 _zz_276;
+  reg                 _zz_277;
+  reg                 _zz_278;
+  reg                 _zz_279;
+  reg        [1:0]    _zz_280;
+  reg        [31:0]   _zz_281;
+  reg                 _zz_282;
+  reg                 _zz_283;
+  reg                 _zz_284;
+  reg                 _zz_285;
+  reg        [1:0]    _zz_286;
+  reg        [31:0]   _zz_287;
+  reg                 _zz_288;
+  wire                _zz_289;
+  reg        [31:0]   _zz_290;
+  reg        [31:0]   _zz_291;
+  wire       [31:0]   _zz_292;
+  wire       [31:0]   _zz_293;
+  wire       [31:0]   _zz_294;
+  reg                 _zz_295;
+  reg                 _zz_296;
+  reg                 _zz_297;
+  reg                 _zz_298;
+  reg        [1:0]    _zz_299;
+  reg        [31:0]   _zz_300;
+  reg                 _zz_301;
+  reg                 _zz_302;
+  reg                 _zz_303;
+  reg                 _zz_304;
+  reg        [1:0]    _zz_305;
+  reg        [31:0]   _zz_306;
+  reg                 _zz_307;
+  wire                _zz_308;
+  reg        [31:0]   _zz_309;
+  reg        [31:0]   _zz_310;
+  wire       [31:0]   _zz_311;
+  wire       [31:0]   _zz_312;
+  wire       [31:0]   _zz_313;
+  reg                 _zz_314;
+  reg                 _zz_315;
+  reg                 _zz_316;
+  reg                 _zz_317;
+  reg        [1:0]    _zz_318;
+  reg        [31:0]   _zz_319;
+  reg                 _zz_320;
+  reg                 _zz_321;
+  reg                 _zz_322;
+  reg                 _zz_323;
+  reg        [1:0]    _zz_324;
+  reg        [31:0]   _zz_325;
+  reg                 _zz_326;
+  wire                _zz_327;
+  reg        [31:0]   _zz_328;
+  reg        [31:0]   _zz_329;
+  wire       [31:0]   _zz_330;
+  wire       [31:0]   _zz_331;
+  wire       [31:0]   _zz_332;
+  reg                 _zz_333;
+  reg                 _zz_334;
+  reg                 _zz_335;
+  reg                 _zz_336;
+  reg        [1:0]    _zz_337;
+  reg        [31:0]   _zz_338;
+  reg                 _zz_339;
+  reg                 _zz_340;
+  reg                 _zz_341;
+  reg                 _zz_342;
+  reg        [1:0]    _zz_343;
+  reg        [31:0]   _zz_344;
+  reg                 _zz_345;
+  wire                _zz_346;
+  reg        [31:0]   _zz_347;
+  reg        [31:0]   _zz_348;
+  wire       [31:0]   _zz_349;
+  wire       [31:0]   _zz_350;
+  wire       [31:0]   _zz_351;
+  reg                 _zz_352;
+  reg                 _zz_353;
+  reg                 _zz_354;
+  reg                 _zz_355;
+  reg        [1:0]    _zz_356;
+  reg        [31:0]   _zz_357;
+  reg                 _zz_358;
+  reg                 _zz_359;
+  reg                 _zz_360;
+  reg                 _zz_361;
+  reg        [1:0]    _zz_362;
+  reg        [31:0]   _zz_363;
+  reg                 _zz_364;
+  wire                _zz_365;
+  reg        [31:0]   _zz_366;
+  reg        [31:0]   _zz_367;
+  wire       [31:0]   _zz_368;
+  wire       [31:0]   _zz_369;
+  wire       [31:0]   _zz_370;
+  reg                 _zz_371;
+  reg                 _zz_372;
+  reg                 _zz_373;
+  reg                 _zz_374;
+  reg        [1:0]    _zz_375;
+  reg        [31:0]   _zz_376;
+  reg                 _zz_377;
+  reg                 _zz_378;
+  reg                 _zz_379;
+  reg                 _zz_380;
+  reg        [1:0]    _zz_381;
+  reg        [31:0]   _zz_382;
+  reg                 _zz_383;
+  wire                _zz_384;
+  reg        [31:0]   _zz_385;
+  reg        [31:0]   _zz_386;
+  wire       [31:0]   _zz_387;
+  wire       [31:0]   _zz_388;
+  wire       [31:0]   _zz_389;
   wire                PmpPlugin_ports_0_hits_0;
   wire                PmpPlugin_ports_0_hits_1;
   wire                PmpPlugin_ports_0_hits_2;
@@ -2366,57 +1432,65 @@ module VexRiscv (
   wire                PmpPlugin_ports_0_hits_13;
   wire                PmpPlugin_ports_0_hits_14;
   wire                PmpPlugin_ports_0_hits_15;
-  wire       [15:0]   _zz_345_;
-  wire       [15:0]   _zz_346_;
-  wire                _zz_347_;
-  wire                _zz_348_;
-  wire                _zz_349_;
-  wire                _zz_350_;
-  wire                _zz_351_;
-  wire                _zz_352_;
-  wire                _zz_353_;
-  wire                _zz_354_;
-  wire                _zz_355_;
-  wire                _zz_356_;
-  wire                _zz_357_;
-  wire                _zz_358_;
-  wire                _zz_359_;
-  wire                _zz_360_;
-  wire                _zz_361_;
-  wire       [15:0]   _zz_362_;
-  wire       [15:0]   _zz_363_;
-  wire                _zz_364_;
-  wire                _zz_365_;
-  wire                _zz_366_;
-  wire                _zz_367_;
-  wire                _zz_368_;
-  wire                _zz_369_;
-  wire                _zz_370_;
-  wire                _zz_371_;
-  wire                _zz_372_;
-  wire                _zz_373_;
-  wire                _zz_374_;
-  wire                _zz_375_;
-  wire                _zz_376_;
-  wire                _zz_377_;
-  wire                _zz_378_;
-  wire       [15:0]   _zz_379_;
-  wire       [15:0]   _zz_380_;
-  wire                _zz_381_;
-  wire                _zz_382_;
-  wire                _zz_383_;
-  wire                _zz_384_;
-  wire                _zz_385_;
-  wire                _zz_386_;
-  wire                _zz_387_;
-  wire                _zz_388_;
-  wire                _zz_389_;
-  wire                _zz_390_;
-  wire                _zz_391_;
-  wire                _zz_392_;
-  wire                _zz_393_;
-  wire                _zz_394_;
-  wire                _zz_395_;
+  wire       [4:0]    _zz_390;
+  wire       [4:0]    _zz_391;
+  wire       [4:0]    _zz_392;
+  wire       [4:0]    _zz_393;
+  wire       [4:0]    _zz_394;
+  wire       [4:0]    _zz_395;
+  wire       [4:0]    _zz_396;
+  wire       [4:0]    _zz_397;
+  wire       [15:0]   _zz_398;
+  wire       [15:0]   _zz_399;
+  wire                _zz_400;
+  wire                _zz_401;
+  wire                _zz_402;
+  wire                _zz_403;
+  wire                _zz_404;
+  wire                _zz_405;
+  wire                _zz_406;
+  wire                _zz_407;
+  wire                _zz_408;
+  wire                _zz_409;
+  wire                _zz_410;
+  wire                _zz_411;
+  wire                _zz_412;
+  wire                _zz_413;
+  wire                _zz_414;
+  wire       [15:0]   _zz_415;
+  wire       [15:0]   _zz_416;
+  wire                _zz_417;
+  wire                _zz_418;
+  wire                _zz_419;
+  wire                _zz_420;
+  wire                _zz_421;
+  wire                _zz_422;
+  wire                _zz_423;
+  wire                _zz_424;
+  wire                _zz_425;
+  wire                _zz_426;
+  wire                _zz_427;
+  wire                _zz_428;
+  wire                _zz_429;
+  wire                _zz_430;
+  wire                _zz_431;
+  wire       [15:0]   _zz_432;
+  wire       [15:0]   _zz_433;
+  wire                _zz_434;
+  wire                _zz_435;
+  wire                _zz_436;
+  wire                _zz_437;
+  wire                _zz_438;
+  wire                _zz_439;
+  wire                _zz_440;
+  wire                _zz_441;
+  wire                _zz_442;
+  wire                _zz_443;
+  wire                _zz_444;
+  wire                _zz_445;
+  wire                _zz_446;
+  wire                _zz_447;
+  wire                _zz_448;
   wire                PmpPlugin_ports_1_hits_0;
   wire                PmpPlugin_ports_1_hits_1;
   wire                PmpPlugin_ports_1_hits_2;
@@ -2433,124 +1507,132 @@ module VexRiscv (
   wire                PmpPlugin_ports_1_hits_13;
   wire                PmpPlugin_ports_1_hits_14;
   wire                PmpPlugin_ports_1_hits_15;
-  wire       [15:0]   _zz_396_;
-  wire       [15:0]   _zz_397_;
-  wire                _zz_398_;
-  wire                _zz_399_;
-  wire                _zz_400_;
-  wire                _zz_401_;
-  wire                _zz_402_;
-  wire                _zz_403_;
-  wire                _zz_404_;
-  wire                _zz_405_;
-  wire                _zz_406_;
-  wire                _zz_407_;
-  wire                _zz_408_;
-  wire                _zz_409_;
-  wire                _zz_410_;
-  wire                _zz_411_;
-  wire                _zz_412_;
-  wire       [15:0]   _zz_413_;
-  wire       [15:0]   _zz_414_;
-  wire                _zz_415_;
-  wire                _zz_416_;
-  wire                _zz_417_;
-  wire                _zz_418_;
-  wire                _zz_419_;
-  wire                _zz_420_;
-  wire                _zz_421_;
-  wire                _zz_422_;
-  wire                _zz_423_;
-  wire                _zz_424_;
-  wire                _zz_425_;
-  wire                _zz_426_;
-  wire                _zz_427_;
-  wire                _zz_428_;
-  wire                _zz_429_;
-  wire       [15:0]   _zz_430_;
-  wire       [15:0]   _zz_431_;
-  wire                _zz_432_;
-  wire                _zz_433_;
-  wire                _zz_434_;
-  wire                _zz_435_;
-  wire                _zz_436_;
-  wire                _zz_437_;
-  wire                _zz_438_;
-  wire                _zz_439_;
-  wire                _zz_440_;
-  wire                _zz_441_;
-  wire                _zz_442_;
-  wire                _zz_443_;
-  wire                _zz_444_;
-  wire                _zz_445_;
-  wire                _zz_446_;
-  wire       [31:0]   _zz_447_;
-  wire                _zz_448_;
-  wire                _zz_449_;
-  wire                _zz_450_;
-  wire                _zz_451_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_452_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_453_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_454_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_455_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_456_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_457_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_458_;
+  wire       [4:0]    _zz_449;
+  wire       [4:0]    _zz_450;
+  wire       [4:0]    _zz_451;
+  wire       [4:0]    _zz_452;
+  wire       [4:0]    _zz_453;
+  wire       [4:0]    _zz_454;
+  wire       [4:0]    _zz_455;
+  wire       [4:0]    _zz_456;
+  wire       [15:0]   _zz_457;
+  wire       [15:0]   _zz_458;
+  wire                _zz_459;
+  wire                _zz_460;
+  wire                _zz_461;
+  wire                _zz_462;
+  wire                _zz_463;
+  wire                _zz_464;
+  wire                _zz_465;
+  wire                _zz_466;
+  wire                _zz_467;
+  wire                _zz_468;
+  wire                _zz_469;
+  wire                _zz_470;
+  wire                _zz_471;
+  wire                _zz_472;
+  wire                _zz_473;
+  wire       [15:0]   _zz_474;
+  wire       [15:0]   _zz_475;
+  wire                _zz_476;
+  wire                _zz_477;
+  wire                _zz_478;
+  wire                _zz_479;
+  wire                _zz_480;
+  wire                _zz_481;
+  wire                _zz_482;
+  wire                _zz_483;
+  wire                _zz_484;
+  wire                _zz_485;
+  wire                _zz_486;
+  wire                _zz_487;
+  wire                _zz_488;
+  wire                _zz_489;
+  wire                _zz_490;
+  wire       [15:0]   _zz_491;
+  wire       [15:0]   _zz_492;
+  wire                _zz_493;
+  wire                _zz_494;
+  wire                _zz_495;
+  wire                _zz_496;
+  wire                _zz_497;
+  wire                _zz_498;
+  wire                _zz_499;
+  wire                _zz_500;
+  wire                _zz_501;
+  wire                _zz_502;
+  wire                _zz_503;
+  wire                _zz_504;
+  wire                _zz_505;
+  wire                _zz_506;
+  wire                _zz_507;
+  wire       [31:0]   _zz_508;
+  wire                _zz_509;
+  wire                _zz_510;
+  wire                _zz_511;
+  wire                _zz_512;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_513;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_514;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_515;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_516;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_517;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_518;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_519;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_459_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_520;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_460_;
-  reg        [31:0]   _zz_461_;
-  wire                _zz_462_;
-  reg        [19:0]   _zz_463_;
-  wire                _zz_464_;
-  reg        [19:0]   _zz_465_;
-  reg        [31:0]   _zz_466_;
+  reg        [31:0]   _zz_521;
+  reg        [31:0]   _zz_522;
+  wire                _zz_523;
+  reg        [19:0]   _zz_524;
+  wire                _zz_525;
+  reg        [19:0]   _zz_526;
+  reg        [31:0]   _zz_527;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_467_;
+  reg        [31:0]   _zz_528;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_468_;
-  reg                 _zz_469_;
-  reg                 _zz_470_;
-  reg                 _zz_471_;
-  reg        [4:0]    _zz_472_;
-  reg        [31:0]   _zz_473_;
-  wire                _zz_474_;
-  wire                _zz_475_;
-  wire                _zz_476_;
-  wire                _zz_477_;
-  wire                _zz_478_;
-  wire                _zz_479_;
+  reg        [31:0]   _zz_529;
+  reg                 _zz_530;
+  reg                 _zz_531;
+  reg                 _zz_532;
+  reg        [4:0]    _zz_533;
+  reg        [31:0]   _zz_534;
+  wire                _zz_535;
+  wire                _zz_536;
+  wire                _zz_537;
+  wire                _zz_538;
+  wire                _zz_539;
+  wire                _zz_540;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_480_;
-  reg                 _zz_481_;
-  reg                 _zz_482_;
-  wire                _zz_483_;
-  reg        [19:0]   _zz_484_;
-  wire                _zz_485_;
-  reg        [10:0]   _zz_486_;
-  wire                _zz_487_;
-  reg        [18:0]   _zz_488_;
-  reg                 _zz_489_;
+  wire       [2:0]    _zz_541;
+  reg                 _zz_542;
+  reg                 _zz_543;
+  wire                _zz_544;
+  reg        [19:0]   _zz_545;
+  wire                _zz_546;
+  reg        [10:0]   _zz_547;
+  wire                _zz_548;
+  reg        [18:0]   _zz_549;
+  reg                 _zz_550;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_490_;
-  reg        [19:0]   _zz_491_;
-  wire                _zz_492_;
-  reg        [10:0]   _zz_493_;
-  wire                _zz_494_;
-  reg        [18:0]   _zz_495_;
+  wire                _zz_551;
+  reg        [19:0]   _zz_552;
+  wire                _zz_553;
+  reg        [10:0]   _zz_554;
+  wire                _zz_555;
+  reg        [18:0]   _zz_556;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_496_;
+  reg        [1:0]    _zz_557;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -2571,9 +1653,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_497_;
-  wire                _zz_498_;
-  wire                _zz_499_;
+  wire                _zz_558;
+  wire                _zz_559;
+  wire                _zz_560;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -2586,8 +1668,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_500_;
-  wire                _zz_501_;
+  wire       [1:0]    _zz_561;
+  wire                _zz_562;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -2599,7 +1681,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2640,79 +1722,80 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_502_;
+  wire       [31:0]   _zz_563;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_503_;
-  wire                _zz_504_;
-  wire                _zz_505_;
-  reg        [32:0]   _zz_506_;
+  wire       [31:0]   _zz_564;
+  wire                _zz_565;
+  wire                _zz_566;
+  reg        [32:0]   _zz_567;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_507_;
-  wire       [31:0]   _zz_508_;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg        [31:0]   _zz_568;
+  wire       [31:0]   _zz_569;
   reg        [31:0]   decode_to_execute_PC;
   reg        [31:0]   execute_to_memory_PC;
   reg        [31:0]   memory_to_writeBack_PC;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 memory_to_writeBack_IS_MUL;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [33:0]   execute_to_memory_MUL_HL;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg        [31:0]   decode_to_execute_RS1;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
-  reg                 decode_to_execute_IS_CSR;
-  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   reg                 decode_to_execute_MEMORY_ENABLE;
   reg                 execute_to_memory_MEMORY_ENABLE;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg        [31:0]   execute_to_memory_MUL_LL;
-  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
+  reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
   reg                 decode_to_execute_MEMORY_WR;
   reg                 execute_to_memory_MEMORY_WR;
   reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
   reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 memory_to_writeBack_IS_MUL;
   reg                 decode_to_execute_IS_DIV;
   reg                 execute_to_memory_IS_DIV;
-  reg                 execute_to_memory_BRANCH_DO;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
   reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
   reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_944;
   reg                 execute_CsrPlugin_csr_945;
@@ -2757,1307 +1840,1498 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_3202;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_509_;
-  reg        [31:0]   _zz_510_;
-  reg        [31:0]   _zz_511_;
-  reg        [31:0]   _zz_512_;
-  reg        [31:0]   _zz_513_;
-  reg        [31:0]   _zz_514_;
-  reg        [31:0]   _zz_515_;
-  reg        [31:0]   _zz_516_;
-  reg        [31:0]   _zz_517_;
-  reg        [31:0]   _zz_518_;
-  reg        [31:0]   _zz_519_;
-  reg        [31:0]   _zz_520_;
-  reg        [31:0]   _zz_521_;
-  reg        [31:0]   _zz_522_;
-  reg        [31:0]   _zz_523_;
-  reg        [31:0]   _zz_524_;
-  reg        [31:0]   _zz_525_;
-  reg        [31:0]   _zz_526_;
-  reg        [31:0]   _zz_527_;
-  reg        [31:0]   _zz_528_;
-  reg        [31:0]   _zz_529_;
-  reg        [31:0]   _zz_530_;
-  reg        [31:0]   _zz_531_;
-  reg        [31:0]   _zz_532_;
-  reg        [31:0]   _zz_533_;
-  reg        [31:0]   _zz_534_;
-  reg        [31:0]   _zz_535_;
-  reg        [31:0]   _zz_536_;
-  reg        [31:0]   _zz_537_;
-  reg        [31:0]   _zz_538_;
-  reg        [31:0]   _zz_539_;
-  reg        [31:0]   _zz_540_;
-  reg        [31:0]   _zz_541_;
-  reg        [31:0]   _zz_542_;
-  reg        [31:0]   _zz_543_;
-  reg        [31:0]   _zz_544_;
-  reg        [31:0]   _zz_545_;
-  reg        [31:0]   _zz_546_;
-  reg        [31:0]   _zz_547_;
-  reg        [31:0]   _zz_548_;
-  reg        [31:0]   _zz_549_;
-  reg        [31:0]   _zz_550_;
-  reg        [31:0]   _zz_551_;
-  reg        [2:0]    _zz_552_;
-  reg                 _zz_553_;
+  reg        [31:0]   _zz_570;
+  reg        [31:0]   _zz_571;
+  reg        [31:0]   _zz_572;
+  reg        [31:0]   _zz_573;
+  reg        [31:0]   _zz_574;
+  reg        [31:0]   _zz_575;
+  reg        [31:0]   _zz_576;
+  reg        [31:0]   _zz_577;
+  reg        [31:0]   _zz_578;
+  reg        [31:0]   _zz_579;
+  reg        [31:0]   _zz_580;
+  reg        [31:0]   _zz_581;
+  reg        [31:0]   _zz_582;
+  reg        [31:0]   _zz_583;
+  reg        [31:0]   _zz_584;
+  reg        [31:0]   _zz_585;
+  reg        [31:0]   _zz_586;
+  reg        [31:0]   _zz_587;
+  reg        [31:0]   _zz_588;
+  reg        [31:0]   _zz_589;
+  reg        [31:0]   _zz_590;
+  reg        [31:0]   _zz_591;
+  reg        [31:0]   _zz_592;
+  reg        [31:0]   _zz_593;
+  reg        [31:0]   _zz_594;
+  reg        [31:0]   _zz_595;
+  reg        [31:0]   _zz_596;
+  reg        [31:0]   _zz_597;
+  reg        [31:0]   _zz_598;
+  reg        [31:0]   _zz_599;
+  reg        [31:0]   _zz_600;
+  reg        [31:0]   _zz_601;
+  reg        [31:0]   _zz_602;
+  reg        [31:0]   _zz_603;
+  reg        [31:0]   _zz_604;
+  reg        [31:0]   _zz_605;
+  reg        [31:0]   _zz_606;
+  reg        [31:0]   _zz_607;
+  reg        [31:0]   _zz_608;
+  reg        [31:0]   _zz_609;
+  reg        [31:0]   _zz_610;
+  reg        [31:0]   _zz_611;
+  reg        [31:0]   _zz_612;
+  reg        [2:0]    _zz_613;
+  reg                 _zz_614;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_554_;
-  wire                _zz_555_;
-  wire                _zz_556_;
-  wire                _zz_557_;
-  wire                _zz_558_;
-  wire                _zz_559_;
-  reg                 _zz_560_;
+  reg        [2:0]    _zz_615;
+  wire                _zz_616;
+  wire                _zz_617;
+  wire                _zz_618;
+  wire                _zz_619;
+  wire                _zz_620;
+  reg                 _zz_621;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_1__string;
-  reg [23:0] _zz_2__string;
-  reg [23:0] _zz_3__string;
-  reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_4__string;
-  reg [39:0] _zz_5__string;
-  reg [39:0] _zz_6__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_7__string;
-  reg [95:0] _zz_8__string;
-  reg [95:0] _zz_9__string;
-  reg [71:0] _zz_10__string;
-  reg [71:0] _zz_11__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_12__string;
-  reg [71:0] _zz_13__string;
-  reg [71:0] _zz_14__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_15__string;
-  reg [63:0] _zz_16__string;
-  reg [63:0] _zz_17__string;
-  reg [39:0] _zz_18__string;
-  reg [39:0] _zz_19__string;
-  reg [39:0] _zz_20__string;
-  reg [39:0] _zz_21__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_22__string;
-  reg [39:0] _zz_23__string;
-  reg [39:0] _zz_24__string;
-  reg [31:0] _zz_25__string;
-  reg [31:0] _zz_26__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
+  reg [39:0] decode_ALU_BITWISE_CTRL_string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
+  reg [23:0] decode_SRC2_CTRL_string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [31:0] _zz_43__string;
-  reg [39:0] _zz_44__string;
-  reg [39:0] _zz_45__string;
-  reg [71:0] _zz_46__string;
-  reg [63:0] _zz_47__string;
-  reg [23:0] _zz_48__string;
-  reg [95:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_54__string;
-  reg [95:0] _zz_452__string;
-  reg [23:0] _zz_453__string;
-  reg [63:0] _zz_454__string;
-  reg [71:0] _zz_455__string;
-  reg [39:0] _zz_456__string;
-  reg [39:0] _zz_457__string;
-  reg [31:0] _zz_458__string;
+  reg [31:0] _zz_51_string;
+  reg [95:0] _zz_513_string;
+  reg [63:0] _zz_514_string;
+  reg [23:0] _zz_515_string;
+  reg [39:0] _zz_516_string;
+  reg [71:0] _zz_517_string;
+  reg [31:0] _zz_518_string;
+  reg [39:0] _zz_519_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
+  reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [23:0] decode_to_execute_SRC2_CTRL_string;
+  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
+  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
   reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [63:0] decode_to_execute_ALU_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [23:0] decode_to_execute_SRC2_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_588_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_589_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_590_ = 1'b1;
-  assign _zz_591_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_592_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_593_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_594_ = ((_zz_565_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_53__2));
-  assign _zz_595_ = ((_zz_565_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_53__1));
-  assign _zz_596_ = ((_zz_565_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_53__0));
-  assign _zz_597_ = ((_zz_565_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_598_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_599_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_600_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_601_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_602_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_603_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_604_ = (_zz_51_ == 5'h0);
-  assign _zz_605_ = (_zz_50_ == 5'h0);
-  assign _zz_606_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_607_ = (1'b0 || (! 1'b1));
-  assign _zz_608_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_609_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_610_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_611_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_612_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_613_ = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_614_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_615_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_616_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_617_ = (! memory_arbitration_isStuck);
-  assign _zz_618_ = (iBus_cmd_valid || (_zz_552_ != (3'b000)));
-  assign _zz_619_ = (_zz_578_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_620_ = (! _zz_98_);
-  assign _zz_621_ = (! _zz_114_);
-  assign _zz_622_ = (! _zz_130_);
-  assign _zz_623_ = (! _zz_146_);
-  assign _zz_624_ = (! _zz_162_);
-  assign _zz_625_ = (! _zz_178_);
-  assign _zz_626_ = (! _zz_194_);
-  assign _zz_627_ = (! _zz_210_);
-  assign _zz_628_ = (! _zz_226_);
-  assign _zz_629_ = (! _zz_242_);
-  assign _zz_630_ = (! _zz_258_);
-  assign _zz_631_ = (! _zz_274_);
-  assign _zz_632_ = (! _zz_290_);
-  assign _zz_633_ = (! _zz_306_);
-  assign _zz_634_ = (! _zz_322_);
-  assign _zz_635_ = (! _zz_338_);
-  assign _zz_636_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_637_ = ((_zz_497_ && 1'b1) && (! 1'b0));
-  assign _zz_638_ = ((_zz_498_ && 1'b1) && (! 1'b0));
-  assign _zz_639_ = ((_zz_499_ && 1'b1) && (! 1'b0));
-  assign _zz_640_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_641_ = execute_INSTRUCTION[13];
-  assign _zz_642_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_643_ = _zz_447_[17 : 17];
-  assign _zz_644_ = ($signed(_zz_645_) + $signed(_zz_650_));
-  assign _zz_645_ = ($signed(_zz_646_) + $signed(_zz_648_));
-  assign _zz_646_ = 52'h0;
-  assign _zz_647_ = {1'b0,memory_MUL_LL};
-  assign _zz_648_ = {{19{_zz_647_[32]}}, _zz_647_};
-  assign _zz_649_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_650_ = {{2{_zz_649_[49]}}, _zz_649_};
-  assign _zz_651_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_652_ = {{2{_zz_651_[49]}}, _zz_651_};
-  assign _zz_653_ = _zz_447_[12 : 12];
-  assign _zz_654_ = _zz_447_[13 : 13];
-  assign _zz_655_ = ($signed(_zz_657_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_656_ = _zz_655_[31 : 0];
-  assign _zz_657_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_658_ = _zz_447_[10 : 10];
-  assign _zz_659_ = _zz_447_[28 : 28];
-  assign _zz_660_ = _zz_447_[14 : 14];
-  assign _zz_661_ = _zz_447_[1 : 1];
-  assign _zz_662_ = _zz_447_[16 : 16];
-  assign _zz_663_ = _zz_447_[9 : 9];
-  assign _zz_664_ = _zz_447_[11 : 11];
-  assign _zz_665_ = _zz_447_[0 : 0];
-  assign _zz_666_ = _zz_447_[18 : 18];
-  assign _zz_667_ = _zz_447_[26 : 26];
-  assign _zz_668_ = _zz_447_[29 : 29];
-  assign _zz_669_ = _zz_447_[27 : 27];
-  assign _zz_670_ = _zz_447_[15 : 15];
-  assign _zz_671_ = _zz_447_[4 : 4];
-  assign _zz_672_ = (_zz_57_ - (4'b0001));
-  assign _zz_673_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_674_ = {29'd0, _zz_673_};
-  assign _zz_675_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_676_ = {{_zz_72_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_677_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_678_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_679_ = {{_zz_74_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_680_ = {{_zz_76_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_681_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_682_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_683_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_684_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_685_ = (_zz_94_ + 32'h00000001);
-  assign _zz_686_ = (_zz_687_ <<< 3);
-  assign _zz_687_ = (_zz_103_ + 32'h00000001);
-  assign _zz_688_ = (_zz_110_ + 32'h00000001);
-  assign _zz_689_ = (_zz_690_ <<< 3);
-  assign _zz_690_ = (_zz_119_ + 32'h00000001);
-  assign _zz_691_ = (_zz_126_ + 32'h00000001);
-  assign _zz_692_ = (_zz_693_ <<< 3);
-  assign _zz_693_ = (_zz_135_ + 32'h00000001);
-  assign _zz_694_ = (_zz_142_ + 32'h00000001);
-  assign _zz_695_ = (_zz_696_ <<< 3);
-  assign _zz_696_ = (_zz_151_ + 32'h00000001);
-  assign _zz_697_ = (_zz_158_ + 32'h00000001);
-  assign _zz_698_ = (_zz_699_ <<< 3);
-  assign _zz_699_ = (_zz_167_ + 32'h00000001);
-  assign _zz_700_ = (_zz_174_ + 32'h00000001);
-  assign _zz_701_ = (_zz_702_ <<< 3);
-  assign _zz_702_ = (_zz_183_ + 32'h00000001);
-  assign _zz_703_ = (_zz_190_ + 32'h00000001);
-  assign _zz_704_ = (_zz_705_ <<< 3);
-  assign _zz_705_ = (_zz_199_ + 32'h00000001);
-  assign _zz_706_ = (_zz_206_ + 32'h00000001);
-  assign _zz_707_ = (_zz_708_ <<< 3);
-  assign _zz_708_ = (_zz_215_ + 32'h00000001);
-  assign _zz_709_ = (_zz_222_ + 32'h00000001);
-  assign _zz_710_ = (_zz_711_ <<< 3);
-  assign _zz_711_ = (_zz_231_ + 32'h00000001);
-  assign _zz_712_ = (_zz_238_ + 32'h00000001);
-  assign _zz_713_ = (_zz_714_ <<< 3);
-  assign _zz_714_ = (_zz_247_ + 32'h00000001);
-  assign _zz_715_ = (_zz_254_ + 32'h00000001);
-  assign _zz_716_ = (_zz_717_ <<< 3);
-  assign _zz_717_ = (_zz_263_ + 32'h00000001);
-  assign _zz_718_ = (_zz_270_ + 32'h00000001);
-  assign _zz_719_ = (_zz_720_ <<< 3);
-  assign _zz_720_ = (_zz_279_ + 32'h00000001);
-  assign _zz_721_ = (_zz_286_ + 32'h00000001);
-  assign _zz_722_ = (_zz_723_ <<< 3);
-  assign _zz_723_ = (_zz_295_ + 32'h00000001);
-  assign _zz_724_ = (_zz_302_ + 32'h00000001);
-  assign _zz_725_ = (_zz_726_ <<< 3);
-  assign _zz_726_ = (_zz_311_ + 32'h00000001);
-  assign _zz_727_ = (_zz_318_ + 32'h00000001);
-  assign _zz_728_ = (_zz_729_ <<< 3);
-  assign _zz_729_ = (_zz_327_ + 32'h00000001);
-  assign _zz_730_ = (_zz_334_ + 32'h00000001);
-  assign _zz_731_ = (_zz_732_ <<< 3);
-  assign _zz_732_ = (_zz_343_ + 32'h00000001);
-  assign _zz_733_ = (_zz_345_ - 16'h0001);
-  assign _zz_734_ = (_zz_362_ - 16'h0001);
-  assign _zz_735_ = (_zz_379_ - 16'h0001);
-  assign _zz_736_ = (_zz_396_ - 16'h0001);
-  assign _zz_737_ = (_zz_413_ - 16'h0001);
-  assign _zz_738_ = (_zz_430_ - 16'h0001);
-  assign _zz_739_ = execute_SRC_LESS;
-  assign _zz_740_ = (3'b100);
-  assign _zz_741_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_742_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_743_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_744_ = ($signed(_zz_745_) + $signed(_zz_748_));
-  assign _zz_745_ = ($signed(_zz_746_) + $signed(_zz_747_));
-  assign _zz_746_ = execute_SRC1;
-  assign _zz_747_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_748_ = (execute_SRC_USE_SUB_LESS ? _zz_749_ : _zz_750_);
-  assign _zz_749_ = 32'h00000001;
-  assign _zz_750_ = 32'h0;
-  assign _zz_751_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_752_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_753_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_754_ = {_zz_484_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_755_ = {{_zz_486_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_756_ = {{_zz_488_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_757_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_758_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_759_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_760_ = (3'b100);
-  assign _zz_761_ = (_zz_500_ & (~ _zz_762_));
-  assign _zz_762_ = (_zz_500_ - (2'b01));
-  assign _zz_763_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_764_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_765_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_766_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_767_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_768_ = {5'd0, _zz_767_};
-  assign _zz_769_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_770_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_771_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_772_ = {_zz_502_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_773_ = _zz_774_;
-  assign _zz_774_ = _zz_775_;
-  assign _zz_775_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_503_) : _zz_503_)} + _zz_777_);
-  assign _zz_776_ = memory_DivPlugin_div_needRevert;
-  assign _zz_777_ = {32'd0, _zz_776_};
-  assign _zz_778_ = _zz_505_;
-  assign _zz_779_ = {32'd0, _zz_778_};
-  assign _zz_780_ = _zz_504_;
-  assign _zz_781_ = {31'd0, _zz_780_};
-  assign _zz_782_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_783_ = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_784_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_785_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_786_ = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_787_ = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_788_ = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_789_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_790_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_791_ = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_792_ = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_793_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_794_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_795_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_796_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_797_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_798_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_799_ = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_800_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_801_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_802_ = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_803_ = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_804_ = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_805_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_806_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_807_ = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_808_ = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_809_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_810_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_811_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_812_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_813_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_814_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_815_ = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_816_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_817_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_818_ = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_819_ = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_820_ = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_821_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_822_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_823_ = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_824_ = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_825_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_826_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_827_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_828_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_829_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_830_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_831_ = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_832_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_833_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_834_ = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_835_ = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_836_ = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_837_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_838_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_839_ = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_840_ = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_841_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_842_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_843_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_844_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_845_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_846_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_847_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_848_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_849_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_850_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_851_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_852_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_853_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_854_ = 1'b1;
-  assign _zz_855_ = 1'b1;
-  assign _zz_856_ = {_zz_61_,_zz_60_};
-  assign _zz_857_ = {_zz_361_,{_zz_360_,{_zz_359_,_zz_358_}}};
-  assign _zz_858_ = {_zz_378_,{_zz_377_,{_zz_376_,_zz_375_}}};
-  assign _zz_859_ = {_zz_395_,{_zz_394_,{_zz_393_,_zz_392_}}};
-  assign _zz_860_ = {_zz_412_,{_zz_411_,{_zz_410_,_zz_409_}}};
-  assign _zz_861_ = {_zz_429_,{_zz_428_,{_zz_427_,_zz_426_}}};
-  assign _zz_862_ = {_zz_446_,{_zz_445_,{_zz_444_,_zz_443_}}};
-  assign _zz_863_ = 32'h0000107f;
-  assign _zz_864_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_865_ = 32'h00002073;
-  assign _zz_866_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_867_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_868_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_869_) == 32'h00000003),{(_zz_870_ == _zz_871_),{_zz_872_,{_zz_873_,_zz_874_}}}}}};
-  assign _zz_869_ = 32'h0000505f;
-  assign _zz_870_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_871_ = 32'h00000063;
-  assign _zz_872_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_873_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_874_ = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_875_) == 32'h00001013),{(_zz_876_ == _zz_877_),{_zz_878_,{_zz_879_,_zz_880_}}}}}};
-  assign _zz_875_ = 32'hfc00307f;
-  assign _zz_876_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_877_ = 32'h00005033;
-  assign _zz_878_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_879_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_880_ = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
-  assign _zz_881_ = decode_INSTRUCTION[31];
-  assign _zz_882_ = decode_INSTRUCTION[31];
-  assign _zz_883_ = decode_INSTRUCTION[7];
-  assign _zz_884_ = PmpPlugin_ports_0_hits_5;
-  assign _zz_885_ = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_886_ = PmpPlugin_ports_0_hits_5;
-  assign _zz_887_ = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_888_ = PmpPlugin_ports_0_hits_5;
-  assign _zz_889_ = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_890_ = PmpPlugin_ports_1_hits_5;
-  assign _zz_891_ = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_892_ = PmpPlugin_ports_1_hits_5;
-  assign _zz_893_ = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_894_ = PmpPlugin_ports_1_hits_5;
-  assign _zz_895_ = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_896_ = (decode_INSTRUCTION & 32'h0000001c);
-  assign _zz_897_ = 32'h00000004;
-  assign _zz_898_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_899_ = 32'h00000040;
-  assign _zz_900_ = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
-  assign _zz_901_ = {(_zz_906_ == _zz_907_),{_zz_450_,{_zz_908_,_zz_909_}}};
-  assign _zz_902_ = 5'h0;
-  assign _zz_903_ = ({_zz_451_,{_zz_910_,_zz_911_}} != 6'h0);
-  assign _zz_904_ = ({_zz_912_,_zz_913_} != (3'b000));
-  assign _zz_905_ = {(_zz_914_ != _zz_915_),{_zz_916_,{_zz_917_,_zz_918_}}};
-  assign _zz_906_ = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_907_ = 32'h00000040;
-  assign _zz_908_ = (_zz_919_ == _zz_920_);
-  assign _zz_909_ = {_zz_921_,_zz_922_};
-  assign _zz_910_ = (_zz_923_ == _zz_924_);
-  assign _zz_911_ = {_zz_925_,{_zz_926_,_zz_927_}};
-  assign _zz_912_ = (_zz_928_ == _zz_929_);
-  assign _zz_913_ = {_zz_930_,_zz_931_};
-  assign _zz_914_ = (_zz_932_ == _zz_933_);
-  assign _zz_915_ = (1'b0);
-  assign _zz_916_ = (_zz_934_ != (1'b0));
-  assign _zz_917_ = (_zz_935_ != _zz_936_);
-  assign _zz_918_ = {_zz_937_,{_zz_938_,_zz_939_}};
-  assign _zz_919_ = (decode_INSTRUCTION & 32'h00004020);
-  assign _zz_920_ = 32'h00004020;
-  assign _zz_921_ = ((decode_INSTRUCTION & _zz_940_) == 32'h00000010);
-  assign _zz_922_ = ((decode_INSTRUCTION & _zz_941_) == 32'h00000020);
-  assign _zz_923_ = (decode_INSTRUCTION & 32'h00001010);
-  assign _zz_924_ = 32'h00001010;
-  assign _zz_925_ = ((decode_INSTRUCTION & _zz_942_) == 32'h00002010);
-  assign _zz_926_ = (_zz_943_ == _zz_944_);
-  assign _zz_927_ = {_zz_945_,_zz_946_};
-  assign _zz_928_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_929_ = 32'h00000040;
-  assign _zz_930_ = ((decode_INSTRUCTION & _zz_947_) == 32'h00002010);
-  assign _zz_931_ = ((decode_INSTRUCTION & _zz_948_) == 32'h40000030);
-  assign _zz_932_ = (decode_INSTRUCTION & 32'h00203050);
-  assign _zz_933_ = 32'h00000050;
-  assign _zz_934_ = ((decode_INSTRUCTION & _zz_949_) == 32'h00000050);
-  assign _zz_935_ = (_zz_950_ == _zz_951_);
-  assign _zz_936_ = (1'b0);
-  assign _zz_937_ = (_zz_952_ != (1'b0));
-  assign _zz_938_ = (_zz_953_ != _zz_954_);
-  assign _zz_939_ = {_zz_955_,{_zz_956_,_zz_957_}};
-  assign _zz_940_ = 32'h00000030;
-  assign _zz_941_ = 32'h02000020;
-  assign _zz_942_ = 32'h00002010;
-  assign _zz_943_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_944_ = 32'h00000010;
-  assign _zz_945_ = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
-  assign _zz_946_ = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
-  assign _zz_947_ = 32'h00002014;
-  assign _zz_948_ = 32'h40000034;
-  assign _zz_949_ = 32'h00403050;
-  assign _zz_950_ = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_951_ = 32'h00001000;
-  assign _zz_952_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_953_ = {(_zz_958_ == _zz_959_),{_zz_960_,{_zz_961_,_zz_962_}}};
-  assign _zz_954_ = 5'h0;
-  assign _zz_955_ = ({_zz_963_,_zz_964_} != (2'b00));
-  assign _zz_956_ = ({_zz_965_,_zz_966_} != (3'b000));
-  assign _zz_957_ = {(_zz_967_ != _zz_968_),{_zz_969_,{_zz_970_,_zz_971_}}};
-  assign _zz_958_ = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_959_ = 32'h00002040;
-  assign _zz_960_ = ((decode_INSTRUCTION & _zz_972_) == 32'h00001040);
-  assign _zz_961_ = (_zz_973_ == _zz_974_);
-  assign _zz_962_ = {_zz_975_,_zz_976_};
-  assign _zz_963_ = ((decode_INSTRUCTION & _zz_977_) == 32'h00005010);
-  assign _zz_964_ = ((decode_INSTRUCTION & _zz_978_) == 32'h00005020);
-  assign _zz_965_ = (_zz_979_ == _zz_980_);
-  assign _zz_966_ = {_zz_981_,_zz_982_};
-  assign _zz_967_ = {_zz_983_,{_zz_984_,_zz_985_}};
-  assign _zz_968_ = (4'b0000);
-  assign _zz_969_ = (_zz_986_ != (1'b0));
-  assign _zz_970_ = (_zz_987_ != _zz_988_);
-  assign _zz_971_ = {_zz_989_,{_zz_990_,_zz_991_}};
-  assign _zz_972_ = 32'h00001040;
-  assign _zz_973_ = (decode_INSTRUCTION & 32'h00000050);
-  assign _zz_974_ = 32'h00000040;
-  assign _zz_975_ = ((decode_INSTRUCTION & _zz_992_) == 32'h00000040);
-  assign _zz_976_ = ((decode_INSTRUCTION & _zz_993_) == 32'h0);
-  assign _zz_977_ = 32'h00007034;
-  assign _zz_978_ = 32'h02007064;
-  assign _zz_979_ = (decode_INSTRUCTION & 32'h40003054);
-  assign _zz_980_ = 32'h40001010;
-  assign _zz_981_ = ((decode_INSTRUCTION & _zz_994_) == 32'h00001010);
-  assign _zz_982_ = ((decode_INSTRUCTION & _zz_995_) == 32'h00001010);
-  assign _zz_983_ = ((decode_INSTRUCTION & _zz_996_) == 32'h0);
-  assign _zz_984_ = (_zz_997_ == _zz_998_);
-  assign _zz_985_ = {_zz_999_,_zz_1000_};
-  assign _zz_986_ = ((decode_INSTRUCTION & _zz_1001_) == 32'h02004020);
-  assign _zz_987_ = (_zz_1002_ == _zz_1003_);
-  assign _zz_988_ = (1'b0);
-  assign _zz_989_ = (_zz_1004_ != (1'b0));
-  assign _zz_990_ = (_zz_1005_ != _zz_1006_);
-  assign _zz_991_ = {_zz_1007_,{_zz_1008_,_zz_1009_}};
-  assign _zz_992_ = 32'h00400040;
-  assign _zz_993_ = 32'h00000038;
-  assign _zz_994_ = 32'h00007034;
-  assign _zz_995_ = 32'h02007054;
-  assign _zz_996_ = 32'h00000044;
-  assign _zz_997_ = (decode_INSTRUCTION & 32'h00000018);
-  assign _zz_998_ = 32'h0;
-  assign _zz_999_ = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
-  assign _zz_1000_ = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
-  assign _zz_1001_ = 32'h02004064;
-  assign _zz_1002_ = (decode_INSTRUCTION & 32'h02004074);
-  assign _zz_1003_ = 32'h02000030;
-  assign _zz_1004_ = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
-  assign _zz_1005_ = {_zz_450_,{_zz_1010_,{_zz_1011_,_zz_1012_}}};
-  assign _zz_1006_ = 5'h0;
-  assign _zz_1007_ = ({_zz_1013_,_zz_1014_} != (2'b00));
-  assign _zz_1008_ = (_zz_1015_ != (1'b0));
-  assign _zz_1009_ = {(_zz_1016_ != _zz_1017_),{_zz_1018_,{_zz_1019_,_zz_1020_}}};
-  assign _zz_1010_ = ((decode_INSTRUCTION & _zz_1021_) == 32'h00002010);
-  assign _zz_1011_ = (_zz_1022_ == _zz_1023_);
-  assign _zz_1012_ = {_zz_1024_,_zz_1025_};
-  assign _zz_1013_ = ((decode_INSTRUCTION & _zz_1026_) == 32'h00001050);
-  assign _zz_1014_ = ((decode_INSTRUCTION & _zz_1027_) == 32'h00002050);
-  assign _zz_1015_ = ((decode_INSTRUCTION & _zz_1028_) == 32'h00000020);
-  assign _zz_1016_ = _zz_448_;
-  assign _zz_1017_ = (1'b0);
-  assign _zz_1018_ = ({_zz_1029_,_zz_1030_} != (2'b00));
-  assign _zz_1019_ = (_zz_1031_ != _zz_1032_);
-  assign _zz_1020_ = {_zz_1033_,{_zz_1034_,_zz_1035_}};
-  assign _zz_1021_ = 32'h00002030;
-  assign _zz_1022_ = (decode_INSTRUCTION & 32'h00001030);
-  assign _zz_1023_ = 32'h00000010;
-  assign _zz_1024_ = ((decode_INSTRUCTION & 32'h02002060) == 32'h00002020);
-  assign _zz_1025_ = ((decode_INSTRUCTION & 32'h02003020) == 32'h00000020);
-  assign _zz_1026_ = 32'h00001050;
-  assign _zz_1027_ = 32'h00002050;
-  assign _zz_1028_ = 32'h00000020;
-  assign _zz_1029_ = ((decode_INSTRUCTION & _zz_1036_) == 32'h00002000);
-  assign _zz_1030_ = ((decode_INSTRUCTION & _zz_1037_) == 32'h00001000);
-  assign _zz_1031_ = ((decode_INSTRUCTION & _zz_1038_) == 32'h00004008);
-  assign _zz_1032_ = (1'b0);
-  assign _zz_1033_ = ((_zz_1039_ == _zz_1040_) != (1'b0));
-  assign _zz_1034_ = (_zz_1041_ != (1'b0));
-  assign _zz_1035_ = {(_zz_1042_ != _zz_1043_),{_zz_1044_,{_zz_1045_,_zz_1046_}}};
-  assign _zz_1036_ = 32'h00002010;
-  assign _zz_1037_ = 32'h00005000;
-  assign _zz_1038_ = 32'h00004048;
-  assign _zz_1039_ = (decode_INSTRUCTION & 32'h00004014);
-  assign _zz_1040_ = 32'h00004010;
-  assign _zz_1041_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz_1042_ = {_zz_450_,((decode_INSTRUCTION & _zz_1047_) == 32'h00000020)};
-  assign _zz_1043_ = (2'b00);
-  assign _zz_1044_ = ({_zz_450_,(_zz_1048_ == _zz_1049_)} != (2'b00));
-  assign _zz_1045_ = ((_zz_1050_ == _zz_1051_) != (1'b0));
-  assign _zz_1046_ = {({_zz_1052_,_zz_1053_} != (2'b00)),{(_zz_1054_ != _zz_1055_),{_zz_1056_,_zz_1057_}}};
-  assign _zz_1047_ = 32'h00000070;
-  assign _zz_1048_ = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_1049_ = 32'h0;
-  assign _zz_1050_ = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz_1051_ = 32'h00001008;
-  assign _zz_1052_ = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_1053_ = _zz_449_;
-  assign _zz_1054_ = {((decode_INSTRUCTION & 32'h00000044) == 32'h00000004),_zz_449_};
-  assign _zz_1055_ = (2'b00);
-  assign _zz_1056_ = (_zz_448_ != (1'b0));
-  assign _zz_1057_ = ({((decode_INSTRUCTION & 32'h00000034) == 32'h00000020),((decode_INSTRUCTION & 32'h00000064) == 32'h00000020)} != (2'b00));
-  assign _zz_1058_ = execute_INSTRUCTION[31];
-  assign _zz_1059_ = execute_INSTRUCTION[31];
-  assign _zz_1060_ = execute_INSTRUCTION[7];
-  assign _zz_1061_ = (_zz_509_ | _zz_510_);
-  assign _zz_1062_ = (_zz_511_ | _zz_512_);
-  assign _zz_1063_ = (_zz_513_ | _zz_514_);
-  assign _zz_1064_ = (_zz_515_ | _zz_516_);
-  assign _zz_1065_ = (_zz_517_ | _zz_518_);
-  assign _zz_1066_ = (_zz_519_ | _zz_520_);
-  assign _zz_1067_ = (_zz_521_ | _zz_522_);
-  assign _zz_1068_ = (_zz_523_ | _zz_524_);
-  assign _zz_1069_ = (_zz_525_ | _zz_526_);
-  assign _zz_1070_ = (_zz_527_ | _zz_528_);
-  assign _zz_1071_ = (_zz_529_ | _zz_530_);
-  assign _zz_1072_ = (_zz_531_ | _zz_532_);
-  assign _zz_1073_ = (_zz_1077_ | _zz_533_);
-  assign _zz_1074_ = (_zz_534_ | _zz_535_);
-  assign _zz_1075_ = (_zz_536_ | _zz_537_);
-  assign _zz_1076_ = (_zz_538_ | _zz_539_);
-  assign _zz_1077_ = 32'h0;
+  assign _zz_671 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_672 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_673 = 1'b1;
+  assign _zz_674 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_675 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_676 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_677 = ((_zz_627 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_678 = ((_zz_627 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_679 = ((_zz_627 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_680 = ((_zz_627 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_681 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_682 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_683 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_684 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_685 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_686 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_687 = (_zz_816 == 5'h0);
+  assign _zz_688 = (_zz_826 == 5'h0);
+  assign _zz_689 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_690 = (1'b0 || (! 1'b1));
+  assign _zz_691 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_692 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_693 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_694 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_695 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_696 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_697 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_698 = execute_INSTRUCTION[13 : 12];
+  assign _zz_699 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_700 = (! memory_arbitration_isStuck);
+  assign _zz_701 = (iBus_cmd_valid || (_zz_613 != 3'b000));
+  assign _zz_702 = (_zz_649 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_703 = (! _zz_89);
+  assign _zz_704 = (! _zz_108);
+  assign _zz_705 = (! _zz_127);
+  assign _zz_706 = (! _zz_146);
+  assign _zz_707 = (! _zz_165);
+  assign _zz_708 = (! _zz_184);
+  assign _zz_709 = (! _zz_203);
+  assign _zz_710 = (! _zz_222);
+  assign _zz_711 = (! _zz_241);
+  assign _zz_712 = (! _zz_260);
+  assign _zz_713 = (! _zz_279);
+  assign _zz_714 = (! _zz_298);
+  assign _zz_715 = (! _zz_317);
+  assign _zz_716 = (! _zz_336);
+  assign _zz_717 = (! _zz_355);
+  assign _zz_718 = (! _zz_374);
+  assign _zz_719 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_720 = ((_zz_558 && 1'b1) && (! 1'b0));
+  assign _zz_721 = ((_zz_559 && 1'b1) && (! 1'b0));
+  assign _zz_722 = ((_zz_560 && 1'b1) && (! 1'b0));
+  assign _zz_723 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_724 = execute_INSTRUCTION[13];
+  assign _zz_725 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_726 = ($signed(_zz_727) + $signed(_zz_732));
+  assign _zz_727 = ($signed(_zz_728) + $signed(_zz_730));
+  assign _zz_728 = 52'h0;
+  assign _zz_729 = {1'b0,memory_MUL_LL};
+  assign _zz_730 = {{19{_zz_729[32]}}, _zz_729};
+  assign _zz_731 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_732 = {{2{_zz_731[49]}}, _zz_731};
+  assign _zz_733 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_734 = {{2{_zz_733[49]}}, _zz_733};
+  assign _zz_735 = ($signed(_zz_737) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_736 = _zz_735[31 : 0];
+  assign _zz_737 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_738 = _zz_508[31 : 31];
+  assign _zz_739 = _zz_508[30 : 30];
+  assign _zz_740 = _zz_508[29 : 29];
+  assign _zz_741 = _zz_508[28 : 28];
+  assign _zz_742 = _zz_508[25 : 25];
+  assign _zz_743 = _zz_508[17 : 17];
+  assign _zz_744 = _zz_508[16 : 16];
+  assign _zz_745 = _zz_508[13 : 13];
+  assign _zz_746 = _zz_508[12 : 12];
+  assign _zz_747 = _zz_508[11 : 11];
+  assign _zz_748 = _zz_508[15 : 15];
+  assign _zz_749 = _zz_508[5 : 5];
+  assign _zz_750 = _zz_508[3 : 3];
+  assign _zz_751 = _zz_508[20 : 20];
+  assign _zz_752 = _zz_508[10 : 10];
+  assign _zz_753 = _zz_508[4 : 4];
+  assign _zz_754 = _zz_508[0 : 0];
+  assign _zz_755 = (_zz_54 - 4'b0001);
+  assign _zz_756 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_757 = {29'd0, _zz_756};
+  assign _zz_758 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_759 = {{_zz_69,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_760 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_761 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_762 = {{_zz_71,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_763 = {{_zz_73,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_764 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_765 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_766 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_767 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_768 = (_zz_91 + 32'h00000001);
+  assign _zz_769 = (_zz_770 <<< 3);
+  assign _zz_770 = (_zz_103 + 32'h00000001);
+  assign _zz_771 = (_zz_110 + 32'h00000001);
+  assign _zz_772 = (_zz_773 <<< 3);
+  assign _zz_773 = (_zz_122 + 32'h00000001);
+  assign _zz_774 = (_zz_129 + 32'h00000001);
+  assign _zz_775 = (_zz_776 <<< 3);
+  assign _zz_776 = (_zz_141 + 32'h00000001);
+  assign _zz_777 = (_zz_148 + 32'h00000001);
+  assign _zz_778 = (_zz_779 <<< 3);
+  assign _zz_779 = (_zz_160 + 32'h00000001);
+  assign _zz_780 = (_zz_167 + 32'h00000001);
+  assign _zz_781 = (_zz_782 <<< 3);
+  assign _zz_782 = (_zz_179 + 32'h00000001);
+  assign _zz_783 = (_zz_186 + 32'h00000001);
+  assign _zz_784 = (_zz_785 <<< 3);
+  assign _zz_785 = (_zz_198 + 32'h00000001);
+  assign _zz_786 = (_zz_205 + 32'h00000001);
+  assign _zz_787 = (_zz_788 <<< 3);
+  assign _zz_788 = (_zz_217 + 32'h00000001);
+  assign _zz_789 = (_zz_224 + 32'h00000001);
+  assign _zz_790 = (_zz_791 <<< 3);
+  assign _zz_791 = (_zz_236 + 32'h00000001);
+  assign _zz_792 = (_zz_243 + 32'h00000001);
+  assign _zz_793 = (_zz_794 <<< 3);
+  assign _zz_794 = (_zz_255 + 32'h00000001);
+  assign _zz_795 = (_zz_262 + 32'h00000001);
+  assign _zz_796 = (_zz_797 <<< 3);
+  assign _zz_797 = (_zz_274 + 32'h00000001);
+  assign _zz_798 = (_zz_281 + 32'h00000001);
+  assign _zz_799 = (_zz_800 <<< 3);
+  assign _zz_800 = (_zz_293 + 32'h00000001);
+  assign _zz_801 = (_zz_300 + 32'h00000001);
+  assign _zz_802 = (_zz_803 <<< 3);
+  assign _zz_803 = (_zz_312 + 32'h00000001);
+  assign _zz_804 = (_zz_319 + 32'h00000001);
+  assign _zz_805 = (_zz_806 <<< 3);
+  assign _zz_806 = (_zz_331 + 32'h00000001);
+  assign _zz_807 = (_zz_338 + 32'h00000001);
+  assign _zz_808 = (_zz_809 <<< 3);
+  assign _zz_809 = (_zz_350 + 32'h00000001);
+  assign _zz_810 = (_zz_357 + 32'h00000001);
+  assign _zz_811 = (_zz_812 <<< 3);
+  assign _zz_812 = (_zz_369 + 32'h00000001);
+  assign _zz_813 = (_zz_376 + 32'h00000001);
+  assign _zz_814 = (_zz_815 <<< 3);
+  assign _zz_815 = (_zz_388 + 32'h00000001);
+  assign _zz_816 = (_zz_817 + _zz_820);
+  assign _zz_817 = (_zz_818 + _zz_819);
+  assign _zz_818 = (_zz_653 + _zz_654);
+  assign _zz_819 = (_zz_655 + _zz_656);
+  assign _zz_820 = (_zz_657 + _zz_658);
+  assign _zz_821 = PmpPlugin_ports_0_hits_15;
+  assign _zz_822 = {2'd0, _zz_821};
+  assign _zz_823 = (_zz_398 - 16'h0001);
+  assign _zz_824 = (_zz_415 - 16'h0001);
+  assign _zz_825 = (_zz_432 - 16'h0001);
+  assign _zz_826 = (_zz_827 + _zz_830);
+  assign _zz_827 = (_zz_828 + _zz_829);
+  assign _zz_828 = (_zz_662 + _zz_663);
+  assign _zz_829 = (_zz_664 + _zz_665);
+  assign _zz_830 = (_zz_666 + _zz_667);
+  assign _zz_831 = PmpPlugin_ports_1_hits_15;
+  assign _zz_832 = {2'd0, _zz_831};
+  assign _zz_833 = (_zz_457 - 16'h0001);
+  assign _zz_834 = (_zz_474 - 16'h0001);
+  assign _zz_835 = (_zz_491 - 16'h0001);
+  assign _zz_836 = execute_SRC_LESS;
+  assign _zz_837 = 3'b100;
+  assign _zz_838 = execute_INSTRUCTION[19 : 15];
+  assign _zz_839 = execute_INSTRUCTION[31 : 20];
+  assign _zz_840 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_841 = ($signed(_zz_842) + $signed(_zz_845));
+  assign _zz_842 = ($signed(_zz_843) + $signed(_zz_844));
+  assign _zz_843 = execute_SRC1;
+  assign _zz_844 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_845 = (execute_SRC_USE_SUB_LESS ? _zz_846 : _zz_847);
+  assign _zz_846 = 32'h00000001;
+  assign _zz_847 = 32'h0;
+  assign _zz_848 = execute_INSTRUCTION[31 : 20];
+  assign _zz_849 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_850 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_851 = {_zz_545,execute_INSTRUCTION[31 : 20]};
+  assign _zz_852 = {{_zz_547,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_853 = {{_zz_549,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_854 = execute_INSTRUCTION[31 : 20];
+  assign _zz_855 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_856 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_857 = 3'b100;
+  assign _zz_858 = (_zz_561 & (~ _zz_859));
+  assign _zz_859 = (_zz_561 - 2'b01);
+  assign _zz_860 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_861 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_862 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_863 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_864 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_865 = {5'd0, _zz_864};
+  assign _zz_866 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_867 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_868 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_869 = {_zz_563,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_870 = _zz_871;
+  assign _zz_871 = _zz_872;
+  assign _zz_872 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_564) : _zz_564)} + _zz_874);
+  assign _zz_873 = memory_DivPlugin_div_needRevert;
+  assign _zz_874 = {32'd0, _zz_873};
+  assign _zz_875 = _zz_566;
+  assign _zz_876 = {32'd0, _zz_875};
+  assign _zz_877 = _zz_565;
+  assign _zz_878 = {31'd0, _zz_877};
+  assign _zz_879 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_880 = execute_CsrPlugin_writeData[23 : 23];
+  assign _zz_881 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_882 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_883 = execute_CsrPlugin_writeData[26 : 26];
+  assign _zz_884 = execute_CsrPlugin_writeData[25 : 25];
+  assign _zz_885 = execute_CsrPlugin_writeData[24 : 24];
+  assign _zz_886 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_887 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_888 = execute_CsrPlugin_writeData[16 : 16];
+  assign _zz_889 = execute_CsrPlugin_writeData[10 : 10];
+  assign _zz_890 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_891 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_892 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_893 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_894 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_895 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_896 = execute_CsrPlugin_writeData[23 : 23];
+  assign _zz_897 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_898 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_899 = execute_CsrPlugin_writeData[26 : 26];
+  assign _zz_900 = execute_CsrPlugin_writeData[25 : 25];
+  assign _zz_901 = execute_CsrPlugin_writeData[24 : 24];
+  assign _zz_902 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_903 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_904 = execute_CsrPlugin_writeData[16 : 16];
+  assign _zz_905 = execute_CsrPlugin_writeData[10 : 10];
+  assign _zz_906 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_907 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_908 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_909 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_910 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_911 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_912 = execute_CsrPlugin_writeData[23 : 23];
+  assign _zz_913 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_914 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_915 = execute_CsrPlugin_writeData[26 : 26];
+  assign _zz_916 = execute_CsrPlugin_writeData[25 : 25];
+  assign _zz_917 = execute_CsrPlugin_writeData[24 : 24];
+  assign _zz_918 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_919 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_920 = execute_CsrPlugin_writeData[16 : 16];
+  assign _zz_921 = execute_CsrPlugin_writeData[10 : 10];
+  assign _zz_922 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_923 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_924 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_925 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_926 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_927 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_928 = execute_CsrPlugin_writeData[23 : 23];
+  assign _zz_929 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_930 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_931 = execute_CsrPlugin_writeData[26 : 26];
+  assign _zz_932 = execute_CsrPlugin_writeData[25 : 25];
+  assign _zz_933 = execute_CsrPlugin_writeData[24 : 24];
+  assign _zz_934 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_935 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_936 = execute_CsrPlugin_writeData[16 : 16];
+  assign _zz_937 = execute_CsrPlugin_writeData[10 : 10];
+  assign _zz_938 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_939 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_940 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_941 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_942 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_943 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_944 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_945 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_946 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_947 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_948 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_949 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_950 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_951 = 1'b1;
+  assign _zz_952 = 1'b1;
+  assign _zz_953 = {_zz_58,_zz_57};
+  assign _zz_954 = {PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}};
+  assign _zz_955 = {PmpPlugin_ports_0_hits_5,{PmpPlugin_ports_0_hits_4,PmpPlugin_ports_0_hits_3}};
+  assign _zz_956 = {PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,PmpPlugin_ports_0_hits_6}};
+  assign _zz_957 = {PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,PmpPlugin_ports_0_hits_9}};
+  assign _zz_958 = {PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,PmpPlugin_ports_0_hits_12}};
+  assign _zz_959 = {_zz_414,{_zz_413,{_zz_412,_zz_411}}};
+  assign _zz_960 = {_zz_431,{_zz_430,{_zz_429,_zz_428}}};
+  assign _zz_961 = {_zz_448,{_zz_447,{_zz_446,_zz_445}}};
+  assign _zz_962 = {PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}};
+  assign _zz_963 = {PmpPlugin_ports_1_hits_5,{PmpPlugin_ports_1_hits_4,PmpPlugin_ports_1_hits_3}};
+  assign _zz_964 = {PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,PmpPlugin_ports_1_hits_6}};
+  assign _zz_965 = {PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,PmpPlugin_ports_1_hits_9}};
+  assign _zz_966 = {PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,PmpPlugin_ports_1_hits_12}};
+  assign _zz_967 = {_zz_473,{_zz_472,{_zz_471,_zz_470}}};
+  assign _zz_968 = {_zz_490,{_zz_489,{_zz_488,_zz_487}}};
+  assign _zz_969 = {_zz_507,{_zz_506,{_zz_505,_zz_504}}};
+  assign _zz_970 = 32'h0000107f;
+  assign _zz_971 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_972 = 32'h00002073;
+  assign _zz_973 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_974 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_975 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_976) == 32'h00000003),{(_zz_977 == _zz_978),{_zz_979,{_zz_980,_zz_981}}}}}};
+  assign _zz_976 = 32'h0000505f;
+  assign _zz_977 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_978 = 32'h00000063;
+  assign _zz_979 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_980 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_981 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_982) == 32'h00001013),{(_zz_983 == _zz_984),{_zz_985,{_zz_986,_zz_987}}}}}};
+  assign _zz_982 = 32'hfc00307f;
+  assign _zz_983 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_984 = 32'h00005033;
+  assign _zz_985 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_986 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_987 = {((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073),((decode_INSTRUCTION & 32'hffffffff) == 32'h00000073)};
+  assign _zz_988 = decode_INSTRUCTION[31];
+  assign _zz_989 = decode_INSTRUCTION[31];
+  assign _zz_990 = decode_INSTRUCTION[7];
+  assign _zz_991 = PmpPlugin_ports_0_hits_5;
+  assign _zz_992 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz_993 = PmpPlugin_ports_0_hits_5;
+  assign _zz_994 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz_995 = PmpPlugin_ports_0_hits_5;
+  assign _zz_996 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz_997 = PmpPlugin_ports_1_hits_5;
+  assign _zz_998 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz_999 = PmpPlugin_ports_1_hits_5;
+  assign _zz_1000 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz_1001 = PmpPlugin_ports_1_hits_5;
+  assign _zz_1002 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz_1003 = (decode_INSTRUCTION & 32'h02004064);
+  assign _zz_1004 = 32'h02004020;
+  assign _zz_1005 = ((decode_INSTRUCTION & 32'h02004074) == 32'h02000030);
+  assign _zz_1006 = ((decode_INSTRUCTION & 32'h00203050) == 32'h00000050);
+  assign _zz_1007 = 1'b0;
+  assign _zz_1008 = (((decode_INSTRUCTION & _zz_1011) == 32'h00000050) != 1'b0);
+  assign _zz_1009 = ({_zz_1012,_zz_1013} != 2'b00);
+  assign _zz_1010 = {({_zz_1014,_zz_1015} != 2'b00),{(_zz_1016 != _zz_1017),{_zz_1018,{_zz_1019,_zz_1020}}}};
+  assign _zz_1011 = 32'h00403050;
+  assign _zz_1012 = ((decode_INSTRUCTION & 32'h00001050) == 32'h00001050);
+  assign _zz_1013 = ((decode_INSTRUCTION & 32'h00002050) == 32'h00002050);
+  assign _zz_1014 = _zz_511;
+  assign _zz_1015 = ((decode_INSTRUCTION & _zz_1021) == 32'h00000004);
+  assign _zz_1016 = ((decode_INSTRUCTION & _zz_1022) == 32'h00000040);
+  assign _zz_1017 = 1'b0;
+  assign _zz_1018 = ({_zz_1023,_zz_1024} != 2'b00);
+  assign _zz_1019 = ({_zz_1025,_zz_1026} != 3'b000);
+  assign _zz_1020 = {(_zz_1027 != _zz_1028),{_zz_1029,{_zz_1030,_zz_1031}}};
+  assign _zz_1021 = 32'h0000001c;
+  assign _zz_1022 = 32'h00000058;
+  assign _zz_1023 = ((decode_INSTRUCTION & 32'h00007034) == 32'h00005010);
+  assign _zz_1024 = ((decode_INSTRUCTION & 32'h02007064) == 32'h00005020);
+  assign _zz_1025 = ((decode_INSTRUCTION & _zz_1032) == 32'h40001010);
+  assign _zz_1026 = {(_zz_1033 == _zz_1034),(_zz_1035 == _zz_1036)};
+  assign _zz_1027 = ((decode_INSTRUCTION & _zz_1037) == 32'h00000024);
+  assign _zz_1028 = 1'b0;
+  assign _zz_1029 = ((_zz_1038 == _zz_1039) != 1'b0);
+  assign _zz_1030 = (_zz_1040 != 1'b0);
+  assign _zz_1031 = {(_zz_1041 != _zz_1042),{_zz_1043,{_zz_1044,_zz_1045}}};
+  assign _zz_1032 = 32'h40003054;
+  assign _zz_1033 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_1034 = 32'h00001010;
+  assign _zz_1035 = (decode_INSTRUCTION & 32'h02007054);
+  assign _zz_1036 = 32'h00001010;
+  assign _zz_1037 = 32'h00000064;
+  assign _zz_1038 = (decode_INSTRUCTION & 32'h00001000);
+  assign _zz_1039 = 32'h00001000;
+  assign _zz_1040 = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
+  assign _zz_1041 = {(_zz_1046 == _zz_1047),(_zz_1048 == _zz_1049)};
+  assign _zz_1042 = 2'b00;
+  assign _zz_1043 = ((_zz_1050 == _zz_1051) != 1'b0);
+  assign _zz_1044 = ({_zz_1052,_zz_1053} != 2'b00);
+  assign _zz_1045 = {(_zz_1054 != _zz_1055),{_zz_1056,{_zz_1057,_zz_1058}}};
+  assign _zz_1046 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_1047 = 32'h00002000;
+  assign _zz_1048 = (decode_INSTRUCTION & 32'h00005000);
+  assign _zz_1049 = 32'h00001000;
+  assign _zz_1050 = (decode_INSTRUCTION & 32'h00004048);
+  assign _zz_1051 = 32'h00004008;
+  assign _zz_1052 = ((decode_INSTRUCTION & _zz_1059) == 32'h00000020);
+  assign _zz_1053 = ((decode_INSTRUCTION & _zz_1060) == 32'h00000020);
+  assign _zz_1054 = {(_zz_1061 == _zz_1062),{_zz_1063,{_zz_1064,_zz_1065}}};
+  assign _zz_1055 = 5'h0;
+  assign _zz_1056 = ((_zz_1066 == _zz_1067) != 1'b0);
+  assign _zz_1057 = ({_zz_1068,_zz_1069} != 5'h0);
+  assign _zz_1058 = {(_zz_1070 != _zz_1071),{_zz_1072,{_zz_1073,_zz_1074}}};
+  assign _zz_1059 = 32'h00000034;
+  assign _zz_1060 = 32'h00000064;
+  assign _zz_1061 = (decode_INSTRUCTION & 32'h00002040);
+  assign _zz_1062 = 32'h00002040;
+  assign _zz_1063 = ((decode_INSTRUCTION & _zz_1075) == 32'h00001040);
+  assign _zz_1064 = (_zz_1076 == _zz_1077);
+  assign _zz_1065 = {_zz_1078,_zz_1079};
+  assign _zz_1066 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_1067 = 32'h00000020;
+  assign _zz_1068 = (_zz_1080 == _zz_1081);
+  assign _zz_1069 = {_zz_510,{_zz_1082,_zz_1083}};
+  assign _zz_1070 = {_zz_510,{_zz_1084,_zz_1085}};
+  assign _zz_1071 = 5'h0;
+  assign _zz_1072 = ({_zz_1086,_zz_1087} != 6'h0);
+  assign _zz_1073 = (_zz_1088 != _zz_1089);
+  assign _zz_1074 = {_zz_1090,{_zz_1091,_zz_1092}};
+  assign _zz_1075 = 32'h00001040;
+  assign _zz_1076 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_1077 = 32'h00000040;
+  assign _zz_1078 = ((decode_INSTRUCTION & _zz_1093) == 32'h00000040);
+  assign _zz_1079 = ((decode_INSTRUCTION & _zz_1094) == 32'h0);
+  assign _zz_1080 = (decode_INSTRUCTION & 32'h00000040);
+  assign _zz_1081 = 32'h00000040;
+  assign _zz_1082 = (_zz_1095 == _zz_1096);
+  assign _zz_1083 = {_zz_1097,_zz_1098};
+  assign _zz_1084 = (_zz_1099 == _zz_1100);
+  assign _zz_1085 = {_zz_1101,{_zz_1102,_zz_1103}};
+  assign _zz_1086 = _zz_511;
+  assign _zz_1087 = {_zz_1104,{_zz_1105,_zz_1106}};
+  assign _zz_1088 = {_zz_510,_zz_1107};
+  assign _zz_1089 = 2'b00;
+  assign _zz_1090 = ({_zz_1108,_zz_1109} != 2'b00);
+  assign _zz_1091 = (_zz_1110 != _zz_1111);
+  assign _zz_1092 = {_zz_1112,{_zz_1113,_zz_1114}};
+  assign _zz_1093 = 32'h00400040;
+  assign _zz_1094 = 32'h00000038;
+  assign _zz_1095 = (decode_INSTRUCTION & 32'h00004020);
+  assign _zz_1096 = 32'h00004020;
+  assign _zz_1097 = ((decode_INSTRUCTION & _zz_1115) == 32'h00000010);
+  assign _zz_1098 = ((decode_INSTRUCTION & _zz_1116) == 32'h00000020);
+  assign _zz_1099 = (decode_INSTRUCTION & 32'h00002030);
+  assign _zz_1100 = 32'h00002010;
+  assign _zz_1101 = ((decode_INSTRUCTION & _zz_1117) == 32'h00000010);
+  assign _zz_1102 = (_zz_1118 == _zz_1119);
+  assign _zz_1103 = (_zz_1120 == _zz_1121);
+  assign _zz_1104 = ((decode_INSTRUCTION & _zz_1122) == 32'h00001010);
+  assign _zz_1105 = (_zz_1123 == _zz_1124);
+  assign _zz_1106 = {_zz_1125,{_zz_1126,_zz_1127}};
+  assign _zz_1107 = ((decode_INSTRUCTION & _zz_1128) == 32'h00000020);
+  assign _zz_1108 = _zz_510;
+  assign _zz_1109 = (_zz_1129 == _zz_1130);
+  assign _zz_1110 = (_zz_1131 == _zz_1132);
+  assign _zz_1111 = 1'b0;
+  assign _zz_1112 = (_zz_1133 != 1'b0);
+  assign _zz_1113 = (_zz_1134 != _zz_1135);
+  assign _zz_1114 = {_zz_1136,{_zz_1137,_zz_1138}};
+  assign _zz_1115 = 32'h00000030;
+  assign _zz_1116 = 32'h02000020;
+  assign _zz_1117 = 32'h00001030;
+  assign _zz_1118 = (decode_INSTRUCTION & 32'h02002060);
+  assign _zz_1119 = 32'h00002020;
+  assign _zz_1120 = (decode_INSTRUCTION & 32'h02003020);
+  assign _zz_1121 = 32'h00000020;
+  assign _zz_1122 = 32'h00001010;
+  assign _zz_1123 = (decode_INSTRUCTION & 32'h00002010);
+  assign _zz_1124 = 32'h00002010;
+  assign _zz_1125 = ((decode_INSTRUCTION & _zz_1139) == 32'h00000010);
+  assign _zz_1126 = (_zz_1140 == _zz_1141);
+  assign _zz_1127 = (_zz_1142 == _zz_1143);
+  assign _zz_1128 = 32'h00000070;
+  assign _zz_1129 = (decode_INSTRUCTION & 32'h00000020);
+  assign _zz_1130 = 32'h0;
+  assign _zz_1131 = (decode_INSTRUCTION & 32'h00004014);
+  assign _zz_1132 = 32'h00004010;
+  assign _zz_1133 = ((decode_INSTRUCTION & _zz_1144) == 32'h00002010);
+  assign _zz_1134 = {_zz_1145,{_zz_1146,_zz_1147}};
+  assign _zz_1135 = 4'b0000;
+  assign _zz_1136 = (_zz_1148 != 1'b0);
+  assign _zz_1137 = (_zz_1149 != _zz_1150);
+  assign _zz_1138 = {_zz_1151,{_zz_1152,_zz_1153}};
+  assign _zz_1139 = 32'h00000050;
+  assign _zz_1140 = (decode_INSTRUCTION & 32'h0000000c);
+  assign _zz_1141 = 32'h00000004;
+  assign _zz_1142 = (decode_INSTRUCTION & 32'h00000028);
+  assign _zz_1143 = 32'h0;
+  assign _zz_1144 = 32'h00006014;
+  assign _zz_1145 = ((decode_INSTRUCTION & 32'h00000044) == 32'h0);
+  assign _zz_1146 = ((decode_INSTRUCTION & _zz_1154) == 32'h0);
+  assign _zz_1147 = {(_zz_1155 == _zz_1156),(_zz_1157 == _zz_1158)};
+  assign _zz_1148 = ((decode_INSTRUCTION & 32'h00000058) == 32'h0);
+  assign _zz_1149 = {(_zz_1159 == _zz_1160),{_zz_1161,_zz_1162}};
+  assign _zz_1150 = 3'b000;
+  assign _zz_1151 = ({_zz_1163,_zz_509} != 2'b00);
+  assign _zz_1152 = ({_zz_1164,_zz_1165} != 2'b00);
+  assign _zz_1153 = (_zz_1166 != 1'b0);
+  assign _zz_1154 = 32'h00000018;
+  assign _zz_1155 = (decode_INSTRUCTION & 32'h00006004);
+  assign _zz_1156 = 32'h00002000;
+  assign _zz_1157 = (decode_INSTRUCTION & 32'h00005004);
+  assign _zz_1158 = 32'h00001000;
+  assign _zz_1159 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_1160 = 32'h00000040;
+  assign _zz_1161 = ((decode_INSTRUCTION & 32'h00002014) == 32'h00002010);
+  assign _zz_1162 = ((decode_INSTRUCTION & 32'h40000034) == 32'h40000030);
+  assign _zz_1163 = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
+  assign _zz_1164 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000004);
+  assign _zz_1165 = _zz_509;
+  assign _zz_1166 = ((decode_INSTRUCTION & 32'h00005048) == 32'h00001008);
+  assign _zz_1167 = execute_INSTRUCTION[31];
+  assign _zz_1168 = execute_INSTRUCTION[31];
+  assign _zz_1169 = execute_INSTRUCTION[7];
+  assign _zz_1170 = (_zz_570 | _zz_571);
+  assign _zz_1171 = (_zz_572 | _zz_573);
+  assign _zz_1172 = (_zz_574 | _zz_575);
+  assign _zz_1173 = (_zz_576 | _zz_577);
+  assign _zz_1174 = (_zz_578 | _zz_579);
+  assign _zz_1175 = (_zz_580 | _zz_581);
+  assign _zz_1176 = (_zz_582 | _zz_583);
+  assign _zz_1177 = (_zz_584 | _zz_585);
+  assign _zz_1178 = (_zz_586 | _zz_587);
+  assign _zz_1179 = (_zz_588 | _zz_589);
+  assign _zz_1180 = (_zz_590 | _zz_591);
+  assign _zz_1181 = (_zz_592 | _zz_593);
+  assign _zz_1182 = (_zz_1186 | _zz_594);
+  assign _zz_1183 = (_zz_595 | _zz_596);
+  assign _zz_1184 = (_zz_597 | _zz_598);
+  assign _zz_1185 = (_zz_599 | _zz_600);
+  assign _zz_1186 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_854_) begin
-      _zz_579_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_951) begin
+      _zz_650 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_855_) begin
-      _zz_580_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_952) begin
+      _zz_651 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_561_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_562_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_563_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_564_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_565_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_566_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_567_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_568_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_622                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_623                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_624                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_625                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_626                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_627                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_628                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_629                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_630                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_569_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_570_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (execute_MEMORY_WR                                           ), //i
-    .io_cpu_execute_args_data                      (_zz_84_[31:0]                                               ), //i
-    .io_cpu_execute_args_size                      (execute_DBusCachedPlugin_size[1:0]                          ), //i
-    .io_cpu_memory_isValid                         (_zz_571_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_572_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_573_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_574_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_575_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_576_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_577_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_578_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_631                                            ), //i
+    .io_cpu_execute_address                    (_zz_632[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
+    .io_cpu_execute_args_data                  (_zz_81[31:0]                                       ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_633                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_634[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_635                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_writeBack_isValid                  (_zz_636                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_637                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_638[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_639                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_640                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_641                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_642                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_643                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_644                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_645                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_646                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_647[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_648                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_649                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_856_)
+    case(_zz_953)
       2'b00 : begin
-        _zz_581_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_652 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_581_ = CsrPlugin_jumpInterface_payload;
+        _zz_652 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_581_ = BranchPlugin_jumpInterface_payload;
+        _zz_652 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_581_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_652 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_857_)
-      4'b0000 : begin
-        _zz_582_ = _zz_95_;
+    case(_zz_954)
+      3'b000 : begin
+        _zz_653 = _zz_390;
       end
-      4'b0001 : begin
-        _zz_582_ = _zz_111_;
+      3'b001 : begin
+        _zz_653 = _zz_391;
       end
-      4'b0010 : begin
-        _zz_582_ = _zz_127_;
+      3'b010 : begin
+        _zz_653 = _zz_392;
       end
-      4'b0011 : begin
-        _zz_582_ = _zz_143_;
+      3'b011 : begin
+        _zz_653 = _zz_393;
       end
-      4'b0100 : begin
-        _zz_582_ = _zz_159_;
+      3'b100 : begin
+        _zz_653 = _zz_394;
       end
-      4'b0101 : begin
-        _zz_582_ = _zz_175_;
+      3'b101 : begin
+        _zz_653 = _zz_395;
       end
-      4'b0110 : begin
-        _zz_582_ = _zz_191_;
-      end
-      4'b0111 : begin
-        _zz_582_ = _zz_207_;
-      end
-      4'b1000 : begin
-        _zz_582_ = _zz_223_;
-      end
-      4'b1001 : begin
-        _zz_582_ = _zz_239_;
-      end
-      4'b1010 : begin
-        _zz_582_ = _zz_255_;
-      end
-      4'b1011 : begin
-        _zz_582_ = _zz_271_;
-      end
-      4'b1100 : begin
-        _zz_582_ = _zz_287_;
-      end
-      4'b1101 : begin
-        _zz_582_ = _zz_303_;
-      end
-      4'b1110 : begin
-        _zz_582_ = _zz_319_;
+      3'b110 : begin
+        _zz_653 = _zz_396;
       end
       default : begin
-        _zz_582_ = _zz_335_;
+        _zz_653 = _zz_397;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_858_)
-      4'b0000 : begin
-        _zz_583_ = _zz_96_;
+    case(_zz_955)
+      3'b000 : begin
+        _zz_654 = _zz_390;
       end
-      4'b0001 : begin
-        _zz_583_ = _zz_112_;
+      3'b001 : begin
+        _zz_654 = _zz_391;
       end
-      4'b0010 : begin
-        _zz_583_ = _zz_128_;
+      3'b010 : begin
+        _zz_654 = _zz_392;
       end
-      4'b0011 : begin
-        _zz_583_ = _zz_144_;
+      3'b011 : begin
+        _zz_654 = _zz_393;
       end
-      4'b0100 : begin
-        _zz_583_ = _zz_160_;
+      3'b100 : begin
+        _zz_654 = _zz_394;
       end
-      4'b0101 : begin
-        _zz_583_ = _zz_176_;
+      3'b101 : begin
+        _zz_654 = _zz_395;
       end
-      4'b0110 : begin
-        _zz_583_ = _zz_192_;
-      end
-      4'b0111 : begin
-        _zz_583_ = _zz_208_;
-      end
-      4'b1000 : begin
-        _zz_583_ = _zz_224_;
-      end
-      4'b1001 : begin
-        _zz_583_ = _zz_240_;
-      end
-      4'b1010 : begin
-        _zz_583_ = _zz_256_;
-      end
-      4'b1011 : begin
-        _zz_583_ = _zz_272_;
-      end
-      4'b1100 : begin
-        _zz_583_ = _zz_288_;
-      end
-      4'b1101 : begin
-        _zz_583_ = _zz_304_;
-      end
-      4'b1110 : begin
-        _zz_583_ = _zz_320_;
+      3'b110 : begin
+        _zz_654 = _zz_396;
       end
       default : begin
-        _zz_583_ = _zz_336_;
+        _zz_654 = _zz_397;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_859_)
-      4'b0000 : begin
-        _zz_584_ = _zz_97_;
+    case(_zz_956)
+      3'b000 : begin
+        _zz_655 = _zz_390;
       end
-      4'b0001 : begin
-        _zz_584_ = _zz_113_;
+      3'b001 : begin
+        _zz_655 = _zz_391;
       end
-      4'b0010 : begin
-        _zz_584_ = _zz_129_;
+      3'b010 : begin
+        _zz_655 = _zz_392;
       end
-      4'b0011 : begin
-        _zz_584_ = _zz_145_;
+      3'b011 : begin
+        _zz_655 = _zz_393;
       end
-      4'b0100 : begin
-        _zz_584_ = _zz_161_;
+      3'b100 : begin
+        _zz_655 = _zz_394;
       end
-      4'b0101 : begin
-        _zz_584_ = _zz_177_;
+      3'b101 : begin
+        _zz_655 = _zz_395;
       end
-      4'b0110 : begin
-        _zz_584_ = _zz_193_;
-      end
-      4'b0111 : begin
-        _zz_584_ = _zz_209_;
-      end
-      4'b1000 : begin
-        _zz_584_ = _zz_225_;
-      end
-      4'b1001 : begin
-        _zz_584_ = _zz_241_;
-      end
-      4'b1010 : begin
-        _zz_584_ = _zz_257_;
-      end
-      4'b1011 : begin
-        _zz_584_ = _zz_273_;
-      end
-      4'b1100 : begin
-        _zz_584_ = _zz_289_;
-      end
-      4'b1101 : begin
-        _zz_584_ = _zz_305_;
-      end
-      4'b1110 : begin
-        _zz_584_ = _zz_321_;
+      3'b110 : begin
+        _zz_655 = _zz_396;
       end
       default : begin
-        _zz_584_ = _zz_337_;
+        _zz_655 = _zz_397;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_860_)
-      4'b0000 : begin
-        _zz_585_ = _zz_95_;
+    case(_zz_957)
+      3'b000 : begin
+        _zz_656 = _zz_390;
       end
-      4'b0001 : begin
-        _zz_585_ = _zz_111_;
+      3'b001 : begin
+        _zz_656 = _zz_391;
       end
-      4'b0010 : begin
-        _zz_585_ = _zz_127_;
+      3'b010 : begin
+        _zz_656 = _zz_392;
       end
-      4'b0011 : begin
-        _zz_585_ = _zz_143_;
+      3'b011 : begin
+        _zz_656 = _zz_393;
       end
-      4'b0100 : begin
-        _zz_585_ = _zz_159_;
+      3'b100 : begin
+        _zz_656 = _zz_394;
       end
-      4'b0101 : begin
-        _zz_585_ = _zz_175_;
+      3'b101 : begin
+        _zz_656 = _zz_395;
       end
-      4'b0110 : begin
-        _zz_585_ = _zz_191_;
-      end
-      4'b0111 : begin
-        _zz_585_ = _zz_207_;
-      end
-      4'b1000 : begin
-        _zz_585_ = _zz_223_;
-      end
-      4'b1001 : begin
-        _zz_585_ = _zz_239_;
-      end
-      4'b1010 : begin
-        _zz_585_ = _zz_255_;
-      end
-      4'b1011 : begin
-        _zz_585_ = _zz_271_;
-      end
-      4'b1100 : begin
-        _zz_585_ = _zz_287_;
-      end
-      4'b1101 : begin
-        _zz_585_ = _zz_303_;
-      end
-      4'b1110 : begin
-        _zz_585_ = _zz_319_;
+      3'b110 : begin
+        _zz_656 = _zz_396;
       end
       default : begin
-        _zz_585_ = _zz_335_;
+        _zz_656 = _zz_397;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_861_)
-      4'b0000 : begin
-        _zz_586_ = _zz_96_;
+    case(_zz_958)
+      3'b000 : begin
+        _zz_657 = _zz_390;
       end
-      4'b0001 : begin
-        _zz_586_ = _zz_112_;
+      3'b001 : begin
+        _zz_657 = _zz_391;
       end
-      4'b0010 : begin
-        _zz_586_ = _zz_128_;
+      3'b010 : begin
+        _zz_657 = _zz_392;
       end
-      4'b0011 : begin
-        _zz_586_ = _zz_144_;
+      3'b011 : begin
+        _zz_657 = _zz_393;
       end
-      4'b0100 : begin
-        _zz_586_ = _zz_160_;
+      3'b100 : begin
+        _zz_657 = _zz_394;
       end
-      4'b0101 : begin
-        _zz_586_ = _zz_176_;
+      3'b101 : begin
+        _zz_657 = _zz_395;
       end
-      4'b0110 : begin
-        _zz_586_ = _zz_192_;
-      end
-      4'b0111 : begin
-        _zz_586_ = _zz_208_;
-      end
-      4'b1000 : begin
-        _zz_586_ = _zz_224_;
-      end
-      4'b1001 : begin
-        _zz_586_ = _zz_240_;
-      end
-      4'b1010 : begin
-        _zz_586_ = _zz_256_;
-      end
-      4'b1011 : begin
-        _zz_586_ = _zz_272_;
-      end
-      4'b1100 : begin
-        _zz_586_ = _zz_288_;
-      end
-      4'b1101 : begin
-        _zz_586_ = _zz_304_;
-      end
-      4'b1110 : begin
-        _zz_586_ = _zz_320_;
+      3'b110 : begin
+        _zz_657 = _zz_396;
       end
       default : begin
-        _zz_586_ = _zz_336_;
+        _zz_657 = _zz_397;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_862_)
-      4'b0000 : begin
-        _zz_587_ = _zz_97_;
+    case(_zz_822)
+      3'b000 : begin
+        _zz_658 = _zz_390;
       end
-      4'b0001 : begin
-        _zz_587_ = _zz_113_;
+      3'b001 : begin
+        _zz_658 = _zz_391;
       end
-      4'b0010 : begin
-        _zz_587_ = _zz_129_;
+      3'b010 : begin
+        _zz_658 = _zz_392;
       end
-      4'b0011 : begin
-        _zz_587_ = _zz_145_;
+      3'b011 : begin
+        _zz_658 = _zz_393;
       end
-      4'b0100 : begin
-        _zz_587_ = _zz_161_;
+      3'b100 : begin
+        _zz_658 = _zz_394;
       end
-      4'b0101 : begin
-        _zz_587_ = _zz_177_;
+      3'b101 : begin
+        _zz_658 = _zz_395;
       end
-      4'b0110 : begin
-        _zz_587_ = _zz_193_;
-      end
-      4'b0111 : begin
-        _zz_587_ = _zz_209_;
-      end
-      4'b1000 : begin
-        _zz_587_ = _zz_225_;
-      end
-      4'b1001 : begin
-        _zz_587_ = _zz_241_;
-      end
-      4'b1010 : begin
-        _zz_587_ = _zz_257_;
-      end
-      4'b1011 : begin
-        _zz_587_ = _zz_273_;
-      end
-      4'b1100 : begin
-        _zz_587_ = _zz_289_;
-      end
-      4'b1101 : begin
-        _zz_587_ = _zz_305_;
-      end
-      4'b1110 : begin
-        _zz_587_ = _zz_321_;
+      3'b110 : begin
+        _zz_658 = _zz_396;
       end
       default : begin
-        _zz_587_ = _zz_337_;
+        _zz_658 = _zz_397;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_959)
+      4'b0000 : begin
+        _zz_659 = _zz_86;
+      end
+      4'b0001 : begin
+        _zz_659 = _zz_105;
+      end
+      4'b0010 : begin
+        _zz_659 = _zz_124;
+      end
+      4'b0011 : begin
+        _zz_659 = _zz_143;
+      end
+      4'b0100 : begin
+        _zz_659 = _zz_162;
+      end
+      4'b0101 : begin
+        _zz_659 = _zz_181;
+      end
+      4'b0110 : begin
+        _zz_659 = _zz_200;
+      end
+      4'b0111 : begin
+        _zz_659 = _zz_219;
+      end
+      4'b1000 : begin
+        _zz_659 = _zz_238;
+      end
+      4'b1001 : begin
+        _zz_659 = _zz_257;
+      end
+      4'b1010 : begin
+        _zz_659 = _zz_276;
+      end
+      4'b1011 : begin
+        _zz_659 = _zz_295;
+      end
+      4'b1100 : begin
+        _zz_659 = _zz_314;
+      end
+      4'b1101 : begin
+        _zz_659 = _zz_333;
+      end
+      4'b1110 : begin
+        _zz_659 = _zz_352;
+      end
+      default : begin
+        _zz_659 = _zz_371;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_960)
+      4'b0000 : begin
+        _zz_660 = _zz_87;
+      end
+      4'b0001 : begin
+        _zz_660 = _zz_106;
+      end
+      4'b0010 : begin
+        _zz_660 = _zz_125;
+      end
+      4'b0011 : begin
+        _zz_660 = _zz_144;
+      end
+      4'b0100 : begin
+        _zz_660 = _zz_163;
+      end
+      4'b0101 : begin
+        _zz_660 = _zz_182;
+      end
+      4'b0110 : begin
+        _zz_660 = _zz_201;
+      end
+      4'b0111 : begin
+        _zz_660 = _zz_220;
+      end
+      4'b1000 : begin
+        _zz_660 = _zz_239;
+      end
+      4'b1001 : begin
+        _zz_660 = _zz_258;
+      end
+      4'b1010 : begin
+        _zz_660 = _zz_277;
+      end
+      4'b1011 : begin
+        _zz_660 = _zz_296;
+      end
+      4'b1100 : begin
+        _zz_660 = _zz_315;
+      end
+      4'b1101 : begin
+        _zz_660 = _zz_334;
+      end
+      4'b1110 : begin
+        _zz_660 = _zz_353;
+      end
+      default : begin
+        _zz_660 = _zz_372;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_961)
+      4'b0000 : begin
+        _zz_661 = _zz_88;
+      end
+      4'b0001 : begin
+        _zz_661 = _zz_107;
+      end
+      4'b0010 : begin
+        _zz_661 = _zz_126;
+      end
+      4'b0011 : begin
+        _zz_661 = _zz_145;
+      end
+      4'b0100 : begin
+        _zz_661 = _zz_164;
+      end
+      4'b0101 : begin
+        _zz_661 = _zz_183;
+      end
+      4'b0110 : begin
+        _zz_661 = _zz_202;
+      end
+      4'b0111 : begin
+        _zz_661 = _zz_221;
+      end
+      4'b1000 : begin
+        _zz_661 = _zz_240;
+      end
+      4'b1001 : begin
+        _zz_661 = _zz_259;
+      end
+      4'b1010 : begin
+        _zz_661 = _zz_278;
+      end
+      4'b1011 : begin
+        _zz_661 = _zz_297;
+      end
+      4'b1100 : begin
+        _zz_661 = _zz_316;
+      end
+      4'b1101 : begin
+        _zz_661 = _zz_335;
+      end
+      4'b1110 : begin
+        _zz_661 = _zz_354;
+      end
+      default : begin
+        _zz_661 = _zz_373;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_962)
+      3'b000 : begin
+        _zz_662 = _zz_449;
+      end
+      3'b001 : begin
+        _zz_662 = _zz_450;
+      end
+      3'b010 : begin
+        _zz_662 = _zz_451;
+      end
+      3'b011 : begin
+        _zz_662 = _zz_452;
+      end
+      3'b100 : begin
+        _zz_662 = _zz_453;
+      end
+      3'b101 : begin
+        _zz_662 = _zz_454;
+      end
+      3'b110 : begin
+        _zz_662 = _zz_455;
+      end
+      default : begin
+        _zz_662 = _zz_456;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_963)
+      3'b000 : begin
+        _zz_663 = _zz_449;
+      end
+      3'b001 : begin
+        _zz_663 = _zz_450;
+      end
+      3'b010 : begin
+        _zz_663 = _zz_451;
+      end
+      3'b011 : begin
+        _zz_663 = _zz_452;
+      end
+      3'b100 : begin
+        _zz_663 = _zz_453;
+      end
+      3'b101 : begin
+        _zz_663 = _zz_454;
+      end
+      3'b110 : begin
+        _zz_663 = _zz_455;
+      end
+      default : begin
+        _zz_663 = _zz_456;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_964)
+      3'b000 : begin
+        _zz_664 = _zz_449;
+      end
+      3'b001 : begin
+        _zz_664 = _zz_450;
+      end
+      3'b010 : begin
+        _zz_664 = _zz_451;
+      end
+      3'b011 : begin
+        _zz_664 = _zz_452;
+      end
+      3'b100 : begin
+        _zz_664 = _zz_453;
+      end
+      3'b101 : begin
+        _zz_664 = _zz_454;
+      end
+      3'b110 : begin
+        _zz_664 = _zz_455;
+      end
+      default : begin
+        _zz_664 = _zz_456;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_965)
+      3'b000 : begin
+        _zz_665 = _zz_449;
+      end
+      3'b001 : begin
+        _zz_665 = _zz_450;
+      end
+      3'b010 : begin
+        _zz_665 = _zz_451;
+      end
+      3'b011 : begin
+        _zz_665 = _zz_452;
+      end
+      3'b100 : begin
+        _zz_665 = _zz_453;
+      end
+      3'b101 : begin
+        _zz_665 = _zz_454;
+      end
+      3'b110 : begin
+        _zz_665 = _zz_455;
+      end
+      default : begin
+        _zz_665 = _zz_456;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_966)
+      3'b000 : begin
+        _zz_666 = _zz_449;
+      end
+      3'b001 : begin
+        _zz_666 = _zz_450;
+      end
+      3'b010 : begin
+        _zz_666 = _zz_451;
+      end
+      3'b011 : begin
+        _zz_666 = _zz_452;
+      end
+      3'b100 : begin
+        _zz_666 = _zz_453;
+      end
+      3'b101 : begin
+        _zz_666 = _zz_454;
+      end
+      3'b110 : begin
+        _zz_666 = _zz_455;
+      end
+      default : begin
+        _zz_666 = _zz_456;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_832)
+      3'b000 : begin
+        _zz_667 = _zz_449;
+      end
+      3'b001 : begin
+        _zz_667 = _zz_450;
+      end
+      3'b010 : begin
+        _zz_667 = _zz_451;
+      end
+      3'b011 : begin
+        _zz_667 = _zz_452;
+      end
+      3'b100 : begin
+        _zz_667 = _zz_453;
+      end
+      3'b101 : begin
+        _zz_667 = _zz_454;
+      end
+      3'b110 : begin
+        _zz_667 = _zz_455;
+      end
+      default : begin
+        _zz_667 = _zz_456;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_967)
+      4'b0000 : begin
+        _zz_668 = _zz_86;
+      end
+      4'b0001 : begin
+        _zz_668 = _zz_105;
+      end
+      4'b0010 : begin
+        _zz_668 = _zz_124;
+      end
+      4'b0011 : begin
+        _zz_668 = _zz_143;
+      end
+      4'b0100 : begin
+        _zz_668 = _zz_162;
+      end
+      4'b0101 : begin
+        _zz_668 = _zz_181;
+      end
+      4'b0110 : begin
+        _zz_668 = _zz_200;
+      end
+      4'b0111 : begin
+        _zz_668 = _zz_219;
+      end
+      4'b1000 : begin
+        _zz_668 = _zz_238;
+      end
+      4'b1001 : begin
+        _zz_668 = _zz_257;
+      end
+      4'b1010 : begin
+        _zz_668 = _zz_276;
+      end
+      4'b1011 : begin
+        _zz_668 = _zz_295;
+      end
+      4'b1100 : begin
+        _zz_668 = _zz_314;
+      end
+      4'b1101 : begin
+        _zz_668 = _zz_333;
+      end
+      4'b1110 : begin
+        _zz_668 = _zz_352;
+      end
+      default : begin
+        _zz_668 = _zz_371;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_968)
+      4'b0000 : begin
+        _zz_669 = _zz_87;
+      end
+      4'b0001 : begin
+        _zz_669 = _zz_106;
+      end
+      4'b0010 : begin
+        _zz_669 = _zz_125;
+      end
+      4'b0011 : begin
+        _zz_669 = _zz_144;
+      end
+      4'b0100 : begin
+        _zz_669 = _zz_163;
+      end
+      4'b0101 : begin
+        _zz_669 = _zz_182;
+      end
+      4'b0110 : begin
+        _zz_669 = _zz_201;
+      end
+      4'b0111 : begin
+        _zz_669 = _zz_220;
+      end
+      4'b1000 : begin
+        _zz_669 = _zz_239;
+      end
+      4'b1001 : begin
+        _zz_669 = _zz_258;
+      end
+      4'b1010 : begin
+        _zz_669 = _zz_277;
+      end
+      4'b1011 : begin
+        _zz_669 = _zz_296;
+      end
+      4'b1100 : begin
+        _zz_669 = _zz_315;
+      end
+      4'b1101 : begin
+        _zz_669 = _zz_334;
+      end
+      4'b1110 : begin
+        _zz_669 = _zz_353;
+      end
+      default : begin
+        _zz_669 = _zz_372;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_969)
+      4'b0000 : begin
+        _zz_670 = _zz_88;
+      end
+      4'b0001 : begin
+        _zz_670 = _zz_107;
+      end
+      4'b0010 : begin
+        _zz_670 = _zz_126;
+      end
+      4'b0011 : begin
+        _zz_670 = _zz_145;
+      end
+      4'b0100 : begin
+        _zz_670 = _zz_164;
+      end
+      4'b0101 : begin
+        _zz_670 = _zz_183;
+      end
+      4'b0110 : begin
+        _zz_670 = _zz_202;
+      end
+      4'b0111 : begin
+        _zz_670 = _zz_221;
+      end
+      4'b1000 : begin
+        _zz_670 = _zz_240;
+      end
+      4'b1001 : begin
+        _zz_670 = _zz_259;
+      end
+      4'b1010 : begin
+        _zz_670 = _zz_278;
+      end
+      4'b1011 : begin
+        _zz_670 = _zz_297;
+      end
+      4'b1100 : begin
+        _zz_670 = _zz_316;
+      end
+      4'b1101 : begin
+        _zz_670 = _zz_335;
+      end
+      4'b1110 : begin
+        _zz_670 = _zz_354;
+      end
+      default : begin
+        _zz_670 = _zz_373;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(decode_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
-      default : decode_SRC2_CTRL_string = "???";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_1_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_1__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_1__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_1__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_1__string = "PC ";
-      default : _zz_1__string = "???";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_2__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_2__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_2__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_2__string = "PC ";
-      default : _zz_2__string = "???";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_3__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_3__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_3__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_3__string = "PC ";
-      default : _zz_3__string = "???";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_4__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_4__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_4__string = "AND_1";
-      default : _zz_4__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_5__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_5__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_5__string = "AND_1";
-      default : _zz_5__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_6__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_6__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_6__string = "AND_1";
-      default : _zz_6__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_7__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_7__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_7__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_7__string = "URS1        ";
-      default : _zz_7__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_8__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_8__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_8__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_8__string = "URS1        ";
-      default : _zz_8__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_9__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_9__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_9__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_9__string = "URS1        ";
-      default : _zz_9__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10__string = "SRA_1    ";
-      default : _zz_10__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_11_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11__string = "SRA_1    ";
-      default : _zz_11__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12__string = "SRA_1    ";
-      default : _zz_12__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_13_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13__string = "SRA_1    ";
-      default : _zz_13__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_14_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14__string = "SRA_1    ";
-      default : _zz_14__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_15_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_15__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_15__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_15__string = "BITWISE ";
-      default : _zz_15__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_16_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_16__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_16__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_16__string = "BITWISE ";
-      default : _zz_16__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_17_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_17__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_17__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_17__string = "BITWISE ";
-      default : _zz_17__string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_18_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_18__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_18__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_18__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_18__string = "ECALL";
-      default : _zz_18__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_19_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_19__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_19__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_19__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_19__string = "ECALL";
-      default : _zz_19__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_20_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_20__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_20__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_20__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_20__string = "ECALL";
-      default : _zz_20__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_21_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_21__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_21__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_21__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_21__string = "ECALL";
-      default : _zz_21__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4070,48 +3344,238 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_22__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_22__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_22__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_22__string = "ECALL";
-      default : _zz_22__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_23__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_23__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_23__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_23__string = "ECALL";
-      default : _zz_23__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_24__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_24__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_24__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_24__string = "ECALL";
-      default : _zz_24__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_25__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_25__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_25__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_25__string = "JALR";
-      default : _zz_25__string = "????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_26__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_26__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_26__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_26__string = "JALR";
-      default : _zz_26__string = "????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_SRC2_CTRL_string = "PC ";
+      default : decode_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4124,12 +3588,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4142,12 +3606,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4160,12 +3624,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4178,12 +3642,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -4196,12 +3660,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -4214,12 +3678,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -4232,12 +3696,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -4250,12 +3714,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4267,11 +3731,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -4283,72 +3747,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_43__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_43__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_43__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_43__string = "JALR";
-      default : _zz_43__string = "????";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_44__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_44__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_44__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_44__string = "ECALL";
-      default : _zz_44__string = "?????";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_45__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_45__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_45__string = "AND_1";
-      default : _zz_45__string = "?????";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46__string = "SRA_1    ";
-      default : _zz_46__string = "?????????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_47__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_47__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_47__string = "BITWISE ";
-      default : _zz_47__string = "????????";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_48__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_48__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_48__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_48__string = "PC ";
-      default : _zz_48__string = "???";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_49__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49__string = "URS1        ";
-      default : _zz_49__string = "????????????";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4361,73 +3825,125 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_54_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_54__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_54__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_54__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_54__string = "JALR";
-      default : _zz_54__string = "????";
+    case(_zz_51)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
+      default : _zz_51_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_452_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_452__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_452__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_452__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_452__string = "URS1        ";
-      default : _zz_452__string = "????????????";
+    case(_zz_513)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_513_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_513_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_513_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_513_string = "URS1        ";
+      default : _zz_513_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_453_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_453__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_453__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_453__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_453__string = "PC ";
-      default : _zz_453__string = "???";
+    case(_zz_514)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_514_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_514_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_514_string = "BITWISE ";
+      default : _zz_514_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_454_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_454__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_454__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_454__string = "BITWISE ";
-      default : _zz_454__string = "????????";
+    case(_zz_515)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_515_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_515_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_515_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_515_string = "PC ";
+      default : _zz_515_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_455_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_455__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_455__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_455__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_455__string = "SRA_1    ";
-      default : _zz_455__string = "?????????";
+    case(_zz_516)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_516_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_516_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_516_string = "AND_1";
+      default : _zz_516_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_456_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_456__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_456__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_456__string = "AND_1";
-      default : _zz_456__string = "?????";
+    case(_zz_517)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_517_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_517_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_517_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_517_string = "SRA_1    ";
+      default : _zz_517_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_457_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_457__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_457__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_457__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_457__string = "ECALL";
-      default : _zz_457__string = "?????";
+    case(_zz_518)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_518_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_518_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_518_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_518_string = "JALR";
+      default : _zz_518_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_458_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_458__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_458__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_458__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_458__string = "JALR";
-      default : _zz_458__string = "????";
+    case(_zz_519)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_519_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_519_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_519_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_519_string = "ECALL";
+      default : _zz_519_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SRC2_CTRL)
+      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
+      default : decode_to_execute_SRC2_CTRL_string = "???";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_BITWISE_CTRL)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
+      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -4466,111 +3982,60 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
-      default : decode_to_execute_ALU_CTRL_string = "????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_ALU_BITWISE_CTRL)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : decode_to_execute_ALU_BITWISE_CTRL_string = "AND_1";
-      default : decode_to_execute_ALU_BITWISE_CTRL_string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SRC2_CTRL)
-      `Src2CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC2_CTRL_string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : decode_to_execute_SRC2_CTRL_string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : decode_to_execute_SRC2_CTRL_string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : decode_to_execute_SRC2_CTRL_string = "PC ";
-      default : decode_to_execute_SRC2_CTRL_string = "???";
-    endcase
-  end
   `endif
 
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign execute_REGFILE_WRITE_DATA = _zz_460_;
-  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign decode_IS_DIV = _zz_643_[0];
-  assign decode_SRC2_CTRL = _zz_1_;
-  assign _zz_2_ = _zz_3_;
-  assign memory_MUL_LOW = ($signed(_zz_644_) + $signed(_zz_652_));
-  assign decode_ALU_BITWISE_CTRL = _zz_4_;
-  assign _zz_5_ = _zz_6_;
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_653_[0];
+  assign memory_MUL_LOW = ($signed(_zz_726) + $signed(_zz_734));
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
+  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
   assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
+  assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
+  assign execute_SHIFT_RIGHT = _zz_736;
+  assign execute_REGFILE_WRITE_DATA = _zz_521;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_632[1 : 0];
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign decode_SRC1_CTRL = _zz_7_;
-  assign _zz_8_ = _zz_9_;
-  assign decode_IS_CSR = _zz_654_[0];
-  assign execute_SHIFT_RIGHT = _zz_656_;
+  assign decode_IS_RS2_SIGNED = _zz_738[0];
+  assign decode_IS_RS1_SIGNED = _zz_739[0];
+  assign decode_IS_DIV = _zz_740[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_741[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_742[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_743[0];
+  assign decode_MEMORY_MANAGMENT = _zz_744[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_745[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_746[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_747[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign _zz_10_ = _zz_11_;
-  assign decode_SHIFT_CTRL = _zz_12_;
-  assign _zz_13_ = _zz_14_;
-  assign decode_SRC_LESS_UNSIGNED = _zz_658_[0];
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_659_[0];
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_570_[1 : 0];
-  assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_660_[0];
-  assign decode_ALU_CTRL = _zz_15_;
-  assign _zz_16_ = _zz_17_;
-  assign _zz_18_ = _zz_19_;
-  assign _zz_20_ = _zz_21_;
-  assign decode_ENV_CTRL = _zz_22_;
-  assign _zz_23_ = _zz_24_;
-  assign decode_IS_RS1_SIGNED = _zz_661_[0];
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_662_[0];
-  assign memory_MUL_HH = execute_to_memory_MUL_HH;
-  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign _zz_25_ = _zz_26_;
   assign memory_PC = execute_to_memory_PC;
-  assign decode_MEMORY_MANAGMENT = _zz_663_[0];
-  assign decode_IS_RS2_SIGNED = _zz_664_[0];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -4584,22 +4049,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_482_;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_665_[0];
-  assign decode_RS1_USE = _zz_666_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_543;
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_748[0];
+  assign decode_RS1_USE = _zz_749[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_588_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_671)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
   end
 
@@ -4611,29 +4076,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_471_)begin
-      if((_zz_472_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_473_;
+    if(_zz_532)begin
+      if((_zz_533 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_534;
       end
     end
-    if(_zz_589_)begin
-      if(_zz_590_)begin
-        if(_zz_475_)begin
-          decode_RS2 = _zz_52_;
+    if(_zz_672)begin
+      if(_zz_673)begin
+        if(_zz_536)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_591_)begin
+    if(_zz_674)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_477_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_538)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_592_)begin
+    if(_zz_675)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_479_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_540)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -4641,29 +4106,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_471_)begin
-      if((_zz_472_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_473_;
+    if(_zz_532)begin
+      if((_zz_533 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_534;
       end
     end
-    if(_zz_589_)begin
-      if(_zz_590_)begin
-        if(_zz_474_)begin
-          decode_RS1 = _zz_52_;
+    if(_zz_672)begin
+      if(_zz_673)begin
+        if(_zz_535)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_591_)begin
+    if(_zz_674)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_476_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_537)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_592_)begin
+    if(_zz_675)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_478_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_539)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -4671,294 +4136,70 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_468_;
+          _zz_32 = _zz_529;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_593_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_676)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_667_[0];
-  assign decode_SRC_ADD_ZERO = _zz_668_[0];
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_750[0];
+  assign decode_SRC_ADD_ZERO = _zz_751[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_466_;
-  assign execute_SRC1 = _zz_461_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_527;
+  assign execute_SRC1 = _zz_522;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_669_[0];
+    decode_REGFILE_WRITE_VALID = _zz_752[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_863_) == 32'h00001073),{(_zz_864_ == _zz_865_),{_zz_866_,{_zz_867_,_zz_868_}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_970) == 32'h00001073),{(_zz_971 == _zz_972),{_zz_973,{_zz_974,_zz_975}}}}}}} != 21'h0);
   always @ (*) begin
-    _zz_50_ = _zz_50__14;
-    if(PmpPlugin_ports_1_hits_15)begin
-      _zz_50_ = (_zz_50__14 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__14 = _zz_50__13;
-    if(PmpPlugin_ports_1_hits_14)begin
-      _zz_50__14 = (_zz_50__13 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__13 = _zz_50__12;
-    if(PmpPlugin_ports_1_hits_13)begin
-      _zz_50__13 = (_zz_50__12 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__12 = _zz_50__11;
-    if(PmpPlugin_ports_1_hits_12)begin
-      _zz_50__12 = (_zz_50__11 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__11 = _zz_50__10;
-    if(PmpPlugin_ports_1_hits_11)begin
-      _zz_50__11 = (_zz_50__10 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__10 = _zz_50__9;
-    if(PmpPlugin_ports_1_hits_10)begin
-      _zz_50__10 = (_zz_50__9 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__9 = _zz_50__8;
-    if(PmpPlugin_ports_1_hits_9)begin
-      _zz_50__9 = (_zz_50__8 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__8 = _zz_50__7;
-    if(PmpPlugin_ports_1_hits_8)begin
-      _zz_50__8 = (_zz_50__7 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__7 = _zz_50__6;
-    if(PmpPlugin_ports_1_hits_7)begin
-      _zz_50__7 = (_zz_50__6 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__6 = _zz_50__5;
-    if(PmpPlugin_ports_1_hits_6)begin
-      _zz_50__6 = (_zz_50__5 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__5 = _zz_50__4;
-    if(PmpPlugin_ports_1_hits_5)begin
-      _zz_50__5 = (_zz_50__4 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__4 = _zz_50__3;
-    if(PmpPlugin_ports_1_hits_4)begin
-      _zz_50__4 = (_zz_50__3 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__3 = _zz_50__2;
-    if(PmpPlugin_ports_1_hits_3)begin
-      _zz_50__3 = (_zz_50__2 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__2 = _zz_50__1;
-    if(PmpPlugin_ports_1_hits_2)begin
-      _zz_50__2 = (_zz_50__1 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__1 = _zz_50__0;
-    if(PmpPlugin_ports_1_hits_1)begin
-      _zz_50__1 = (_zz_50__0 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__0 = 5'h0;
-    if(PmpPlugin_ports_1_hits_0)begin
-      _zz_50__0 = (5'h0 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51_ = _zz_51__14;
-    if(PmpPlugin_ports_0_hits_15)begin
-      _zz_51_ = (_zz_51__14 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__14 = _zz_51__13;
-    if(PmpPlugin_ports_0_hits_14)begin
-      _zz_51__14 = (_zz_51__13 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__13 = _zz_51__12;
-    if(PmpPlugin_ports_0_hits_13)begin
-      _zz_51__13 = (_zz_51__12 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__12 = _zz_51__11;
-    if(PmpPlugin_ports_0_hits_12)begin
-      _zz_51__12 = (_zz_51__11 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__11 = _zz_51__10;
-    if(PmpPlugin_ports_0_hits_11)begin
-      _zz_51__11 = (_zz_51__10 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__10 = _zz_51__9;
-    if(PmpPlugin_ports_0_hits_10)begin
-      _zz_51__10 = (_zz_51__9 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__9 = _zz_51__8;
-    if(PmpPlugin_ports_0_hits_9)begin
-      _zz_51__9 = (_zz_51__8 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__8 = _zz_51__7;
-    if(PmpPlugin_ports_0_hits_8)begin
-      _zz_51__8 = (_zz_51__7 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__7 = _zz_51__6;
-    if(PmpPlugin_ports_0_hits_7)begin
-      _zz_51__7 = (_zz_51__6 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__6 = _zz_51__5;
-    if(PmpPlugin_ports_0_hits_6)begin
-      _zz_51__6 = (_zz_51__5 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__5 = _zz_51__4;
-    if(PmpPlugin_ports_0_hits_5)begin
-      _zz_51__5 = (_zz_51__4 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__4 = _zz_51__3;
-    if(PmpPlugin_ports_0_hits_4)begin
-      _zz_51__4 = (_zz_51__3 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__3 = _zz_51__2;
-    if(PmpPlugin_ports_0_hits_3)begin
-      _zz_51__3 = (_zz_51__2 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(PmpPlugin_ports_0_hits_2)begin
-      _zz_51__2 = (_zz_51__1 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(PmpPlugin_ports_0_hits_1)begin
-      _zz_51__1 = (_zz_51__0 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__0 = 5'h0;
-    if(PmpPlugin_ports_0_hits_0)begin
-      _zz_51__0 = (5'h0 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_52_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_52_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_642_)
+      case(_zz_725)
         2'b00 : begin
-          _zz_52_ = _zz_765_;
+          _zz_50 = _zz_862;
         end
         default : begin
-          _zz_52_ = _zz_766_;
+          _zz_50 = _zz_863;
         end
       endcase
     end
@@ -4970,55 +4211,56 @@ module VexRiscv (
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_670_[0];
-  assign decode_FLUSH_ALL = _zz_671_[0];
+  assign decode_MEMORY_ENABLE = _zz_753[0];
+  assign decode_FLUSH_ALL = _zz_754[0];
   always @ (*) begin
-    _zz_53_ = _zz_53__2;
-    if(_zz_594_)begin
-      _zz_53_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_677)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_53__2 = _zz_53__1;
-    if(_zz_595_)begin
-      _zz_53__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_678)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_53__1 = _zz_53__0;
-    if(_zz_596_)begin
-      _zz_53__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_679)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_53__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_597_)begin
-      _zz_53__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_680)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_54_;
+  assign decode_BRANCH_CTRL = _zz_51;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_55_ = memory_FORMAL_PC_NEXT;
+    _zz_52 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_55_ = BranchPlugin_jumpInterface_payload;
+      _zz_52 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_56_ = decode_FORMAL_PC_NEXT;
+    _zz_53 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_56_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -5034,20 +4276,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_469_ || _zz_470_)))begin
+    if((decode_arbitration_isValid && (_zz_530 || _zz_531)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_598_)begin
+    if(_zz_681)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -5061,32 +4303,35 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_598_)begin
+    if(_zz_681)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_577_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_648 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_599_)begin
+    if(_zz_682)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_588_)begin
+    if(_zz_671)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
   end
 
-  assign execute_arbitration_haltByOther = 1'b0;
+  always @ (*) begin
+    execute_arbitration_haltByOther = 1'b0;
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+  end
+
   always @ (*) begin
     execute_arbitration_removeIt = 1'b0;
     if(CsrPlugin_selfException_valid)begin
@@ -5107,7 +4352,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_593_)begin
+    if(_zz_676)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -5138,7 +4383,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -5169,10 +4414,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_600_)begin
+    if(_zz_683)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_601_)begin
+    if(_zz_684)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -5183,13 +4428,13 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_600_)begin
+    if(_zz_683)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_601_)begin
+    if(_zz_684)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -5203,7 +4448,7 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_599_)begin
+    if(_zz_682)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -5211,21 +4456,21 @@ module VexRiscv (
   assign CsrPlugin_thirdPartyWake = 1'b0;
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_600_)begin
+    if(_zz_683)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_601_)begin
+    if(_zz_684)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_600_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_683)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_601_)begin
-      case(_zz_602_)
+    if(_zz_684)begin
+      case(_zz_685)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -5238,14 +4483,14 @@ module VexRiscv (
   assign CsrPlugin_forceMachineWire = 1'b0;
   assign CsrPlugin_allowInterrupts = 1'b1;
   assign CsrPlugin_allowException = 1'b1;
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_57_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_58_ = (_zz_57_ & (~ _zz_672_));
-  assign _zz_59_ = _zz_58_[3];
-  assign _zz_60_ = (_zz_58_[1] || _zz_59_);
-  assign _zz_61_ = (_zz_58_[2] || _zz_59_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_581_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
+  assign _zz_54 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_55 = (_zz_54 & (~ _zz_755));
+  assign _zz_56 = _zz_55[3];
+  assign _zz_57 = (_zz_55[1] || _zz_56);
+  assign _zz_58 = (_zz_55[2] || _zz_56);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_652;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -5265,7 +4510,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_674_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_757);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -5305,44 +4550,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_62_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_62_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_62_);
+  assign _zz_59 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_59);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_59);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_63_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_63_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_63_);
+  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_60);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_60);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_53_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_64_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_64_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_64_);
+  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_61);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_61);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_65_;
-  assign _zz_65_ = ((1'b0 && (! _zz_66_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_66_ = _zz_67_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_66_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_62;
+  assign _zz_62 = ((1'b0 && (! _zz_63)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_63 = _zz_64;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_63;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_68_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_68_ = _zz_69_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_68_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_70_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_65)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_65 = _zz_66;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_65;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_67;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -5356,125 +4601,125 @@ module VexRiscv (
   assign IBusCachedPlugin_pcValids_3 = IBusCachedPlugin_injector_nextPcCalc_valids_4;
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   assign decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-  assign _zz_71_ = _zz_675_[11];
+  assign _zz_68 = _zz_758[11];
   always @ (*) begin
-    _zz_72_[18] = _zz_71_;
-    _zz_72_[17] = _zz_71_;
-    _zz_72_[16] = _zz_71_;
-    _zz_72_[15] = _zz_71_;
-    _zz_72_[14] = _zz_71_;
-    _zz_72_[13] = _zz_71_;
-    _zz_72_[12] = _zz_71_;
-    _zz_72_[11] = _zz_71_;
-    _zz_72_[10] = _zz_71_;
-    _zz_72_[9] = _zz_71_;
-    _zz_72_[8] = _zz_71_;
-    _zz_72_[7] = _zz_71_;
-    _zz_72_[6] = _zz_71_;
-    _zz_72_[5] = _zz_71_;
-    _zz_72_[4] = _zz_71_;
-    _zz_72_[3] = _zz_71_;
-    _zz_72_[2] = _zz_71_;
-    _zz_72_[1] = _zz_71_;
-    _zz_72_[0] = _zz_71_;
+    _zz_69[18] = _zz_68;
+    _zz_69[17] = _zz_68;
+    _zz_69[16] = _zz_68;
+    _zz_69[15] = _zz_68;
+    _zz_69[14] = _zz_68;
+    _zz_69[13] = _zz_68;
+    _zz_69[12] = _zz_68;
+    _zz_69[11] = _zz_68;
+    _zz_69[10] = _zz_68;
+    _zz_69[9] = _zz_68;
+    _zz_69[8] = _zz_68;
+    _zz_69[7] = _zz_68;
+    _zz_69[6] = _zz_68;
+    _zz_69[5] = _zz_68;
+    _zz_69[4] = _zz_68;
+    _zz_69[3] = _zz_68;
+    _zz_69[2] = _zz_68;
+    _zz_69[1] = _zz_68;
+    _zz_69[0] = _zz_68;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_676_[31]));
-    if(_zz_77_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_759[31]));
+    if(_zz_74)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_73_ = _zz_677_[19];
+  assign _zz_70 = _zz_760[19];
   always @ (*) begin
-    _zz_74_[10] = _zz_73_;
-    _zz_74_[9] = _zz_73_;
-    _zz_74_[8] = _zz_73_;
-    _zz_74_[7] = _zz_73_;
-    _zz_74_[6] = _zz_73_;
-    _zz_74_[5] = _zz_73_;
-    _zz_74_[4] = _zz_73_;
-    _zz_74_[3] = _zz_73_;
-    _zz_74_[2] = _zz_73_;
-    _zz_74_[1] = _zz_73_;
-    _zz_74_[0] = _zz_73_;
+    _zz_71[10] = _zz_70;
+    _zz_71[9] = _zz_70;
+    _zz_71[8] = _zz_70;
+    _zz_71[7] = _zz_70;
+    _zz_71[6] = _zz_70;
+    _zz_71[5] = _zz_70;
+    _zz_71[4] = _zz_70;
+    _zz_71[3] = _zz_70;
+    _zz_71[2] = _zz_70;
+    _zz_71[1] = _zz_70;
+    _zz_71[0] = _zz_70;
   end
 
-  assign _zz_75_ = _zz_678_[11];
+  assign _zz_72 = _zz_761[11];
   always @ (*) begin
-    _zz_76_[18] = _zz_75_;
-    _zz_76_[17] = _zz_75_;
-    _zz_76_[16] = _zz_75_;
-    _zz_76_[15] = _zz_75_;
-    _zz_76_[14] = _zz_75_;
-    _zz_76_[13] = _zz_75_;
-    _zz_76_[12] = _zz_75_;
-    _zz_76_[11] = _zz_75_;
-    _zz_76_[10] = _zz_75_;
-    _zz_76_[9] = _zz_75_;
-    _zz_76_[8] = _zz_75_;
-    _zz_76_[7] = _zz_75_;
-    _zz_76_[6] = _zz_75_;
-    _zz_76_[5] = _zz_75_;
-    _zz_76_[4] = _zz_75_;
-    _zz_76_[3] = _zz_75_;
-    _zz_76_[2] = _zz_75_;
-    _zz_76_[1] = _zz_75_;
-    _zz_76_[0] = _zz_75_;
+    _zz_73[18] = _zz_72;
+    _zz_73[17] = _zz_72;
+    _zz_73[16] = _zz_72;
+    _zz_73[15] = _zz_72;
+    _zz_73[14] = _zz_72;
+    _zz_73[13] = _zz_72;
+    _zz_73[12] = _zz_72;
+    _zz_73[11] = _zz_72;
+    _zz_73[10] = _zz_72;
+    _zz_73[9] = _zz_72;
+    _zz_73[8] = _zz_72;
+    _zz_73[7] = _zz_72;
+    _zz_73[6] = _zz_72;
+    _zz_73[5] = _zz_72;
+    _zz_73[4] = _zz_72;
+    _zz_73[3] = _zz_72;
+    _zz_73[2] = _zz_72;
+    _zz_73[1] = _zz_72;
+    _zz_73[0] = _zz_72;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_77_ = _zz_679_[1];
+        _zz_74 = _zz_762[1];
       end
       default : begin
-        _zz_77_ = _zz_680_[1];
+        _zz_74 = _zz_763[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_78_ = _zz_681_[19];
+  assign _zz_75 = _zz_764[19];
   always @ (*) begin
-    _zz_79_[10] = _zz_78_;
-    _zz_79_[9] = _zz_78_;
-    _zz_79_[8] = _zz_78_;
-    _zz_79_[7] = _zz_78_;
-    _zz_79_[6] = _zz_78_;
-    _zz_79_[5] = _zz_78_;
-    _zz_79_[4] = _zz_78_;
-    _zz_79_[3] = _zz_78_;
-    _zz_79_[2] = _zz_78_;
-    _zz_79_[1] = _zz_78_;
-    _zz_79_[0] = _zz_78_;
+    _zz_76[10] = _zz_75;
+    _zz_76[9] = _zz_75;
+    _zz_76[8] = _zz_75;
+    _zz_76[7] = _zz_75;
+    _zz_76[6] = _zz_75;
+    _zz_76[5] = _zz_75;
+    _zz_76[4] = _zz_75;
+    _zz_76[3] = _zz_75;
+    _zz_76[2] = _zz_75;
+    _zz_76[1] = _zz_75;
+    _zz_76[0] = _zz_75;
   end
 
-  assign _zz_80_ = _zz_682_[11];
+  assign _zz_77 = _zz_765[11];
   always @ (*) begin
-    _zz_81_[18] = _zz_80_;
-    _zz_81_[17] = _zz_80_;
-    _zz_81_[16] = _zz_80_;
-    _zz_81_[15] = _zz_80_;
-    _zz_81_[14] = _zz_80_;
-    _zz_81_[13] = _zz_80_;
-    _zz_81_[12] = _zz_80_;
-    _zz_81_[11] = _zz_80_;
-    _zz_81_[10] = _zz_80_;
-    _zz_81_[9] = _zz_80_;
-    _zz_81_[8] = _zz_80_;
-    _zz_81_[7] = _zz_80_;
-    _zz_81_[6] = _zz_80_;
-    _zz_81_[5] = _zz_80_;
-    _zz_81_[4] = _zz_80_;
-    _zz_81_[3] = _zz_80_;
-    _zz_81_[2] = _zz_80_;
-    _zz_81_[1] = _zz_80_;
-    _zz_81_[0] = _zz_80_;
+    _zz_78[18] = _zz_77;
+    _zz_78[17] = _zz_77;
+    _zz_78[16] = _zz_77;
+    _zz_78[15] = _zz_77;
+    _zz_78[14] = _zz_77;
+    _zz_78[13] = _zz_77;
+    _zz_78[12] = _zz_77;
+    _zz_78[11] = _zz_77;
+    _zz_78[10] = _zz_77;
+    _zz_78[9] = _zz_77;
+    _zz_78[8] = _zz_77;
+    _zz_78[7] = _zz_77;
+    _zz_78[6] = _zz_77;
+    _zz_78[5] = _zz_77;
+    _zz_78[4] = _zz_77;
+    _zz_78[3] = _zz_77;
+    _zz_78[2] = _zz_77;
+    _zz_78[1] = _zz_77;
+    _zz_78[0] = _zz_77;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_79_,{{{_zz_881_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_81_,{{{_zz_882_,_zz_883_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_76,{{{_zz_988,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_78,{{{_zz_989,_zz_990},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -5483,123 +4728,128 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_562_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_563_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_564_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_565_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_566_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_567_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_623 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_624 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_625 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_624;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_627 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_628 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_629 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_597_)begin
+    if(_zz_680)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_595_)begin
+    if(_zz_678)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_568_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_595_)begin
-      _zz_568_ = 1'b1;
+    _zz_630 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_678)begin
+      _zz_630 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_596_)begin
+    if(_zz_679)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_594_)begin
+    if(_zz_677)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_596_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_679)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_594_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_677)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_561_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_578_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_622 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_649 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_569_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_570_ = execute_SRC_ADD;
+  assign _zz_631 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_632 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_84_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_81 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_84_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_81 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_84_ = execute_RS2[31 : 0];
+        _zz_81 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_577_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_571_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_572_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+  assign _zz_648 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_633 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_634 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_633;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_634;
+  assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @ (*) begin
-    _zz_573_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((1'b0 && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_573_ = 1'b1;
+    _zz_635 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((1'b0 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_635 = 1'b1;
     end
   end
 
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_574_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_575_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_576_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_636 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_637 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_638 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_603_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_686)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -5608,17 +4858,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_603_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_686)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -5626,94 +4876,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_603_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_683_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_686)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_766};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_684_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_767};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_85_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_82 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_86_[31] = _zz_85_;
-    _zz_86_[30] = _zz_85_;
-    _zz_86_[29] = _zz_85_;
-    _zz_86_[28] = _zz_85_;
-    _zz_86_[27] = _zz_85_;
-    _zz_86_[26] = _zz_85_;
-    _zz_86_[25] = _zz_85_;
-    _zz_86_[24] = _zz_85_;
-    _zz_86_[23] = _zz_85_;
-    _zz_86_[22] = _zz_85_;
-    _zz_86_[21] = _zz_85_;
-    _zz_86_[20] = _zz_85_;
-    _zz_86_[19] = _zz_85_;
-    _zz_86_[18] = _zz_85_;
-    _zz_86_[17] = _zz_85_;
-    _zz_86_[16] = _zz_85_;
-    _zz_86_[15] = _zz_85_;
-    _zz_86_[14] = _zz_85_;
-    _zz_86_[13] = _zz_85_;
-    _zz_86_[12] = _zz_85_;
-    _zz_86_[11] = _zz_85_;
-    _zz_86_[10] = _zz_85_;
-    _zz_86_[9] = _zz_85_;
-    _zz_86_[8] = _zz_85_;
-    _zz_86_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_83[31] = _zz_82;
+    _zz_83[30] = _zz_82;
+    _zz_83[29] = _zz_82;
+    _zz_83[28] = _zz_82;
+    _zz_83[27] = _zz_82;
+    _zz_83[26] = _zz_82;
+    _zz_83[25] = _zz_82;
+    _zz_83[24] = _zz_82;
+    _zz_83[23] = _zz_82;
+    _zz_83[22] = _zz_82;
+    _zz_83[21] = _zz_82;
+    _zz_83[20] = _zz_82;
+    _zz_83[19] = _zz_82;
+    _zz_83[18] = _zz_82;
+    _zz_83[17] = _zz_82;
+    _zz_83[16] = _zz_82;
+    _zz_83[15] = _zz_82;
+    _zz_83[14] = _zz_82;
+    _zz_83[13] = _zz_82;
+    _zz_83[12] = _zz_82;
+    _zz_83[11] = _zz_82;
+    _zz_83[10] = _zz_82;
+    _zz_83[9] = _zz_82;
+    _zz_83[8] = _zz_82;
+    _zz_83[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_87_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_84 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_88_[31] = _zz_87_;
-    _zz_88_[30] = _zz_87_;
-    _zz_88_[29] = _zz_87_;
-    _zz_88_[28] = _zz_87_;
-    _zz_88_[27] = _zz_87_;
-    _zz_88_[26] = _zz_87_;
-    _zz_88_[25] = _zz_87_;
-    _zz_88_[24] = _zz_87_;
-    _zz_88_[23] = _zz_87_;
-    _zz_88_[22] = _zz_87_;
-    _zz_88_[21] = _zz_87_;
-    _zz_88_[20] = _zz_87_;
-    _zz_88_[19] = _zz_87_;
-    _zz_88_[18] = _zz_87_;
-    _zz_88_[17] = _zz_87_;
-    _zz_88_[16] = _zz_87_;
-    _zz_88_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_85[31] = _zz_84;
+    _zz_85[30] = _zz_84;
+    _zz_85[29] = _zz_84;
+    _zz_85[28] = _zz_84;
+    _zz_85[27] = _zz_84;
+    _zz_85[26] = _zz_84;
+    _zz_85[25] = _zz_84;
+    _zz_85[24] = _zz_84;
+    _zz_85[23] = _zz_84;
+    _zz_85[22] = _zz_84;
+    _zz_85[21] = _zz_84;
+    _zz_85[20] = _zz_84;
+    _zz_85[19] = _zz_84;
+    _zz_85[18] = _zz_84;
+    _zz_85[17] = _zz_84;
+    _zz_85[16] = _zz_84;
+    _zz_85[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_640_)
+    case(_zz_723)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_86_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_83;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_88_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_85;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -5721,281 +4971,1975 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_102_ = (_zz_94_ <<< 2);
-  assign _zz_103_ = (_zz_94_ & (~ _zz_685_));
-  assign _zz_104_ = ((_zz_94_ & (~ _zz_103_)) <<< 2);
-  assign _zz_118_ = (_zz_110_ <<< 2);
-  assign _zz_119_ = (_zz_110_ & (~ _zz_688_));
-  assign _zz_120_ = ((_zz_110_ & (~ _zz_119_)) <<< 2);
-  assign _zz_134_ = (_zz_126_ <<< 2);
-  assign _zz_135_ = (_zz_126_ & (~ _zz_691_));
-  assign _zz_136_ = ((_zz_126_ & (~ _zz_135_)) <<< 2);
-  assign _zz_150_ = (_zz_142_ <<< 2);
-  assign _zz_151_ = (_zz_142_ & (~ _zz_694_));
-  assign _zz_152_ = ((_zz_142_ & (~ _zz_151_)) <<< 2);
-  assign _zz_166_ = (_zz_158_ <<< 2);
-  assign _zz_167_ = (_zz_158_ & (~ _zz_697_));
-  assign _zz_168_ = ((_zz_158_ & (~ _zz_167_)) <<< 2);
-  assign _zz_182_ = (_zz_174_ <<< 2);
-  assign _zz_183_ = (_zz_174_ & (~ _zz_700_));
-  assign _zz_184_ = ((_zz_174_ & (~ _zz_183_)) <<< 2);
-  assign _zz_198_ = (_zz_190_ <<< 2);
-  assign _zz_199_ = (_zz_190_ & (~ _zz_703_));
-  assign _zz_200_ = ((_zz_190_ & (~ _zz_199_)) <<< 2);
-  assign _zz_214_ = (_zz_206_ <<< 2);
-  assign _zz_215_ = (_zz_206_ & (~ _zz_706_));
-  assign _zz_216_ = ((_zz_206_ & (~ _zz_215_)) <<< 2);
-  assign _zz_230_ = (_zz_222_ <<< 2);
-  assign _zz_231_ = (_zz_222_ & (~ _zz_709_));
-  assign _zz_232_ = ((_zz_222_ & (~ _zz_231_)) <<< 2);
-  assign _zz_246_ = (_zz_238_ <<< 2);
-  assign _zz_247_ = (_zz_238_ & (~ _zz_712_));
-  assign _zz_248_ = ((_zz_238_ & (~ _zz_247_)) <<< 2);
-  assign _zz_262_ = (_zz_254_ <<< 2);
-  assign _zz_263_ = (_zz_254_ & (~ _zz_715_));
-  assign _zz_264_ = ((_zz_254_ & (~ _zz_263_)) <<< 2);
-  assign _zz_278_ = (_zz_270_ <<< 2);
-  assign _zz_279_ = (_zz_270_ & (~ _zz_718_));
-  assign _zz_280_ = ((_zz_270_ & (~ _zz_279_)) <<< 2);
-  assign _zz_294_ = (_zz_286_ <<< 2);
-  assign _zz_295_ = (_zz_286_ & (~ _zz_721_));
-  assign _zz_296_ = ((_zz_286_ & (~ _zz_295_)) <<< 2);
-  assign _zz_310_ = (_zz_302_ <<< 2);
-  assign _zz_311_ = (_zz_302_ & (~ _zz_724_));
-  assign _zz_312_ = ((_zz_302_ & (~ _zz_311_)) <<< 2);
-  assign _zz_326_ = (_zz_318_ <<< 2);
-  assign _zz_327_ = (_zz_318_ & (~ _zz_727_));
-  assign _zz_328_ = ((_zz_318_ & (~ _zz_327_)) <<< 2);
-  assign _zz_342_ = (_zz_334_ <<< 2);
-  assign _zz_343_ = (_zz_334_ & (~ _zz_730_));
-  assign _zz_344_ = ((_zz_334_ & (~ _zz_343_)) <<< 2);
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  assign PmpPlugin_ports_0_hits_0 = (((_zz_99_ && (_zz_100_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_101_)) && (_zz_98_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_1 = (((_zz_115_ && (_zz_116_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_117_)) && (_zz_114_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_2 = (((_zz_131_ && (_zz_132_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_133_)) && (_zz_130_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_3 = (((_zz_147_ && (_zz_148_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_149_)) && (_zz_146_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_4 = (((_zz_163_ && (_zz_164_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_165_)) && (_zz_162_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_5 = (((_zz_179_ && (_zz_180_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_181_)) && (_zz_178_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_6 = (((_zz_195_ && (_zz_196_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_197_)) && (_zz_194_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_7 = (((_zz_211_ && (_zz_212_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_213_)) && (_zz_210_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_8 = (((_zz_227_ && (_zz_228_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_229_)) && (_zz_226_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_9 = (((_zz_243_ && (_zz_244_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_245_)) && (_zz_242_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_10 = (((_zz_259_ && (_zz_260_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_261_)) && (_zz_258_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_11 = (((_zz_275_ && (_zz_276_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_277_)) && (_zz_274_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_12 = (((_zz_291_ && (_zz_292_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_293_)) && (_zz_290_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_13 = (((_zz_307_ && (_zz_308_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_309_)) && (_zz_306_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_14 = (((_zz_323_ && (_zz_324_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_325_)) && (_zz_322_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_15 = (((_zz_339_ && (_zz_340_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_341_)) && (_zz_338_ || (! (CsrPlugin_privilege == (2'b11)))));
   always @ (*) begin
-    if(_zz_604_)begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == (2'b11));
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = _zz_582_;
+    _zz_92 = _zz_86;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_92 = _zz_894[0];
+      end
     end
   end
 
   always @ (*) begin
-    if(_zz_604_)begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == (2'b11));
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_583_;
+    _zz_93 = _zz_87;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_93 = _zz_893[0];
+      end
     end
   end
 
   always @ (*) begin
-    if(_zz_604_)begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == (2'b11));
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_584_;
+    _zz_94 = _zz_88;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_94 = _zz_892[0];
+      end
     end
   end
 
-  assign _zz_345_ = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_884_,_zz_885_}}}}}}}}}}};
-  assign _zz_346_ = (_zz_345_ & (~ _zz_733_));
-  assign _zz_347_ = _zz_346_[3];
-  assign _zz_348_ = _zz_346_[5];
-  assign _zz_349_ = _zz_346_[6];
-  assign _zz_350_ = _zz_346_[7];
-  assign _zz_351_ = _zz_346_[9];
-  assign _zz_352_ = _zz_346_[10];
-  assign _zz_353_ = _zz_346_[11];
-  assign _zz_354_ = _zz_346_[12];
-  assign _zz_355_ = _zz_346_[13];
-  assign _zz_356_ = _zz_346_[14];
-  assign _zz_357_ = _zz_346_[15];
-  assign _zz_358_ = (((((((_zz_346_[1] || _zz_347_) || _zz_348_) || _zz_350_) || _zz_351_) || _zz_353_) || _zz_355_) || _zz_357_);
-  assign _zz_359_ = (((((((_zz_346_[2] || _zz_347_) || _zz_349_) || _zz_350_) || _zz_352_) || _zz_353_) || _zz_356_) || _zz_357_);
-  assign _zz_360_ = (((((((_zz_346_[4] || _zz_348_) || _zz_349_) || _zz_350_) || _zz_354_) || _zz_355_) || _zz_356_) || _zz_357_);
-  assign _zz_361_ = (((((((_zz_346_[8] || _zz_351_) || _zz_352_) || _zz_353_) || _zz_354_) || _zz_355_) || _zz_356_) || _zz_357_);
-  assign _zz_362_ = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_886_,_zz_887_}}}}}}}}}}};
-  assign _zz_363_ = (_zz_362_ & (~ _zz_734_));
-  assign _zz_364_ = _zz_363_[3];
-  assign _zz_365_ = _zz_363_[5];
-  assign _zz_366_ = _zz_363_[6];
-  assign _zz_367_ = _zz_363_[7];
-  assign _zz_368_ = _zz_363_[9];
-  assign _zz_369_ = _zz_363_[10];
-  assign _zz_370_ = _zz_363_[11];
-  assign _zz_371_ = _zz_363_[12];
-  assign _zz_372_ = _zz_363_[13];
-  assign _zz_373_ = _zz_363_[14];
-  assign _zz_374_ = _zz_363_[15];
-  assign _zz_375_ = (((((((_zz_363_[1] || _zz_364_) || _zz_365_) || _zz_367_) || _zz_368_) || _zz_370_) || _zz_372_) || _zz_374_);
-  assign _zz_376_ = (((((((_zz_363_[2] || _zz_364_) || _zz_366_) || _zz_367_) || _zz_369_) || _zz_370_) || _zz_373_) || _zz_374_);
-  assign _zz_377_ = (((((((_zz_363_[4] || _zz_365_) || _zz_366_) || _zz_367_) || _zz_371_) || _zz_372_) || _zz_373_) || _zz_374_);
-  assign _zz_378_ = (((((((_zz_363_[8] || _zz_368_) || _zz_369_) || _zz_370_) || _zz_371_) || _zz_372_) || _zz_373_) || _zz_374_);
-  assign _zz_379_ = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_888_,_zz_889_}}}}}}}}}}};
-  assign _zz_380_ = (_zz_379_ & (~ _zz_735_));
-  assign _zz_381_ = _zz_380_[3];
-  assign _zz_382_ = _zz_380_[5];
-  assign _zz_383_ = _zz_380_[6];
-  assign _zz_384_ = _zz_380_[7];
-  assign _zz_385_ = _zz_380_[9];
-  assign _zz_386_ = _zz_380_[10];
-  assign _zz_387_ = _zz_380_[11];
-  assign _zz_388_ = _zz_380_[12];
-  assign _zz_389_ = _zz_380_[13];
-  assign _zz_390_ = _zz_380_[14];
-  assign _zz_391_ = _zz_380_[15];
-  assign _zz_392_ = (((((((_zz_380_[1] || _zz_381_) || _zz_382_) || _zz_384_) || _zz_385_) || _zz_387_) || _zz_389_) || _zz_391_);
-  assign _zz_393_ = (((((((_zz_380_[2] || _zz_381_) || _zz_383_) || _zz_384_) || _zz_386_) || _zz_387_) || _zz_390_) || _zz_391_);
-  assign _zz_394_ = (((((((_zz_380_[4] || _zz_382_) || _zz_383_) || _zz_384_) || _zz_388_) || _zz_389_) || _zz_390_) || _zz_391_);
-  assign _zz_395_ = (((((((_zz_380_[8] || _zz_385_) || _zz_386_) || _zz_387_) || _zz_388_) || _zz_389_) || _zz_390_) || _zz_391_);
+  always @ (*) begin
+    _zz_95 = _zz_89;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_95 = _zz_882[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_96 = _zz_90;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_96 = execute_CsrPlugin_writeData[4 : 3];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_97 = _zz_91;
+    if(execute_CsrPlugin_csr_944)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_97 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_102 = (_zz_91 <<< 2);
+  assign _zz_103 = (_zz_91 & (~ _zz_768));
+  assign _zz_104 = ((_zz_91 & (~ _zz_103)) <<< 2);
+  assign _zz_99 = _zz_89;
+  always @ (*) begin
+    _zz_98 = 1'b1;
+    case(_zz_96)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_98 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_96)
+      2'b01 : begin
+        _zz_100 = 32'h0;
+      end
+      2'b10 : begin
+        _zz_100 = _zz_102;
+      end
+      2'b11 : begin
+        _zz_100 = _zz_104;
+      end
+      default : begin
+        _zz_100 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_96)
+      2'b01 : begin
+        _zz_101 = _zz_102;
+      end
+      2'b10 : begin
+        _zz_101 = (_zz_102 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_101 = (_zz_104 + _zz_769);
+      end
+      default : begin
+        _zz_101 = _zz_102;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_111 = _zz_105;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_111 = _zz_891[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_112 = _zz_106;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_112 = _zz_890[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_113 = _zz_107;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_113 = _zz_889[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_114 = _zz_108;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_114 = _zz_881[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_115 = _zz_109;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_115 = execute_CsrPlugin_writeData[12 : 11];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_116 = _zz_110;
+    if(execute_CsrPlugin_csr_945)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_116 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_121 = (_zz_110 <<< 2);
+  assign _zz_122 = (_zz_110 & (~ _zz_771));
+  assign _zz_123 = ((_zz_110 & (~ _zz_122)) <<< 2);
+  assign _zz_118 = _zz_108;
+  always @ (*) begin
+    _zz_117 = 1'b1;
+    case(_zz_115)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_117 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_115)
+      2'b01 : begin
+        _zz_119 = _zz_101;
+      end
+      2'b10 : begin
+        _zz_119 = _zz_121;
+      end
+      2'b11 : begin
+        _zz_119 = _zz_123;
+      end
+      default : begin
+        _zz_119 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_115)
+      2'b01 : begin
+        _zz_120 = _zz_121;
+      end
+      2'b10 : begin
+        _zz_120 = (_zz_121 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_120 = (_zz_123 + _zz_772);
+      end
+      default : begin
+        _zz_120 = _zz_121;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_130 = _zz_124;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_130 = _zz_888[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_131 = _zz_125;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_131 = _zz_887[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_132 = _zz_126;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_132 = _zz_886[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_133 = _zz_127;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_133 = _zz_880[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_134 = _zz_128;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_134 = execute_CsrPlugin_writeData[20 : 19];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_135 = _zz_129;
+    if(execute_CsrPlugin_csr_946)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_135 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_140 = (_zz_129 <<< 2);
+  assign _zz_141 = (_zz_129 & (~ _zz_774));
+  assign _zz_142 = ((_zz_129 & (~ _zz_141)) <<< 2);
+  assign _zz_137 = _zz_127;
+  always @ (*) begin
+    _zz_136 = 1'b1;
+    case(_zz_134)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_136 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_134)
+      2'b01 : begin
+        _zz_138 = _zz_120;
+      end
+      2'b10 : begin
+        _zz_138 = _zz_140;
+      end
+      2'b11 : begin
+        _zz_138 = _zz_142;
+      end
+      default : begin
+        _zz_138 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_134)
+      2'b01 : begin
+        _zz_139 = _zz_140;
+      end
+      2'b10 : begin
+        _zz_139 = (_zz_140 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_139 = (_zz_142 + _zz_775);
+      end
+      default : begin
+        _zz_139 = _zz_140;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_149 = _zz_143;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_149 = _zz_885[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_150 = _zz_144;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_150 = _zz_884[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_151 = _zz_145;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_151 = _zz_883[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_152 = _zz_146;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_152 = _zz_879[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_153 = _zz_147;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_153 = execute_CsrPlugin_writeData[28 : 27];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_154 = _zz_148;
+    if(execute_CsrPlugin_csr_947)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_154 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_159 = (_zz_148 <<< 2);
+  assign _zz_160 = (_zz_148 & (~ _zz_777));
+  assign _zz_161 = ((_zz_148 & (~ _zz_160)) <<< 2);
+  assign _zz_156 = _zz_146;
+  always @ (*) begin
+    _zz_155 = 1'b1;
+    case(_zz_153)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_155 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_153)
+      2'b01 : begin
+        _zz_157 = _zz_139;
+      end
+      2'b10 : begin
+        _zz_157 = _zz_159;
+      end
+      2'b11 : begin
+        _zz_157 = _zz_161;
+      end
+      default : begin
+        _zz_157 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_153)
+      2'b01 : begin
+        _zz_158 = _zz_159;
+      end
+      2'b10 : begin
+        _zz_158 = (_zz_159 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_158 = (_zz_161 + _zz_778);
+      end
+      default : begin
+        _zz_158 = _zz_159;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_168 = _zz_162;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_168 = _zz_910[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_169 = _zz_163;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_169 = _zz_909[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_170 = _zz_164;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_170 = _zz_908[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_171 = _zz_165;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_171 = _zz_898[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_172 = _zz_166;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_172 = execute_CsrPlugin_writeData[4 : 3];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_173 = _zz_167;
+    if(execute_CsrPlugin_csr_948)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_173 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_178 = (_zz_167 <<< 2);
+  assign _zz_179 = (_zz_167 & (~ _zz_780));
+  assign _zz_180 = ((_zz_167 & (~ _zz_179)) <<< 2);
+  assign _zz_175 = _zz_165;
+  always @ (*) begin
+    _zz_174 = 1'b1;
+    case(_zz_172)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_174 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_172)
+      2'b01 : begin
+        _zz_176 = _zz_158;
+      end
+      2'b10 : begin
+        _zz_176 = _zz_178;
+      end
+      2'b11 : begin
+        _zz_176 = _zz_180;
+      end
+      default : begin
+        _zz_176 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_172)
+      2'b01 : begin
+        _zz_177 = _zz_178;
+      end
+      2'b10 : begin
+        _zz_177 = (_zz_178 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_177 = (_zz_180 + _zz_781);
+      end
+      default : begin
+        _zz_177 = _zz_178;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_187 = _zz_181;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_187 = _zz_907[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_188 = _zz_182;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_188 = _zz_906[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_189 = _zz_183;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_189 = _zz_905[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_190 = _zz_184;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_190 = _zz_897[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_191 = _zz_185;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_191 = execute_CsrPlugin_writeData[12 : 11];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_192 = _zz_186;
+    if(execute_CsrPlugin_csr_949)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_192 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_197 = (_zz_186 <<< 2);
+  assign _zz_198 = (_zz_186 & (~ _zz_783));
+  assign _zz_199 = ((_zz_186 & (~ _zz_198)) <<< 2);
+  assign _zz_194 = _zz_184;
+  always @ (*) begin
+    _zz_193 = 1'b1;
+    case(_zz_191)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_193 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_191)
+      2'b01 : begin
+        _zz_195 = _zz_177;
+      end
+      2'b10 : begin
+        _zz_195 = _zz_197;
+      end
+      2'b11 : begin
+        _zz_195 = _zz_199;
+      end
+      default : begin
+        _zz_195 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_191)
+      2'b01 : begin
+        _zz_196 = _zz_197;
+      end
+      2'b10 : begin
+        _zz_196 = (_zz_197 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_196 = (_zz_199 + _zz_784);
+      end
+      default : begin
+        _zz_196 = _zz_197;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_206 = _zz_200;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_206 = _zz_904[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_207 = _zz_201;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_207 = _zz_903[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_208 = _zz_202;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_208 = _zz_902[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_209 = _zz_203;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_209 = _zz_896[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_210 = _zz_204;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_210 = execute_CsrPlugin_writeData[20 : 19];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_211 = _zz_205;
+    if(execute_CsrPlugin_csr_950)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_211 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_216 = (_zz_205 <<< 2);
+  assign _zz_217 = (_zz_205 & (~ _zz_786));
+  assign _zz_218 = ((_zz_205 & (~ _zz_217)) <<< 2);
+  assign _zz_213 = _zz_203;
+  always @ (*) begin
+    _zz_212 = 1'b1;
+    case(_zz_210)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_212 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_210)
+      2'b01 : begin
+        _zz_214 = _zz_196;
+      end
+      2'b10 : begin
+        _zz_214 = _zz_216;
+      end
+      2'b11 : begin
+        _zz_214 = _zz_218;
+      end
+      default : begin
+        _zz_214 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_210)
+      2'b01 : begin
+        _zz_215 = _zz_216;
+      end
+      2'b10 : begin
+        _zz_215 = (_zz_216 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_215 = (_zz_218 + _zz_787);
+      end
+      default : begin
+        _zz_215 = _zz_216;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_225 = _zz_219;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_225 = _zz_901[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_226 = _zz_220;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_226 = _zz_900[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_227 = _zz_221;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_227 = _zz_899[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_228 = _zz_222;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_228 = _zz_895[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_229 = _zz_223;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_229 = execute_CsrPlugin_writeData[28 : 27];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_230 = _zz_224;
+    if(execute_CsrPlugin_csr_951)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_230 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_235 = (_zz_224 <<< 2);
+  assign _zz_236 = (_zz_224 & (~ _zz_789));
+  assign _zz_237 = ((_zz_224 & (~ _zz_236)) <<< 2);
+  assign _zz_232 = _zz_222;
+  always @ (*) begin
+    _zz_231 = 1'b1;
+    case(_zz_229)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_231 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_229)
+      2'b01 : begin
+        _zz_233 = _zz_215;
+      end
+      2'b10 : begin
+        _zz_233 = _zz_235;
+      end
+      2'b11 : begin
+        _zz_233 = _zz_237;
+      end
+      default : begin
+        _zz_233 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_229)
+      2'b01 : begin
+        _zz_234 = _zz_235;
+      end
+      2'b10 : begin
+        _zz_234 = (_zz_235 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_234 = (_zz_237 + _zz_790);
+      end
+      default : begin
+        _zz_234 = _zz_235;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_244 = _zz_238;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_244 = _zz_926[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_245 = _zz_239;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_245 = _zz_925[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_246 = _zz_240;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_246 = _zz_924[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_247 = _zz_241;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_247 = _zz_914[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_248 = _zz_242;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_248 = execute_CsrPlugin_writeData[4 : 3];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_249 = _zz_243;
+    if(execute_CsrPlugin_csr_952)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_249 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_254 = (_zz_243 <<< 2);
+  assign _zz_255 = (_zz_243 & (~ _zz_792));
+  assign _zz_256 = ((_zz_243 & (~ _zz_255)) <<< 2);
+  assign _zz_251 = _zz_241;
+  always @ (*) begin
+    _zz_250 = 1'b1;
+    case(_zz_248)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_250 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_248)
+      2'b01 : begin
+        _zz_252 = _zz_234;
+      end
+      2'b10 : begin
+        _zz_252 = _zz_254;
+      end
+      2'b11 : begin
+        _zz_252 = _zz_256;
+      end
+      default : begin
+        _zz_252 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_248)
+      2'b01 : begin
+        _zz_253 = _zz_254;
+      end
+      2'b10 : begin
+        _zz_253 = (_zz_254 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_253 = (_zz_256 + _zz_793);
+      end
+      default : begin
+        _zz_253 = _zz_254;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_263 = _zz_257;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_263 = _zz_923[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_264 = _zz_258;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_264 = _zz_922[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_265 = _zz_259;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_265 = _zz_921[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_266 = _zz_260;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_266 = _zz_913[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_267 = _zz_261;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_267 = execute_CsrPlugin_writeData[12 : 11];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_268 = _zz_262;
+    if(execute_CsrPlugin_csr_953)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_268 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_273 = (_zz_262 <<< 2);
+  assign _zz_274 = (_zz_262 & (~ _zz_795));
+  assign _zz_275 = ((_zz_262 & (~ _zz_274)) <<< 2);
+  assign _zz_270 = _zz_260;
+  always @ (*) begin
+    _zz_269 = 1'b1;
+    case(_zz_267)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_269 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_267)
+      2'b01 : begin
+        _zz_271 = _zz_253;
+      end
+      2'b10 : begin
+        _zz_271 = _zz_273;
+      end
+      2'b11 : begin
+        _zz_271 = _zz_275;
+      end
+      default : begin
+        _zz_271 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_267)
+      2'b01 : begin
+        _zz_272 = _zz_273;
+      end
+      2'b10 : begin
+        _zz_272 = (_zz_273 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_272 = (_zz_275 + _zz_796);
+      end
+      default : begin
+        _zz_272 = _zz_273;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_282 = _zz_276;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_282 = _zz_920[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_283 = _zz_277;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_283 = _zz_919[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_284 = _zz_278;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_284 = _zz_918[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_285 = _zz_279;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_285 = _zz_912[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_286 = _zz_280;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_286 = execute_CsrPlugin_writeData[20 : 19];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_287 = _zz_281;
+    if(execute_CsrPlugin_csr_954)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_287 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_292 = (_zz_281 <<< 2);
+  assign _zz_293 = (_zz_281 & (~ _zz_798));
+  assign _zz_294 = ((_zz_281 & (~ _zz_293)) <<< 2);
+  assign _zz_289 = _zz_279;
+  always @ (*) begin
+    _zz_288 = 1'b1;
+    case(_zz_286)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_288 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_286)
+      2'b01 : begin
+        _zz_290 = _zz_272;
+      end
+      2'b10 : begin
+        _zz_290 = _zz_292;
+      end
+      2'b11 : begin
+        _zz_290 = _zz_294;
+      end
+      default : begin
+        _zz_290 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_286)
+      2'b01 : begin
+        _zz_291 = _zz_292;
+      end
+      2'b10 : begin
+        _zz_291 = (_zz_292 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_291 = (_zz_294 + _zz_799);
+      end
+      default : begin
+        _zz_291 = _zz_292;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_301 = _zz_295;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_301 = _zz_917[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_302 = _zz_296;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_302 = _zz_916[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_303 = _zz_297;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_303 = _zz_915[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_304 = _zz_298;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_304 = _zz_911[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_305 = _zz_299;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_305 = execute_CsrPlugin_writeData[28 : 27];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_306 = _zz_300;
+    if(execute_CsrPlugin_csr_955)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_306 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_311 = (_zz_300 <<< 2);
+  assign _zz_312 = (_zz_300 & (~ _zz_801));
+  assign _zz_313 = ((_zz_300 & (~ _zz_312)) <<< 2);
+  assign _zz_308 = _zz_298;
+  always @ (*) begin
+    _zz_307 = 1'b1;
+    case(_zz_305)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_307 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_305)
+      2'b01 : begin
+        _zz_309 = _zz_291;
+      end
+      2'b10 : begin
+        _zz_309 = _zz_311;
+      end
+      2'b11 : begin
+        _zz_309 = _zz_313;
+      end
+      default : begin
+        _zz_309 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_305)
+      2'b01 : begin
+        _zz_310 = _zz_311;
+      end
+      2'b10 : begin
+        _zz_310 = (_zz_311 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_310 = (_zz_313 + _zz_802);
+      end
+      default : begin
+        _zz_310 = _zz_311;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_320 = _zz_314;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_320 = _zz_942[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_321 = _zz_315;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_321 = _zz_941[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_322 = _zz_316;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_322 = _zz_940[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_323 = _zz_317;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_323 = _zz_930[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_324 = _zz_318;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_324 = execute_CsrPlugin_writeData[4 : 3];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_325 = _zz_319;
+    if(execute_CsrPlugin_csr_956)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_325 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_330 = (_zz_319 <<< 2);
+  assign _zz_331 = (_zz_319 & (~ _zz_804));
+  assign _zz_332 = ((_zz_319 & (~ _zz_331)) <<< 2);
+  assign _zz_327 = _zz_317;
+  always @ (*) begin
+    _zz_326 = 1'b1;
+    case(_zz_324)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_326 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_324)
+      2'b01 : begin
+        _zz_328 = _zz_310;
+      end
+      2'b10 : begin
+        _zz_328 = _zz_330;
+      end
+      2'b11 : begin
+        _zz_328 = _zz_332;
+      end
+      default : begin
+        _zz_328 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_324)
+      2'b01 : begin
+        _zz_329 = _zz_330;
+      end
+      2'b10 : begin
+        _zz_329 = (_zz_330 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_329 = (_zz_332 + _zz_805);
+      end
+      default : begin
+        _zz_329 = _zz_330;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_339 = _zz_333;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_339 = _zz_939[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_340 = _zz_334;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_340 = _zz_938[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_341 = _zz_335;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_341 = _zz_937[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_342 = _zz_336;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_342 = _zz_929[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_343 = _zz_337;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_343 = execute_CsrPlugin_writeData[12 : 11];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_344 = _zz_338;
+    if(execute_CsrPlugin_csr_957)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_344 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_349 = (_zz_338 <<< 2);
+  assign _zz_350 = (_zz_338 & (~ _zz_807));
+  assign _zz_351 = ((_zz_338 & (~ _zz_350)) <<< 2);
+  assign _zz_346 = _zz_336;
+  always @ (*) begin
+    _zz_345 = 1'b1;
+    case(_zz_343)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_345 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_343)
+      2'b01 : begin
+        _zz_347 = _zz_329;
+      end
+      2'b10 : begin
+        _zz_347 = _zz_349;
+      end
+      2'b11 : begin
+        _zz_347 = _zz_351;
+      end
+      default : begin
+        _zz_347 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_343)
+      2'b01 : begin
+        _zz_348 = _zz_349;
+      end
+      2'b10 : begin
+        _zz_348 = (_zz_349 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_348 = (_zz_351 + _zz_808);
+      end
+      default : begin
+        _zz_348 = _zz_349;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_358 = _zz_352;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_358 = _zz_936[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_359 = _zz_353;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_359 = _zz_935[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_360 = _zz_354;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_360 = _zz_934[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_361 = _zz_355;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_361 = _zz_928[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_362 = _zz_356;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_362 = execute_CsrPlugin_writeData[20 : 19];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_363 = _zz_357;
+    if(execute_CsrPlugin_csr_958)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_363 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_368 = (_zz_357 <<< 2);
+  assign _zz_369 = (_zz_357 & (~ _zz_810));
+  assign _zz_370 = ((_zz_357 & (~ _zz_369)) <<< 2);
+  assign _zz_365 = _zz_355;
+  always @ (*) begin
+    _zz_364 = 1'b1;
+    case(_zz_362)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_364 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_362)
+      2'b01 : begin
+        _zz_366 = _zz_348;
+      end
+      2'b10 : begin
+        _zz_366 = _zz_368;
+      end
+      2'b11 : begin
+        _zz_366 = _zz_370;
+      end
+      default : begin
+        _zz_366 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_362)
+      2'b01 : begin
+        _zz_367 = _zz_368;
+      end
+      2'b10 : begin
+        _zz_367 = (_zz_368 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_367 = (_zz_370 + _zz_811);
+      end
+      default : begin
+        _zz_367 = _zz_368;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_377 = _zz_371;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_377 = _zz_933[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_378 = _zz_372;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_378 = _zz_932[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_379 = _zz_373;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_379 = _zz_931[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_380 = _zz_374;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_380 = _zz_927[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_381 = _zz_375;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_381 = execute_CsrPlugin_writeData[28 : 27];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_382 = _zz_376;
+    if(execute_CsrPlugin_csr_959)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_382 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_387 = (_zz_376 <<< 2);
+  assign _zz_388 = (_zz_376 & (~ _zz_813));
+  assign _zz_389 = ((_zz_376 & (~ _zz_388)) <<< 2);
+  assign _zz_384 = _zz_374;
+  always @ (*) begin
+    _zz_383 = 1'b1;
+    case(_zz_381)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_383 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_381)
+      2'b01 : begin
+        _zz_385 = _zz_367;
+      end
+      2'b10 : begin
+        _zz_385 = _zz_387;
+      end
+      2'b11 : begin
+        _zz_385 = _zz_389;
+      end
+      default : begin
+        _zz_385 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_381)
+      2'b01 : begin
+        _zz_386 = _zz_387;
+      end
+      2'b10 : begin
+        _zz_386 = (_zz_387 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_386 = (_zz_389 + _zz_814);
+      end
+      default : begin
+        _zz_386 = _zz_387;
+      end
+    endcase
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign PmpPlugin_ports_0_hits_0 = (((_zz_98 && (_zz_100 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_101)) && (_zz_99 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_1 = (((_zz_117 && (_zz_119 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_120)) && (_zz_118 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_2 = (((_zz_136 && (_zz_138 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_139)) && (_zz_137 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_3 = (((_zz_155 && (_zz_157 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_158)) && (_zz_156 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_4 = (((_zz_174 && (_zz_176 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_177)) && (_zz_175 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_5 = (((_zz_193 && (_zz_195 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_196)) && (_zz_194 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_6 = (((_zz_212 && (_zz_214 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_215)) && (_zz_213 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_7 = (((_zz_231 && (_zz_233 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_234)) && (_zz_232 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_8 = (((_zz_250 && (_zz_252 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_253)) && (_zz_251 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_9 = (((_zz_269 && (_zz_271 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_272)) && (_zz_270 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_10 = (((_zz_288 && (_zz_290 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_291)) && (_zz_289 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_11 = (((_zz_307 && (_zz_309 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_310)) && (_zz_308 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_12 = (((_zz_326 && (_zz_328 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_329)) && (_zz_327 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_13 = (((_zz_345 && (_zz_347 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_348)) && (_zz_346 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_14 = (((_zz_364 && (_zz_366 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_367)) && (_zz_365 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_15 = (((_zz_383 && (_zz_385 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_386)) && (_zz_384 || (! (CsrPlugin_privilege == 2'b11))));
+  assign _zz_390 = 5'h0;
+  assign _zz_391 = 5'h01;
+  assign _zz_392 = 5'h01;
+  assign _zz_393 = 5'h02;
+  assign _zz_394 = 5'h01;
+  assign _zz_395 = 5'h02;
+  assign _zz_396 = 5'h02;
+  assign _zz_397 = 5'h03;
+  always @ (*) begin
+    if(_zz_687)begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = _zz_659;
+    end
+  end
+
+  always @ (*) begin
+    if(_zz_687)begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_660;
+    end
+  end
+
+  always @ (*) begin
+    if(_zz_687)begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_661;
+    end
+  end
+
+  assign _zz_398 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_991,_zz_992}}}}}}}}}}};
+  assign _zz_399 = (_zz_398 & (~ _zz_823));
+  assign _zz_400 = _zz_399[3];
+  assign _zz_401 = _zz_399[5];
+  assign _zz_402 = _zz_399[6];
+  assign _zz_403 = _zz_399[7];
+  assign _zz_404 = _zz_399[9];
+  assign _zz_405 = _zz_399[10];
+  assign _zz_406 = _zz_399[11];
+  assign _zz_407 = _zz_399[12];
+  assign _zz_408 = _zz_399[13];
+  assign _zz_409 = _zz_399[14];
+  assign _zz_410 = _zz_399[15];
+  assign _zz_411 = (((((((_zz_399[1] || _zz_400) || _zz_401) || _zz_403) || _zz_404) || _zz_406) || _zz_408) || _zz_410);
+  assign _zz_412 = (((((((_zz_399[2] || _zz_400) || _zz_402) || _zz_403) || _zz_405) || _zz_406) || _zz_409) || _zz_410);
+  assign _zz_413 = (((((((_zz_399[4] || _zz_401) || _zz_402) || _zz_403) || _zz_407) || _zz_408) || _zz_409) || _zz_410);
+  assign _zz_414 = (((((((_zz_399[8] || _zz_404) || _zz_405) || _zz_406) || _zz_407) || _zz_408) || _zz_409) || _zz_410);
+  assign _zz_415 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_993,_zz_994}}}}}}}}}}};
+  assign _zz_416 = (_zz_415 & (~ _zz_824));
+  assign _zz_417 = _zz_416[3];
+  assign _zz_418 = _zz_416[5];
+  assign _zz_419 = _zz_416[6];
+  assign _zz_420 = _zz_416[7];
+  assign _zz_421 = _zz_416[9];
+  assign _zz_422 = _zz_416[10];
+  assign _zz_423 = _zz_416[11];
+  assign _zz_424 = _zz_416[12];
+  assign _zz_425 = _zz_416[13];
+  assign _zz_426 = _zz_416[14];
+  assign _zz_427 = _zz_416[15];
+  assign _zz_428 = (((((((_zz_416[1] || _zz_417) || _zz_418) || _zz_420) || _zz_421) || _zz_423) || _zz_425) || _zz_427);
+  assign _zz_429 = (((((((_zz_416[2] || _zz_417) || _zz_419) || _zz_420) || _zz_422) || _zz_423) || _zz_426) || _zz_427);
+  assign _zz_430 = (((((((_zz_416[4] || _zz_418) || _zz_419) || _zz_420) || _zz_424) || _zz_425) || _zz_426) || _zz_427);
+  assign _zz_431 = (((((((_zz_416[8] || _zz_421) || _zz_422) || _zz_423) || _zz_424) || _zz_425) || _zz_426) || _zz_427);
+  assign _zz_432 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_995,_zz_996}}}}}}}}}}};
+  assign _zz_433 = (_zz_432 & (~ _zz_825));
+  assign _zz_434 = _zz_433[3];
+  assign _zz_435 = _zz_433[5];
+  assign _zz_436 = _zz_433[6];
+  assign _zz_437 = _zz_433[7];
+  assign _zz_438 = _zz_433[9];
+  assign _zz_439 = _zz_433[10];
+  assign _zz_440 = _zz_433[11];
+  assign _zz_441 = _zz_433[12];
+  assign _zz_442 = _zz_433[13];
+  assign _zz_443 = _zz_433[14];
+  assign _zz_444 = _zz_433[15];
+  assign _zz_445 = (((((((_zz_433[1] || _zz_434) || _zz_435) || _zz_437) || _zz_438) || _zz_440) || _zz_442) || _zz_444);
+  assign _zz_446 = (((((((_zz_433[2] || _zz_434) || _zz_436) || _zz_437) || _zz_439) || _zz_440) || _zz_443) || _zz_444);
+  assign _zz_447 = (((((((_zz_433[4] || _zz_435) || _zz_436) || _zz_437) || _zz_441) || _zz_442) || _zz_443) || _zz_444);
+  assign _zz_448 = (((((((_zz_433[8] || _zz_438) || _zz_439) || _zz_440) || _zz_441) || _zz_442) || _zz_443) || _zz_444);
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  assign PmpPlugin_ports_1_hits_0 = (((_zz_99_ && (_zz_100_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_101_)) && (_zz_98_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_1 = (((_zz_115_ && (_zz_116_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_117_)) && (_zz_114_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_2 = (((_zz_131_ && (_zz_132_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_133_)) && (_zz_130_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_3 = (((_zz_147_ && (_zz_148_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_149_)) && (_zz_146_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_4 = (((_zz_163_ && (_zz_164_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_165_)) && (_zz_162_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_5 = (((_zz_179_ && (_zz_180_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_181_)) && (_zz_178_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_6 = (((_zz_195_ && (_zz_196_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_197_)) && (_zz_194_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_7 = (((_zz_211_ && (_zz_212_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_213_)) && (_zz_210_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_8 = (((_zz_227_ && (_zz_228_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_229_)) && (_zz_226_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_9 = (((_zz_243_ && (_zz_244_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_245_)) && (_zz_242_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_10 = (((_zz_259_ && (_zz_260_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_261_)) && (_zz_258_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_11 = (((_zz_275_ && (_zz_276_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_277_)) && (_zz_274_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_12 = (((_zz_291_ && (_zz_292_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_293_)) && (_zz_290_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_13 = (((_zz_307_ && (_zz_308_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_309_)) && (_zz_306_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_14 = (((_zz_323_ && (_zz_324_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_325_)) && (_zz_322_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_15 = (((_zz_339_ && (_zz_340_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_341_)) && (_zz_338_ || (! (CsrPlugin_privilege == (2'b11)))));
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign PmpPlugin_ports_1_hits_0 = (((_zz_98 && (_zz_100 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_101)) && (_zz_99 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_1 = (((_zz_117 && (_zz_119 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_120)) && (_zz_118 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_2 = (((_zz_136 && (_zz_138 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_139)) && (_zz_137 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_3 = (((_zz_155 && (_zz_157 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_158)) && (_zz_156 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_4 = (((_zz_174 && (_zz_176 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_177)) && (_zz_175 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_5 = (((_zz_193 && (_zz_195 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_196)) && (_zz_194 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_6 = (((_zz_212 && (_zz_214 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_215)) && (_zz_213 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_7 = (((_zz_231 && (_zz_233 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_234)) && (_zz_232 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_8 = (((_zz_250 && (_zz_252 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_253)) && (_zz_251 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_9 = (((_zz_269 && (_zz_271 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_272)) && (_zz_270 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_10 = (((_zz_288 && (_zz_290 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_291)) && (_zz_289 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_11 = (((_zz_307 && (_zz_309 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_310)) && (_zz_308 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_12 = (((_zz_326 && (_zz_328 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_329)) && (_zz_327 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_13 = (((_zz_345 && (_zz_347 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_348)) && (_zz_346 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_14 = (((_zz_364 && (_zz_366 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_367)) && (_zz_365 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_15 = (((_zz_383 && (_zz_385 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_386)) && (_zz_384 || (! (CsrPlugin_privilege == 2'b11))));
+  assign _zz_449 = 5'h0;
+  assign _zz_450 = 5'h01;
+  assign _zz_451 = 5'h01;
+  assign _zz_452 = 5'h02;
+  assign _zz_453 = 5'h01;
+  assign _zz_454 = 5'h02;
+  assign _zz_455 = 5'h02;
+  assign _zz_456 = 5'h03;
   always @ (*) begin
-    if(_zz_605_)begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == (2'b11));
+    if(_zz_688)begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = _zz_585_;
+      DBusCachedPlugin_mmuBus_rsp_allowRead = _zz_668;
     end
   end
 
   always @ (*) begin
-    if(_zz_605_)begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == (2'b11));
+    if(_zz_688)begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_586_;
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_669;
     end
   end
 
   always @ (*) begin
-    if(_zz_605_)begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == (2'b11));
+    if(_zz_688)begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_587_;
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_670;
     end
   end
 
-  assign _zz_396_ = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_890_,_zz_891_}}}}}}}}}}};
-  assign _zz_397_ = (_zz_396_ & (~ _zz_736_));
-  assign _zz_398_ = _zz_397_[3];
-  assign _zz_399_ = _zz_397_[5];
-  assign _zz_400_ = _zz_397_[6];
-  assign _zz_401_ = _zz_397_[7];
-  assign _zz_402_ = _zz_397_[9];
-  assign _zz_403_ = _zz_397_[10];
-  assign _zz_404_ = _zz_397_[11];
-  assign _zz_405_ = _zz_397_[12];
-  assign _zz_406_ = _zz_397_[13];
-  assign _zz_407_ = _zz_397_[14];
-  assign _zz_408_ = _zz_397_[15];
-  assign _zz_409_ = (((((((_zz_397_[1] || _zz_398_) || _zz_399_) || _zz_401_) || _zz_402_) || _zz_404_) || _zz_406_) || _zz_408_);
-  assign _zz_410_ = (((((((_zz_397_[2] || _zz_398_) || _zz_400_) || _zz_401_) || _zz_403_) || _zz_404_) || _zz_407_) || _zz_408_);
-  assign _zz_411_ = (((((((_zz_397_[4] || _zz_399_) || _zz_400_) || _zz_401_) || _zz_405_) || _zz_406_) || _zz_407_) || _zz_408_);
-  assign _zz_412_ = (((((((_zz_397_[8] || _zz_402_) || _zz_403_) || _zz_404_) || _zz_405_) || _zz_406_) || _zz_407_) || _zz_408_);
-  assign _zz_413_ = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_892_,_zz_893_}}}}}}}}}}};
-  assign _zz_414_ = (_zz_413_ & (~ _zz_737_));
-  assign _zz_415_ = _zz_414_[3];
-  assign _zz_416_ = _zz_414_[5];
-  assign _zz_417_ = _zz_414_[6];
-  assign _zz_418_ = _zz_414_[7];
-  assign _zz_419_ = _zz_414_[9];
-  assign _zz_420_ = _zz_414_[10];
-  assign _zz_421_ = _zz_414_[11];
-  assign _zz_422_ = _zz_414_[12];
-  assign _zz_423_ = _zz_414_[13];
-  assign _zz_424_ = _zz_414_[14];
-  assign _zz_425_ = _zz_414_[15];
-  assign _zz_426_ = (((((((_zz_414_[1] || _zz_415_) || _zz_416_) || _zz_418_) || _zz_419_) || _zz_421_) || _zz_423_) || _zz_425_);
-  assign _zz_427_ = (((((((_zz_414_[2] || _zz_415_) || _zz_417_) || _zz_418_) || _zz_420_) || _zz_421_) || _zz_424_) || _zz_425_);
-  assign _zz_428_ = (((((((_zz_414_[4] || _zz_416_) || _zz_417_) || _zz_418_) || _zz_422_) || _zz_423_) || _zz_424_) || _zz_425_);
-  assign _zz_429_ = (((((((_zz_414_[8] || _zz_419_) || _zz_420_) || _zz_421_) || _zz_422_) || _zz_423_) || _zz_424_) || _zz_425_);
-  assign _zz_430_ = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_894_,_zz_895_}}}}}}}}}}};
-  assign _zz_431_ = (_zz_430_ & (~ _zz_738_));
-  assign _zz_432_ = _zz_431_[3];
-  assign _zz_433_ = _zz_431_[5];
-  assign _zz_434_ = _zz_431_[6];
-  assign _zz_435_ = _zz_431_[7];
-  assign _zz_436_ = _zz_431_[9];
-  assign _zz_437_ = _zz_431_[10];
-  assign _zz_438_ = _zz_431_[11];
-  assign _zz_439_ = _zz_431_[12];
-  assign _zz_440_ = _zz_431_[13];
-  assign _zz_441_ = _zz_431_[14];
-  assign _zz_442_ = _zz_431_[15];
-  assign _zz_443_ = (((((((_zz_431_[1] || _zz_432_) || _zz_433_) || _zz_435_) || _zz_436_) || _zz_438_) || _zz_440_) || _zz_442_);
-  assign _zz_444_ = (((((((_zz_431_[2] || _zz_432_) || _zz_434_) || _zz_435_) || _zz_437_) || _zz_438_) || _zz_441_) || _zz_442_);
-  assign _zz_445_ = (((((((_zz_431_[4] || _zz_433_) || _zz_434_) || _zz_435_) || _zz_439_) || _zz_440_) || _zz_441_) || _zz_442_);
-  assign _zz_446_ = (((((((_zz_431_[8] || _zz_436_) || _zz_437_) || _zz_438_) || _zz_439_) || _zz_440_) || _zz_441_) || _zz_442_);
+  assign _zz_457 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_997,_zz_998}}}}}}}}}}};
+  assign _zz_458 = (_zz_457 & (~ _zz_833));
+  assign _zz_459 = _zz_458[3];
+  assign _zz_460 = _zz_458[5];
+  assign _zz_461 = _zz_458[6];
+  assign _zz_462 = _zz_458[7];
+  assign _zz_463 = _zz_458[9];
+  assign _zz_464 = _zz_458[10];
+  assign _zz_465 = _zz_458[11];
+  assign _zz_466 = _zz_458[12];
+  assign _zz_467 = _zz_458[13];
+  assign _zz_468 = _zz_458[14];
+  assign _zz_469 = _zz_458[15];
+  assign _zz_470 = (((((((_zz_458[1] || _zz_459) || _zz_460) || _zz_462) || _zz_463) || _zz_465) || _zz_467) || _zz_469);
+  assign _zz_471 = (((((((_zz_458[2] || _zz_459) || _zz_461) || _zz_462) || _zz_464) || _zz_465) || _zz_468) || _zz_469);
+  assign _zz_472 = (((((((_zz_458[4] || _zz_460) || _zz_461) || _zz_462) || _zz_466) || _zz_467) || _zz_468) || _zz_469);
+  assign _zz_473 = (((((((_zz_458[8] || _zz_463) || _zz_464) || _zz_465) || _zz_466) || _zz_467) || _zz_468) || _zz_469);
+  assign _zz_474 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_999,_zz_1000}}}}}}}}}}};
+  assign _zz_475 = (_zz_474 & (~ _zz_834));
+  assign _zz_476 = _zz_475[3];
+  assign _zz_477 = _zz_475[5];
+  assign _zz_478 = _zz_475[6];
+  assign _zz_479 = _zz_475[7];
+  assign _zz_480 = _zz_475[9];
+  assign _zz_481 = _zz_475[10];
+  assign _zz_482 = _zz_475[11];
+  assign _zz_483 = _zz_475[12];
+  assign _zz_484 = _zz_475[13];
+  assign _zz_485 = _zz_475[14];
+  assign _zz_486 = _zz_475[15];
+  assign _zz_487 = (((((((_zz_475[1] || _zz_476) || _zz_477) || _zz_479) || _zz_480) || _zz_482) || _zz_484) || _zz_486);
+  assign _zz_488 = (((((((_zz_475[2] || _zz_476) || _zz_478) || _zz_479) || _zz_481) || _zz_482) || _zz_485) || _zz_486);
+  assign _zz_489 = (((((((_zz_475[4] || _zz_477) || _zz_478) || _zz_479) || _zz_483) || _zz_484) || _zz_485) || _zz_486);
+  assign _zz_490 = (((((((_zz_475[8] || _zz_480) || _zz_481) || _zz_482) || _zz_483) || _zz_484) || _zz_485) || _zz_486);
+  assign _zz_491 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_1001,_zz_1002}}}}}}}}}}};
+  assign _zz_492 = (_zz_491 & (~ _zz_835));
+  assign _zz_493 = _zz_492[3];
+  assign _zz_494 = _zz_492[5];
+  assign _zz_495 = _zz_492[6];
+  assign _zz_496 = _zz_492[7];
+  assign _zz_497 = _zz_492[9];
+  assign _zz_498 = _zz_492[10];
+  assign _zz_499 = _zz_492[11];
+  assign _zz_500 = _zz_492[12];
+  assign _zz_501 = _zz_492[13];
+  assign _zz_502 = _zz_492[14];
+  assign _zz_503 = _zz_492[15];
+  assign _zz_504 = (((((((_zz_492[1] || _zz_493) || _zz_494) || _zz_496) || _zz_497) || _zz_499) || _zz_501) || _zz_503);
+  assign _zz_505 = (((((((_zz_492[2] || _zz_493) || _zz_495) || _zz_496) || _zz_498) || _zz_499) || _zz_502) || _zz_503);
+  assign _zz_506 = (((((((_zz_492[4] || _zz_494) || _zz_495) || _zz_496) || _zz_500) || _zz_501) || _zz_502) || _zz_503);
+  assign _zz_507 = (((((((_zz_492[8] || _zz_497) || _zz_498) || _zz_499) || _zz_500) || _zz_501) || _zz_502) || _zz_503);
   assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_448_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_449_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_450_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_451_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_447_ = {({_zz_451_,(_zz_896_ == _zz_897_)} != (2'b00)),{((_zz_898_ == _zz_899_) != (1'b0)),{(_zz_900_ != (1'b0)),{(_zz_901_ != _zz_902_),{_zz_903_,{_zz_904_,_zz_905_}}}}}};
-  assign _zz_452_ = _zz_447_[3 : 2];
-  assign _zz_49_ = _zz_452_;
-  assign _zz_453_ = _zz_447_[6 : 5];
-  assign _zz_48_ = _zz_453_;
-  assign _zz_454_ = _zz_447_[8 : 7];
-  assign _zz_47_ = _zz_454_;
-  assign _zz_455_ = _zz_447_[20 : 19];
-  assign _zz_46_ = _zz_455_;
-  assign _zz_456_ = _zz_447_[23 : 22];
-  assign _zz_45_ = _zz_456_;
-  assign _zz_457_ = _zz_447_[25 : 24];
-  assign _zz_44_ = _zz_457_;
-  assign _zz_458_ = _zz_447_[31 : 30];
-  assign _zz_43_ = _zz_458_;
+  assign _zz_509 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_510 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_511 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_512 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_508 = {(_zz_512 != 1'b0),{(_zz_512 != 1'b0),{((_zz_1003 == _zz_1004) != 1'b0),{(_zz_1005 != 1'b0),{(_zz_1006 != _zz_1007),{_zz_1008,{_zz_1009,_zz_1010}}}}}}};
+  assign _zz_513 = _zz_508[2 : 1];
+  assign _zz_49 = _zz_513;
+  assign _zz_514 = _zz_508[7 : 6];
+  assign _zz_48 = _zz_514;
+  assign _zz_515 = _zz_508[9 : 8];
+  assign _zz_47 = _zz_515;
+  assign _zz_516 = _zz_508[19 : 18];
+  assign _zz_46 = _zz_516;
+  assign _zz_517 = _zz_508[22 : 21];
+  assign _zz_45 = _zz_517;
+  assign _zz_518 = _zz_508[24 : 23];
+  assign _zz_44 = _zz_518;
+  assign _zz_519 = _zz_508[27 : 26];
+  assign _zz_43 = _zz_519;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_579_;
-  assign decode_RegFilePlugin_rs2Data = _zz_580_;
+  assign decode_RegFilePlugin_rs1Data = _zz_650;
+  assign decode_RegFilePlugin_rs2Data = _zz_651;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_459_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_520)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_52_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_520)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_520)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -6013,13 +6957,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_460_ = execute_IntAluPlugin_bitwise;
+        _zz_521 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_460_ = {31'd0, _zz_739_};
+        _zz_521 = {31'd0, _zz_836};
       end
       default : begin
-        _zz_460_ = execute_SRC_ADD_SUB;
+        _zz_521 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -6027,87 +6971,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_461_ = execute_RS1;
+        _zz_522 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_461_ = {29'd0, _zz_740_};
+        _zz_522 = {29'd0, _zz_837};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_461_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_522 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_461_ = {27'd0, _zz_741_};
+        _zz_522 = {27'd0, _zz_838};
       end
     endcase
   end
 
-  assign _zz_462_ = _zz_742_[11];
+  assign _zz_523 = _zz_839[11];
   always @ (*) begin
-    _zz_463_[19] = _zz_462_;
-    _zz_463_[18] = _zz_462_;
-    _zz_463_[17] = _zz_462_;
-    _zz_463_[16] = _zz_462_;
-    _zz_463_[15] = _zz_462_;
-    _zz_463_[14] = _zz_462_;
-    _zz_463_[13] = _zz_462_;
-    _zz_463_[12] = _zz_462_;
-    _zz_463_[11] = _zz_462_;
-    _zz_463_[10] = _zz_462_;
-    _zz_463_[9] = _zz_462_;
-    _zz_463_[8] = _zz_462_;
-    _zz_463_[7] = _zz_462_;
-    _zz_463_[6] = _zz_462_;
-    _zz_463_[5] = _zz_462_;
-    _zz_463_[4] = _zz_462_;
-    _zz_463_[3] = _zz_462_;
-    _zz_463_[2] = _zz_462_;
-    _zz_463_[1] = _zz_462_;
-    _zz_463_[0] = _zz_462_;
+    _zz_524[19] = _zz_523;
+    _zz_524[18] = _zz_523;
+    _zz_524[17] = _zz_523;
+    _zz_524[16] = _zz_523;
+    _zz_524[15] = _zz_523;
+    _zz_524[14] = _zz_523;
+    _zz_524[13] = _zz_523;
+    _zz_524[12] = _zz_523;
+    _zz_524[11] = _zz_523;
+    _zz_524[10] = _zz_523;
+    _zz_524[9] = _zz_523;
+    _zz_524[8] = _zz_523;
+    _zz_524[7] = _zz_523;
+    _zz_524[6] = _zz_523;
+    _zz_524[5] = _zz_523;
+    _zz_524[4] = _zz_523;
+    _zz_524[3] = _zz_523;
+    _zz_524[2] = _zz_523;
+    _zz_524[1] = _zz_523;
+    _zz_524[0] = _zz_523;
   end
 
-  assign _zz_464_ = _zz_743_[11];
+  assign _zz_525 = _zz_840[11];
   always @ (*) begin
-    _zz_465_[19] = _zz_464_;
-    _zz_465_[18] = _zz_464_;
-    _zz_465_[17] = _zz_464_;
-    _zz_465_[16] = _zz_464_;
-    _zz_465_[15] = _zz_464_;
-    _zz_465_[14] = _zz_464_;
-    _zz_465_[13] = _zz_464_;
-    _zz_465_[12] = _zz_464_;
-    _zz_465_[11] = _zz_464_;
-    _zz_465_[10] = _zz_464_;
-    _zz_465_[9] = _zz_464_;
-    _zz_465_[8] = _zz_464_;
-    _zz_465_[7] = _zz_464_;
-    _zz_465_[6] = _zz_464_;
-    _zz_465_[5] = _zz_464_;
-    _zz_465_[4] = _zz_464_;
-    _zz_465_[3] = _zz_464_;
-    _zz_465_[2] = _zz_464_;
-    _zz_465_[1] = _zz_464_;
-    _zz_465_[0] = _zz_464_;
+    _zz_526[19] = _zz_525;
+    _zz_526[18] = _zz_525;
+    _zz_526[17] = _zz_525;
+    _zz_526[16] = _zz_525;
+    _zz_526[15] = _zz_525;
+    _zz_526[14] = _zz_525;
+    _zz_526[13] = _zz_525;
+    _zz_526[12] = _zz_525;
+    _zz_526[11] = _zz_525;
+    _zz_526[10] = _zz_525;
+    _zz_526[9] = _zz_525;
+    _zz_526[8] = _zz_525;
+    _zz_526[7] = _zz_525;
+    _zz_526[6] = _zz_525;
+    _zz_526[5] = _zz_525;
+    _zz_526[4] = _zz_525;
+    _zz_526[3] = _zz_525;
+    _zz_526[2] = _zz_525;
+    _zz_526[1] = _zz_525;
+    _zz_526[0] = _zz_525;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_466_ = execute_RS2;
+        _zz_527 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_466_ = {_zz_463_,execute_INSTRUCTION[31 : 20]};
+        _zz_527 = {_zz_524,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_466_ = {_zz_465_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_527 = {_zz_526,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_466_ = _zz_35_;
+        _zz_527 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_744_;
+    execute_SrcPlugin_addSub = _zz_841;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -6116,246 +7060,246 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_467_[0] = execute_SRC1[31];
-    _zz_467_[1] = execute_SRC1[30];
-    _zz_467_[2] = execute_SRC1[29];
-    _zz_467_[3] = execute_SRC1[28];
-    _zz_467_[4] = execute_SRC1[27];
-    _zz_467_[5] = execute_SRC1[26];
-    _zz_467_[6] = execute_SRC1[25];
-    _zz_467_[7] = execute_SRC1[24];
-    _zz_467_[8] = execute_SRC1[23];
-    _zz_467_[9] = execute_SRC1[22];
-    _zz_467_[10] = execute_SRC1[21];
-    _zz_467_[11] = execute_SRC1[20];
-    _zz_467_[12] = execute_SRC1[19];
-    _zz_467_[13] = execute_SRC1[18];
-    _zz_467_[14] = execute_SRC1[17];
-    _zz_467_[15] = execute_SRC1[16];
-    _zz_467_[16] = execute_SRC1[15];
-    _zz_467_[17] = execute_SRC1[14];
-    _zz_467_[18] = execute_SRC1[13];
-    _zz_467_[19] = execute_SRC1[12];
-    _zz_467_[20] = execute_SRC1[11];
-    _zz_467_[21] = execute_SRC1[10];
-    _zz_467_[22] = execute_SRC1[9];
-    _zz_467_[23] = execute_SRC1[8];
-    _zz_467_[24] = execute_SRC1[7];
-    _zz_467_[25] = execute_SRC1[6];
-    _zz_467_[26] = execute_SRC1[5];
-    _zz_467_[27] = execute_SRC1[4];
-    _zz_467_[28] = execute_SRC1[3];
-    _zz_467_[29] = execute_SRC1[2];
-    _zz_467_[30] = execute_SRC1[1];
-    _zz_467_[31] = execute_SRC1[0];
+    _zz_528[0] = execute_SRC1[31];
+    _zz_528[1] = execute_SRC1[30];
+    _zz_528[2] = execute_SRC1[29];
+    _zz_528[3] = execute_SRC1[28];
+    _zz_528[4] = execute_SRC1[27];
+    _zz_528[5] = execute_SRC1[26];
+    _zz_528[6] = execute_SRC1[25];
+    _zz_528[7] = execute_SRC1[24];
+    _zz_528[8] = execute_SRC1[23];
+    _zz_528[9] = execute_SRC1[22];
+    _zz_528[10] = execute_SRC1[21];
+    _zz_528[11] = execute_SRC1[20];
+    _zz_528[12] = execute_SRC1[19];
+    _zz_528[13] = execute_SRC1[18];
+    _zz_528[14] = execute_SRC1[17];
+    _zz_528[15] = execute_SRC1[16];
+    _zz_528[16] = execute_SRC1[15];
+    _zz_528[17] = execute_SRC1[14];
+    _zz_528[18] = execute_SRC1[13];
+    _zz_528[19] = execute_SRC1[12];
+    _zz_528[20] = execute_SRC1[11];
+    _zz_528[21] = execute_SRC1[10];
+    _zz_528[22] = execute_SRC1[9];
+    _zz_528[23] = execute_SRC1[8];
+    _zz_528[24] = execute_SRC1[7];
+    _zz_528[25] = execute_SRC1[6];
+    _zz_528[26] = execute_SRC1[5];
+    _zz_528[27] = execute_SRC1[4];
+    _zz_528[28] = execute_SRC1[3];
+    _zz_528[29] = execute_SRC1[2];
+    _zz_528[30] = execute_SRC1[1];
+    _zz_528[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_467_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_528 : execute_SRC1);
   always @ (*) begin
-    _zz_468_[0] = memory_SHIFT_RIGHT[31];
-    _zz_468_[1] = memory_SHIFT_RIGHT[30];
-    _zz_468_[2] = memory_SHIFT_RIGHT[29];
-    _zz_468_[3] = memory_SHIFT_RIGHT[28];
-    _zz_468_[4] = memory_SHIFT_RIGHT[27];
-    _zz_468_[5] = memory_SHIFT_RIGHT[26];
-    _zz_468_[6] = memory_SHIFT_RIGHT[25];
-    _zz_468_[7] = memory_SHIFT_RIGHT[24];
-    _zz_468_[8] = memory_SHIFT_RIGHT[23];
-    _zz_468_[9] = memory_SHIFT_RIGHT[22];
-    _zz_468_[10] = memory_SHIFT_RIGHT[21];
-    _zz_468_[11] = memory_SHIFT_RIGHT[20];
-    _zz_468_[12] = memory_SHIFT_RIGHT[19];
-    _zz_468_[13] = memory_SHIFT_RIGHT[18];
-    _zz_468_[14] = memory_SHIFT_RIGHT[17];
-    _zz_468_[15] = memory_SHIFT_RIGHT[16];
-    _zz_468_[16] = memory_SHIFT_RIGHT[15];
-    _zz_468_[17] = memory_SHIFT_RIGHT[14];
-    _zz_468_[18] = memory_SHIFT_RIGHT[13];
-    _zz_468_[19] = memory_SHIFT_RIGHT[12];
-    _zz_468_[20] = memory_SHIFT_RIGHT[11];
-    _zz_468_[21] = memory_SHIFT_RIGHT[10];
-    _zz_468_[22] = memory_SHIFT_RIGHT[9];
-    _zz_468_[23] = memory_SHIFT_RIGHT[8];
-    _zz_468_[24] = memory_SHIFT_RIGHT[7];
-    _zz_468_[25] = memory_SHIFT_RIGHT[6];
-    _zz_468_[26] = memory_SHIFT_RIGHT[5];
-    _zz_468_[27] = memory_SHIFT_RIGHT[4];
-    _zz_468_[28] = memory_SHIFT_RIGHT[3];
-    _zz_468_[29] = memory_SHIFT_RIGHT[2];
-    _zz_468_[30] = memory_SHIFT_RIGHT[1];
-    _zz_468_[31] = memory_SHIFT_RIGHT[0];
+    _zz_529[0] = memory_SHIFT_RIGHT[31];
+    _zz_529[1] = memory_SHIFT_RIGHT[30];
+    _zz_529[2] = memory_SHIFT_RIGHT[29];
+    _zz_529[3] = memory_SHIFT_RIGHT[28];
+    _zz_529[4] = memory_SHIFT_RIGHT[27];
+    _zz_529[5] = memory_SHIFT_RIGHT[26];
+    _zz_529[6] = memory_SHIFT_RIGHT[25];
+    _zz_529[7] = memory_SHIFT_RIGHT[24];
+    _zz_529[8] = memory_SHIFT_RIGHT[23];
+    _zz_529[9] = memory_SHIFT_RIGHT[22];
+    _zz_529[10] = memory_SHIFT_RIGHT[21];
+    _zz_529[11] = memory_SHIFT_RIGHT[20];
+    _zz_529[12] = memory_SHIFT_RIGHT[19];
+    _zz_529[13] = memory_SHIFT_RIGHT[18];
+    _zz_529[14] = memory_SHIFT_RIGHT[17];
+    _zz_529[15] = memory_SHIFT_RIGHT[16];
+    _zz_529[16] = memory_SHIFT_RIGHT[15];
+    _zz_529[17] = memory_SHIFT_RIGHT[14];
+    _zz_529[18] = memory_SHIFT_RIGHT[13];
+    _zz_529[19] = memory_SHIFT_RIGHT[12];
+    _zz_529[20] = memory_SHIFT_RIGHT[11];
+    _zz_529[21] = memory_SHIFT_RIGHT[10];
+    _zz_529[22] = memory_SHIFT_RIGHT[9];
+    _zz_529[23] = memory_SHIFT_RIGHT[8];
+    _zz_529[24] = memory_SHIFT_RIGHT[7];
+    _zz_529[25] = memory_SHIFT_RIGHT[6];
+    _zz_529[26] = memory_SHIFT_RIGHT[5];
+    _zz_529[27] = memory_SHIFT_RIGHT[4];
+    _zz_529[28] = memory_SHIFT_RIGHT[3];
+    _zz_529[29] = memory_SHIFT_RIGHT[2];
+    _zz_529[30] = memory_SHIFT_RIGHT[1];
+    _zz_529[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_469_ = 1'b0;
-    if(_zz_606_)begin
-      if(_zz_607_)begin
-        if(_zz_474_)begin
-          _zz_469_ = 1'b1;
+    _zz_530 = 1'b0;
+    if(_zz_689)begin
+      if(_zz_690)begin
+        if(_zz_535)begin
+          _zz_530 = 1'b1;
         end
       end
     end
-    if(_zz_608_)begin
-      if(_zz_609_)begin
-        if(_zz_476_)begin
-          _zz_469_ = 1'b1;
+    if(_zz_691)begin
+      if(_zz_692)begin
+        if(_zz_537)begin
+          _zz_530 = 1'b1;
         end
       end
     end
-    if(_zz_610_)begin
-      if(_zz_611_)begin
-        if(_zz_478_)begin
-          _zz_469_ = 1'b1;
+    if(_zz_693)begin
+      if(_zz_694)begin
+        if(_zz_539)begin
+          _zz_530 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_469_ = 1'b0;
+      _zz_530 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_470_ = 1'b0;
-    if(_zz_606_)begin
-      if(_zz_607_)begin
-        if(_zz_475_)begin
-          _zz_470_ = 1'b1;
+    _zz_531 = 1'b0;
+    if(_zz_689)begin
+      if(_zz_690)begin
+        if(_zz_536)begin
+          _zz_531 = 1'b1;
         end
       end
     end
-    if(_zz_608_)begin
-      if(_zz_609_)begin
-        if(_zz_477_)begin
-          _zz_470_ = 1'b1;
+    if(_zz_691)begin
+      if(_zz_692)begin
+        if(_zz_538)begin
+          _zz_531 = 1'b1;
         end
       end
     end
-    if(_zz_610_)begin
-      if(_zz_611_)begin
-        if(_zz_479_)begin
-          _zz_470_ = 1'b1;
+    if(_zz_693)begin
+      if(_zz_694)begin
+        if(_zz_540)begin
+          _zz_531 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_470_ = 1'b0;
+      _zz_531 = 1'b0;
     end
   end
 
-  assign _zz_474_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_475_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_476_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_477_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_478_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_479_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_535 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_536 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_537 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_538 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_539 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_540 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_480_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_541 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_480_ == (3'b000))) begin
-        _zz_481_ = execute_BranchPlugin_eq;
-    end else if((_zz_480_ == (3'b001))) begin
-        _zz_481_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_480_ & (3'b101)) == (3'b101)))) begin
-        _zz_481_ = (! execute_SRC_LESS);
+    if((_zz_541 == 3'b000)) begin
+        _zz_542 = execute_BranchPlugin_eq;
+    end else if((_zz_541 == 3'b001)) begin
+        _zz_542 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_541 & 3'b101) == 3'b101))) begin
+        _zz_542 = (! execute_SRC_LESS);
     end else begin
-        _zz_481_ = execute_SRC_LESS;
+        _zz_542 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_482_ = 1'b0;
+        _zz_543 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_482_ = 1'b1;
+        _zz_543 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_482_ = 1'b1;
+        _zz_543 = 1'b1;
       end
       default : begin
-        _zz_482_ = _zz_481_;
+        _zz_543 = _zz_542;
       end
     endcase
   end
 
-  assign _zz_483_ = _zz_751_[11];
+  assign _zz_544 = _zz_848[11];
   always @ (*) begin
-    _zz_484_[19] = _zz_483_;
-    _zz_484_[18] = _zz_483_;
-    _zz_484_[17] = _zz_483_;
-    _zz_484_[16] = _zz_483_;
-    _zz_484_[15] = _zz_483_;
-    _zz_484_[14] = _zz_483_;
-    _zz_484_[13] = _zz_483_;
-    _zz_484_[12] = _zz_483_;
-    _zz_484_[11] = _zz_483_;
-    _zz_484_[10] = _zz_483_;
-    _zz_484_[9] = _zz_483_;
-    _zz_484_[8] = _zz_483_;
-    _zz_484_[7] = _zz_483_;
-    _zz_484_[6] = _zz_483_;
-    _zz_484_[5] = _zz_483_;
-    _zz_484_[4] = _zz_483_;
-    _zz_484_[3] = _zz_483_;
-    _zz_484_[2] = _zz_483_;
-    _zz_484_[1] = _zz_483_;
-    _zz_484_[0] = _zz_483_;
+    _zz_545[19] = _zz_544;
+    _zz_545[18] = _zz_544;
+    _zz_545[17] = _zz_544;
+    _zz_545[16] = _zz_544;
+    _zz_545[15] = _zz_544;
+    _zz_545[14] = _zz_544;
+    _zz_545[13] = _zz_544;
+    _zz_545[12] = _zz_544;
+    _zz_545[11] = _zz_544;
+    _zz_545[10] = _zz_544;
+    _zz_545[9] = _zz_544;
+    _zz_545[8] = _zz_544;
+    _zz_545[7] = _zz_544;
+    _zz_545[6] = _zz_544;
+    _zz_545[5] = _zz_544;
+    _zz_545[4] = _zz_544;
+    _zz_545[3] = _zz_544;
+    _zz_545[2] = _zz_544;
+    _zz_545[1] = _zz_544;
+    _zz_545[0] = _zz_544;
   end
 
-  assign _zz_485_ = _zz_752_[19];
+  assign _zz_546 = _zz_849[19];
   always @ (*) begin
-    _zz_486_[10] = _zz_485_;
-    _zz_486_[9] = _zz_485_;
-    _zz_486_[8] = _zz_485_;
-    _zz_486_[7] = _zz_485_;
-    _zz_486_[6] = _zz_485_;
-    _zz_486_[5] = _zz_485_;
-    _zz_486_[4] = _zz_485_;
-    _zz_486_[3] = _zz_485_;
-    _zz_486_[2] = _zz_485_;
-    _zz_486_[1] = _zz_485_;
-    _zz_486_[0] = _zz_485_;
+    _zz_547[10] = _zz_546;
+    _zz_547[9] = _zz_546;
+    _zz_547[8] = _zz_546;
+    _zz_547[7] = _zz_546;
+    _zz_547[6] = _zz_546;
+    _zz_547[5] = _zz_546;
+    _zz_547[4] = _zz_546;
+    _zz_547[3] = _zz_546;
+    _zz_547[2] = _zz_546;
+    _zz_547[1] = _zz_546;
+    _zz_547[0] = _zz_546;
   end
 
-  assign _zz_487_ = _zz_753_[11];
+  assign _zz_548 = _zz_850[11];
   always @ (*) begin
-    _zz_488_[18] = _zz_487_;
-    _zz_488_[17] = _zz_487_;
-    _zz_488_[16] = _zz_487_;
-    _zz_488_[15] = _zz_487_;
-    _zz_488_[14] = _zz_487_;
-    _zz_488_[13] = _zz_487_;
-    _zz_488_[12] = _zz_487_;
-    _zz_488_[11] = _zz_487_;
-    _zz_488_[10] = _zz_487_;
-    _zz_488_[9] = _zz_487_;
-    _zz_488_[8] = _zz_487_;
-    _zz_488_[7] = _zz_487_;
-    _zz_488_[6] = _zz_487_;
-    _zz_488_[5] = _zz_487_;
-    _zz_488_[4] = _zz_487_;
-    _zz_488_[3] = _zz_487_;
-    _zz_488_[2] = _zz_487_;
-    _zz_488_[1] = _zz_487_;
-    _zz_488_[0] = _zz_487_;
+    _zz_549[18] = _zz_548;
+    _zz_549[17] = _zz_548;
+    _zz_549[16] = _zz_548;
+    _zz_549[15] = _zz_548;
+    _zz_549[14] = _zz_548;
+    _zz_549[13] = _zz_548;
+    _zz_549[12] = _zz_548;
+    _zz_549[11] = _zz_548;
+    _zz_549[10] = _zz_548;
+    _zz_549[9] = _zz_548;
+    _zz_549[8] = _zz_548;
+    _zz_549[7] = _zz_548;
+    _zz_549[6] = _zz_548;
+    _zz_549[5] = _zz_548;
+    _zz_549[4] = _zz_548;
+    _zz_549[3] = _zz_548;
+    _zz_549[2] = _zz_548;
+    _zz_549[1] = _zz_548;
+    _zz_549[0] = _zz_548;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_489_ = (_zz_754_[1] ^ execute_RS1[1]);
+        _zz_550 = (_zz_851[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_489_ = _zz_755_[1];
+        _zz_550 = _zz_852[1];
       end
       default : begin
-        _zz_489_ = _zz_756_[1];
+        _zz_550 = _zz_853[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_489_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_550);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -6367,106 +7311,106 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_490_ = _zz_757_[11];
+  assign _zz_551 = _zz_854[11];
   always @ (*) begin
-    _zz_491_[19] = _zz_490_;
-    _zz_491_[18] = _zz_490_;
-    _zz_491_[17] = _zz_490_;
-    _zz_491_[16] = _zz_490_;
-    _zz_491_[15] = _zz_490_;
-    _zz_491_[14] = _zz_490_;
-    _zz_491_[13] = _zz_490_;
-    _zz_491_[12] = _zz_490_;
-    _zz_491_[11] = _zz_490_;
-    _zz_491_[10] = _zz_490_;
-    _zz_491_[9] = _zz_490_;
-    _zz_491_[8] = _zz_490_;
-    _zz_491_[7] = _zz_490_;
-    _zz_491_[6] = _zz_490_;
-    _zz_491_[5] = _zz_490_;
-    _zz_491_[4] = _zz_490_;
-    _zz_491_[3] = _zz_490_;
-    _zz_491_[2] = _zz_490_;
-    _zz_491_[1] = _zz_490_;
-    _zz_491_[0] = _zz_490_;
+    _zz_552[19] = _zz_551;
+    _zz_552[18] = _zz_551;
+    _zz_552[17] = _zz_551;
+    _zz_552[16] = _zz_551;
+    _zz_552[15] = _zz_551;
+    _zz_552[14] = _zz_551;
+    _zz_552[13] = _zz_551;
+    _zz_552[12] = _zz_551;
+    _zz_552[11] = _zz_551;
+    _zz_552[10] = _zz_551;
+    _zz_552[9] = _zz_551;
+    _zz_552[8] = _zz_551;
+    _zz_552[7] = _zz_551;
+    _zz_552[6] = _zz_551;
+    _zz_552[5] = _zz_551;
+    _zz_552[4] = _zz_551;
+    _zz_552[3] = _zz_551;
+    _zz_552[2] = _zz_551;
+    _zz_552[1] = _zz_551;
+    _zz_552[0] = _zz_551;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_491_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_552,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_493_,{{{_zz_1058_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_495_,{{{_zz_1059_,_zz_1060_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_554,{{{_zz_1167,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_556,{{{_zz_1168,_zz_1169},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_760_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_857};
         end
       end
     endcase
   end
 
-  assign _zz_492_ = _zz_758_[19];
+  assign _zz_553 = _zz_855[19];
   always @ (*) begin
-    _zz_493_[10] = _zz_492_;
-    _zz_493_[9] = _zz_492_;
-    _zz_493_[8] = _zz_492_;
-    _zz_493_[7] = _zz_492_;
-    _zz_493_[6] = _zz_492_;
-    _zz_493_[5] = _zz_492_;
-    _zz_493_[4] = _zz_492_;
-    _zz_493_[3] = _zz_492_;
-    _zz_493_[2] = _zz_492_;
-    _zz_493_[1] = _zz_492_;
-    _zz_493_[0] = _zz_492_;
+    _zz_554[10] = _zz_553;
+    _zz_554[9] = _zz_553;
+    _zz_554[8] = _zz_553;
+    _zz_554[7] = _zz_553;
+    _zz_554[6] = _zz_553;
+    _zz_554[5] = _zz_553;
+    _zz_554[4] = _zz_553;
+    _zz_554[3] = _zz_553;
+    _zz_554[2] = _zz_553;
+    _zz_554[1] = _zz_553;
+    _zz_554[0] = _zz_553;
   end
 
-  assign _zz_494_ = _zz_759_[11];
+  assign _zz_555 = _zz_856[11];
   always @ (*) begin
-    _zz_495_[18] = _zz_494_;
-    _zz_495_[17] = _zz_494_;
-    _zz_495_[16] = _zz_494_;
-    _zz_495_[15] = _zz_494_;
-    _zz_495_[14] = _zz_494_;
-    _zz_495_[13] = _zz_494_;
-    _zz_495_[12] = _zz_494_;
-    _zz_495_[11] = _zz_494_;
-    _zz_495_[10] = _zz_494_;
-    _zz_495_[9] = _zz_494_;
-    _zz_495_[8] = _zz_494_;
-    _zz_495_[7] = _zz_494_;
-    _zz_495_[6] = _zz_494_;
-    _zz_495_[5] = _zz_494_;
-    _zz_495_[4] = _zz_494_;
-    _zz_495_[3] = _zz_494_;
-    _zz_495_[2] = _zz_494_;
-    _zz_495_[1] = _zz_494_;
-    _zz_495_[0] = _zz_494_;
+    _zz_556[18] = _zz_555;
+    _zz_556[17] = _zz_555;
+    _zz_556[16] = _zz_555;
+    _zz_556[15] = _zz_555;
+    _zz_556[14] = _zz_555;
+    _zz_556[13] = _zz_555;
+    _zz_556[12] = _zz_555;
+    _zz_556[11] = _zz_555;
+    _zz_556[10] = _zz_555;
+    _zz_556[9] = _zz_555;
+    _zz_556[8] = _zz_555;
+    _zz_556[7] = _zz_555;
+    _zz_556[6] = _zz_555;
+    _zz_556[5] = _zz_555;
+    _zz_556[4] = _zz_555;
+    _zz_556[3] = _zz_555;
+    _zz_556[2] = _zz_555;
+    _zz_556[1] = _zz_555;
+    _zz_556[0] = _zz_555;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = _zz_496_;
+    CsrPlugin_privilege = _zz_557;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_497_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_498_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_499_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_558 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_559 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_560 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_500_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_501_ = _zz_761_[0];
+  assign _zz_561 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_562 = _zz_858[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_598_)begin
+    if(_zz_681)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -6512,7 +7456,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -6536,7 +7480,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -6558,7 +7502,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -6713,7 +7657,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_612_)begin
+    if(_zz_695)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -6732,26 +7676,26 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_613_)begin
+    if(_zz_696)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_614_)begin
+    if(_zz_697)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_613_)begin
-      CsrPlugin_selfException_payload_code = (4'b0010);
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_696)begin
+      CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_614_)begin
+    if(_zz_697)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -6760,14 +7704,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_612_)begin
+    if(_zz_695)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_612_)begin
+    if(_zz_695)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -6776,7 +7720,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_641_)
+    case(_zz_724)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -6790,7 +7734,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_615_)
+    case(_zz_698)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -6804,7 +7748,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_615_)
+    case(_zz_698)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -6823,12 +7767,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_763_) + $signed(_zz_764_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_860) + $signed(_zz_861));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_593_)begin
-      if(_zz_616_)begin
+    if(_zz_676)begin
+      if(_zz_699)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -6836,7 +7780,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_617_)begin
+    if(_zz_700)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -6847,59 +7791,59 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_768_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_865);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_502_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_502_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_769_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_770_ : _zz_771_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_772_[31:0];
-  assign _zz_503_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_504_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_505_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_563 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_563[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_866);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_867 : _zz_868);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_869[31:0];
+  assign _zz_564 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_565 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_566 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_506_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_506_[31 : 0] = execute_RS1;
+    _zz_567[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_567[31 : 0] = execute_RS1;
   end
 
-  assign _zz_508_ = (_zz_507_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_508_ != 32'h0);
-  assign _zz_26_ = decode_BRANCH_CTRL;
-  assign _zz_54_ = _zz_43_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_24_ = decode_ENV_CTRL;
-  assign _zz_21_ = execute_ENV_CTRL;
-  assign _zz_19_ = memory_ENV_CTRL;
-  assign _zz_22_ = _zz_44_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_17_ = decode_ALU_CTRL;
-  assign _zz_15_ = _zz_47_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign _zz_14_ = decode_SHIFT_CTRL;
-  assign _zz_11_ = execute_SHIFT_CTRL;
-  assign _zz_12_ = _zz_46_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign _zz_9_ = decode_SRC1_CTRL;
-  assign _zz_7_ = _zz_49_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_6_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_4_ = _zz_45_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_3_ = decode_SRC2_CTRL;
-  assign _zz_1_ = _zz_48_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_569 = (_zz_568 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_569 != 32'h0);
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_51 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -6917,432 +7861,432 @@ module VexRiscv (
   assign writeBack_arbitration_isMoving = ((! writeBack_arbitration_isStuck) && (! writeBack_arbitration_removeIt));
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
-    _zz_509_ = 32'h0;
+    _zz_570 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_509_[12 : 0] = 13'h1000;
-      _zz_509_[25 : 20] = 6'h20;
+      _zz_570[12 : 0] = 13'h1000;
+      _zz_570[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_510_ = 32'h0;
+    _zz_571 = 32'h0;
     if(execute_CsrPlugin_csr_944)begin
-      _zz_510_[31 : 0] = _zz_94_;
+      _zz_571[31 : 0] = _zz_91;
     end
   end
 
   always @ (*) begin
-    _zz_511_ = 32'h0;
+    _zz_572 = 32'h0;
     if(execute_CsrPlugin_csr_945)begin
-      _zz_511_[31 : 0] = _zz_110_;
+      _zz_572[31 : 0] = _zz_110;
     end
   end
 
   always @ (*) begin
-    _zz_512_ = 32'h0;
+    _zz_573 = 32'h0;
     if(execute_CsrPlugin_csr_946)begin
-      _zz_512_[31 : 0] = _zz_126_;
+      _zz_573[31 : 0] = _zz_129;
     end
   end
 
   always @ (*) begin
-    _zz_513_ = 32'h0;
+    _zz_574 = 32'h0;
     if(execute_CsrPlugin_csr_947)begin
-      _zz_513_[31 : 0] = _zz_142_;
+      _zz_574[31 : 0] = _zz_148;
     end
   end
 
   always @ (*) begin
-    _zz_514_ = 32'h0;
+    _zz_575 = 32'h0;
     if(execute_CsrPlugin_csr_948)begin
-      _zz_514_[31 : 0] = _zz_158_;
+      _zz_575[31 : 0] = _zz_167;
     end
   end
 
   always @ (*) begin
-    _zz_515_ = 32'h0;
+    _zz_576 = 32'h0;
     if(execute_CsrPlugin_csr_949)begin
-      _zz_515_[31 : 0] = _zz_174_;
+      _zz_576[31 : 0] = _zz_186;
     end
   end
 
   always @ (*) begin
-    _zz_516_ = 32'h0;
+    _zz_577 = 32'h0;
     if(execute_CsrPlugin_csr_950)begin
-      _zz_516_[31 : 0] = _zz_190_;
+      _zz_577[31 : 0] = _zz_205;
     end
   end
 
   always @ (*) begin
-    _zz_517_ = 32'h0;
+    _zz_578 = 32'h0;
     if(execute_CsrPlugin_csr_951)begin
-      _zz_517_[31 : 0] = _zz_206_;
+      _zz_578[31 : 0] = _zz_224;
     end
   end
 
   always @ (*) begin
-    _zz_518_ = 32'h0;
+    _zz_579 = 32'h0;
     if(execute_CsrPlugin_csr_952)begin
-      _zz_518_[31 : 0] = _zz_222_;
+      _zz_579[31 : 0] = _zz_243;
     end
   end
 
   always @ (*) begin
-    _zz_519_ = 32'h0;
+    _zz_580 = 32'h0;
     if(execute_CsrPlugin_csr_953)begin
-      _zz_519_[31 : 0] = _zz_238_;
+      _zz_580[31 : 0] = _zz_262;
     end
   end
 
   always @ (*) begin
-    _zz_520_ = 32'h0;
+    _zz_581 = 32'h0;
     if(execute_CsrPlugin_csr_954)begin
-      _zz_520_[31 : 0] = _zz_254_;
+      _zz_581[31 : 0] = _zz_281;
     end
   end
 
   always @ (*) begin
-    _zz_521_ = 32'h0;
+    _zz_582 = 32'h0;
     if(execute_CsrPlugin_csr_955)begin
-      _zz_521_[31 : 0] = _zz_270_;
+      _zz_582[31 : 0] = _zz_300;
     end
   end
 
   always @ (*) begin
-    _zz_522_ = 32'h0;
+    _zz_583 = 32'h0;
     if(execute_CsrPlugin_csr_956)begin
-      _zz_522_[31 : 0] = _zz_286_;
+      _zz_583[31 : 0] = _zz_319;
     end
   end
 
   always @ (*) begin
-    _zz_523_ = 32'h0;
+    _zz_584 = 32'h0;
     if(execute_CsrPlugin_csr_957)begin
-      _zz_523_[31 : 0] = _zz_302_;
+      _zz_584[31 : 0] = _zz_338;
     end
   end
 
   always @ (*) begin
-    _zz_524_ = 32'h0;
+    _zz_585 = 32'h0;
     if(execute_CsrPlugin_csr_958)begin
-      _zz_524_[31 : 0] = _zz_318_;
+      _zz_585[31 : 0] = _zz_357;
     end
   end
 
   always @ (*) begin
-    _zz_525_ = 32'h0;
+    _zz_586 = 32'h0;
     if(execute_CsrPlugin_csr_959)begin
-      _zz_525_[31 : 0] = _zz_334_;
+      _zz_586[31 : 0] = _zz_376;
     end
   end
 
   always @ (*) begin
-    _zz_526_ = 32'h0;
+    _zz_587 = 32'h0;
     if(execute_CsrPlugin_csr_928)begin
-      _zz_526_[31 : 31] = _zz_140_;
-      _zz_526_[23 : 23] = _zz_124_;
-      _zz_526_[15 : 15] = _zz_108_;
-      _zz_526_[7 : 7] = _zz_92_;
-      _zz_526_[28 : 27] = _zz_141_;
-      _zz_526_[26 : 26] = _zz_139_;
-      _zz_526_[25 : 25] = _zz_138_;
-      _zz_526_[24 : 24] = _zz_137_;
-      _zz_526_[20 : 19] = _zz_125_;
-      _zz_526_[18 : 18] = _zz_123_;
-      _zz_526_[17 : 17] = _zz_122_;
-      _zz_526_[16 : 16] = _zz_121_;
-      _zz_526_[12 : 11] = _zz_109_;
-      _zz_526_[10 : 10] = _zz_107_;
-      _zz_526_[9 : 9] = _zz_106_;
-      _zz_526_[8 : 8] = _zz_105_;
-      _zz_526_[4 : 3] = _zz_93_;
-      _zz_526_[2 : 2] = _zz_91_;
-      _zz_526_[1 : 1] = _zz_90_;
-      _zz_526_[0 : 0] = _zz_89_;
+      _zz_587[31 : 31] = _zz_146;
+      _zz_587[23 : 23] = _zz_127;
+      _zz_587[15 : 15] = _zz_108;
+      _zz_587[7 : 7] = _zz_89;
+      _zz_587[28 : 27] = _zz_147;
+      _zz_587[26 : 26] = _zz_145;
+      _zz_587[25 : 25] = _zz_144;
+      _zz_587[24 : 24] = _zz_143;
+      _zz_587[20 : 19] = _zz_128;
+      _zz_587[18 : 18] = _zz_126;
+      _zz_587[17 : 17] = _zz_125;
+      _zz_587[16 : 16] = _zz_124;
+      _zz_587[12 : 11] = _zz_109;
+      _zz_587[10 : 10] = _zz_107;
+      _zz_587[9 : 9] = _zz_106;
+      _zz_587[8 : 8] = _zz_105;
+      _zz_587[4 : 3] = _zz_90;
+      _zz_587[2 : 2] = _zz_88;
+      _zz_587[1 : 1] = _zz_87;
+      _zz_587[0 : 0] = _zz_86;
     end
   end
 
   always @ (*) begin
-    _zz_527_ = 32'h0;
+    _zz_588 = 32'h0;
     if(execute_CsrPlugin_csr_929)begin
-      _zz_527_[31 : 31] = _zz_204_;
-      _zz_527_[23 : 23] = _zz_188_;
-      _zz_527_[15 : 15] = _zz_172_;
-      _zz_527_[7 : 7] = _zz_156_;
-      _zz_527_[28 : 27] = _zz_205_;
-      _zz_527_[26 : 26] = _zz_203_;
-      _zz_527_[25 : 25] = _zz_202_;
-      _zz_527_[24 : 24] = _zz_201_;
-      _zz_527_[20 : 19] = _zz_189_;
-      _zz_527_[18 : 18] = _zz_187_;
-      _zz_527_[17 : 17] = _zz_186_;
-      _zz_527_[16 : 16] = _zz_185_;
-      _zz_527_[12 : 11] = _zz_173_;
-      _zz_527_[10 : 10] = _zz_171_;
-      _zz_527_[9 : 9] = _zz_170_;
-      _zz_527_[8 : 8] = _zz_169_;
-      _zz_527_[4 : 3] = _zz_157_;
-      _zz_527_[2 : 2] = _zz_155_;
-      _zz_527_[1 : 1] = _zz_154_;
-      _zz_527_[0 : 0] = _zz_153_;
+      _zz_588[31 : 31] = _zz_222;
+      _zz_588[23 : 23] = _zz_203;
+      _zz_588[15 : 15] = _zz_184;
+      _zz_588[7 : 7] = _zz_165;
+      _zz_588[28 : 27] = _zz_223;
+      _zz_588[26 : 26] = _zz_221;
+      _zz_588[25 : 25] = _zz_220;
+      _zz_588[24 : 24] = _zz_219;
+      _zz_588[20 : 19] = _zz_204;
+      _zz_588[18 : 18] = _zz_202;
+      _zz_588[17 : 17] = _zz_201;
+      _zz_588[16 : 16] = _zz_200;
+      _zz_588[12 : 11] = _zz_185;
+      _zz_588[10 : 10] = _zz_183;
+      _zz_588[9 : 9] = _zz_182;
+      _zz_588[8 : 8] = _zz_181;
+      _zz_588[4 : 3] = _zz_166;
+      _zz_588[2 : 2] = _zz_164;
+      _zz_588[1 : 1] = _zz_163;
+      _zz_588[0 : 0] = _zz_162;
     end
   end
 
   always @ (*) begin
-    _zz_528_ = 32'h0;
+    _zz_589 = 32'h0;
     if(execute_CsrPlugin_csr_930)begin
-      _zz_528_[31 : 31] = _zz_268_;
-      _zz_528_[23 : 23] = _zz_252_;
-      _zz_528_[15 : 15] = _zz_236_;
-      _zz_528_[7 : 7] = _zz_220_;
-      _zz_528_[28 : 27] = _zz_269_;
-      _zz_528_[26 : 26] = _zz_267_;
-      _zz_528_[25 : 25] = _zz_266_;
-      _zz_528_[24 : 24] = _zz_265_;
-      _zz_528_[20 : 19] = _zz_253_;
-      _zz_528_[18 : 18] = _zz_251_;
-      _zz_528_[17 : 17] = _zz_250_;
-      _zz_528_[16 : 16] = _zz_249_;
-      _zz_528_[12 : 11] = _zz_237_;
-      _zz_528_[10 : 10] = _zz_235_;
-      _zz_528_[9 : 9] = _zz_234_;
-      _zz_528_[8 : 8] = _zz_233_;
-      _zz_528_[4 : 3] = _zz_221_;
-      _zz_528_[2 : 2] = _zz_219_;
-      _zz_528_[1 : 1] = _zz_218_;
-      _zz_528_[0 : 0] = _zz_217_;
+      _zz_589[31 : 31] = _zz_298;
+      _zz_589[23 : 23] = _zz_279;
+      _zz_589[15 : 15] = _zz_260;
+      _zz_589[7 : 7] = _zz_241;
+      _zz_589[28 : 27] = _zz_299;
+      _zz_589[26 : 26] = _zz_297;
+      _zz_589[25 : 25] = _zz_296;
+      _zz_589[24 : 24] = _zz_295;
+      _zz_589[20 : 19] = _zz_280;
+      _zz_589[18 : 18] = _zz_278;
+      _zz_589[17 : 17] = _zz_277;
+      _zz_589[16 : 16] = _zz_276;
+      _zz_589[12 : 11] = _zz_261;
+      _zz_589[10 : 10] = _zz_259;
+      _zz_589[9 : 9] = _zz_258;
+      _zz_589[8 : 8] = _zz_257;
+      _zz_589[4 : 3] = _zz_242;
+      _zz_589[2 : 2] = _zz_240;
+      _zz_589[1 : 1] = _zz_239;
+      _zz_589[0 : 0] = _zz_238;
     end
   end
 
   always @ (*) begin
-    _zz_529_ = 32'h0;
+    _zz_590 = 32'h0;
     if(execute_CsrPlugin_csr_931)begin
-      _zz_529_[31 : 31] = _zz_332_;
-      _zz_529_[23 : 23] = _zz_316_;
-      _zz_529_[15 : 15] = _zz_300_;
-      _zz_529_[7 : 7] = _zz_284_;
-      _zz_529_[28 : 27] = _zz_333_;
-      _zz_529_[26 : 26] = _zz_331_;
-      _zz_529_[25 : 25] = _zz_330_;
-      _zz_529_[24 : 24] = _zz_329_;
-      _zz_529_[20 : 19] = _zz_317_;
-      _zz_529_[18 : 18] = _zz_315_;
-      _zz_529_[17 : 17] = _zz_314_;
-      _zz_529_[16 : 16] = _zz_313_;
-      _zz_529_[12 : 11] = _zz_301_;
-      _zz_529_[10 : 10] = _zz_299_;
-      _zz_529_[9 : 9] = _zz_298_;
-      _zz_529_[8 : 8] = _zz_297_;
-      _zz_529_[4 : 3] = _zz_285_;
-      _zz_529_[2 : 2] = _zz_283_;
-      _zz_529_[1 : 1] = _zz_282_;
-      _zz_529_[0 : 0] = _zz_281_;
+      _zz_590[31 : 31] = _zz_374;
+      _zz_590[23 : 23] = _zz_355;
+      _zz_590[15 : 15] = _zz_336;
+      _zz_590[7 : 7] = _zz_317;
+      _zz_590[28 : 27] = _zz_375;
+      _zz_590[26 : 26] = _zz_373;
+      _zz_590[25 : 25] = _zz_372;
+      _zz_590[24 : 24] = _zz_371;
+      _zz_590[20 : 19] = _zz_356;
+      _zz_590[18 : 18] = _zz_354;
+      _zz_590[17 : 17] = _zz_353;
+      _zz_590[16 : 16] = _zz_352;
+      _zz_590[12 : 11] = _zz_337;
+      _zz_590[10 : 10] = _zz_335;
+      _zz_590[9 : 9] = _zz_334;
+      _zz_590[8 : 8] = _zz_333;
+      _zz_590[4 : 3] = _zz_318;
+      _zz_590[2 : 2] = _zz_316;
+      _zz_590[1 : 1] = _zz_315;
+      _zz_590[0 : 0] = _zz_314;
     end
   end
 
   always @ (*) begin
-    _zz_530_ = 32'h0;
+    _zz_591 = 32'h0;
     if(execute_CsrPlugin_csr_3857)begin
-      _zz_530_[0 : 0] = (1'b1);
+      _zz_591[0 : 0] = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_531_ = 32'h0;
+    _zz_592 = 32'h0;
     if(execute_CsrPlugin_csr_3858)begin
-      _zz_531_[1 : 0] = (2'b10);
+      _zz_592[1 : 0] = 2'b10;
     end
   end
 
   always @ (*) begin
-    _zz_532_ = 32'h0;
+    _zz_593 = 32'h0;
     if(execute_CsrPlugin_csr_3859)begin
-      _zz_532_[1 : 0] = (2'b11);
+      _zz_593[1 : 0] = 2'b11;
     end
   end
 
   always @ (*) begin
-    _zz_533_ = 32'h0;
+    _zz_594 = 32'h0;
     if(execute_CsrPlugin_csr_769)begin
-      _zz_533_[31 : 30] = CsrPlugin_misa_base;
-      _zz_533_[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_594[31 : 30] = CsrPlugin_misa_base;
+      _zz_594[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
   always @ (*) begin
-    _zz_534_ = 32'h0;
+    _zz_595 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_534_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_534_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_534_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_595[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_595[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_595[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_535_ = 32'h0;
+    _zz_596 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_535_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_535_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_535_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_596[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_596[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_596[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_536_ = 32'h0;
+    _zz_597 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_536_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_536_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_536_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_597[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_597[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_597[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_537_ = 32'h0;
+    _zz_598 = 32'h0;
     if(execute_CsrPlugin_csr_773)begin
-      _zz_537_[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_537_[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_598[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_598[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
   always @ (*) begin
-    _zz_538_ = 32'h0;
+    _zz_599 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_538_[31 : 0] = CsrPlugin_mepc;
+      _zz_599[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_539_ = 32'h0;
+    _zz_600 = 32'h0;
     if(execute_CsrPlugin_csr_832)begin
-      _zz_539_[31 : 0] = CsrPlugin_mscratch;
+      _zz_600[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
-    _zz_540_ = 32'h0;
+    _zz_601 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_540_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_540_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_601[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_601[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_541_ = 32'h0;
+    _zz_602 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_541_[31 : 0] = CsrPlugin_mtval;
+      _zz_602[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_542_ = 32'h0;
+    _zz_603 = 32'h0;
     if(execute_CsrPlugin_csr_2816)begin
-      _zz_542_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_603[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_543_ = 32'h0;
+    _zz_604 = 32'h0;
     if(execute_CsrPlugin_csr_2944)begin
-      _zz_543_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_604[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_544_ = 32'h0;
+    _zz_605 = 32'h0;
     if(execute_CsrPlugin_csr_2818)begin
-      _zz_544_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_605[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_545_ = 32'h0;
+    _zz_606 = 32'h0;
     if(execute_CsrPlugin_csr_2946)begin
-      _zz_545_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_606[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_546_ = 32'h0;
+    _zz_607 = 32'h0;
     if(execute_CsrPlugin_csr_3072)begin
-      _zz_546_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_607[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_547_ = 32'h0;
+    _zz_608 = 32'h0;
     if(execute_CsrPlugin_csr_3200)begin
-      _zz_547_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_608[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_548_ = 32'h0;
+    _zz_609 = 32'h0;
     if(execute_CsrPlugin_csr_3074)begin
-      _zz_548_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_609[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_549_ = 32'h0;
+    _zz_610 = 32'h0;
     if(execute_CsrPlugin_csr_3202)begin
-      _zz_549_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_610[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_550_ = 32'h0;
+    _zz_611 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_550_[31 : 0] = _zz_507_;
+      _zz_611[31 : 0] = _zz_568;
     end
   end
 
   always @ (*) begin
-    _zz_551_ = 32'h0;
+    _zz_612 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_551_[31 : 0] = _zz_508_;
+      _zz_612[31 : 0] = _zz_569;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_1061_ | _zz_1062_) | (_zz_1063_ | _zz_1064_)) | ((_zz_1065_ | _zz_1066_) | (_zz_1067_ | _zz_1068_))) | (((_zz_1069_ | _zz_1070_) | (_zz_1071_ | _zz_1072_)) | ((_zz_1073_ | _zz_1074_) | (_zz_1075_ | _zz_1076_)))) | ((((_zz_540_ | _zz_541_) | (_zz_542_ | _zz_543_)) | ((_zz_544_ | _zz_545_) | (_zz_546_ | _zz_547_))) | ((_zz_548_ | _zz_549_) | (_zz_550_ | _zz_551_))));
-  assign iBusWishbone_ADR = {_zz_853_,_zz_552_};
-  assign iBusWishbone_CTI = ((_zz_552_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((((_zz_1170 | _zz_1171) | (_zz_1172 | _zz_1173)) | ((_zz_1174 | _zz_1175) | (_zz_1176 | _zz_1177))) | (((_zz_1178 | _zz_1179) | (_zz_1180 | _zz_1181)) | ((_zz_1182 | _zz_1183) | (_zz_1184 | _zz_1185)))) | ((((_zz_601 | _zz_602) | (_zz_603 | _zz_604)) | ((_zz_605 | _zz_606) | (_zz_607 | _zz_608))) | ((_zz_609 | _zz_610) | (_zz_611 | _zz_612))));
+  assign iBusWishbone_ADR = {_zz_950,_zz_613};
+  assign iBusWishbone_CTI = ((_zz_613 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_618_)begin
+    if(_zz_701)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_618_)begin
+    if(_zz_701)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_553_;
+  assign iBus_rsp_valid = _zz_614;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_559_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_555_ = dBus_cmd_valid;
-  assign _zz_557_ = dBus_cmd_payload_wr;
-  assign _zz_558_ = (_zz_554_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_556_ && (_zz_557_ || _zz_558_));
-  assign dBusWishbone_ADR = ((_zz_559_ ? {{dBus_cmd_payload_address[31 : 5],_zz_554_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_559_ ? (_zz_558_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_557_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_557_;
+  assign _zz_620 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_616 = dBus_cmd_valid;
+  assign _zz_618 = dBus_cmd_payload_wr;
+  assign _zz_619 = (_zz_615 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_617 && (_zz_618 || _zz_619));
+  assign dBusWishbone_ADR = ((_zz_620 ? {{dBus_cmd_payload_address[31 : 5],_zz_615},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_620 ? (_zz_619 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_618 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_618;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_556_ = (_zz_555_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_555_;
-  assign dBusWishbone_STB = _zz_555_;
-  assign dBus_rsp_valid = _zz_560_;
+  assign _zz_617 = (_zz_616 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_616;
+  assign dBusWishbone_STB = _zz_616;
+  assign dBus_rsp_valid = _zz_621;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -7351,91 +8295,59 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_67_ <= 1'b0;
-      _zz_69_ <= 1'b0;
+      _zz_64 <= 1'b0;
+      _zz_66 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_82_;
+      IBusCachedPlugin_rspCounter <= _zz_79;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_83_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_80;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_92_ <= 1'b0;
-      _zz_93_ <= (2'b00);
-      _zz_98_ <= 1'b0;
-      _zz_99_ <= 1'b0;
-      _zz_108_ <= 1'b0;
-      _zz_109_ <= (2'b00);
-      _zz_114_ <= 1'b0;
-      _zz_115_ <= 1'b0;
-      _zz_124_ <= 1'b0;
-      _zz_125_ <= (2'b00);
-      _zz_130_ <= 1'b0;
-      _zz_131_ <= 1'b0;
-      _zz_140_ <= 1'b0;
-      _zz_141_ <= (2'b00);
-      _zz_146_ <= 1'b0;
-      _zz_147_ <= 1'b0;
-      _zz_156_ <= 1'b0;
-      _zz_157_ <= (2'b00);
-      _zz_162_ <= 1'b0;
-      _zz_163_ <= 1'b0;
-      _zz_172_ <= 1'b0;
-      _zz_173_ <= (2'b00);
-      _zz_178_ <= 1'b0;
-      _zz_179_ <= 1'b0;
-      _zz_188_ <= 1'b0;
-      _zz_189_ <= (2'b00);
-      _zz_194_ <= 1'b0;
-      _zz_195_ <= 1'b0;
-      _zz_204_ <= 1'b0;
-      _zz_205_ <= (2'b00);
-      _zz_210_ <= 1'b0;
-      _zz_211_ <= 1'b0;
-      _zz_220_ <= 1'b0;
-      _zz_221_ <= (2'b00);
-      _zz_226_ <= 1'b0;
-      _zz_227_ <= 1'b0;
-      _zz_236_ <= 1'b0;
-      _zz_237_ <= (2'b00);
-      _zz_242_ <= 1'b0;
-      _zz_243_ <= 1'b0;
-      _zz_252_ <= 1'b0;
-      _zz_253_ <= (2'b00);
-      _zz_258_ <= 1'b0;
-      _zz_259_ <= 1'b0;
-      _zz_268_ <= 1'b0;
-      _zz_269_ <= (2'b00);
-      _zz_274_ <= 1'b0;
-      _zz_275_ <= 1'b0;
-      _zz_284_ <= 1'b0;
-      _zz_285_ <= (2'b00);
-      _zz_290_ <= 1'b0;
-      _zz_291_ <= 1'b0;
-      _zz_300_ <= 1'b0;
-      _zz_301_ <= (2'b00);
-      _zz_306_ <= 1'b0;
-      _zz_307_ <= 1'b0;
-      _zz_316_ <= 1'b0;
-      _zz_317_ <= (2'b00);
-      _zz_322_ <= 1'b0;
-      _zz_323_ <= 1'b0;
-      _zz_332_ <= 1'b0;
-      _zz_333_ <= (2'b00);
-      _zz_338_ <= 1'b0;
-      _zz_339_ <= 1'b0;
-      _zz_459_ <= 1'b1;
-      _zz_471_ <= 1'b0;
-      _zz_496_ <= (2'b11);
-      CsrPlugin_misa_base <= (2'b01);
+      _zz_89 <= 1'b0;
+      _zz_90 <= 2'b00;
+      _zz_108 <= 1'b0;
+      _zz_109 <= 2'b00;
+      _zz_127 <= 1'b0;
+      _zz_128 <= 2'b00;
+      _zz_146 <= 1'b0;
+      _zz_147 <= 2'b00;
+      _zz_165 <= 1'b0;
+      _zz_166 <= 2'b00;
+      _zz_184 <= 1'b0;
+      _zz_185 <= 2'b00;
+      _zz_203 <= 1'b0;
+      _zz_204 <= 2'b00;
+      _zz_222 <= 1'b0;
+      _zz_223 <= 2'b00;
+      _zz_241 <= 1'b0;
+      _zz_242 <= 2'b00;
+      _zz_260 <= 1'b0;
+      _zz_261 <= 2'b00;
+      _zz_279 <= 1'b0;
+      _zz_280 <= 2'b00;
+      _zz_298 <= 1'b0;
+      _zz_299 <= 2'b00;
+      _zz_317 <= 1'b0;
+      _zz_318 <= 2'b00;
+      _zz_336 <= 1'b0;
+      _zz_337 <= 2'b00;
+      _zz_355 <= 1'b0;
+      _zz_356 <= 2'b00;
+      _zz_374 <= 1'b0;
+      _zz_375 <= 2'b00;
+      _zz_520 <= 1'b1;
+      _zz_532 <= 1'b0;
+      _zz_557 <= 2'b11;
+      CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0101064;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -7451,16 +8363,14 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_507_ <= 32'h0;
+      _zz_568 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_552_ <= (3'b000);
-      _zz_553_ <= 1'b0;
-      _zz_554_ <= (3'b000);
-      _zz_560_ <= 1'b0;
+      _zz_613 <= 3'b000;
+      _zz_614 <= 1'b0;
+      _zz_615 <= 3'b000;
+      _zz_621 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -7482,16 +8392,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_67_ <= 1'b0;
+        _zz_64 <= 1'b0;
       end
-      if(_zz_65_)begin
-        _zz_67_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_62)begin
+        _zz_64 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_69_ <= 1'b0;
+        _zz_66 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_69_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_66 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -7538,260 +8448,84 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_619_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_702)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(_zz_620_)begin
-        _zz_98_ <= _zz_92_;
-        _zz_99_ <= 1'b1;
-        case(_zz_93_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_99_ <= 1'b0;
-          end
-        endcase
+      if(_zz_703)begin
+        _zz_89 <= _zz_95;
+        _zz_90 <= _zz_96;
       end
-      if(_zz_621_)begin
-        _zz_114_ <= _zz_108_;
-        _zz_115_ <= 1'b1;
-        case(_zz_109_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_115_ <= 1'b0;
-          end
-        endcase
+      if(_zz_704)begin
+        _zz_108 <= _zz_114;
+        _zz_109 <= _zz_115;
       end
-      if(_zz_622_)begin
-        _zz_130_ <= _zz_124_;
-        _zz_131_ <= 1'b1;
-        case(_zz_125_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_131_ <= 1'b0;
-          end
-        endcase
+      if(_zz_705)begin
+        _zz_127 <= _zz_133;
+        _zz_128 <= _zz_134;
       end
-      if(_zz_623_)begin
-        _zz_146_ <= _zz_140_;
-        _zz_147_ <= 1'b1;
-        case(_zz_141_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_147_ <= 1'b0;
-          end
-        endcase
+      if(_zz_706)begin
+        _zz_146 <= _zz_152;
+        _zz_147 <= _zz_153;
       end
-      if(_zz_624_)begin
-        _zz_162_ <= _zz_156_;
-        _zz_163_ <= 1'b1;
-        case(_zz_157_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_163_ <= 1'b0;
-          end
-        endcase
+      if(_zz_707)begin
+        _zz_165 <= _zz_171;
+        _zz_166 <= _zz_172;
       end
-      if(_zz_625_)begin
-        _zz_178_ <= _zz_172_;
-        _zz_179_ <= 1'b1;
-        case(_zz_173_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_179_ <= 1'b0;
-          end
-        endcase
+      if(_zz_708)begin
+        _zz_184 <= _zz_190;
+        _zz_185 <= _zz_191;
       end
-      if(_zz_626_)begin
-        _zz_194_ <= _zz_188_;
-        _zz_195_ <= 1'b1;
-        case(_zz_189_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_195_ <= 1'b0;
-          end
-        endcase
+      if(_zz_709)begin
+        _zz_203 <= _zz_209;
+        _zz_204 <= _zz_210;
       end
-      if(_zz_627_)begin
-        _zz_210_ <= _zz_204_;
-        _zz_211_ <= 1'b1;
-        case(_zz_205_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_211_ <= 1'b0;
-          end
-        endcase
+      if(_zz_710)begin
+        _zz_222 <= _zz_228;
+        _zz_223 <= _zz_229;
       end
-      if(_zz_628_)begin
-        _zz_226_ <= _zz_220_;
-        _zz_227_ <= 1'b1;
-        case(_zz_221_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_227_ <= 1'b0;
-          end
-        endcase
+      if(_zz_711)begin
+        _zz_241 <= _zz_247;
+        _zz_242 <= _zz_248;
       end
-      if(_zz_629_)begin
-        _zz_242_ <= _zz_236_;
-        _zz_243_ <= 1'b1;
-        case(_zz_237_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_243_ <= 1'b0;
-          end
-        endcase
+      if(_zz_712)begin
+        _zz_260 <= _zz_266;
+        _zz_261 <= _zz_267;
       end
-      if(_zz_630_)begin
-        _zz_258_ <= _zz_252_;
-        _zz_259_ <= 1'b1;
-        case(_zz_253_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_259_ <= 1'b0;
-          end
-        endcase
+      if(_zz_713)begin
+        _zz_279 <= _zz_285;
+        _zz_280 <= _zz_286;
       end
-      if(_zz_631_)begin
-        _zz_274_ <= _zz_268_;
-        _zz_275_ <= 1'b1;
-        case(_zz_269_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_275_ <= 1'b0;
-          end
-        endcase
+      if(_zz_714)begin
+        _zz_298 <= _zz_304;
+        _zz_299 <= _zz_305;
       end
-      if(_zz_632_)begin
-        _zz_290_ <= _zz_284_;
-        _zz_291_ <= 1'b1;
-        case(_zz_285_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_291_ <= 1'b0;
-          end
-        endcase
+      if(_zz_715)begin
+        _zz_317 <= _zz_323;
+        _zz_318 <= _zz_324;
       end
-      if(_zz_633_)begin
-        _zz_306_ <= _zz_300_;
-        _zz_307_ <= 1'b1;
-        case(_zz_301_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_307_ <= 1'b0;
-          end
-        endcase
+      if(_zz_716)begin
+        _zz_336 <= _zz_342;
+        _zz_337 <= _zz_343;
       end
-      if(_zz_634_)begin
-        _zz_322_ <= _zz_316_;
-        _zz_323_ <= 1'b1;
-        case(_zz_317_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_323_ <= 1'b0;
-          end
-        endcase
+      if(_zz_717)begin
+        _zz_355 <= _zz_361;
+        _zz_356 <= _zz_362;
       end
-      if(_zz_635_)begin
-        _zz_338_ <= _zz_332_;
-        _zz_339_ <= 1'b1;
-        case(_zz_333_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_339_ <= 1'b0;
-          end
-        endcase
+      if(_zz_718)begin
+        _zz_374 <= _zz_380;
+        _zz_375 <= _zz_381;
       end
-      _zz_459_ <= 1'b0;
-      _zz_471_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_520 <= 1'b0;
+      _zz_532 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -7813,14 +8547,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_636_)begin
-        if(_zz_637_)begin
+      if(_zz_719)begin
+        if(_zz_720)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_638_)begin
+        if(_zz_721)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_639_)begin
+        if(_zz_722)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -7845,8 +8579,8 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_600_)begin
-        _zz_496_ <= CsrPlugin_targetPrivilege;
+      if(_zz_683)begin
+        _zz_557 <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -7857,26 +8591,20 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_601_)begin
-        case(_zz_602_)
+      if(_zz_684)begin
+        case(_zz_685)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_496_ <= CsrPlugin_mstatus_MPP;
+            _zz_557 <= CsrPlugin_mstatus_MPP;
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_499_,{_zz_498_,_zz_497_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_560,{_zz_559,_zz_558}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -7895,54 +8623,6 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      if(execute_CsrPlugin_csr_928)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_140_ <= _zz_782_[0];
-          _zz_124_ <= _zz_783_[0];
-          _zz_108_ <= _zz_784_[0];
-          _zz_92_ <= _zz_785_[0];
-          _zz_141_ <= execute_CsrPlugin_writeData[28 : 27];
-          _zz_125_ <= execute_CsrPlugin_writeData[20 : 19];
-          _zz_109_ <= execute_CsrPlugin_writeData[12 : 11];
-          _zz_93_ <= execute_CsrPlugin_writeData[4 : 3];
-        end
-      end
-      if(execute_CsrPlugin_csr_929)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_204_ <= _zz_798_[0];
-          _zz_188_ <= _zz_799_[0];
-          _zz_172_ <= _zz_800_[0];
-          _zz_156_ <= _zz_801_[0];
-          _zz_205_ <= execute_CsrPlugin_writeData[28 : 27];
-          _zz_189_ <= execute_CsrPlugin_writeData[20 : 19];
-          _zz_173_ <= execute_CsrPlugin_writeData[12 : 11];
-          _zz_157_ <= execute_CsrPlugin_writeData[4 : 3];
-        end
-      end
-      if(execute_CsrPlugin_csr_930)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_268_ <= _zz_814_[0];
-          _zz_252_ <= _zz_815_[0];
-          _zz_236_ <= _zz_816_[0];
-          _zz_220_ <= _zz_817_[0];
-          _zz_269_ <= execute_CsrPlugin_writeData[28 : 27];
-          _zz_253_ <= execute_CsrPlugin_writeData[20 : 19];
-          _zz_237_ <= execute_CsrPlugin_writeData[12 : 11];
-          _zz_221_ <= execute_CsrPlugin_writeData[4 : 3];
-        end
-      end
-      if(execute_CsrPlugin_csr_931)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_332_ <= _zz_830_[0];
-          _zz_316_ <= _zz_831_[0];
-          _zz_300_ <= _zz_832_[0];
-          _zz_284_ <= _zz_833_[0];
-          _zz_333_ <= execute_CsrPlugin_writeData[28 : 27];
-          _zz_317_ <= execute_CsrPlugin_writeData[20 : 19];
-          _zz_301_ <= execute_CsrPlugin_writeData[12 : 11];
-          _zz_285_ <= execute_CsrPlugin_writeData[4 : 3];
-        end
-      end
       if(execute_CsrPlugin_csr_769)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
@@ -7952,41 +8632,41 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_846_[0];
-          CsrPlugin_mstatus_MIE <= _zz_847_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_943[0];
+          CsrPlugin_mstatus_MIE <= _zz_944[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_849_[0];
-          CsrPlugin_mie_MTIE <= _zz_850_[0];
-          CsrPlugin_mie_MSIE <= _zz_851_[0];
+          CsrPlugin_mie_MEIE <= _zz_946[0];
+          CsrPlugin_mie_MTIE <= _zz_947[0];
+          CsrPlugin_mie_MSIE <= _zz_948[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_507_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_568 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_618_)begin
+      if(_zz_701)begin
         if(iBusWishbone_ACK)begin
-          _zz_552_ <= (_zz_552_ + (3'b001));
+          _zz_613 <= (_zz_613 + 3'b001);
         end
       end
-      _zz_553_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_555_ && _zz_556_))begin
-        _zz_554_ <= (_zz_554_ + (3'b001));
-        if(_zz_558_)begin
-          _zz_554_ <= (3'b000);
+      _zz_614 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_616 && _zz_617))begin
+        _zz_615 <= (_zz_615 + 3'b001);
+        if(_zz_619)begin
+          _zz_615 <= 3'b000;
         end
       end
-      _zz_560_ <= ((_zz_555_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_621 <= ((_zz_616 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_70_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_67 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -7994,376 +8674,122 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_619_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_702)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if(_zz_620_)begin
-      _zz_95_ <= _zz_89_;
-      _zz_96_ <= _zz_90_;
-      _zz_97_ <= _zz_91_;
-      case(_zz_93_)
-        2'b01 : begin
-          _zz_100_ <= 32'h0;
-          _zz_101_ <= _zz_102_;
-        end
-        2'b10 : begin
-          _zz_100_ <= _zz_102_;
-          _zz_101_ <= (_zz_102_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_100_ <= _zz_104_;
-          _zz_101_ <= (_zz_104_ + _zz_686_);
-        end
-        default : begin
-          _zz_101_ <= _zz_102_;
-        end
-      endcase
+    if(_zz_703)begin
+      _zz_86 <= _zz_92;
+      _zz_87 <= _zz_93;
+      _zz_88 <= _zz_94;
+      _zz_91 <= _zz_97;
     end
-    if(_zz_621_)begin
-      _zz_111_ <= _zz_105_;
-      _zz_112_ <= _zz_106_;
-      _zz_113_ <= _zz_107_;
-      case(_zz_109_)
-        2'b01 : begin
-          _zz_116_ <= _zz_101_;
-          _zz_117_ <= _zz_118_;
-        end
-        2'b10 : begin
-          _zz_116_ <= _zz_118_;
-          _zz_117_ <= (_zz_118_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_116_ <= _zz_120_;
-          _zz_117_ <= (_zz_120_ + _zz_689_);
-        end
-        default : begin
-          _zz_117_ <= _zz_118_;
-        end
-      endcase
+    if(_zz_704)begin
+      _zz_105 <= _zz_111;
+      _zz_106 <= _zz_112;
+      _zz_107 <= _zz_113;
+      _zz_110 <= _zz_116;
     end
-    if(_zz_622_)begin
-      _zz_127_ <= _zz_121_;
-      _zz_128_ <= _zz_122_;
-      _zz_129_ <= _zz_123_;
-      case(_zz_125_)
-        2'b01 : begin
-          _zz_132_ <= _zz_117_;
-          _zz_133_ <= _zz_134_;
-        end
-        2'b10 : begin
-          _zz_132_ <= _zz_134_;
-          _zz_133_ <= (_zz_134_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_132_ <= _zz_136_;
-          _zz_133_ <= (_zz_136_ + _zz_692_);
-        end
-        default : begin
-          _zz_133_ <= _zz_134_;
-        end
-      endcase
+    if(_zz_705)begin
+      _zz_124 <= _zz_130;
+      _zz_125 <= _zz_131;
+      _zz_126 <= _zz_132;
+      _zz_129 <= _zz_135;
     end
-    if(_zz_623_)begin
-      _zz_143_ <= _zz_137_;
-      _zz_144_ <= _zz_138_;
-      _zz_145_ <= _zz_139_;
-      case(_zz_141_)
-        2'b01 : begin
-          _zz_148_ <= _zz_133_;
-          _zz_149_ <= _zz_150_;
-        end
-        2'b10 : begin
-          _zz_148_ <= _zz_150_;
-          _zz_149_ <= (_zz_150_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_148_ <= _zz_152_;
-          _zz_149_ <= (_zz_152_ + _zz_695_);
-        end
-        default : begin
-          _zz_149_ <= _zz_150_;
-        end
-      endcase
+    if(_zz_706)begin
+      _zz_143 <= _zz_149;
+      _zz_144 <= _zz_150;
+      _zz_145 <= _zz_151;
+      _zz_148 <= _zz_154;
     end
-    if(_zz_624_)begin
-      _zz_159_ <= _zz_153_;
-      _zz_160_ <= _zz_154_;
-      _zz_161_ <= _zz_155_;
-      case(_zz_157_)
-        2'b01 : begin
-          _zz_164_ <= _zz_149_;
-          _zz_165_ <= _zz_166_;
-        end
-        2'b10 : begin
-          _zz_164_ <= _zz_166_;
-          _zz_165_ <= (_zz_166_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_164_ <= _zz_168_;
-          _zz_165_ <= (_zz_168_ + _zz_698_);
-        end
-        default : begin
-          _zz_165_ <= _zz_166_;
-        end
-      endcase
+    if(_zz_707)begin
+      _zz_162 <= _zz_168;
+      _zz_163 <= _zz_169;
+      _zz_164 <= _zz_170;
+      _zz_167 <= _zz_173;
     end
-    if(_zz_625_)begin
-      _zz_175_ <= _zz_169_;
-      _zz_176_ <= _zz_170_;
-      _zz_177_ <= _zz_171_;
-      case(_zz_173_)
-        2'b01 : begin
-          _zz_180_ <= _zz_165_;
-          _zz_181_ <= _zz_182_;
-        end
-        2'b10 : begin
-          _zz_180_ <= _zz_182_;
-          _zz_181_ <= (_zz_182_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_180_ <= _zz_184_;
-          _zz_181_ <= (_zz_184_ + _zz_701_);
-        end
-        default : begin
-          _zz_181_ <= _zz_182_;
-        end
-      endcase
+    if(_zz_708)begin
+      _zz_181 <= _zz_187;
+      _zz_182 <= _zz_188;
+      _zz_183 <= _zz_189;
+      _zz_186 <= _zz_192;
     end
-    if(_zz_626_)begin
-      _zz_191_ <= _zz_185_;
-      _zz_192_ <= _zz_186_;
-      _zz_193_ <= _zz_187_;
-      case(_zz_189_)
-        2'b01 : begin
-          _zz_196_ <= _zz_181_;
-          _zz_197_ <= _zz_198_;
-        end
-        2'b10 : begin
-          _zz_196_ <= _zz_198_;
-          _zz_197_ <= (_zz_198_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_196_ <= _zz_200_;
-          _zz_197_ <= (_zz_200_ + _zz_704_);
-        end
-        default : begin
-          _zz_197_ <= _zz_198_;
-        end
-      endcase
+    if(_zz_709)begin
+      _zz_200 <= _zz_206;
+      _zz_201 <= _zz_207;
+      _zz_202 <= _zz_208;
+      _zz_205 <= _zz_211;
     end
-    if(_zz_627_)begin
-      _zz_207_ <= _zz_201_;
-      _zz_208_ <= _zz_202_;
-      _zz_209_ <= _zz_203_;
-      case(_zz_205_)
-        2'b01 : begin
-          _zz_212_ <= _zz_197_;
-          _zz_213_ <= _zz_214_;
-        end
-        2'b10 : begin
-          _zz_212_ <= _zz_214_;
-          _zz_213_ <= (_zz_214_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_212_ <= _zz_216_;
-          _zz_213_ <= (_zz_216_ + _zz_707_);
-        end
-        default : begin
-          _zz_213_ <= _zz_214_;
-        end
-      endcase
+    if(_zz_710)begin
+      _zz_219 <= _zz_225;
+      _zz_220 <= _zz_226;
+      _zz_221 <= _zz_227;
+      _zz_224 <= _zz_230;
     end
-    if(_zz_628_)begin
-      _zz_223_ <= _zz_217_;
-      _zz_224_ <= _zz_218_;
-      _zz_225_ <= _zz_219_;
-      case(_zz_221_)
-        2'b01 : begin
-          _zz_228_ <= _zz_213_;
-          _zz_229_ <= _zz_230_;
-        end
-        2'b10 : begin
-          _zz_228_ <= _zz_230_;
-          _zz_229_ <= (_zz_230_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_228_ <= _zz_232_;
-          _zz_229_ <= (_zz_232_ + _zz_710_);
-        end
-        default : begin
-          _zz_229_ <= _zz_230_;
-        end
-      endcase
+    if(_zz_711)begin
+      _zz_238 <= _zz_244;
+      _zz_239 <= _zz_245;
+      _zz_240 <= _zz_246;
+      _zz_243 <= _zz_249;
     end
-    if(_zz_629_)begin
-      _zz_239_ <= _zz_233_;
-      _zz_240_ <= _zz_234_;
-      _zz_241_ <= _zz_235_;
-      case(_zz_237_)
-        2'b01 : begin
-          _zz_244_ <= _zz_229_;
-          _zz_245_ <= _zz_246_;
-        end
-        2'b10 : begin
-          _zz_244_ <= _zz_246_;
-          _zz_245_ <= (_zz_246_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_244_ <= _zz_248_;
-          _zz_245_ <= (_zz_248_ + _zz_713_);
-        end
-        default : begin
-          _zz_245_ <= _zz_246_;
-        end
-      endcase
+    if(_zz_712)begin
+      _zz_257 <= _zz_263;
+      _zz_258 <= _zz_264;
+      _zz_259 <= _zz_265;
+      _zz_262 <= _zz_268;
     end
-    if(_zz_630_)begin
-      _zz_255_ <= _zz_249_;
-      _zz_256_ <= _zz_250_;
-      _zz_257_ <= _zz_251_;
-      case(_zz_253_)
-        2'b01 : begin
-          _zz_260_ <= _zz_245_;
-          _zz_261_ <= _zz_262_;
-        end
-        2'b10 : begin
-          _zz_260_ <= _zz_262_;
-          _zz_261_ <= (_zz_262_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_260_ <= _zz_264_;
-          _zz_261_ <= (_zz_264_ + _zz_716_);
-        end
-        default : begin
-          _zz_261_ <= _zz_262_;
-        end
-      endcase
+    if(_zz_713)begin
+      _zz_276 <= _zz_282;
+      _zz_277 <= _zz_283;
+      _zz_278 <= _zz_284;
+      _zz_281 <= _zz_287;
     end
-    if(_zz_631_)begin
-      _zz_271_ <= _zz_265_;
-      _zz_272_ <= _zz_266_;
-      _zz_273_ <= _zz_267_;
-      case(_zz_269_)
-        2'b01 : begin
-          _zz_276_ <= _zz_261_;
-          _zz_277_ <= _zz_278_;
-        end
-        2'b10 : begin
-          _zz_276_ <= _zz_278_;
-          _zz_277_ <= (_zz_278_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_276_ <= _zz_280_;
-          _zz_277_ <= (_zz_280_ + _zz_719_);
-        end
-        default : begin
-          _zz_277_ <= _zz_278_;
-        end
-      endcase
+    if(_zz_714)begin
+      _zz_295 <= _zz_301;
+      _zz_296 <= _zz_302;
+      _zz_297 <= _zz_303;
+      _zz_300 <= _zz_306;
     end
-    if(_zz_632_)begin
-      _zz_287_ <= _zz_281_;
-      _zz_288_ <= _zz_282_;
-      _zz_289_ <= _zz_283_;
-      case(_zz_285_)
-        2'b01 : begin
-          _zz_292_ <= _zz_277_;
-          _zz_293_ <= _zz_294_;
-        end
-        2'b10 : begin
-          _zz_292_ <= _zz_294_;
-          _zz_293_ <= (_zz_294_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_292_ <= _zz_296_;
-          _zz_293_ <= (_zz_296_ + _zz_722_);
-        end
-        default : begin
-          _zz_293_ <= _zz_294_;
-        end
-      endcase
+    if(_zz_715)begin
+      _zz_314 <= _zz_320;
+      _zz_315 <= _zz_321;
+      _zz_316 <= _zz_322;
+      _zz_319 <= _zz_325;
     end
-    if(_zz_633_)begin
-      _zz_303_ <= _zz_297_;
-      _zz_304_ <= _zz_298_;
-      _zz_305_ <= _zz_299_;
-      case(_zz_301_)
-        2'b01 : begin
-          _zz_308_ <= _zz_293_;
-          _zz_309_ <= _zz_310_;
-        end
-        2'b10 : begin
-          _zz_308_ <= _zz_310_;
-          _zz_309_ <= (_zz_310_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_308_ <= _zz_312_;
-          _zz_309_ <= (_zz_312_ + _zz_725_);
-        end
-        default : begin
-          _zz_309_ <= _zz_310_;
-        end
-      endcase
+    if(_zz_716)begin
+      _zz_333 <= _zz_339;
+      _zz_334 <= _zz_340;
+      _zz_335 <= _zz_341;
+      _zz_338 <= _zz_344;
     end
-    if(_zz_634_)begin
-      _zz_319_ <= _zz_313_;
-      _zz_320_ <= _zz_314_;
-      _zz_321_ <= _zz_315_;
-      case(_zz_317_)
-        2'b01 : begin
-          _zz_324_ <= _zz_309_;
-          _zz_325_ <= _zz_326_;
-        end
-        2'b10 : begin
-          _zz_324_ <= _zz_326_;
-          _zz_325_ <= (_zz_326_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_324_ <= _zz_328_;
-          _zz_325_ <= (_zz_328_ + _zz_728_);
-        end
-        default : begin
-          _zz_325_ <= _zz_326_;
-        end
-      endcase
+    if(_zz_717)begin
+      _zz_352 <= _zz_358;
+      _zz_353 <= _zz_359;
+      _zz_354 <= _zz_360;
+      _zz_357 <= _zz_363;
     end
-    if(_zz_635_)begin
-      _zz_335_ <= _zz_329_;
-      _zz_336_ <= _zz_330_;
-      _zz_337_ <= _zz_331_;
-      case(_zz_333_)
-        2'b01 : begin
-          _zz_340_ <= _zz_325_;
-          _zz_341_ <= _zz_342_;
-        end
-        2'b10 : begin
-          _zz_340_ <= _zz_342_;
-          _zz_341_ <= (_zz_342_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_340_ <= _zz_344_;
-          _zz_341_ <= (_zz_344_ + _zz_731_);
-        end
-        default : begin
-          _zz_341_ <= _zz_342_;
-        end
-      endcase
+    if(_zz_718)begin
+      _zz_371 <= _zz_377;
+      _zz_372 <= _zz_378;
+      _zz_373 <= _zz_379;
+      _zz_376 <= _zz_382;
     end
-    _zz_472_ <= _zz_40_[11 : 7];
-    _zz_473_ <= _zz_52_;
+    _zz_533 <= _zz_40[11 : 7];
+    _zz_534 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -8371,9 +8797,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_598_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_501_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_501_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_681)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_562 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_562 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -8387,21 +8813,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_636_)begin
-      if(_zz_637_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_719)begin
+      if(_zz_720)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_638_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_721)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_639_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_722)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_600_)begin
+    if(_zz_683)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -8421,48 +8847,30 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_593_)begin
-      if(_zz_616_)begin
+    if(_zz_676)begin
+      if(_zz_699)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_773_[31:0];
+          memory_DivPlugin_div_result <= _zz_870[31:0];
         end
       end
     end
-    if(_zz_617_)begin
+    if(_zz_700)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_505_ ? (~ _zz_506_) : _zz_506_) + _zz_779_);
-      memory_DivPlugin_rs2 <= ((_zz_504_ ? (~ execute_RS2) : execute_RS2) + _zz_781_);
-      memory_DivPlugin_div_needRevert <= ((_zz_505_ ^ (_zz_504_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_566 ? (~ _zz_567) : _zz_567) + _zz_876);
+      memory_DivPlugin_rs2 <= ((_zz_565 ? (~ execute_RS2) : execute_RS2) + _zz_878);
+      memory_DivPlugin_div_needRevert <= ((_zz_566 ^ (_zz_565 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
+      execute_to_memory_PC <= _zz_35;
     end
     if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
       memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_25_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
@@ -8470,95 +8878,26 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
-    end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_23_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_20_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_18_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_16_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_13_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_10_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_56_;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_55_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
+      decode_to_execute_SRC1_CTRL <= _zz_25;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_8_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -8570,13 +8909,28 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_ALU_CTRL <= _zz_22;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_CTRL <= _zz_19;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
+      execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
@@ -8588,13 +8942,43 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_5_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_2_;
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_IS_DIV <= decode_IS_DIV;
@@ -8602,17 +8986,68 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_IS_DIV <= execute_IS_DIV;
     end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
     end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -8746,153 +9181,9 @@ module VexRiscv (
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_94_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_945)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_110_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_126_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_947)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_142_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_948)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_158_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_949)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_174_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_950)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_190_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_951)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_206_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_952)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_222_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_953)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_238_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_954)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_254_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_955)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_270_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_956)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_286_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_957)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_302_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_958)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_318_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_959)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_334_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_139_ <= _zz_786_[0];
-        _zz_138_ <= _zz_787_[0];
-        _zz_137_ <= _zz_788_[0];
-        _zz_123_ <= _zz_789_[0];
-        _zz_122_ <= _zz_790_[0];
-        _zz_121_ <= _zz_791_[0];
-        _zz_107_ <= _zz_792_[0];
-        _zz_106_ <= _zz_793_[0];
-        _zz_105_ <= _zz_794_[0];
-        _zz_91_ <= _zz_795_[0];
-        _zz_90_ <= _zz_796_[0];
-        _zz_89_ <= _zz_797_[0];
-      end
-    end
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_203_ <= _zz_802_[0];
-        _zz_202_ <= _zz_803_[0];
-        _zz_201_ <= _zz_804_[0];
-        _zz_187_ <= _zz_805_[0];
-        _zz_186_ <= _zz_806_[0];
-        _zz_185_ <= _zz_807_[0];
-        _zz_171_ <= _zz_808_[0];
-        _zz_170_ <= _zz_809_[0];
-        _zz_169_ <= _zz_810_[0];
-        _zz_155_ <= _zz_811_[0];
-        _zz_154_ <= _zz_812_[0];
-        _zz_153_ <= _zz_813_[0];
-      end
-    end
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_267_ <= _zz_818_[0];
-        _zz_266_ <= _zz_819_[0];
-        _zz_265_ <= _zz_820_[0];
-        _zz_251_ <= _zz_821_[0];
-        _zz_250_ <= _zz_822_[0];
-        _zz_249_ <= _zz_823_[0];
-        _zz_235_ <= _zz_824_[0];
-        _zz_234_ <= _zz_825_[0];
-        _zz_233_ <= _zz_826_[0];
-        _zz_219_ <= _zz_827_[0];
-        _zz_218_ <= _zz_828_[0];
-        _zz_217_ <= _zz_829_[0];
-      end
-    end
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_331_ <= _zz_834_[0];
-        _zz_330_ <= _zz_835_[0];
-        _zz_329_ <= _zz_836_[0];
-        _zz_315_ <= _zz_837_[0];
-        _zz_314_ <= _zz_838_[0];
-        _zz_313_ <= _zz_839_[0];
-        _zz_299_ <= _zz_840_[0];
-        _zz_298_ <= _zz_841_[0];
-        _zz_297_ <= _zz_842_[0];
-        _zz_283_ <= _zz_843_[0];
-        _zz_282_ <= _zz_844_[0];
-        _zz_281_ <= _zz_845_[0];
-      end
-    end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_848_[0];
+        CsrPlugin_mip_MSIP <= _zz_945[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -8913,7 +9204,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_834)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_852_[0];
+        CsrPlugin_mcause_interrupt <= _zz_949[0];
         CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -8944,6 +9235,1092 @@ module VexRiscv (
     end
     iBusWishbone_DAT_MISO_regNext <= iBusWishbone_DAT_MISO;
     dBusWishbone_DAT_MISO_regNext <= dBusWishbone_DAT_MISO;
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire       [0:0]    _zz_19;
+  wire       [0:0]    _zz_20;
+  wire       [9:0]    _zz_21;
+  wire       [9:0]    _zz_22;
+  wire       [0:0]    _zz_23;
+  wire       [0:0]    _zz_24;
+  wire       [2:0]    _zz_25;
+  wire       [1:0]    _zz_26;
+  wire       [21:0]   _zz_27;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  wire                stage0_isAmo;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire                stageA_isAmo;
+  wire                stageA_isLrsc;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  wire                stageB_isAmo;
+  wire                stageB_isAmoCached;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  wire       [31:0]   stageB_requestDataBypass;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_28;
+  reg [7:0] _zz_29;
+  reg [7:0] _zz_30;
+  reg [7:0] _zz_31;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign _zz_17 = (! stageB_flusher_hold);
+  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_19 = _zz_4[0 : 0];
+  assign _zz_20 = _zz_4[1 : 1];
+  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_23 = 1'b1;
+  assign _zz_24 = loader_counter_willIncrement;
+  assign _zz_25 = {2'd0, _zz_24};
+  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_19[0];
+  assign ways_0_tagsReadRsp_error = _zz_20[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_23[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign stage0_isAmo = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign stageA_isAmo = 1'b0;
+  assign stageA_isLrsc = 1'b0;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_16)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isAmo = 1'b0;
+  assign stageB_isAmoCached = 1'b0;
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  assign stageB_requestDataBypass = stageB_request_data;
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          io_mem_cmd_valid = (! memCmdSent);
+        end else begin
+          if(_zz_16)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_14)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_25);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_17)begin
+        if(_zz_18)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_17)begin
+          if(! _zz_18) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_14)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_26[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_9;
+  reg        [21:0]   _zz_10;
+  wire                _zz_11;
+  wire                _zz_12;
+  wire       [0:0]    _zz_13;
+  wire       [0:0]    _zz_14;
+  wire       [21:0]   _zz_15;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_11 = (! lineLoader_flushCounter[7]);
+  assign _zz_12 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_13 = _zz_8[0 : 0];
+  assign _zz_14 = _zz_8[1 : 1];
+  assign _zz_15 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_9 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_15;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_10 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_11)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_9;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_10;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_13[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_14[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_12)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_11)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_12)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
   end
 
 

--- a/pythondata_cpu_vexriscv/verilog/VexRiscv_SecureDebug.v
+++ b/pythondata_cpu_vexriscv/verilog/VexRiscv_SecureDebug.v
@@ -1,19 +1,7 @@
-// Generator : SpinalHDL v1.4.0    git head : ecb5a80b713566f417ea3ea061f9969e73770a7f
-// Date      : 11/12/2020, 16:43:04
+// Generator : SpinalHDL v1.4.3    git head : adf552d8f500e7419fff395b7049228e4bc5de26
 // Component : VexRiscv
+// Git hash  : d26367c5fef9a3c0b9267252e516580d792fcca0
 
-
-`define ShiftCtrlEnum_defaultEncoding_type [1:0]
-`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
-`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
-`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
-`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
-
-`define Src1CtrlEnum_defaultEncoding_type [1:0]
-`define Src1CtrlEnum_defaultEncoding_RS 2'b00
-`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
-`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
-`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
 `define EnvCtrlEnum_defaultEncoding_type [1:0]
 `define EnvCtrlEnum_defaultEncoding_NONE 2'b00
@@ -21,10 +9,17 @@
 `define EnvCtrlEnum_defaultEncoding_WFI 2'b10
 `define EnvCtrlEnum_defaultEncoding_ECALL 2'b11
 
-`define AluCtrlEnum_defaultEncoding_type [1:0]
-`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
-`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
-`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
+`define BranchCtrlEnum_defaultEncoding_type [1:0]
+`define BranchCtrlEnum_defaultEncoding_INC 2'b00
+`define BranchCtrlEnum_defaultEncoding_B 2'b01
+`define BranchCtrlEnum_defaultEncoding_JAL 2'b10
+`define BranchCtrlEnum_defaultEncoding_JALR 2'b11
+
+`define ShiftCtrlEnum_defaultEncoding_type [1:0]
+`define ShiftCtrlEnum_defaultEncoding_DISABLE_1 2'b00
+`define ShiftCtrlEnum_defaultEncoding_SLL_1 2'b01
+`define ShiftCtrlEnum_defaultEncoding_SRL_1 2'b10
+`define ShiftCtrlEnum_defaultEncoding_SRA_1 2'b11
 
 `define AluBitwiseCtrlEnum_defaultEncoding_type [1:0]
 `define AluBitwiseCtrlEnum_defaultEncoding_XOR_1 2'b00
@@ -37,1024 +32,17 @@
 `define Src2CtrlEnum_defaultEncoding_IMS 2'b10
 `define Src2CtrlEnum_defaultEncoding_PC 2'b11
 
-`define BranchCtrlEnum_defaultEncoding_type [1:0]
-`define BranchCtrlEnum_defaultEncoding_INC 2'b00
-`define BranchCtrlEnum_defaultEncoding_B 2'b01
-`define BranchCtrlEnum_defaultEncoding_JAL 2'b10
-`define BranchCtrlEnum_defaultEncoding_JALR 2'b11
+`define AluCtrlEnum_defaultEncoding_type [1:0]
+`define AluCtrlEnum_defaultEncoding_ADD_SUB 2'b00
+`define AluCtrlEnum_defaultEncoding_SLT_SLTU 2'b01
+`define AluCtrlEnum_defaultEncoding_BITWISE 2'b10
 
+`define Src1CtrlEnum_defaultEncoding_type [1:0]
+`define Src1CtrlEnum_defaultEncoding_RS 2'b00
+`define Src1CtrlEnum_defaultEncoding_IMU 2'b01
+`define Src1CtrlEnum_defaultEncoding_PC_INCREMENT 2'b10
+`define Src1CtrlEnum_defaultEncoding_URS1 2'b11
 
-module InstructionCache (
-  input               io_flush,
-  input               io_cpu_prefetch_isValid,
-  output reg          io_cpu_prefetch_haltIt,
-  input      [31:0]   io_cpu_prefetch_pc,
-  input               io_cpu_fetch_isValid,
-  input               io_cpu_fetch_isStuck,
-  input               io_cpu_fetch_isRemoved,
-  input      [31:0]   io_cpu_fetch_pc,
-  output     [31:0]   io_cpu_fetch_data,
-  output              io_cpu_fetch_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_fetch_mmuBus_cmd_virtualAddress,
-  output              io_cpu_fetch_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_fetch_mmuBus_rsp_physicalAddress,
-  input               io_cpu_fetch_mmuBus_rsp_isIoAccess,
-  input               io_cpu_fetch_mmuBus_rsp_allowRead,
-  input               io_cpu_fetch_mmuBus_rsp_allowWrite,
-  input               io_cpu_fetch_mmuBus_rsp_allowExecute,
-  input               io_cpu_fetch_mmuBus_rsp_exception,
-  input               io_cpu_fetch_mmuBus_rsp_refilling,
-  output              io_cpu_fetch_mmuBus_end,
-  input               io_cpu_fetch_mmuBus_busy,
-  output     [31:0]   io_cpu_fetch_physicalAddress,
-  output              io_cpu_fetch_haltIt,
-  input               io_cpu_decode_isValid,
-  input               io_cpu_decode_isStuck,
-  input      [31:0]   io_cpu_decode_pc,
-  output     [31:0]   io_cpu_decode_physicalAddress,
-  output     [31:0]   io_cpu_decode_data,
-  output              io_cpu_decode_cacheMiss,
-  output              io_cpu_decode_error,
-  output              io_cpu_decode_mmuRefilling,
-  output              io_cpu_decode_mmuException,
-  input               io_cpu_decode_isUser,
-  input               io_cpu_fill_valid,
-  input      [31:0]   io_cpu_fill_payload,
-  output              io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output     [31:0]   io_mem_cmd_payload_address,
-  output     [2:0]    io_mem_cmd_payload_size,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input      [2:0]    _zz_10_,
-  input      [31:0]   _zz_11_,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_12_;
-  reg        [31:0]   _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire       [0:0]    _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [21:0]   _zz_18_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  reg                 lineLoader_fire;
-  reg                 lineLoader_valid;
-  (* syn_keep , keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
-  reg                 lineLoader_hadError;
-  reg                 lineLoader_flushPending;
-  reg        [7:0]    lineLoader_flushCounter;
-  reg                 _zz_3_;
-  reg                 lineLoader_cmdSent;
-  reg                 lineLoader_wayToAllocate_willIncrement;
-  wire                lineLoader_wayToAllocate_willClear;
-  wire                lineLoader_wayToAllocate_willOverflowIfInc;
-  wire                lineLoader_wayToAllocate_willOverflow;
-  (* syn_keep , keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
-  wire                lineLoader_write_tag_0_valid;
-  wire       [6:0]    lineLoader_write_tag_0_payload_address;
-  wire                lineLoader_write_tag_0_payload_data_valid;
-  wire                lineLoader_write_tag_0_payload_data_error;
-  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
-  wire                lineLoader_write_data_0_valid;
-  wire       [9:0]    lineLoader_write_data_0_payload_address;
-  wire       [31:0]   lineLoader_write_data_0_payload_data;
-  wire                _zz_4_;
-  wire       [6:0]    _zz_5_;
-  wire                _zz_6_;
-  wire                fetchStage_read_waysValues_0_tag_valid;
-  wire                fetchStage_read_waysValues_0_tag_error;
-  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
-  wire       [21:0]   _zz_7_;
-  wire       [9:0]    _zz_8_;
-  wire                _zz_9_;
-  wire       [31:0]   fetchStage_read_waysValues_0_data;
-  wire                fetchStage_hit_hits_0;
-  wire                fetchStage_hit_valid;
-  wire                fetchStage_hit_error;
-  wire       [31:0]   fetchStage_hit_data;
-  wire       [31:0]   fetchStage_hit_word;
-  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
-  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
-  reg                 decodeStage_mmuRsp_isIoAccess;
-  reg                 decodeStage_mmuRsp_allowRead;
-  reg                 decodeStage_mmuRsp_allowWrite;
-  reg                 decodeStage_mmuRsp_allowExecute;
-  reg                 decodeStage_mmuRsp_exception;
-  reg                 decodeStage_mmuRsp_refilling;
-  reg                 decodeStage_hit_valid;
-  reg                 decodeStage_hit_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [31:0] ways_0_datas [0:1023];
-
-  assign _zz_14_ = (! lineLoader_flushCounter[7]);
-  assign _zz_15_ = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
-  assign _zz_16_ = _zz_7_[0 : 0];
-  assign _zz_17_ = _zz_7_[1 : 1];
-  assign _zz_18_ = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_18_;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_6_) begin
-      _zz_12_ <= ways_0_tags[_zz_5_];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_1_) begin
-      ways_0_datas[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_9_) begin
-      _zz_13_ <= ways_0_datas[_zz_8_];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if(lineLoader_write_data_0_valid)begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if(lineLoader_write_tag_0_valid)begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign io_cpu_fetch_haltIt = io_cpu_fetch_mmuBus_busy;
-  always @ (*) begin
-    lineLoader_fire = 1'b0;
-    if(io_mem_rsp_valid)begin
-      if((lineLoader_wordIndex == (3'b111)))begin
-        lineLoader_fire = 1'b1;
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
-    if(_zz_14_)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if((! _zz_3_))begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-    if(io_flush)begin
-      io_cpu_prefetch_haltIt = 1'b1;
-    end
-  end
-
-  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
-  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
-  assign io_mem_cmd_payload_size = (3'b101);
-  always @ (*) begin
-    lineLoader_wayToAllocate_willIncrement = 1'b0;
-    if((! lineLoader_valid))begin
-      lineLoader_wayToAllocate_willIncrement = 1'b1;
-    end
-  end
-
-  assign lineLoader_wayToAllocate_willClear = 1'b0;
-  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
-  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
-  assign _zz_4_ = 1'b1;
-  assign lineLoader_write_tag_0_valid = ((_zz_4_ && lineLoader_fire) || (! lineLoader_flushCounter[7]));
-  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
-  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
-  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
-  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
-  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && _zz_4_);
-  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
-  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
-  assign _zz_5_ = io_cpu_prefetch_pc[11 : 5];
-  assign _zz_6_ = (! io_cpu_fetch_isStuck);
-  assign _zz_7_ = _zz_12_;
-  assign fetchStage_read_waysValues_0_tag_valid = _zz_16_[0];
-  assign fetchStage_read_waysValues_0_tag_error = _zz_17_[0];
-  assign fetchStage_read_waysValues_0_tag_address = _zz_7_[21 : 2];
-  assign _zz_8_ = io_cpu_prefetch_pc[11 : 2];
-  assign _zz_9_ = (! io_cpu_fetch_isStuck);
-  assign fetchStage_read_waysValues_0_data = _zz_13_;
-  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuBus_rsp_physicalAddress[31 : 12]));
-  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != (1'b0));
-  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
-  assign fetchStage_hit_data = fetchStage_read_waysValues_0_data;
-  assign fetchStage_hit_word = fetchStage_hit_data;
-  assign io_cpu_fetch_data = fetchStage_hit_word;
-  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
-  assign io_cpu_fetch_mmuBus_cmd_isValid = io_cpu_fetch_isValid;
-  assign io_cpu_fetch_mmuBus_cmd_virtualAddress = io_cpu_fetch_pc;
-  assign io_cpu_fetch_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_fetch_mmuBus_end = ((! io_cpu_fetch_isStuck) || io_cpu_fetch_isRemoved);
-  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuBus_rsp_physicalAddress;
-  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
-  assign io_cpu_decode_error = decodeStage_hit_error;
-  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
-  assign io_cpu_decode_mmuException = ((! decodeStage_mmuRsp_refilling) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
-  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
-  always @ (posedge clk) begin
-    if(reset) begin
-      lineLoader_valid <= 1'b0;
-      lineLoader_hadError <= 1'b0;
-      lineLoader_flushPending <= 1'b1;
-      lineLoader_cmdSent <= 1'b0;
-      lineLoader_wordIndex <= (3'b000);
-    end else begin
-      if(lineLoader_fire)begin
-        lineLoader_valid <= 1'b0;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_hadError <= 1'b0;
-      end
-      if(io_cpu_fill_valid)begin
-        lineLoader_valid <= 1'b1;
-      end
-      if(io_flush)begin
-        lineLoader_flushPending <= 1'b1;
-      end
-      if(_zz_15_)begin
-        lineLoader_flushPending <= 1'b0;
-      end
-      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
-        lineLoader_cmdSent <= 1'b1;
-      end
-      if(lineLoader_fire)begin
-        lineLoader_cmdSent <= 1'b0;
-      end
-      if(io_mem_rsp_valid)begin
-        lineLoader_wordIndex <= (lineLoader_wordIndex + (3'b001));
-        if(io_mem_rsp_payload_error)begin
-          lineLoader_hadError <= 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(io_cpu_fill_valid)begin
-      lineLoader_address <= io_cpu_fill_payload;
-    end
-    if(_zz_14_)begin
-      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
-    end
-    _zz_3_ <= lineLoader_flushCounter[7];
-    if(_zz_15_)begin
-      lineLoader_flushCounter <= 8'h0;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuBus_rsp_physicalAddress;
-      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuBus_rsp_isIoAccess;
-      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuBus_rsp_allowRead;
-      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuBus_rsp_allowWrite;
-      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuBus_rsp_allowExecute;
-      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuBus_rsp_exception;
-      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_valid <= fetchStage_hit_valid;
-    end
-    if((! io_cpu_decode_isStuck))begin
-      decodeStage_hit_error <= fetchStage_hit_error;
-    end
-    if((_zz_10_ != (3'b000)))begin
-      io_cpu_fetch_data_regNextWhen <= _zz_11_;
-    end
-  end
-
-
-endmodule
-
-module DataCache (
-  input               io_cpu_execute_isValid,
-  input      [31:0]   io_cpu_execute_address,
-  input               io_cpu_execute_args_wr,
-  input      [31:0]   io_cpu_execute_args_data,
-  input      [1:0]    io_cpu_execute_args_size,
-  input               io_cpu_memory_isValid,
-  input               io_cpu_memory_isStuck,
-  input               io_cpu_memory_isRemoved,
-  output              io_cpu_memory_isWrite,
-  input      [31:0]   io_cpu_memory_address,
-  output              io_cpu_memory_mmuBus_cmd_isValid,
-  output     [31:0]   io_cpu_memory_mmuBus_cmd_virtualAddress,
-  output              io_cpu_memory_mmuBus_cmd_bypassTranslation,
-  input      [31:0]   io_cpu_memory_mmuBus_rsp_physicalAddress,
-  input               io_cpu_memory_mmuBus_rsp_isIoAccess,
-  input               io_cpu_memory_mmuBus_rsp_allowRead,
-  input               io_cpu_memory_mmuBus_rsp_allowWrite,
-  input               io_cpu_memory_mmuBus_rsp_allowExecute,
-  input               io_cpu_memory_mmuBus_rsp_exception,
-  input               io_cpu_memory_mmuBus_rsp_refilling,
-  output              io_cpu_memory_mmuBus_end,
-  input               io_cpu_memory_mmuBus_busy,
-  input               io_cpu_writeBack_isValid,
-  input               io_cpu_writeBack_isStuck,
-  input               io_cpu_writeBack_isUser,
-  output reg          io_cpu_writeBack_haltIt,
-  output              io_cpu_writeBack_isWrite,
-  output reg [31:0]   io_cpu_writeBack_data,
-  input      [31:0]   io_cpu_writeBack_address,
-  output              io_cpu_writeBack_mmuException,
-  output              io_cpu_writeBack_unalignedAccess,
-  output reg          io_cpu_writeBack_accessError,
-  output reg          io_cpu_redo,
-  input               io_cpu_flush_valid,
-  output reg          io_cpu_flush_ready,
-  output reg          io_mem_cmd_valid,
-  input               io_mem_cmd_ready,
-  output reg          io_mem_cmd_payload_wr,
-  output reg [31:0]   io_mem_cmd_payload_address,
-  output     [31:0]   io_mem_cmd_payload_data,
-  output     [3:0]    io_mem_cmd_payload_mask,
-  output reg [2:0]    io_mem_cmd_payload_length,
-  output reg          io_mem_cmd_payload_last,
-  input               io_mem_rsp_valid,
-  input      [31:0]   io_mem_rsp_payload_data,
-  input               io_mem_rsp_payload_error,
-  input               clk,
-  input               reset 
-);
-  reg        [21:0]   _zz_10_;
-  reg        [31:0]   _zz_11_;
-  wire                _zz_12_;
-  wire                _zz_13_;
-  wire                _zz_14_;
-  wire                _zz_15_;
-  wire                _zz_16_;
-  wire       [0:0]    _zz_17_;
-  wire       [0:0]    _zz_18_;
-  wire       [0:0]    _zz_19_;
-  wire       [2:0]    _zz_20_;
-  wire       [1:0]    _zz_21_;
-  wire       [21:0]   _zz_22_;
-  reg                 _zz_1_;
-  reg                 _zz_2_;
-  wire                haltCpu;
-  reg                 tagsReadCmd_valid;
-  reg        [6:0]    tagsReadCmd_payload;
-  reg                 tagsWriteCmd_valid;
-  reg        [0:0]    tagsWriteCmd_payload_way;
-  reg        [6:0]    tagsWriteCmd_payload_address;
-  reg                 tagsWriteCmd_payload_data_valid;
-  reg                 tagsWriteCmd_payload_data_error;
-  reg        [19:0]   tagsWriteCmd_payload_data_address;
-  reg                 tagsWriteLastCmd_valid;
-  reg        [0:0]    tagsWriteLastCmd_payload_way;
-  reg        [6:0]    tagsWriteLastCmd_payload_address;
-  reg                 tagsWriteLastCmd_payload_data_valid;
-  reg                 tagsWriteLastCmd_payload_data_error;
-  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
-  reg                 dataReadCmd_valid;
-  reg        [9:0]    dataReadCmd_payload;
-  reg                 dataWriteCmd_valid;
-  reg        [0:0]    dataWriteCmd_payload_way;
-  reg        [9:0]    dataWriteCmd_payload_address;
-  reg        [31:0]   dataWriteCmd_payload_data;
-  reg        [3:0]    dataWriteCmd_payload_mask;
-  wire                _zz_3_;
-  wire                ways_0_tagsReadRsp_valid;
-  wire                ways_0_tagsReadRsp_error;
-  wire       [19:0]   ways_0_tagsReadRsp_address;
-  wire       [21:0]   _zz_4_;
-  wire                _zz_5_;
-  wire       [31:0]   ways_0_dataReadRsp;
-  reg        [3:0]    _zz_6_;
-  wire       [3:0]    stage0_mask;
-  wire       [0:0]    stage0_colisions;
-  reg                 stageA_request_wr;
-  reg        [31:0]   stageA_request_data;
-  reg        [1:0]    stageA_request_size;
-  reg        [3:0]    stageA_mask;
-  wire                stageA_wayHits_0;
-  reg        [0:0]    stage0_colisions_regNextWhen;
-  wire       [0:0]    _zz_7_;
-  wire       [0:0]    stageA_colisions;
-  reg                 stageB_request_wr;
-  reg        [31:0]   stageB_request_data;
-  reg        [1:0]    stageB_request_size;
-  reg                 stageB_mmuRspFreeze;
-  reg        [31:0]   stageB_mmuRsp_physicalAddress;
-  reg                 stageB_mmuRsp_isIoAccess;
-  reg                 stageB_mmuRsp_allowRead;
-  reg                 stageB_mmuRsp_allowWrite;
-  reg                 stageB_mmuRsp_allowExecute;
-  reg                 stageB_mmuRsp_exception;
-  reg                 stageB_mmuRsp_refilling;
-  reg                 stageB_tagsReadRsp_0_valid;
-  reg                 stageB_tagsReadRsp_0_error;
-  reg        [19:0]   stageB_tagsReadRsp_0_address;
-  reg        [31:0]   stageB_dataReadRsp_0;
-  wire       [0:0]    _zz_8_;
-  reg        [0:0]    stageB_waysHits;
-  wire                stageB_waysHit;
-  wire       [31:0]   stageB_dataMux;
-  reg        [3:0]    stageB_mask;
-  reg        [0:0]    stageB_colisions;
-  reg                 stageB_loaderValid;
-  reg                 stageB_flusher_valid;
-  reg                 stageB_flusher_start;
-  wire       [31:0]   stageB_requestDataBypass;
-  wire                stageB_isAmo;
-  reg                 stageB_memCmdSent;
-  wire       [0:0]    _zz_9_;
-  reg                 loader_valid;
-  reg                 loader_counter_willIncrement;
-  wire                loader_counter_willClear;
-  reg        [2:0]    loader_counter_valueNext;
-  reg        [2:0]    loader_counter_value;
-  wire                loader_counter_willOverflowIfInc;
-  wire                loader_counter_willOverflow;
-  reg        [0:0]    loader_waysAllocator;
-  reg                 loader_error;
-  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
-  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
-  reg [7:0] _zz_23_;
-  reg [7:0] _zz_24_;
-  reg [7:0] _zz_25_;
-  reg [7:0] _zz_26_;
-
-  assign _zz_12_ = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
-  assign _zz_13_ = (((stageB_mmuRsp_refilling || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
-  assign _zz_14_ = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmo)));
-  assign _zz_15_ = (loader_valid && io_mem_rsp_valid);
-  assign _zz_16_ = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
-  assign _zz_17_ = _zz_4_[0 : 0];
-  assign _zz_18_ = _zz_4_[1 : 1];
-  assign _zz_19_ = loader_counter_willIncrement;
-  assign _zz_20_ = {2'd0, _zz_19_};
-  assign _zz_21_ = {loader_waysAllocator,loader_waysAllocator[0]};
-  assign _zz_22_ = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
-  always @ (posedge clk) begin
-    if(_zz_3_) begin
-      _zz_10_ <= ways_0_tags[tagsReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(_zz_2_) begin
-      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_22_;
-    end
-  end
-
-  always @ (*) begin
-    _zz_11_ = {_zz_26_, _zz_25_, _zz_24_, _zz_23_};
-  end
-  always @ (posedge clk) begin
-    if(_zz_5_) begin
-      _zz_23_ <= ways_0_data_symbol0[dataReadCmd_payload];
-      _zz_24_ <= ways_0_data_symbol1[dataReadCmd_payload];
-      _zz_25_ <= ways_0_data_symbol2[dataReadCmd_payload];
-      _zz_26_ <= ways_0_data_symbol3[dataReadCmd_payload];
-    end
-  end
-
-  always @ (posedge clk) begin
-    if(dataWriteCmd_payload_mask[0] && _zz_1_) begin
-      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
-    end
-    if(dataWriteCmd_payload_mask[1] && _zz_1_) begin
-      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
-    end
-    if(dataWriteCmd_payload_mask[2] && _zz_1_) begin
-      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
-    end
-    if(dataWriteCmd_payload_mask[3] && _zz_1_) begin
-      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
-    end
-  end
-
-  always @ (*) begin
-    _zz_1_ = 1'b0;
-    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
-      _zz_1_ = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    _zz_2_ = 1'b0;
-    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
-      _zz_2_ = 1'b1;
-    end
-  end
-
-  assign haltCpu = 1'b0;
-  assign _zz_3_ = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign _zz_4_ = _zz_10_;
-  assign ways_0_tagsReadRsp_valid = _zz_17_[0];
-  assign ways_0_tagsReadRsp_error = _zz_18_[0];
-  assign ways_0_tagsReadRsp_address = _zz_4_[21 : 2];
-  assign _zz_5_ = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
-  assign ways_0_dataReadRsp = _zz_11_;
-  always @ (*) begin
-    tagsReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      tagsReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsReadCmd_payload = 7'h0;
-    if(_zz_12_)begin
-      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_valid = 1'b0;
-    if(_zz_12_)begin
-      dataReadCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataReadCmd_payload = 10'h0;
-    if(_zz_12_)begin
-      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_valid = 1'b0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_valid = stageB_flusher_valid;
-    end
-    if(_zz_13_)begin
-      tagsWriteCmd_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_way = (1'bx);
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_way = (1'b1);
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_address = 7'h0;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_valid = 1'bx;
-    if(stageB_flusher_valid)begin
-      tagsWriteCmd_payload_data_valid = 1'b0;
-    end
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_error = 1'bx;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_error = (loader_error || io_mem_rsp_payload_error);
-    end
-  end
-
-  always @ (*) begin
-    tagsWriteCmd_payload_data_address = 20'h0;
-    if(loader_counter_willOverflow)begin
-      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((stageB_request_wr && stageB_waysHit))begin
-            dataWriteCmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      dataWriteCmd_valid = 1'b0;
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_valid = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_way = (1'bx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_way = stageB_waysHits;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_way = loader_waysAllocator;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_address = 10'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_data = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_data = stageB_requestDataBypass;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
-    end
-  end
-
-  always @ (*) begin
-    dataWriteCmd_payload_mask = (4'bxxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          dataWriteCmd_payload_mask = stageB_mask;
-        end
-      end
-    end
-    if(_zz_15_)begin
-      dataWriteCmd_payload_mask = (4'b1111);
-    end
-  end
-
-  always @ (*) begin
-    case(io_cpu_execute_args_size)
-      2'b00 : begin
-        _zz_6_ = (4'b0001);
-      end
-      2'b01 : begin
-        _zz_6_ = (4'b0011);
-      end
-      default : begin
-        _zz_6_ = (4'b1111);
-      end
-    endcase
-  end
-
-  assign stage0_mask = (_zz_6_ <<< io_cpu_execute_address[1 : 0]);
-  assign stage0_colisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_execute_address[11 : 2])) && ((stage0_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign io_cpu_memory_mmuBus_cmd_isValid = io_cpu_memory_isValid;
-  assign io_cpu_memory_mmuBus_cmd_virtualAddress = io_cpu_memory_address;
-  assign io_cpu_memory_mmuBus_cmd_bypassTranslation = 1'b0;
-  assign io_cpu_memory_mmuBus_end = ((! io_cpu_memory_isStuck) || io_cpu_memory_isRemoved);
-  assign io_cpu_memory_isWrite = stageA_request_wr;
-  assign stageA_wayHits_0 = ((io_cpu_memory_mmuBus_rsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
-  assign _zz_7_[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == io_cpu_memory_address[11 : 2])) && ((stageA_mask & dataWriteCmd_payload_mask) != (4'b0000)));
-  assign stageA_colisions = (stage0_colisions_regNextWhen | _zz_7_);
-  always @ (*) begin
-    stageB_mmuRspFreeze = 1'b0;
-    if((stageB_loaderValid || loader_valid))begin
-      stageB_mmuRspFreeze = 1'b1;
-    end
-  end
-
-  assign _zz_8_[0] = stageA_wayHits_0;
-  assign stageB_waysHit = (stageB_waysHits != (1'b0));
-  assign stageB_dataMux = stageB_dataReadRsp_0;
-  always @ (*) begin
-    stageB_loaderValid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          if(io_mem_cmd_ready)begin
-            stageB_loaderValid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      stageB_loaderValid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
-    if(stageB_flusher_valid)begin
-      io_cpu_writeBack_haltIt = 1'b1;
-    end
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        if((stageB_request_wr ? io_mem_cmd_ready : io_mem_rsp_valid))begin
-          io_cpu_writeBack_haltIt = 1'b0;
-        end
-      end else begin
-        if(_zz_14_)begin
-          if(((! stageB_request_wr) || io_mem_cmd_ready))begin
-            io_cpu_writeBack_haltIt = 1'b0;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_cpu_writeBack_haltIt = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_flush_ready = 1'b0;
-    if(stageB_flusher_start)begin
-      io_cpu_flush_ready = 1'b1;
-    end
-  end
-
-  assign stageB_requestDataBypass = stageB_request_data;
-  assign stageB_isAmo = 1'b0;
-  always @ (*) begin
-    io_cpu_redo = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(_zz_14_)begin
-          if((((! stageB_request_wr) || stageB_isAmo) && ((stageB_colisions & stageB_waysHits) != (1'b0))))begin
-            io_cpu_redo = 1'b1;
-          end
-        end
-      end
-    end
-    if((io_cpu_writeBack_isValid && stageB_mmuRsp_refilling))begin
-      io_cpu_redo = 1'b1;
-    end
-    if(loader_valid)begin
-      io_cpu_redo = 1'b1;
-    end
-  end
-
-  always @ (*) begin
-    io_cpu_writeBack_accessError = 1'b0;
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_accessError = (io_mem_rsp_valid && io_mem_rsp_payload_error);
-    end else begin
-      io_cpu_writeBack_accessError = ((stageB_waysHits & _zz_9_) != (1'b0));
-    end
-  end
-
-  assign io_cpu_writeBack_mmuException = (io_cpu_writeBack_isValid && ((stageB_mmuRsp_exception || ((! stageB_mmuRsp_allowWrite) && stageB_request_wr)) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo))));
-  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && (((stageB_request_size == (2'b10)) && (stageB_mmuRsp_physicalAddress[1 : 0] != (2'b00))) || ((stageB_request_size == (2'b01)) && (stageB_mmuRsp_physicalAddress[0 : 0] != (1'b0)))));
-  assign io_cpu_writeBack_isWrite = stageB_request_wr;
-  always @ (*) begin
-    io_mem_cmd_valid = 1'b0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_valid = (! stageB_memCmdSent);
-      end else begin
-        if(_zz_14_)begin
-          if(stageB_request_wr)begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end else begin
-          if((! stageB_memCmdSent))begin
-            io_mem_cmd_valid = 1'b1;
-          end
-        end
-      end
-    end
-    if(_zz_13_)begin
-      io_mem_cmd_valid = 1'b0;
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_address = 32'h0;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],(2'b00)};
-        end else begin
-          io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_length = (3'bxxx);
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_length = (3'b000);
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_length = (3'b000);
-        end else begin
-          io_mem_cmd_payload_length = (3'b111);
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_last = 1'bx;
-    if(io_cpu_writeBack_isValid)begin
-      if(stageB_mmuRsp_isIoAccess)begin
-        io_mem_cmd_payload_last = 1'b1;
-      end else begin
-        if(_zz_14_)begin
-          io_mem_cmd_payload_last = 1'b1;
-        end else begin
-          io_mem_cmd_payload_last = 1'b1;
-        end
-      end
-    end
-  end
-
-  always @ (*) begin
-    io_mem_cmd_payload_wr = stageB_request_wr;
-    if(io_cpu_writeBack_isValid)begin
-      if(! stageB_mmuRsp_isIoAccess) begin
-        if(! _zz_14_) begin
-          io_mem_cmd_payload_wr = 1'b0;
-        end
-      end
-    end
-  end
-
-  assign io_mem_cmd_payload_mask = stageB_mask;
-  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
-  always @ (*) begin
-    if(stageB_mmuRsp_isIoAccess)begin
-      io_cpu_writeBack_data = io_mem_rsp_payload_data;
-    end else begin
-      io_cpu_writeBack_data = stageB_dataMux;
-    end
-  end
-
-  assign _zz_9_[0] = stageB_tagsReadRsp_0_error;
-  always @ (*) begin
-    loader_counter_willIncrement = 1'b0;
-    if(_zz_15_)begin
-      loader_counter_willIncrement = 1'b1;
-    end
-  end
-
-  assign loader_counter_willClear = 1'b0;
-  assign loader_counter_willOverflowIfInc = (loader_counter_value == (3'b111));
-  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
-  always @ (*) begin
-    loader_counter_valueNext = (loader_counter_value + _zz_20_);
-    if(loader_counter_willClear)begin
-      loader_counter_valueNext = (3'b000);
-    end
-  end
-
-  always @ (posedge clk) begin
-    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
-    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
-    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
-    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
-    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
-    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
-    if((! io_cpu_memory_isStuck))begin
-      stageA_request_wr <= io_cpu_execute_args_wr;
-      stageA_request_data <= io_cpu_execute_args_data;
-      stageA_request_size <= io_cpu_execute_args_size;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stageA_mask <= stage0_mask;
-    end
-    if((! io_cpu_memory_isStuck))begin
-      stage0_colisions_regNextWhen <= stage0_colisions;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_request_wr <= stageA_request_wr;
-      stageB_request_data <= stageA_request_data;
-      stageB_request_size <= stageA_request_size;
-    end
-    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
-      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuBus_rsp_physicalAddress;
-      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuBus_rsp_isIoAccess;
-      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuBus_rsp_allowRead;
-      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuBus_rsp_allowWrite;
-      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuBus_rsp_allowExecute;
-      stageB_mmuRsp_exception <= io_cpu_memory_mmuBus_rsp_exception;
-      stageB_mmuRsp_refilling <= io_cpu_memory_mmuBus_rsp_refilling;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
-      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
-      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_waysHits <= _zz_8_;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_mask <= stageA_mask;
-    end
-    if((! io_cpu_writeBack_isStuck))begin
-      stageB_colisions <= stageA_colisions;
-    end
-    if(stageB_flusher_valid)begin
-      if(_zz_16_)begin
-        stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
-      end
-    end
-    if(stageB_flusher_start)begin
-      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
-    end
-    `ifndef SYNTHESIS
-      `ifdef FORMAL
-        assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)))
-      `else
-        if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
-          $display("FAILURE writeBack stuck by another plugin is not allowed");
-          $finish;
-        end
-      `endif
-    `endif
-  end
-
-  always @ (posedge clk) begin
-    if(reset) begin
-      stageB_flusher_valid <= 1'b0;
-      stageB_flusher_start <= 1'b1;
-      stageB_memCmdSent <= 1'b0;
-      loader_valid <= 1'b0;
-      loader_counter_value <= (3'b000);
-      loader_waysAllocator <= (1'b1);
-      loader_error <= 1'b0;
-    end else begin
-      if(stageB_flusher_valid)begin
-        if(! _zz_16_) begin
-          stageB_flusher_valid <= 1'b0;
-        end
-      end
-      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
-      if(stageB_flusher_start)begin
-        stageB_flusher_valid <= 1'b1;
-      end
-      if(io_mem_cmd_ready)begin
-        stageB_memCmdSent <= 1'b1;
-      end
-      if((! io_cpu_writeBack_isStuck))begin
-        stageB_memCmdSent <= 1'b0;
-      end
-      if(stageB_loaderValid)begin
-        loader_valid <= 1'b1;
-      end
-      loader_counter_value <= loader_counter_valueNext;
-      if(_zz_15_)begin
-        loader_error <= (loader_error || io_mem_rsp_payload_error);
-      end
-      if(loader_counter_willOverflow)begin
-        loader_valid <= 1'b0;
-        loader_error <= 1'b0;
-      end
-      if((! loader_valid))begin
-        loader_waysAllocator <= _zz_21_[0:0];
-      end
-    end
-  end
-
-
-endmodule
 
 module VexRiscv (
   input      [31:0]   externalResetVector,
@@ -1077,8 +65,8 @@ module VexRiscv (
   output     [31:0]   iBusWishbone_DAT_MOSI,
   output     [3:0]    iBusWishbone_SEL,
   input               iBusWishbone_ERR,
-  output     [1:0]    iBusWishbone_BTE,
   output     [2:0]    iBusWishbone_CTI,
+  output     [1:0]    iBusWishbone_BTE,
   output              dBusWishbone_CYC,
   output              dBusWishbone_STB,
   input               dBusWishbone_ACK,
@@ -1088,47 +76,64 @@ module VexRiscv (
   output     [31:0]   dBusWishbone_DAT_MOSI,
   output     [3:0]    dBusWishbone_SEL,
   input               dBusWishbone_ERR,
-  output     [1:0]    dBusWishbone_BTE,
   output     [2:0]    dBusWishbone_CTI,
+  output     [1:0]    dBusWishbone_BTE,
   input               clk,
   input               reset,
-  input               debugReset 
+  input               debugReset
 );
-  wire                _zz_564_;
-  wire                _zz_565_;
-  wire                _zz_566_;
-  wire                _zz_567_;
-  wire                _zz_568_;
-  wire                _zz_569_;
-  wire                _zz_570_;
-  reg                 _zz_571_;
-  wire                _zz_572_;
-  wire       [31:0]   _zz_573_;
-  wire                _zz_574_;
-  wire       [31:0]   _zz_575_;
-  reg                 _zz_576_;
-  wire                _zz_577_;
-  wire                _zz_578_;
-  wire       [31:0]   _zz_579_;
-  wire                _zz_580_;
-  wire                _zz_581_;
-  reg        [31:0]   _zz_582_;
-  reg        [31:0]   _zz_583_;
-  reg        [31:0]   _zz_584_;
-  reg                 _zz_585_;
-  reg                 _zz_586_;
-  reg                 _zz_587_;
-  reg                 _zz_588_;
-  reg                 _zz_589_;
-  reg                 _zz_590_;
+  wire                _zz_625;
+  wire                _zz_626;
+  wire                _zz_627;
+  wire                _zz_628;
+  wire                _zz_629;
+  wire                _zz_630;
+  wire                _zz_631;
+  wire                _zz_632;
+  reg                 _zz_633;
+  wire                _zz_634;
+  wire       [31:0]   _zz_635;
+  wire                _zz_636;
+  wire       [31:0]   _zz_637;
+  reg                 _zz_638;
+  wire                _zz_639;
+  wire                _zz_640;
+  wire       [31:0]   _zz_641;
+  wire                _zz_642;
+  wire                _zz_643;
+  wire                _zz_644;
+  wire                _zz_645;
+  wire                _zz_646;
+  wire                _zz_647;
+  wire                _zz_648;
+  wire                _zz_649;
+  wire       [3:0]    _zz_650;
+  wire                _zz_651;
+  wire                _zz_652;
+  reg        [31:0]   _zz_653;
+  reg        [31:0]   _zz_654;
+  reg        [31:0]   _zz_655;
+  reg        [4:0]    _zz_656;
+  reg        [4:0]    _zz_657;
+  reg        [4:0]    _zz_658;
+  reg        [4:0]    _zz_659;
+  reg        [4:0]    _zz_660;
+  reg        [4:0]    _zz_661;
+  reg                 _zz_662;
+  reg                 _zz_663;
+  reg                 _zz_664;
+  reg        [4:0]    _zz_665;
+  reg        [4:0]    _zz_666;
+  reg        [4:0]    _zz_667;
+  reg        [4:0]    _zz_668;
+  reg        [4:0]    _zz_669;
+  reg        [4:0]    _zz_670;
+  reg                 _zz_671;
+  reg                 _zz_672;
+  reg                 _zz_673;
   wire                IBusCachedPlugin_cache_io_cpu_prefetch_haltIt;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_data;
   wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_haltIt;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  wire                IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
   wire                IBusCachedPlugin_cache_io_cpu_decode_error;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling;
   wire                IBusCachedPlugin_cache_io_cpu_decode_mmuException;
@@ -1138,592 +143,616 @@ module VexRiscv (
   wire                IBusCachedPlugin_cache_io_mem_cmd_valid;
   wire       [31:0]   IBusCachedPlugin_cache_io_mem_cmd_payload_address;
   wire       [2:0]    IBusCachedPlugin_cache_io_mem_cmd_payload_size;
-  wire                dataCache_1__io_cpu_memory_isWrite;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  wire       [31:0]   dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  wire                dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
-  wire                dataCache_1__io_cpu_memory_mmuBus_end;
-  wire                dataCache_1__io_cpu_writeBack_haltIt;
-  wire       [31:0]   dataCache_1__io_cpu_writeBack_data;
-  wire                dataCache_1__io_cpu_writeBack_mmuException;
-  wire                dataCache_1__io_cpu_writeBack_unalignedAccess;
-  wire                dataCache_1__io_cpu_writeBack_accessError;
-  wire                dataCache_1__io_cpu_writeBack_isWrite;
-  wire                dataCache_1__io_cpu_flush_ready;
-  wire                dataCache_1__io_cpu_redo;
-  wire                dataCache_1__io_mem_cmd_valid;
-  wire                dataCache_1__io_mem_cmd_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_payload_length;
-  wire                dataCache_1__io_mem_cmd_payload_last;
-  wire                _zz_591_;
-  wire                _zz_592_;
-  wire                _zz_593_;
-  wire                _zz_594_;
-  wire                _zz_595_;
-  wire                _zz_596_;
-  wire                _zz_597_;
-  wire                _zz_598_;
-  wire                _zz_599_;
-  wire                _zz_600_;
-  wire                _zz_601_;
-  wire                _zz_602_;
-  wire                _zz_603_;
-  wire                _zz_604_;
-  wire                _zz_605_;
-  wire                _zz_606_;
-  wire                _zz_607_;
-  wire       [1:0]    _zz_608_;
-  wire                _zz_609_;
-  wire                _zz_610_;
-  wire                _zz_611_;
-  wire                _zz_612_;
-  wire                _zz_613_;
-  wire                _zz_614_;
-  wire                _zz_615_;
-  wire                _zz_616_;
-  wire                _zz_617_;
-  wire                _zz_618_;
-  wire                _zz_619_;
-  wire                _zz_620_;
-  wire       [1:0]    _zz_621_;
-  wire                _zz_622_;
-  wire                _zz_623_;
-  wire       [5:0]    _zz_624_;
-  wire                _zz_625_;
-  wire                _zz_626_;
-  wire                _zz_627_;
-  wire                _zz_628_;
-  wire                _zz_629_;
-  wire                _zz_630_;
-  wire                _zz_631_;
-  wire                _zz_632_;
-  wire                _zz_633_;
-  wire                _zz_634_;
-  wire                _zz_635_;
-  wire                _zz_636_;
-  wire                _zz_637_;
-  wire                _zz_638_;
-  wire                _zz_639_;
-  wire                _zz_640_;
-  wire                _zz_641_;
-  wire                _zz_642_;
-  wire                _zz_643_;
-  wire                _zz_644_;
-  wire                _zz_645_;
-  wire                _zz_646_;
-  wire       [1:0]    _zz_647_;
-  wire                _zz_648_;
-  wire       [1:0]    _zz_649_;
-  wire       [0:0]    _zz_650_;
-  wire       [0:0]    _zz_651_;
-  wire       [51:0]   _zz_652_;
-  wire       [51:0]   _zz_653_;
-  wire       [51:0]   _zz_654_;
-  wire       [32:0]   _zz_655_;
-  wire       [51:0]   _zz_656_;
-  wire       [49:0]   _zz_657_;
-  wire       [51:0]   _zz_658_;
-  wire       [49:0]   _zz_659_;
-  wire       [51:0]   _zz_660_;
-  wire       [0:0]    _zz_661_;
-  wire       [0:0]    _zz_662_;
-  wire       [0:0]    _zz_663_;
-  wire       [0:0]    _zz_664_;
-  wire       [0:0]    _zz_665_;
-  wire       [0:0]    _zz_666_;
-  wire       [32:0]   _zz_667_;
-  wire       [31:0]   _zz_668_;
-  wire       [32:0]   _zz_669_;
-  wire       [0:0]    _zz_670_;
-  wire       [0:0]    _zz_671_;
-  wire       [0:0]    _zz_672_;
-  wire       [0:0]    _zz_673_;
-  wire       [0:0]    _zz_674_;
-  wire       [0:0]    _zz_675_;
-  wire       [0:0]    _zz_676_;
-  wire       [0:0]    _zz_677_;
-  wire       [0:0]    _zz_678_;
-  wire       [0:0]    _zz_679_;
-  wire       [3:0]    _zz_680_;
-  wire       [2:0]    _zz_681_;
-  wire       [31:0]   _zz_682_;
-  wire       [11:0]   _zz_683_;
-  wire       [31:0]   _zz_684_;
-  wire       [19:0]   _zz_685_;
-  wire       [11:0]   _zz_686_;
-  wire       [31:0]   _zz_687_;
-  wire       [31:0]   _zz_688_;
-  wire       [19:0]   _zz_689_;
-  wire       [11:0]   _zz_690_;
-  wire       [2:0]    _zz_691_;
-  wire       [2:0]    _zz_692_;
-  wire       [31:0]   _zz_693_;
-  wire       [31:0]   _zz_694_;
-  wire       [31:0]   _zz_695_;
-  wire       [31:0]   _zz_696_;
-  wire       [31:0]   _zz_697_;
-  wire       [31:0]   _zz_698_;
-  wire       [31:0]   _zz_699_;
-  wire       [31:0]   _zz_700_;
-  wire       [31:0]   _zz_701_;
-  wire       [31:0]   _zz_702_;
-  wire       [31:0]   _zz_703_;
-  wire       [31:0]   _zz_704_;
-  wire       [31:0]   _zz_705_;
-  wire       [31:0]   _zz_706_;
-  wire       [31:0]   _zz_707_;
-  wire       [31:0]   _zz_708_;
-  wire       [31:0]   _zz_709_;
-  wire       [31:0]   _zz_710_;
-  wire       [31:0]   _zz_711_;
-  wire       [31:0]   _zz_712_;
-  wire       [31:0]   _zz_713_;
-  wire       [31:0]   _zz_714_;
-  wire       [31:0]   _zz_715_;
-  wire       [31:0]   _zz_716_;
-  wire       [31:0]   _zz_717_;
-  wire       [31:0]   _zz_718_;
-  wire       [31:0]   _zz_719_;
-  wire       [31:0]   _zz_720_;
-  wire       [31:0]   _zz_721_;
-  wire       [31:0]   _zz_722_;
-  wire       [31:0]   _zz_723_;
-  wire       [31:0]   _zz_724_;
-  wire       [31:0]   _zz_725_;
-  wire       [31:0]   _zz_726_;
-  wire       [31:0]   _zz_727_;
-  wire       [31:0]   _zz_728_;
-  wire       [31:0]   _zz_729_;
-  wire       [31:0]   _zz_730_;
-  wire       [31:0]   _zz_731_;
-  wire       [31:0]   _zz_732_;
-  wire       [31:0]   _zz_733_;
-  wire       [31:0]   _zz_734_;
-  wire       [31:0]   _zz_735_;
-  wire       [31:0]   _zz_736_;
-  wire       [31:0]   _zz_737_;
-  wire       [31:0]   _zz_738_;
-  wire       [31:0]   _zz_739_;
-  wire       [31:0]   _zz_740_;
-  wire       [15:0]   _zz_741_;
-  wire       [15:0]   _zz_742_;
-  wire       [15:0]   _zz_743_;
-  wire       [15:0]   _zz_744_;
-  wire       [15:0]   _zz_745_;
-  wire       [15:0]   _zz_746_;
-  wire       [0:0]    _zz_747_;
-  wire       [2:0]    _zz_748_;
-  wire       [4:0]    _zz_749_;
-  wire       [11:0]   _zz_750_;
-  wire       [11:0]   _zz_751_;
-  wire       [31:0]   _zz_752_;
-  wire       [31:0]   _zz_753_;
-  wire       [31:0]   _zz_754_;
-  wire       [31:0]   _zz_755_;
-  wire       [31:0]   _zz_756_;
-  wire       [31:0]   _zz_757_;
-  wire       [31:0]   _zz_758_;
-  wire       [11:0]   _zz_759_;
-  wire       [19:0]   _zz_760_;
-  wire       [11:0]   _zz_761_;
-  wire       [31:0]   _zz_762_;
-  wire       [31:0]   _zz_763_;
-  wire       [31:0]   _zz_764_;
-  wire       [11:0]   _zz_765_;
-  wire       [19:0]   _zz_766_;
-  wire       [11:0]   _zz_767_;
-  wire       [2:0]    _zz_768_;
-  wire       [1:0]    _zz_769_;
-  wire       [1:0]    _zz_770_;
-  wire       [65:0]   _zz_771_;
-  wire       [65:0]   _zz_772_;
-  wire       [31:0]   _zz_773_;
-  wire       [31:0]   _zz_774_;
-  wire       [0:0]    _zz_775_;
-  wire       [5:0]    _zz_776_;
-  wire       [32:0]   _zz_777_;
-  wire       [31:0]   _zz_778_;
-  wire       [31:0]   _zz_779_;
-  wire       [32:0]   _zz_780_;
-  wire       [32:0]   _zz_781_;
-  wire       [32:0]   _zz_782_;
-  wire       [32:0]   _zz_783_;
-  wire       [0:0]    _zz_784_;
-  wire       [32:0]   _zz_785_;
-  wire       [0:0]    _zz_786_;
-  wire       [32:0]   _zz_787_;
-  wire       [0:0]    _zz_788_;
-  wire       [31:0]   _zz_789_;
-  wire       [0:0]    _zz_790_;
-  wire       [0:0]    _zz_791_;
-  wire       [0:0]    _zz_792_;
-  wire       [0:0]    _zz_793_;
-  wire       [0:0]    _zz_794_;
-  wire       [0:0]    _zz_795_;
-  wire       [0:0]    _zz_796_;
-  wire       [0:0]    _zz_797_;
-  wire       [0:0]    _zz_798_;
-  wire       [0:0]    _zz_799_;
-  wire       [0:0]    _zz_800_;
-  wire       [0:0]    _zz_801_;
-  wire       [0:0]    _zz_802_;
-  wire       [0:0]    _zz_803_;
-  wire       [0:0]    _zz_804_;
-  wire       [0:0]    _zz_805_;
-  wire       [0:0]    _zz_806_;
-  wire       [0:0]    _zz_807_;
-  wire       [0:0]    _zz_808_;
-  wire       [0:0]    _zz_809_;
-  wire       [0:0]    _zz_810_;
-  wire       [0:0]    _zz_811_;
-  wire       [0:0]    _zz_812_;
-  wire       [0:0]    _zz_813_;
-  wire       [0:0]    _zz_814_;
-  wire       [0:0]    _zz_815_;
-  wire       [0:0]    _zz_816_;
-  wire       [0:0]    _zz_817_;
-  wire       [0:0]    _zz_818_;
-  wire       [0:0]    _zz_819_;
-  wire       [0:0]    _zz_820_;
-  wire       [0:0]    _zz_821_;
-  wire       [0:0]    _zz_822_;
-  wire       [0:0]    _zz_823_;
-  wire       [0:0]    _zz_824_;
-  wire       [0:0]    _zz_825_;
-  wire       [0:0]    _zz_826_;
-  wire       [0:0]    _zz_827_;
-  wire       [0:0]    _zz_828_;
-  wire       [0:0]    _zz_829_;
-  wire       [0:0]    _zz_830_;
-  wire       [0:0]    _zz_831_;
-  wire       [0:0]    _zz_832_;
-  wire       [0:0]    _zz_833_;
-  wire       [0:0]    _zz_834_;
-  wire       [0:0]    _zz_835_;
-  wire       [0:0]    _zz_836_;
-  wire       [0:0]    _zz_837_;
-  wire       [0:0]    _zz_838_;
-  wire       [0:0]    _zz_839_;
-  wire       [0:0]    _zz_840_;
-  wire       [0:0]    _zz_841_;
-  wire       [0:0]    _zz_842_;
-  wire       [0:0]    _zz_843_;
-  wire       [0:0]    _zz_844_;
-  wire       [0:0]    _zz_845_;
-  wire       [0:0]    _zz_846_;
-  wire       [0:0]    _zz_847_;
-  wire       [0:0]    _zz_848_;
-  wire       [0:0]    _zz_849_;
-  wire       [0:0]    _zz_850_;
-  wire       [0:0]    _zz_851_;
-  wire       [0:0]    _zz_852_;
-  wire       [0:0]    _zz_853_;
-  wire       [0:0]    _zz_854_;
-  wire       [0:0]    _zz_855_;
-  wire       [0:0]    _zz_856_;
-  wire       [0:0]    _zz_857_;
-  wire       [0:0]    _zz_858_;
-  wire       [0:0]    _zz_859_;
-  wire       [0:0]    _zz_860_;
-  wire       [26:0]   _zz_861_;
-  wire                _zz_862_;
-  wire                _zz_863_;
-  wire       [1:0]    _zz_864_;
-  wire       [3:0]    _zz_865_;
-  wire       [3:0]    _zz_866_;
-  wire       [3:0]    _zz_867_;
-  wire       [3:0]    _zz_868_;
-  wire       [3:0]    _zz_869_;
-  wire       [3:0]    _zz_870_;
-  wire       [31:0]   _zz_871_;
-  wire       [31:0]   _zz_872_;
-  wire       [31:0]   _zz_873_;
-  wire                _zz_874_;
-  wire       [0:0]    _zz_875_;
-  wire       [13:0]   _zz_876_;
-  wire       [31:0]   _zz_877_;
-  wire       [31:0]   _zz_878_;
-  wire       [31:0]   _zz_879_;
-  wire                _zz_880_;
-  wire       [0:0]    _zz_881_;
-  wire       [7:0]    _zz_882_;
-  wire       [31:0]   _zz_883_;
-  wire       [31:0]   _zz_884_;
-  wire       [31:0]   _zz_885_;
-  wire                _zz_886_;
-  wire       [0:0]    _zz_887_;
-  wire       [1:0]    _zz_888_;
-  wire                _zz_889_;
-  wire                _zz_890_;
-  wire                _zz_891_;
-  wire       [0:0]    _zz_892_;
-  wire       [4:0]    _zz_893_;
-  wire       [0:0]    _zz_894_;
-  wire       [4:0]    _zz_895_;
-  wire       [0:0]    _zz_896_;
-  wire       [4:0]    _zz_897_;
-  wire       [0:0]    _zz_898_;
-  wire       [4:0]    _zz_899_;
-  wire       [0:0]    _zz_900_;
-  wire       [4:0]    _zz_901_;
-  wire       [0:0]    _zz_902_;
-  wire       [4:0]    _zz_903_;
-  wire       [31:0]   _zz_904_;
-  wire       [31:0]   _zz_905_;
-  wire                _zz_906_;
-  wire       [0:0]    _zz_907_;
-  wire       [1:0]    _zz_908_;
-  wire                _zz_909_;
-  wire                _zz_910_;
-  wire                _zz_911_;
-  wire       [1:0]    _zz_912_;
-  wire       [1:0]    _zz_913_;
-  wire                _zz_914_;
-  wire       [0:0]    _zz_915_;
-  wire       [26:0]   _zz_916_;
-  wire       [31:0]   _zz_917_;
-  wire       [31:0]   _zz_918_;
-  wire       [31:0]   _zz_919_;
-  wire                _zz_920_;
-  wire                _zz_921_;
-  wire       [31:0]   _zz_922_;
-  wire       [31:0]   _zz_923_;
-  wire       [31:0]   _zz_924_;
-  wire                _zz_925_;
-  wire                _zz_926_;
-  wire       [0:0]    _zz_927_;
-  wire       [0:0]    _zz_928_;
-  wire       [0:0]    _zz_929_;
-  wire       [0:0]    _zz_930_;
-  wire                _zz_931_;
-  wire       [0:0]    _zz_932_;
-  wire       [24:0]   _zz_933_;
-  wire       [31:0]   _zz_934_;
-  wire       [31:0]   _zz_935_;
-  wire       [31:0]   _zz_936_;
-  wire       [31:0]   _zz_937_;
-  wire       [31:0]   _zz_938_;
-  wire       [31:0]   _zz_939_;
-  wire       [31:0]   _zz_940_;
-  wire       [31:0]   _zz_941_;
-  wire       [31:0]   _zz_942_;
-  wire       [31:0]   _zz_943_;
-  wire       [0:0]    _zz_944_;
-  wire       [0:0]    _zz_945_;
-  wire       [1:0]    _zz_946_;
-  wire       [1:0]    _zz_947_;
-  wire                _zz_948_;
-  wire       [0:0]    _zz_949_;
-  wire       [22:0]   _zz_950_;
-  wire       [31:0]   _zz_951_;
-  wire       [31:0]   _zz_952_;
-  wire       [31:0]   _zz_953_;
-  wire       [31:0]   _zz_954_;
-  wire       [31:0]   _zz_955_;
-  wire                _zz_956_;
-  wire       [0:0]    _zz_957_;
-  wire       [0:0]    _zz_958_;
-  wire                _zz_959_;
-  wire       [0:0]    _zz_960_;
-  wire       [19:0]   _zz_961_;
-  wire       [31:0]   _zz_962_;
-  wire       [31:0]   _zz_963_;
-  wire                _zz_964_;
-  wire       [0:0]    _zz_965_;
-  wire       [0:0]    _zz_966_;
-  wire       [31:0]   _zz_967_;
-  wire       [31:0]   _zz_968_;
-  wire       [0:0]    _zz_969_;
-  wire       [4:0]    _zz_970_;
-  wire       [0:0]    _zz_971_;
-  wire       [0:0]    _zz_972_;
-  wire                _zz_973_;
-  wire       [0:0]    _zz_974_;
-  wire       [15:0]   _zz_975_;
-  wire       [31:0]   _zz_976_;
-  wire       [31:0]   _zz_977_;
-  wire       [31:0]   _zz_978_;
-  wire       [31:0]   _zz_979_;
-  wire       [31:0]   _zz_980_;
-  wire                _zz_981_;
-  wire       [0:0]    _zz_982_;
-  wire       [2:0]    _zz_983_;
-  wire       [31:0]   _zz_984_;
-  wire       [31:0]   _zz_985_;
-  wire       [0:0]    _zz_986_;
-  wire       [0:0]    _zz_987_;
-  wire       [0:0]    _zz_988_;
-  wire       [0:0]    _zz_989_;
-  wire                _zz_990_;
-  wire       [0:0]    _zz_991_;
-  wire       [13:0]   _zz_992_;
-  wire       [31:0]   _zz_993_;
-  wire       [31:0]   _zz_994_;
-  wire       [31:0]   _zz_995_;
-  wire                _zz_996_;
-  wire       [0:0]    _zz_997_;
-  wire       [0:0]    _zz_998_;
-  wire       [31:0]   _zz_999_;
-  wire       [31:0]   _zz_1000_;
-  wire       [31:0]   _zz_1001_;
-  wire       [31:0]   _zz_1002_;
-  wire       [1:0]    _zz_1003_;
-  wire       [1:0]    _zz_1004_;
-  wire                _zz_1005_;
-  wire       [0:0]    _zz_1006_;
-  wire       [11:0]   _zz_1007_;
-  wire       [31:0]   _zz_1008_;
-  wire       [31:0]   _zz_1009_;
-  wire       [31:0]   _zz_1010_;
-  wire       [31:0]   _zz_1011_;
-  wire       [31:0]   _zz_1012_;
-  wire       [31:0]   _zz_1013_;
-  wire                _zz_1014_;
-  wire       [0:0]    _zz_1015_;
-  wire       [0:0]    _zz_1016_;
-  wire                _zz_1017_;
-  wire       [0:0]    _zz_1018_;
-  wire       [0:0]    _zz_1019_;
-  wire                _zz_1020_;
-  wire       [0:0]    _zz_1021_;
-  wire       [8:0]    _zz_1022_;
-  wire       [31:0]   _zz_1023_;
-  wire       [31:0]   _zz_1024_;
-  wire       [31:0]   _zz_1025_;
-  wire                _zz_1026_;
-  wire       [0:0]    _zz_1027_;
-  wire       [0:0]    _zz_1028_;
-  wire                _zz_1029_;
-  wire       [0:0]    _zz_1030_;
-  wire       [0:0]    _zz_1031_;
-  wire                _zz_1032_;
-  wire       [0:0]    _zz_1033_;
-  wire       [5:0]    _zz_1034_;
-  wire       [31:0]   _zz_1035_;
-  wire       [31:0]   _zz_1036_;
-  wire       [31:0]   _zz_1037_;
-  wire       [31:0]   _zz_1038_;
-  wire       [31:0]   _zz_1039_;
-  wire                _zz_1040_;
-  wire       [4:0]    _zz_1041_;
-  wire       [4:0]    _zz_1042_;
-  wire                _zz_1043_;
-  wire       [0:0]    _zz_1044_;
-  wire       [2:0]    _zz_1045_;
-  wire                _zz_1046_;
-  wire       [0:0]    _zz_1047_;
-  wire       [1:0]    _zz_1048_;
-  wire                _zz_1049_;
-  wire       [0:0]    _zz_1050_;
-  wire       [0:0]    _zz_1051_;
-  wire       [4:0]    _zz_1052_;
-  wire       [4:0]    _zz_1053_;
-  wire                _zz_1054_;
-  wire                _zz_1055_;
-  wire       [31:0]   _zz_1056_;
-  wire       [31:0]   _zz_1057_;
-  wire       [31:0]   _zz_1058_;
-  wire       [31:0]   _zz_1059_;
-  wire       [31:0]   _zz_1060_;
-  wire       [31:0]   _zz_1061_;
-  wire       [31:0]   _zz_1062_;
-  wire       [31:0]   _zz_1063_;
-  wire       [0:0]    _zz_1064_;
-  wire       [1:0]    _zz_1065_;
-  wire                _zz_1066_;
-  wire       [31:0]   _zz_1067_;
-  wire       [31:0]   _zz_1068_;
-  wire                _zz_1069_;
-  wire                _zz_1070_;
-  wire                _zz_1071_;
-  wire       [31:0]   _zz_1072_;
-  wire       [31:0]   _zz_1073_;
-  wire       [31:0]   _zz_1074_;
-  wire       [31:0]   _zz_1075_;
-  wire       [31:0]   _zz_1076_;
-  wire       [31:0]   _zz_1077_;
-  wire       [31:0]   _zz_1078_;
-  wire       [31:0]   _zz_1079_;
-  wire       [31:0]   _zz_1080_;
-  wire       [31:0]   _zz_1081_;
-  wire       [31:0]   _zz_1082_;
-  wire       [31:0]   _zz_1083_;
-  wire       [31:0]   _zz_1084_;
-  wire       [31:0]   _zz_1085_;
-  wire       [31:0]   _zz_1086_;
-  wire       [31:0]   _zz_1087_;
-  wire       [31:0]   _zz_1088_;
-  wire                execute_BYPASSABLE_MEMORY_STAGE;
-  wire                decode_BYPASSABLE_MEMORY_STAGE;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_1_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_2_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_3_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_4_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_5_;
-  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_6_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_7_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_8_;
-  wire                decode_IS_RS1_SIGNED;
+  wire                dataCache_1_io_cpu_execute_haltIt;
+  wire                dataCache_1_io_cpu_execute_refilling;
+  wire                dataCache_1_io_cpu_memory_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_haltIt;
+  wire       [31:0]   dataCache_1_io_cpu_writeBack_data;
+  wire                dataCache_1_io_cpu_writeBack_mmuException;
+  wire                dataCache_1_io_cpu_writeBack_unalignedAccess;
+  wire                dataCache_1_io_cpu_writeBack_accessError;
+  wire                dataCache_1_io_cpu_writeBack_isWrite;
+  wire                dataCache_1_io_cpu_writeBack_keepMemRspData;
+  wire                dataCache_1_io_cpu_flush_ready;
+  wire                dataCache_1_io_cpu_redo;
+  wire                dataCache_1_io_mem_cmd_valid;
+  wire                dataCache_1_io_mem_cmd_payload_wr;
+  wire                dataCache_1_io_mem_cmd_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_payload_length;
+  wire                dataCache_1_io_mem_cmd_payload_last;
+  wire                _zz_674;
+  wire                _zz_675;
+  wire                _zz_676;
+  wire                _zz_677;
+  wire                _zz_678;
+  wire                _zz_679;
+  wire                _zz_680;
+  wire                _zz_681;
+  wire                _zz_682;
+  wire                _zz_683;
+  wire                _zz_684;
+  wire                _zz_685;
+  wire                _zz_686;
+  wire                _zz_687;
+  wire                _zz_688;
+  wire                _zz_689;
+  wire                _zz_690;
+  wire       [1:0]    _zz_691;
+  wire                _zz_692;
+  wire                _zz_693;
+  wire                _zz_694;
+  wire                _zz_695;
+  wire                _zz_696;
+  wire                _zz_697;
+  wire                _zz_698;
+  wire                _zz_699;
+  wire                _zz_700;
+  wire                _zz_701;
+  wire                _zz_702;
+  wire                _zz_703;
+  wire       [1:0]    _zz_704;
+  wire                _zz_705;
+  wire                _zz_706;
+  wire       [5:0]    _zz_707;
+  wire                _zz_708;
+  wire                _zz_709;
+  wire                _zz_710;
+  wire                _zz_711;
+  wire                _zz_712;
+  wire                _zz_713;
+  wire                _zz_714;
+  wire                _zz_715;
+  wire                _zz_716;
+  wire                _zz_717;
+  wire                _zz_718;
+  wire                _zz_719;
+  wire                _zz_720;
+  wire                _zz_721;
+  wire                _zz_722;
+  wire                _zz_723;
+  wire                _zz_724;
+  wire                _zz_725;
+  wire                _zz_726;
+  wire                _zz_727;
+  wire                _zz_728;
+  wire                _zz_729;
+  wire       [1:0]    _zz_730;
+  wire                _zz_731;
+  wire       [1:0]    _zz_732;
+  wire       [51:0]   _zz_733;
+  wire       [51:0]   _zz_734;
+  wire       [51:0]   _zz_735;
+  wire       [32:0]   _zz_736;
+  wire       [51:0]   _zz_737;
+  wire       [49:0]   _zz_738;
+  wire       [51:0]   _zz_739;
+  wire       [49:0]   _zz_740;
+  wire       [51:0]   _zz_741;
+  wire       [32:0]   _zz_742;
+  wire       [31:0]   _zz_743;
+  wire       [32:0]   _zz_744;
+  wire       [0:0]    _zz_745;
+  wire       [0:0]    _zz_746;
+  wire       [0:0]    _zz_747;
+  wire       [0:0]    _zz_748;
+  wire       [0:0]    _zz_749;
+  wire       [0:0]    _zz_750;
+  wire       [0:0]    _zz_751;
+  wire       [0:0]    _zz_752;
+  wire       [0:0]    _zz_753;
+  wire       [0:0]    _zz_754;
+  wire       [0:0]    _zz_755;
+  wire       [0:0]    _zz_756;
+  wire       [0:0]    _zz_757;
+  wire       [0:0]    _zz_758;
+  wire       [0:0]    _zz_759;
+  wire       [0:0]    _zz_760;
+  wire       [0:0]    _zz_761;
+  wire       [0:0]    _zz_762;
+  wire       [3:0]    _zz_763;
+  wire       [2:0]    _zz_764;
+  wire       [31:0]   _zz_765;
+  wire       [11:0]   _zz_766;
+  wire       [31:0]   _zz_767;
+  wire       [19:0]   _zz_768;
+  wire       [11:0]   _zz_769;
+  wire       [31:0]   _zz_770;
+  wire       [31:0]   _zz_771;
+  wire       [19:0]   _zz_772;
+  wire       [11:0]   _zz_773;
+  wire       [2:0]    _zz_774;
+  wire       [2:0]    _zz_775;
+  wire       [31:0]   _zz_776;
+  wire       [31:0]   _zz_777;
+  wire       [31:0]   _zz_778;
+  wire       [31:0]   _zz_779;
+  wire       [31:0]   _zz_780;
+  wire       [31:0]   _zz_781;
+  wire       [31:0]   _zz_782;
+  wire       [31:0]   _zz_783;
+  wire       [31:0]   _zz_784;
+  wire       [31:0]   _zz_785;
+  wire       [31:0]   _zz_786;
+  wire       [31:0]   _zz_787;
+  wire       [31:0]   _zz_788;
+  wire       [31:0]   _zz_789;
+  wire       [31:0]   _zz_790;
+  wire       [31:0]   _zz_791;
+  wire       [31:0]   _zz_792;
+  wire       [31:0]   _zz_793;
+  wire       [31:0]   _zz_794;
+  wire       [31:0]   _zz_795;
+  wire       [31:0]   _zz_796;
+  wire       [31:0]   _zz_797;
+  wire       [31:0]   _zz_798;
+  wire       [31:0]   _zz_799;
+  wire       [31:0]   _zz_800;
+  wire       [31:0]   _zz_801;
+  wire       [31:0]   _zz_802;
+  wire       [31:0]   _zz_803;
+  wire       [31:0]   _zz_804;
+  wire       [31:0]   _zz_805;
+  wire       [31:0]   _zz_806;
+  wire       [31:0]   _zz_807;
+  wire       [31:0]   _zz_808;
+  wire       [31:0]   _zz_809;
+  wire       [31:0]   _zz_810;
+  wire       [31:0]   _zz_811;
+  wire       [31:0]   _zz_812;
+  wire       [31:0]   _zz_813;
+  wire       [31:0]   _zz_814;
+  wire       [31:0]   _zz_815;
+  wire       [31:0]   _zz_816;
+  wire       [31:0]   _zz_817;
+  wire       [31:0]   _zz_818;
+  wire       [31:0]   _zz_819;
+  wire       [31:0]   _zz_820;
+  wire       [31:0]   _zz_821;
+  wire       [31:0]   _zz_822;
+  wire       [31:0]   _zz_823;
+  wire       [4:0]    _zz_824;
+  wire       [4:0]    _zz_825;
+  wire       [4:0]    _zz_826;
+  wire       [4:0]    _zz_827;
+  wire       [4:0]    _zz_828;
+  wire       [0:0]    _zz_829;
+  wire       [2:0]    _zz_830;
+  wire       [15:0]   _zz_831;
+  wire       [15:0]   _zz_832;
+  wire       [15:0]   _zz_833;
+  wire       [4:0]    _zz_834;
+  wire       [4:0]    _zz_835;
+  wire       [4:0]    _zz_836;
+  wire       [4:0]    _zz_837;
+  wire       [4:0]    _zz_838;
+  wire       [0:0]    _zz_839;
+  wire       [2:0]    _zz_840;
+  wire       [15:0]   _zz_841;
+  wire       [15:0]   _zz_842;
+  wire       [15:0]   _zz_843;
+  wire       [0:0]    _zz_844;
+  wire       [2:0]    _zz_845;
+  wire       [4:0]    _zz_846;
+  wire       [11:0]   _zz_847;
+  wire       [11:0]   _zz_848;
+  wire       [31:0]   _zz_849;
+  wire       [31:0]   _zz_850;
+  wire       [31:0]   _zz_851;
+  wire       [31:0]   _zz_852;
+  wire       [31:0]   _zz_853;
+  wire       [31:0]   _zz_854;
+  wire       [31:0]   _zz_855;
+  wire       [11:0]   _zz_856;
+  wire       [19:0]   _zz_857;
+  wire       [11:0]   _zz_858;
+  wire       [31:0]   _zz_859;
+  wire       [31:0]   _zz_860;
+  wire       [31:0]   _zz_861;
+  wire       [11:0]   _zz_862;
+  wire       [19:0]   _zz_863;
+  wire       [11:0]   _zz_864;
+  wire       [2:0]    _zz_865;
+  wire       [1:0]    _zz_866;
+  wire       [1:0]    _zz_867;
+  wire       [65:0]   _zz_868;
+  wire       [65:0]   _zz_869;
+  wire       [31:0]   _zz_870;
+  wire       [31:0]   _zz_871;
+  wire       [0:0]    _zz_872;
+  wire       [5:0]    _zz_873;
+  wire       [32:0]   _zz_874;
+  wire       [31:0]   _zz_875;
+  wire       [31:0]   _zz_876;
+  wire       [32:0]   _zz_877;
+  wire       [32:0]   _zz_878;
+  wire       [32:0]   _zz_879;
+  wire       [32:0]   _zz_880;
+  wire       [0:0]    _zz_881;
+  wire       [32:0]   _zz_882;
+  wire       [0:0]    _zz_883;
+  wire       [32:0]   _zz_884;
+  wire       [0:0]    _zz_885;
+  wire       [31:0]   _zz_886;
+  wire       [0:0]    _zz_887;
+  wire       [0:0]    _zz_888;
+  wire       [0:0]    _zz_889;
+  wire       [0:0]    _zz_890;
+  wire       [0:0]    _zz_891;
+  wire       [0:0]    _zz_892;
+  wire       [0:0]    _zz_893;
+  wire       [0:0]    _zz_894;
+  wire       [0:0]    _zz_895;
+  wire       [0:0]    _zz_896;
+  wire       [0:0]    _zz_897;
+  wire       [0:0]    _zz_898;
+  wire       [0:0]    _zz_899;
+  wire       [0:0]    _zz_900;
+  wire       [0:0]    _zz_901;
+  wire       [0:0]    _zz_902;
+  wire       [0:0]    _zz_903;
+  wire       [0:0]    _zz_904;
+  wire       [0:0]    _zz_905;
+  wire       [0:0]    _zz_906;
+  wire       [0:0]    _zz_907;
+  wire       [0:0]    _zz_908;
+  wire       [0:0]    _zz_909;
+  wire       [0:0]    _zz_910;
+  wire       [0:0]    _zz_911;
+  wire       [0:0]    _zz_912;
+  wire       [0:0]    _zz_913;
+  wire       [0:0]    _zz_914;
+  wire       [0:0]    _zz_915;
+  wire       [0:0]    _zz_916;
+  wire       [0:0]    _zz_917;
+  wire       [0:0]    _zz_918;
+  wire       [0:0]    _zz_919;
+  wire       [0:0]    _zz_920;
+  wire       [0:0]    _zz_921;
+  wire       [0:0]    _zz_922;
+  wire       [0:0]    _zz_923;
+  wire       [0:0]    _zz_924;
+  wire       [0:0]    _zz_925;
+  wire       [0:0]    _zz_926;
+  wire       [0:0]    _zz_927;
+  wire       [0:0]    _zz_928;
+  wire       [0:0]    _zz_929;
+  wire       [0:0]    _zz_930;
+  wire       [0:0]    _zz_931;
+  wire       [0:0]    _zz_932;
+  wire       [0:0]    _zz_933;
+  wire       [0:0]    _zz_934;
+  wire       [0:0]    _zz_935;
+  wire       [0:0]    _zz_936;
+  wire       [0:0]    _zz_937;
+  wire       [0:0]    _zz_938;
+  wire       [0:0]    _zz_939;
+  wire       [0:0]    _zz_940;
+  wire       [0:0]    _zz_941;
+  wire       [0:0]    _zz_942;
+  wire       [0:0]    _zz_943;
+  wire       [0:0]    _zz_944;
+  wire       [0:0]    _zz_945;
+  wire       [0:0]    _zz_946;
+  wire       [0:0]    _zz_947;
+  wire       [0:0]    _zz_948;
+  wire       [0:0]    _zz_949;
+  wire       [0:0]    _zz_950;
+  wire       [0:0]    _zz_951;
+  wire       [0:0]    _zz_952;
+  wire       [0:0]    _zz_953;
+  wire       [0:0]    _zz_954;
+  wire       [0:0]    _zz_955;
+  wire       [0:0]    _zz_956;
+  wire       [0:0]    _zz_957;
+  wire       [26:0]   _zz_958;
+  wire                _zz_959;
+  wire                _zz_960;
+  wire       [1:0]    _zz_961;
+  wire       [2:0]    _zz_962;
+  wire       [2:0]    _zz_963;
+  wire       [2:0]    _zz_964;
+  wire       [2:0]    _zz_965;
+  wire       [2:0]    _zz_966;
+  wire       [3:0]    _zz_967;
+  wire       [3:0]    _zz_968;
+  wire       [3:0]    _zz_969;
+  wire       [2:0]    _zz_970;
+  wire       [2:0]    _zz_971;
+  wire       [2:0]    _zz_972;
+  wire       [2:0]    _zz_973;
+  wire       [2:0]    _zz_974;
+  wire       [3:0]    _zz_975;
+  wire       [3:0]    _zz_976;
+  wire       [3:0]    _zz_977;
+  wire       [31:0]   _zz_978;
+  wire       [31:0]   _zz_979;
+  wire       [31:0]   _zz_980;
+  wire                _zz_981;
+  wire       [0:0]    _zz_982;
+  wire       [13:0]   _zz_983;
+  wire       [31:0]   _zz_984;
+  wire       [31:0]   _zz_985;
+  wire       [31:0]   _zz_986;
+  wire                _zz_987;
+  wire       [0:0]    _zz_988;
+  wire       [7:0]    _zz_989;
+  wire       [31:0]   _zz_990;
+  wire       [31:0]   _zz_991;
+  wire       [31:0]   _zz_992;
+  wire                _zz_993;
+  wire       [0:0]    _zz_994;
+  wire       [1:0]    _zz_995;
+  wire                _zz_996;
+  wire                _zz_997;
+  wire                _zz_998;
+  wire       [0:0]    _zz_999;
+  wire       [4:0]    _zz_1000;
+  wire       [0:0]    _zz_1001;
+  wire       [4:0]    _zz_1002;
+  wire       [0:0]    _zz_1003;
+  wire       [4:0]    _zz_1004;
+  wire       [0:0]    _zz_1005;
+  wire       [4:0]    _zz_1006;
+  wire       [0:0]    _zz_1007;
+  wire       [4:0]    _zz_1008;
+  wire       [0:0]    _zz_1009;
+  wire       [4:0]    _zz_1010;
+  wire       [31:0]   _zz_1011;
+  wire       [0:0]    _zz_1012;
+  wire       [0:0]    _zz_1013;
+  wire                _zz_1014;
+  wire       [0:0]    _zz_1015;
+  wire       [26:0]   _zz_1016;
+  wire       [31:0]   _zz_1017;
+  wire                _zz_1018;
+  wire                _zz_1019;
+  wire                _zz_1020;
+  wire       [1:0]    _zz_1021;
+  wire       [1:0]    _zz_1022;
+  wire                _zz_1023;
+  wire       [0:0]    _zz_1024;
+  wire       [22:0]   _zz_1025;
+  wire       [31:0]   _zz_1026;
+  wire       [31:0]   _zz_1027;
+  wire       [31:0]   _zz_1028;
+  wire       [31:0]   _zz_1029;
+  wire                _zz_1030;
+  wire                _zz_1031;
+  wire       [1:0]    _zz_1032;
+  wire       [1:0]    _zz_1033;
+  wire                _zz_1034;
+  wire       [0:0]    _zz_1035;
+  wire       [19:0]   _zz_1036;
+  wire       [31:0]   _zz_1037;
+  wire       [31:0]   _zz_1038;
+  wire       [31:0]   _zz_1039;
+  wire       [31:0]   _zz_1040;
+  wire                _zz_1041;
+  wire       [0:0]    _zz_1042;
+  wire       [0:0]    _zz_1043;
+  wire                _zz_1044;
+  wire       [0:0]    _zz_1045;
+  wire       [0:0]    _zz_1046;
+  wire                _zz_1047;
+  wire       [0:0]    _zz_1048;
+  wire       [16:0]   _zz_1049;
+  wire       [31:0]   _zz_1050;
+  wire       [31:0]   _zz_1051;
+  wire       [31:0]   _zz_1052;
+  wire       [31:0]   _zz_1053;
+  wire       [31:0]   _zz_1054;
+  wire       [0:0]    _zz_1055;
+  wire       [0:0]    _zz_1056;
+  wire       [0:0]    _zz_1057;
+  wire       [0:0]    _zz_1058;
+  wire                _zz_1059;
+  wire       [0:0]    _zz_1060;
+  wire       [13:0]   _zz_1061;
+  wire       [31:0]   _zz_1062;
+  wire       [31:0]   _zz_1063;
+  wire       [31:0]   _zz_1064;
+  wire                _zz_1065;
+  wire                _zz_1066;
+  wire       [0:0]    _zz_1067;
+  wire       [3:0]    _zz_1068;
+  wire       [0:0]    _zz_1069;
+  wire       [0:0]    _zz_1070;
+  wire                _zz_1071;
+  wire       [0:0]    _zz_1072;
+  wire       [10:0]   _zz_1073;
+  wire       [31:0]   _zz_1074;
+  wire       [31:0]   _zz_1075;
+  wire       [31:0]   _zz_1076;
+  wire                _zz_1077;
+  wire       [0:0]    _zz_1078;
+  wire       [0:0]    _zz_1079;
+  wire       [31:0]   _zz_1080;
+  wire                _zz_1081;
+  wire       [0:0]    _zz_1082;
+  wire       [2:0]    _zz_1083;
+  wire       [0:0]    _zz_1084;
+  wire       [3:0]    _zz_1085;
+  wire       [5:0]    _zz_1086;
+  wire       [5:0]    _zz_1087;
+  wire                _zz_1088;
+  wire       [0:0]    _zz_1089;
+  wire       [7:0]    _zz_1090;
+  wire       [31:0]   _zz_1091;
+  wire       [31:0]   _zz_1092;
+  wire       [31:0]   _zz_1093;
+  wire       [31:0]   _zz_1094;
+  wire       [31:0]   _zz_1095;
+  wire       [31:0]   _zz_1096;
+  wire                _zz_1097;
+  wire       [0:0]    _zz_1098;
+  wire       [0:0]    _zz_1099;
+  wire                _zz_1100;
+  wire       [0:0]    _zz_1101;
+  wire       [1:0]    _zz_1102;
+  wire       [0:0]    _zz_1103;
+  wire       [3:0]    _zz_1104;
+  wire       [0:0]    _zz_1105;
+  wire       [0:0]    _zz_1106;
+  wire       [1:0]    _zz_1107;
+  wire       [1:0]    _zz_1108;
+  wire                _zz_1109;
+  wire       [0:0]    _zz_1110;
+  wire       [5:0]    _zz_1111;
+  wire       [31:0]   _zz_1112;
+  wire       [31:0]   _zz_1113;
+  wire       [31:0]   _zz_1114;
+  wire       [31:0]   _zz_1115;
+  wire       [31:0]   _zz_1116;
+  wire       [31:0]   _zz_1117;
+  wire       [31:0]   _zz_1118;
+  wire       [31:0]   _zz_1119;
+  wire                _zz_1120;
+  wire                _zz_1121;
+  wire       [31:0]   _zz_1122;
+  wire       [31:0]   _zz_1123;
+  wire                _zz_1124;
+  wire       [0:0]    _zz_1125;
+  wire       [1:0]    _zz_1126;
+  wire       [31:0]   _zz_1127;
+  wire       [31:0]   _zz_1128;
+  wire                _zz_1129;
+  wire                _zz_1130;
+  wire       [0:0]    _zz_1131;
+  wire       [0:0]    _zz_1132;
+  wire                _zz_1133;
+  wire       [0:0]    _zz_1134;
+  wire       [3:0]    _zz_1135;
+  wire       [31:0]   _zz_1136;
+  wire       [31:0]   _zz_1137;
+  wire       [31:0]   _zz_1138;
+  wire       [31:0]   _zz_1139;
+  wire       [31:0]   _zz_1140;
+  wire                _zz_1141;
+  wire                _zz_1142;
+  wire       [31:0]   _zz_1143;
+  wire       [31:0]   _zz_1144;
+  wire       [31:0]   _zz_1145;
+  wire       [31:0]   _zz_1146;
+  wire       [0:0]    _zz_1147;
+  wire       [2:0]    _zz_1148;
+  wire       [0:0]    _zz_1149;
+  wire       [0:0]    _zz_1150;
+  wire                _zz_1151;
+  wire       [0:0]    _zz_1152;
+  wire       [1:0]    _zz_1153;
+  wire       [31:0]   _zz_1154;
+  wire       [31:0]   _zz_1155;
+  wire       [31:0]   _zz_1156;
+  wire                _zz_1157;
+  wire                _zz_1158;
+  wire       [31:0]   _zz_1159;
+  wire                _zz_1160;
+  wire       [0:0]    _zz_1161;
+  wire       [0:0]    _zz_1162;
+  wire       [0:0]    _zz_1163;
+  wire       [0:0]    _zz_1164;
+  wire       [1:0]    _zz_1165;
+  wire       [1:0]    _zz_1166;
+  wire       [0:0]    _zz_1167;
+  wire       [0:0]    _zz_1168;
+  wire       [31:0]   _zz_1169;
+  wire       [31:0]   _zz_1170;
+  wire       [31:0]   _zz_1171;
+  wire       [31:0]   _zz_1172;
+  wire       [31:0]   _zz_1173;
+  wire       [31:0]   _zz_1174;
+  wire                _zz_1175;
+  wire                _zz_1176;
+  wire                _zz_1177;
+  wire       [31:0]   _zz_1178;
+  wire       [31:0]   _zz_1179;
+  wire       [31:0]   _zz_1180;
+  wire       [31:0]   _zz_1181;
+  wire       [31:0]   _zz_1182;
+  wire       [31:0]   _zz_1183;
+  wire       [31:0]   _zz_1184;
+  wire       [31:0]   _zz_1185;
+  wire       [31:0]   _zz_1186;
+  wire       [31:0]   _zz_1187;
+  wire       [31:0]   _zz_1188;
+  wire       [31:0]   _zz_1189;
+  wire       [31:0]   _zz_1190;
+  wire       [31:0]   _zz_1191;
+  wire       [31:0]   _zz_1192;
+  wire       [31:0]   _zz_1193;
+  wire       [31:0]   _zz_1194;
   wire       [51:0]   memory_MUL_LOW;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_9_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_10_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_11_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_12_;
+  wire       [33:0]   memory_MUL_HH;
+  wire       [33:0]   execute_MUL_HH;
+  wire       [33:0]   execute_MUL_HL;
+  wire       [33:0]   execute_MUL_LH;
+  wire       [31:0]   execute_MUL_LL;
+  wire       [31:0]   execute_BRANCH_CALC;
+  wire                execute_BRANCH_DO;
+  wire       [31:0]   execute_SHIFT_RIGHT;
+  wire       [31:0]   execute_REGFILE_WRITE_DATA;
+  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
+  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
+  wire                decode_DO_EBREAK;
+  wire                decode_CSR_READ_OPCODE;
+  wire                decode_CSR_WRITE_OPCODE;
+  wire                decode_PREDICTION_HAD_BRANCHED2;
+  wire                decode_SRC2_FORCE_ZERO;
+  wire                decode_IS_RS2_SIGNED;
+  wire                decode_IS_RS1_SIGNED;
+  wire                decode_IS_DIV;
+  wire                memory_IS_MUL;
+  wire                execute_IS_MUL;
+  wire                decode_IS_MUL;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_1;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_2;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_3;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_4;
   wire       `EnvCtrlEnum_defaultEncoding_type decode_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_13_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_14_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_15_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_5;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_6;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_7;
+  wire                decode_IS_CSR;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_8;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_9;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_10;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_11;
+  wire       `ShiftCtrlEnum_defaultEncoding_type decode_SHIFT_CTRL;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_12;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_13;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_14;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_15;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_16;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_17;
   wire                decode_SRC_LESS_UNSIGNED;
+  wire                decode_MEMORY_MANAGMENT;
   wire                memory_MEMORY_WR;
   wire                decode_MEMORY_WR;
-  wire                decode_IS_CSR;
-  wire       [33:0]   execute_MUL_HL;
-  wire       [31:0]   execute_MUL_LL;
+  wire                execute_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_MEMORY_STAGE;
+  wire                decode_BYPASSABLE_EXECUTE_STAGE;
+  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_18;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_19;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_20;
   wire       `AluCtrlEnum_defaultEncoding_type decode_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_16_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_17_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_18_;
-  wire                decode_MEMORY_MANAGMENT;
-  wire                execute_BRANCH_DO;
-  wire                decode_IS_RS2_SIGNED;
-  wire                decode_IS_DIV;
-  wire                decode_SRC2_FORCE_ZERO;
-  wire       [31:0]   memory_PC;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type decode_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_19_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_20_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_21_;
-  wire                decode_CSR_WRITE_OPCODE;
-  wire                decode_DO_EBREAK;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_21;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_22;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_23;
+  wire       `Src1CtrlEnum_defaultEncoding_type decode_SRC1_CTRL;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_24;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_25;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_26;
+  wire                decode_MEMORY_FORCE_CONSTISTENCY;
   wire       [31:0]   writeBack_FORMAL_PC_NEXT;
   wire       [31:0]   memory_FORMAL_PC_NEXT;
   wire       [31:0]   execute_FORMAL_PC_NEXT;
   wire       [31:0]   decode_FORMAL_PC_NEXT;
-  wire       [31:0]   execute_SHIFT_RIGHT;
-  wire       [1:0]    memory_MEMORY_ADDRESS_LOW;
-  wire       [1:0]    execute_MEMORY_ADDRESS_LOW;
-  wire       [31:0]   execute_REGFILE_WRITE_DATA;
-  wire                decode_BYPASSABLE_EXECUTE_STAGE;
-  wire       [31:0]   execute_BRANCH_CALC;
-  wire       [33:0]   execute_MUL_LH;
-  wire       [33:0]   memory_MUL_HH;
-  wire       [33:0]   execute_MUL_HH;
-  wire                decode_PREDICTION_HAD_BRANCHED2;
-  wire       `Src2CtrlEnum_defaultEncoding_type decode_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_22_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_23_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_24_;
-  wire                decode_CSR_READ_OPCODE;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_25_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_26_;
-  wire                memory_IS_MUL;
-  wire                execute_IS_MUL;
-  wire                decode_IS_MUL;
+  wire       [31:0]   memory_PC;
   wire                execute_DO_EBREAK;
   wire                decode_IS_EBREAK;
   wire                execute_IS_RS1_SIGNED;
@@ -1740,22 +769,22 @@ module VexRiscv (
   wire                execute_CSR_WRITE_OPCODE;
   wire                execute_IS_CSR;
   wire       `EnvCtrlEnum_defaultEncoding_type memory_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_27;
   wire       `EnvCtrlEnum_defaultEncoding_type execute_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_28;
   wire       `EnvCtrlEnum_defaultEncoding_type writeBack_ENV_CTRL;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_29;
   wire       [31:0]   memory_BRANCH_CALC;
   wire                memory_BRANCH_DO;
   wire       [31:0]   execute_PC;
   wire                execute_PREDICTION_HAD_BRANCHED2;
-  (* syn_keep , keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS1 /* synthesis syn_keep = 1 */ ;
   wire                execute_BRANCH_COND_RESULT;
   wire       `BranchCtrlEnum_defaultEncoding_type execute_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_30;
   wire                decode_RS2_USE;
   wire                decode_RS1_USE;
-  reg        [31:0]   _zz_31_;
+  reg        [31:0]   _zz_31;
   wire                execute_REGFILE_WRITE_VALID;
   wire                execute_BYPASSABLE_EXECUTE_STAGE;
   wire                memory_REGFILE_WRITE_VALID;
@@ -1765,98 +794,67 @@ module VexRiscv (
   reg        [31:0]   decode_RS2;
   reg        [31:0]   decode_RS1;
   wire       [31:0]   memory_SHIFT_RIGHT;
-  reg        [31:0]   _zz_32_;
+  reg        [31:0]   _zz_32;
   wire       `ShiftCtrlEnum_defaultEncoding_type memory_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_33;
   wire       `ShiftCtrlEnum_defaultEncoding_type execute_SHIFT_CTRL;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34_;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_34;
   wire                execute_SRC_LESS_UNSIGNED;
   wire                execute_SRC2_FORCE_ZERO;
   wire                execute_SRC_USE_SUB_LESS;
-  wire       [31:0]   _zz_35_;
+  wire       [31:0]   _zz_35;
   wire       `Src2CtrlEnum_defaultEncoding_type execute_SRC2_CTRL;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36_;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_36;
   wire       `Src1CtrlEnum_defaultEncoding_type execute_SRC1_CTRL;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37_;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_37;
   wire                decode_SRC_USE_SUB_LESS;
   wire                decode_SRC_ADD_ZERO;
   wire       [31:0]   execute_SRC_ADD_SUB;
   wire                execute_SRC_LESS;
   wire       `AluCtrlEnum_defaultEncoding_type execute_ALU_CTRL;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_38_;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_38;
   wire       [31:0]   execute_SRC2;
   wire       [31:0]   execute_SRC1;
   wire       `AluBitwiseCtrlEnum_defaultEncoding_type execute_ALU_BITWISE_CTRL;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39_;
-  wire       [31:0]   _zz_40_;
-  wire                _zz_41_;
-  reg                 _zz_42_;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_39;
+  wire       [31:0]   _zz_40;
+  wire                _zz_41;
+  reg                 _zz_42;
   wire       [31:0]   decode_INSTRUCTION_ANTICIPATED;
   reg                 decode_REGFILE_WRITE_VALID;
   wire                decode_LEGAL_INSTRUCTION;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_44_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_45_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_46_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_47_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_48_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_49_;
-  reg        [4:0]    _zz_50_;
-  reg        [4:0]    _zz_50__14;
-  reg        [4:0]    _zz_50__13;
-  reg        [4:0]    _zz_50__12;
-  reg        [4:0]    _zz_50__11;
-  reg        [4:0]    _zz_50__10;
-  reg        [4:0]    _zz_50__9;
-  reg        [4:0]    _zz_50__8;
-  reg        [4:0]    _zz_50__7;
-  reg        [4:0]    _zz_50__6;
-  reg        [4:0]    _zz_50__5;
-  reg        [4:0]    _zz_50__4;
-  reg        [4:0]    _zz_50__3;
-  reg        [4:0]    _zz_50__2;
-  reg        [4:0]    _zz_50__1;
-  reg        [4:0]    _zz_50__0;
-  reg        [4:0]    _zz_51_;
-  reg        [4:0]    _zz_51__14;
-  reg        [4:0]    _zz_51__13;
-  reg        [4:0]    _zz_51__12;
-  reg        [4:0]    _zz_51__11;
-  reg        [4:0]    _zz_51__10;
-  reg        [4:0]    _zz_51__9;
-  reg        [4:0]    _zz_51__8;
-  reg        [4:0]    _zz_51__7;
-  reg        [4:0]    _zz_51__6;
-  reg        [4:0]    _zz_51__5;
-  reg        [4:0]    _zz_51__4;
-  reg        [4:0]    _zz_51__3;
-  reg        [4:0]    _zz_51__2;
-  reg        [4:0]    _zz_51__1;
-  reg        [4:0]    _zz_51__0;
-  reg        [31:0]   _zz_52_;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_43;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_44;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_45;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_46;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_47;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_48;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_49;
+  reg        [31:0]   _zz_50;
   wire       [1:0]    writeBack_MEMORY_ADDRESS_LOW;
   wire                writeBack_MEMORY_WR;
   wire       [31:0]   writeBack_REGFILE_WRITE_DATA;
   wire                writeBack_MEMORY_ENABLE;
   wire       [31:0]   memory_REGFILE_WRITE_DATA;
   wire                memory_MEMORY_ENABLE;
+  wire                execute_MEMORY_FORCE_CONSTISTENCY;
   wire                execute_MEMORY_MANAGMENT;
-  (* syn_keep , keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   execute_RS2 /* synthesis syn_keep = 1 */ ;
   wire                execute_MEMORY_WR;
   wire       [31:0]   execute_SRC_ADD;
   wire                execute_MEMORY_ENABLE;
   wire       [31:0]   execute_INSTRUCTION;
   wire                decode_MEMORY_ENABLE;
   wire                decode_FLUSH_ALL;
-  reg                 _zz_53_;
-  reg                 _zz_53__2;
-  reg                 _zz_53__1;
-  reg                 _zz_53__0;
+  reg                 IBusCachedPlugin_rsp_issueDetected_4;
+  reg                 IBusCachedPlugin_rsp_issueDetected_3;
+  reg                 IBusCachedPlugin_rsp_issueDetected_2;
+  reg                 IBusCachedPlugin_rsp_issueDetected_1;
   wire       `BranchCtrlEnum_defaultEncoding_type decode_BRANCH_CTRL;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_54_;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_51;
   wire       [31:0]   decode_INSTRUCTION;
-  reg        [31:0]   _zz_55_;
-  reg        [31:0]   _zz_56_;
+  reg        [31:0]   _zz_52;
+  reg        [31:0]   _zz_53;
   wire       [31:0]   decode_PC;
   wire       [31:0]   writeBack_PC;
   wire       [31:0]   writeBack_INSTRUCTION;
@@ -1911,7 +909,7 @@ module VexRiscv (
   reg                 IBusCachedPlugin_fetcherHalt;
   reg                 IBusCachedPlugin_incomingInstruction;
   wire                IBusCachedPlugin_predictionJumpInterface_valid;
-  (* syn_keep , keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
+  (* keep , syn_keep *) wire       [31:0]   IBusCachedPlugin_predictionJumpInterface_payload /* synthesis syn_keep = 1 */ ;
   reg                 IBusCachedPlugin_decodePrediction_cmd_hadBranch;
   wire                IBusCachedPlugin_decodePrediction_rsp_wasWrong;
   wire                IBusCachedPlugin_pcValids_0;
@@ -1921,28 +919,47 @@ module VexRiscv (
   reg                 IBusCachedPlugin_decodeExceptionPort_valid;
   reg        [3:0]    IBusCachedPlugin_decodeExceptionPort_payload_code;
   wire       [31:0]   IBusCachedPlugin_decodeExceptionPort_payload_badAddr;
-  wire                IBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                IBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   IBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                IBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                IBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 IBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                IBusCachedPlugin_mmuBus_rsp_exception;
   wire                IBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                IBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                IBusCachedPlugin_mmuBus_end;
   wire                IBusCachedPlugin_mmuBus_busy;
-  wire                DBusCachedPlugin_mmuBus_cmd_isValid;
-  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  wire                DBusCachedPlugin_mmuBus_cmd_bypassTranslation;
+  wire                dBus_cmd_valid;
+  wire                dBus_cmd_ready;
+  wire                dBus_cmd_payload_wr;
+  wire                dBus_cmd_payload_uncached;
+  wire       [31:0]   dBus_cmd_payload_address;
+  wire       [31:0]   dBus_cmd_payload_data;
+  wire       [3:0]    dBus_cmd_payload_mask;
+  wire       [2:0]    dBus_cmd_payload_length;
+  wire                dBus_cmd_payload_last;
+  wire                dBus_rsp_valid;
+  wire                dBus_rsp_payload_last;
+  wire       [31:0]   dBus_rsp_payload_data;
+  wire                dBus_rsp_payload_error;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isValid;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_isStuck;
+  wire       [31:0]   DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  wire                DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation;
   wire       [31:0]   DBusCachedPlugin_mmuBus_rsp_physicalAddress;
   wire                DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+  wire                DBusCachedPlugin_mmuBus_rsp_isPaging;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowRead;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowWrite;
   reg                 DBusCachedPlugin_mmuBus_rsp_allowExecute;
   wire                DBusCachedPlugin_mmuBus_rsp_exception;
   wire                DBusCachedPlugin_mmuBus_rsp_refilling;
+  wire                DBusCachedPlugin_mmuBus_rsp_bypassTranslation;
   wire                DBusCachedPlugin_mmuBus_end;
   wire                DBusCachedPlugin_mmuBus_busy;
   reg                 DBusCachedPlugin_redoBranch_valid;
@@ -1950,7 +967,7 @@ module VexRiscv (
   reg                 DBusCachedPlugin_exceptionBus_valid;
   reg        [3:0]    DBusCachedPlugin_exceptionBus_payload_code;
   wire       [31:0]   DBusCachedPlugin_exceptionBus_payload_badAddr;
-  reg                 _zz_57_;
+  reg                 _zz_54;
   wire                decodeExceptionPort_valid;
   wire       [3:0]    decodeExceptionPort_payload_code;
   wire       [31:0]   decodeExceptionPort_payload_badAddr;
@@ -1982,11 +999,11 @@ module VexRiscv (
   wire                IBusCachedPlugin_externalFlush;
   wire                IBusCachedPlugin_jump_pcLoad_valid;
   wire       [31:0]   IBusCachedPlugin_jump_pcLoad_payload;
-  wire       [3:0]    _zz_58_;
-  wire       [3:0]    _zz_59_;
-  wire                _zz_60_;
-  wire                _zz_61_;
-  wire                _zz_62_;
+  wire       [3:0]    _zz_55;
+  wire       [3:0]    _zz_56;
+  wire                _zz_57;
+  wire                _zz_58;
+  wire                _zz_59;
   wire                IBusCachedPlugin_fetchPc_output_valid;
   wire                IBusCachedPlugin_fetchPc_output_ready;
   wire       [31:0]   IBusCachedPlugin_fetchPc_output_payload;
@@ -2023,16 +1040,16 @@ module VexRiscv (
   wire                IBusCachedPlugin_iBusRsp_stages_2_output_ready;
   wire       [31:0]   IBusCachedPlugin_iBusRsp_stages_2_output_payload;
   reg                 IBusCachedPlugin_iBusRsp_stages_2_halt;
-  wire                _zz_63_;
-  wire                _zz_64_;
-  wire                _zz_65_;
+  wire                _zz_60;
+  wire                _zz_61;
+  wire                _zz_62;
   wire                IBusCachedPlugin_iBusRsp_flush;
-  wire                _zz_66_;
-  wire                _zz_67_;
-  reg                 _zz_68_;
-  wire                _zz_69_;
-  reg                 _zz_70_;
-  reg        [31:0]   _zz_71_;
+  wire                _zz_63;
+  wire                _zz_64;
+  reg                 _zz_65;
+  wire                _zz_66;
+  reg                 _zz_67;
+  reg        [31:0]   _zz_68;
   reg                 IBusCachedPlugin_iBusRsp_readyForError;
   wire                IBusCachedPlugin_iBusRsp_output_valid;
   wire                IBusCachedPlugin_iBusRsp_output_ready;
@@ -2045,17 +1062,17 @@ module VexRiscv (
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_2;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_3;
   reg                 IBusCachedPlugin_injector_nextPcCalc_valids_4;
-  wire                _zz_72_;
-  reg        [18:0]   _zz_73_;
-  wire                _zz_74_;
-  reg        [10:0]   _zz_75_;
-  wire                _zz_76_;
-  reg        [18:0]   _zz_77_;
-  reg                 _zz_78_;
-  wire                _zz_79_;
-  reg        [10:0]   _zz_80_;
-  wire                _zz_81_;
-  reg        [18:0]   _zz_82_;
+  wire                _zz_69;
+  reg        [18:0]   _zz_70;
+  wire                _zz_71;
+  reg        [10:0]   _zz_72;
+  wire                _zz_73;
+  reg        [18:0]   _zz_74;
+  reg                 _zz_75;
+  wire                _zz_76;
+  reg        [10:0]   _zz_77;
+  wire                _zz_78;
+  reg        [18:0]   _zz_79;
   wire                iBus_cmd_valid;
   wire                iBus_cmd_ready;
   reg        [31:0]   iBus_cmd_payload_address;
@@ -2063,7 +1080,7 @@ module VexRiscv (
   wire                iBus_rsp_valid;
   wire       [31:0]   iBus_rsp_payload_data;
   wire                iBus_rsp_payload_error;
-  wire       [31:0]   _zz_83_;
+  wire       [31:0]   _zz_80;
   reg        [31:0]   IBusCachedPlugin_rspCounter;
   wire                IBusCachedPlugin_s0_tightlyCoupledHit;
   reg                 IBusCachedPlugin_s1_tightlyCoupledHit;
@@ -2071,313 +1088,354 @@ module VexRiscv (
   wire                IBusCachedPlugin_rsp_iBusRspOutputHalt;
   wire                IBusCachedPlugin_rsp_issueDetected;
   reg                 IBusCachedPlugin_rsp_redoFetch;
-  wire                dBus_cmd_valid;
-  wire                dBus_cmd_ready;
-  wire                dBus_cmd_payload_wr;
-  wire       [31:0]   dBus_cmd_payload_address;
-  wire       [31:0]   dBus_cmd_payload_data;
-  wire       [3:0]    dBus_cmd_payload_mask;
-  wire       [2:0]    dBus_cmd_payload_length;
-  wire                dBus_cmd_payload_last;
-  wire                dBus_rsp_valid;
-  wire       [31:0]   dBus_rsp_payload_data;
-  wire                dBus_rsp_payload_error;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_rData_last;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  wire       [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  wire       [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  wire       [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  wire                dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  reg        [31:0]   dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  reg        [3:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  reg        [2:0]    dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  reg                 dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  wire       [31:0]   _zz_84_;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_rData_last;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  wire       [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  wire       [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  wire       [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  wire                dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  reg        [31:0]   dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  reg        [3:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  reg        [2:0]    dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  reg                 dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  wire       [31:0]   _zz_81;
   reg        [31:0]   DBusCachedPlugin_rspCounter;
   wire       [1:0]    execute_DBusCachedPlugin_size;
-  reg        [31:0]   _zz_85_;
+  reg        [31:0]   _zz_82;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspShifted;
-  wire                _zz_86_;
-  reg        [31:0]   _zz_87_;
-  wire                _zz_88_;
-  reg        [31:0]   _zz_89_;
+  wire                _zz_83;
+  reg        [31:0]   _zz_84;
+  wire                _zz_85;
+  reg        [31:0]   _zz_86;
   reg        [31:0]   writeBack_DBusCachedPlugin_rspFormated;
-  reg                 _zz_90_;
-  reg                 _zz_91_;
-  reg                 _zz_92_;
-  reg                 _zz_93_;
-  reg        [1:0]    _zz_94_;
-  reg        [31:0]   _zz_95_;
-  reg                 _zz_96_;
-  reg                 _zz_97_;
-  reg                 _zz_98_;
-  reg                 _zz_99_;
-  reg                 _zz_100_;
-  reg        [31:0]   _zz_101_;
-  reg        [31:0]   _zz_102_;
-  wire       [31:0]   _zz_103_;
-  wire       [31:0]   _zz_104_;
-  wire       [31:0]   _zz_105_;
-  reg                 _zz_106_;
-  reg                 _zz_107_;
-  reg                 _zz_108_;
-  reg                 _zz_109_;
-  reg        [1:0]    _zz_110_;
-  reg        [31:0]   _zz_111_;
-  reg                 _zz_112_;
-  reg                 _zz_113_;
-  reg                 _zz_114_;
-  reg                 _zz_115_;
-  reg                 _zz_116_;
-  reg        [31:0]   _zz_117_;
-  reg        [31:0]   _zz_118_;
-  wire       [31:0]   _zz_119_;
-  wire       [31:0]   _zz_120_;
-  wire       [31:0]   _zz_121_;
-  reg                 _zz_122_;
-  reg                 _zz_123_;
-  reg                 _zz_124_;
-  reg                 _zz_125_;
-  reg        [1:0]    _zz_126_;
-  reg        [31:0]   _zz_127_;
-  reg                 _zz_128_;
-  reg                 _zz_129_;
-  reg                 _zz_130_;
-  reg                 _zz_131_;
-  reg                 _zz_132_;
-  reg        [31:0]   _zz_133_;
-  reg        [31:0]   _zz_134_;
-  wire       [31:0]   _zz_135_;
-  wire       [31:0]   _zz_136_;
-  wire       [31:0]   _zz_137_;
-  reg                 _zz_138_;
-  reg                 _zz_139_;
-  reg                 _zz_140_;
-  reg                 _zz_141_;
-  reg        [1:0]    _zz_142_;
-  reg        [31:0]   _zz_143_;
-  reg                 _zz_144_;
-  reg                 _zz_145_;
-  reg                 _zz_146_;
-  reg                 _zz_147_;
-  reg                 _zz_148_;
-  reg        [31:0]   _zz_149_;
-  reg        [31:0]   _zz_150_;
-  wire       [31:0]   _zz_151_;
-  wire       [31:0]   _zz_152_;
-  wire       [31:0]   _zz_153_;
-  reg                 _zz_154_;
-  reg                 _zz_155_;
-  reg                 _zz_156_;
-  reg                 _zz_157_;
-  reg        [1:0]    _zz_158_;
-  reg        [31:0]   _zz_159_;
-  reg                 _zz_160_;
-  reg                 _zz_161_;
-  reg                 _zz_162_;
-  reg                 _zz_163_;
-  reg                 _zz_164_;
-  reg        [31:0]   _zz_165_;
-  reg        [31:0]   _zz_166_;
-  wire       [31:0]   _zz_167_;
-  wire       [31:0]   _zz_168_;
-  wire       [31:0]   _zz_169_;
-  reg                 _zz_170_;
-  reg                 _zz_171_;
-  reg                 _zz_172_;
-  reg                 _zz_173_;
-  reg        [1:0]    _zz_174_;
-  reg        [31:0]   _zz_175_;
-  reg                 _zz_176_;
-  reg                 _zz_177_;
-  reg                 _zz_178_;
-  reg                 _zz_179_;
-  reg                 _zz_180_;
-  reg        [31:0]   _zz_181_;
-  reg        [31:0]   _zz_182_;
-  wire       [31:0]   _zz_183_;
-  wire       [31:0]   _zz_184_;
-  wire       [31:0]   _zz_185_;
-  reg                 _zz_186_;
-  reg                 _zz_187_;
-  reg                 _zz_188_;
-  reg                 _zz_189_;
-  reg        [1:0]    _zz_190_;
-  reg        [31:0]   _zz_191_;
-  reg                 _zz_192_;
-  reg                 _zz_193_;
-  reg                 _zz_194_;
-  reg                 _zz_195_;
-  reg                 _zz_196_;
-  reg        [31:0]   _zz_197_;
-  reg        [31:0]   _zz_198_;
-  wire       [31:0]   _zz_199_;
-  wire       [31:0]   _zz_200_;
-  wire       [31:0]   _zz_201_;
-  reg                 _zz_202_;
-  reg                 _zz_203_;
-  reg                 _zz_204_;
-  reg                 _zz_205_;
-  reg        [1:0]    _zz_206_;
-  reg        [31:0]   _zz_207_;
-  reg                 _zz_208_;
-  reg                 _zz_209_;
-  reg                 _zz_210_;
-  reg                 _zz_211_;
-  reg                 _zz_212_;
-  reg        [31:0]   _zz_213_;
-  reg        [31:0]   _zz_214_;
-  wire       [31:0]   _zz_215_;
-  wire       [31:0]   _zz_216_;
-  wire       [31:0]   _zz_217_;
-  reg                 _zz_218_;
-  reg                 _zz_219_;
-  reg                 _zz_220_;
-  reg                 _zz_221_;
-  reg        [1:0]    _zz_222_;
-  reg        [31:0]   _zz_223_;
-  reg                 _zz_224_;
-  reg                 _zz_225_;
-  reg                 _zz_226_;
-  reg                 _zz_227_;
-  reg                 _zz_228_;
-  reg        [31:0]   _zz_229_;
-  reg        [31:0]   _zz_230_;
-  wire       [31:0]   _zz_231_;
-  wire       [31:0]   _zz_232_;
-  wire       [31:0]   _zz_233_;
-  reg                 _zz_234_;
-  reg                 _zz_235_;
-  reg                 _zz_236_;
-  reg                 _zz_237_;
-  reg        [1:0]    _zz_238_;
-  reg        [31:0]   _zz_239_;
-  reg                 _zz_240_;
-  reg                 _zz_241_;
-  reg                 _zz_242_;
-  reg                 _zz_243_;
-  reg                 _zz_244_;
-  reg        [31:0]   _zz_245_;
-  reg        [31:0]   _zz_246_;
-  wire       [31:0]   _zz_247_;
-  wire       [31:0]   _zz_248_;
-  wire       [31:0]   _zz_249_;
-  reg                 _zz_250_;
-  reg                 _zz_251_;
-  reg                 _zz_252_;
-  reg                 _zz_253_;
-  reg        [1:0]    _zz_254_;
-  reg        [31:0]   _zz_255_;
-  reg                 _zz_256_;
-  reg                 _zz_257_;
-  reg                 _zz_258_;
-  reg                 _zz_259_;
-  reg                 _zz_260_;
-  reg        [31:0]   _zz_261_;
-  reg        [31:0]   _zz_262_;
-  wire       [31:0]   _zz_263_;
-  wire       [31:0]   _zz_264_;
-  wire       [31:0]   _zz_265_;
-  reg                 _zz_266_;
-  reg                 _zz_267_;
-  reg                 _zz_268_;
-  reg                 _zz_269_;
-  reg        [1:0]    _zz_270_;
-  reg        [31:0]   _zz_271_;
-  reg                 _zz_272_;
-  reg                 _zz_273_;
-  reg                 _zz_274_;
-  reg                 _zz_275_;
-  reg                 _zz_276_;
-  reg        [31:0]   _zz_277_;
-  reg        [31:0]   _zz_278_;
-  wire       [31:0]   _zz_279_;
-  wire       [31:0]   _zz_280_;
-  wire       [31:0]   _zz_281_;
-  reg                 _zz_282_;
-  reg                 _zz_283_;
-  reg                 _zz_284_;
-  reg                 _zz_285_;
-  reg        [1:0]    _zz_286_;
-  reg        [31:0]   _zz_287_;
-  reg                 _zz_288_;
-  reg                 _zz_289_;
-  reg                 _zz_290_;
-  reg                 _zz_291_;
-  reg                 _zz_292_;
-  reg        [31:0]   _zz_293_;
-  reg        [31:0]   _zz_294_;
-  wire       [31:0]   _zz_295_;
-  wire       [31:0]   _zz_296_;
-  wire       [31:0]   _zz_297_;
-  reg                 _zz_298_;
-  reg                 _zz_299_;
-  reg                 _zz_300_;
-  reg                 _zz_301_;
-  reg        [1:0]    _zz_302_;
-  reg        [31:0]   _zz_303_;
-  reg                 _zz_304_;
-  reg                 _zz_305_;
-  reg                 _zz_306_;
-  reg                 _zz_307_;
-  reg                 _zz_308_;
-  reg        [31:0]   _zz_309_;
-  reg        [31:0]   _zz_310_;
-  wire       [31:0]   _zz_311_;
-  wire       [31:0]   _zz_312_;
-  wire       [31:0]   _zz_313_;
-  reg                 _zz_314_;
-  reg                 _zz_315_;
-  reg                 _zz_316_;
-  reg                 _zz_317_;
-  reg        [1:0]    _zz_318_;
-  reg        [31:0]   _zz_319_;
-  reg                 _zz_320_;
-  reg                 _zz_321_;
-  reg                 _zz_322_;
-  reg                 _zz_323_;
-  reg                 _zz_324_;
-  reg        [31:0]   _zz_325_;
-  reg        [31:0]   _zz_326_;
-  wire       [31:0]   _zz_327_;
-  wire       [31:0]   _zz_328_;
-  wire       [31:0]   _zz_329_;
-  reg                 _zz_330_;
-  reg                 _zz_331_;
-  reg                 _zz_332_;
-  reg                 _zz_333_;
-  reg        [1:0]    _zz_334_;
-  reg        [31:0]   _zz_335_;
-  reg                 _zz_336_;
-  reg                 _zz_337_;
-  reg                 _zz_338_;
-  reg                 _zz_339_;
-  reg                 _zz_340_;
-  reg        [31:0]   _zz_341_;
-  reg        [31:0]   _zz_342_;
-  wire       [31:0]   _zz_343_;
-  wire       [31:0]   _zz_344_;
-  wire       [31:0]   _zz_345_;
+  reg                 _zz_87;
+  reg                 _zz_88;
+  reg                 _zz_89;
+  reg                 _zz_90;
+  reg        [1:0]    _zz_91;
+  reg        [31:0]   _zz_92;
+  reg                 _zz_93;
+  reg                 _zz_94;
+  reg                 _zz_95;
+  reg                 _zz_96;
+  reg        [1:0]    _zz_97;
+  reg        [31:0]   _zz_98;
+  reg                 _zz_99;
+  wire                _zz_100;
+  reg        [31:0]   _zz_101;
+  reg        [31:0]   _zz_102;
+  wire       [31:0]   _zz_103;
+  wire       [31:0]   _zz_104;
+  wire       [31:0]   _zz_105;
+  reg                 _zz_106;
+  reg                 _zz_107;
+  reg                 _zz_108;
+  reg                 _zz_109;
+  reg        [1:0]    _zz_110;
+  reg        [31:0]   _zz_111;
+  reg                 _zz_112;
+  reg                 _zz_113;
+  reg                 _zz_114;
+  reg                 _zz_115;
+  reg        [1:0]    _zz_116;
+  reg        [31:0]   _zz_117;
+  reg                 _zz_118;
+  wire                _zz_119;
+  reg        [31:0]   _zz_120;
+  reg        [31:0]   _zz_121;
+  wire       [31:0]   _zz_122;
+  wire       [31:0]   _zz_123;
+  wire       [31:0]   _zz_124;
+  reg                 _zz_125;
+  reg                 _zz_126;
+  reg                 _zz_127;
+  reg                 _zz_128;
+  reg        [1:0]    _zz_129;
+  reg        [31:0]   _zz_130;
+  reg                 _zz_131;
+  reg                 _zz_132;
+  reg                 _zz_133;
+  reg                 _zz_134;
+  reg        [1:0]    _zz_135;
+  reg        [31:0]   _zz_136;
+  reg                 _zz_137;
+  wire                _zz_138;
+  reg        [31:0]   _zz_139;
+  reg        [31:0]   _zz_140;
+  wire       [31:0]   _zz_141;
+  wire       [31:0]   _zz_142;
+  wire       [31:0]   _zz_143;
+  reg                 _zz_144;
+  reg                 _zz_145;
+  reg                 _zz_146;
+  reg                 _zz_147;
+  reg        [1:0]    _zz_148;
+  reg        [31:0]   _zz_149;
+  reg                 _zz_150;
+  reg                 _zz_151;
+  reg                 _zz_152;
+  reg                 _zz_153;
+  reg        [1:0]    _zz_154;
+  reg        [31:0]   _zz_155;
+  reg                 _zz_156;
+  wire                _zz_157;
+  reg        [31:0]   _zz_158;
+  reg        [31:0]   _zz_159;
+  wire       [31:0]   _zz_160;
+  wire       [31:0]   _zz_161;
+  wire       [31:0]   _zz_162;
+  reg                 _zz_163;
+  reg                 _zz_164;
+  reg                 _zz_165;
+  reg                 _zz_166;
+  reg        [1:0]    _zz_167;
+  reg        [31:0]   _zz_168;
+  reg                 _zz_169;
+  reg                 _zz_170;
+  reg                 _zz_171;
+  reg                 _zz_172;
+  reg        [1:0]    _zz_173;
+  reg        [31:0]   _zz_174;
+  reg                 _zz_175;
+  wire                _zz_176;
+  reg        [31:0]   _zz_177;
+  reg        [31:0]   _zz_178;
+  wire       [31:0]   _zz_179;
+  wire       [31:0]   _zz_180;
+  wire       [31:0]   _zz_181;
+  reg                 _zz_182;
+  reg                 _zz_183;
+  reg                 _zz_184;
+  reg                 _zz_185;
+  reg        [1:0]    _zz_186;
+  reg        [31:0]   _zz_187;
+  reg                 _zz_188;
+  reg                 _zz_189;
+  reg                 _zz_190;
+  reg                 _zz_191;
+  reg        [1:0]    _zz_192;
+  reg        [31:0]   _zz_193;
+  reg                 _zz_194;
+  wire                _zz_195;
+  reg        [31:0]   _zz_196;
+  reg        [31:0]   _zz_197;
+  wire       [31:0]   _zz_198;
+  wire       [31:0]   _zz_199;
+  wire       [31:0]   _zz_200;
+  reg                 _zz_201;
+  reg                 _zz_202;
+  reg                 _zz_203;
+  reg                 _zz_204;
+  reg        [1:0]    _zz_205;
+  reg        [31:0]   _zz_206;
+  reg                 _zz_207;
+  reg                 _zz_208;
+  reg                 _zz_209;
+  reg                 _zz_210;
+  reg        [1:0]    _zz_211;
+  reg        [31:0]   _zz_212;
+  reg                 _zz_213;
+  wire                _zz_214;
+  reg        [31:0]   _zz_215;
+  reg        [31:0]   _zz_216;
+  wire       [31:0]   _zz_217;
+  wire       [31:0]   _zz_218;
+  wire       [31:0]   _zz_219;
+  reg                 _zz_220;
+  reg                 _zz_221;
+  reg                 _zz_222;
+  reg                 _zz_223;
+  reg        [1:0]    _zz_224;
+  reg        [31:0]   _zz_225;
+  reg                 _zz_226;
+  reg                 _zz_227;
+  reg                 _zz_228;
+  reg                 _zz_229;
+  reg        [1:0]    _zz_230;
+  reg        [31:0]   _zz_231;
+  reg                 _zz_232;
+  wire                _zz_233;
+  reg        [31:0]   _zz_234;
+  reg        [31:0]   _zz_235;
+  wire       [31:0]   _zz_236;
+  wire       [31:0]   _zz_237;
+  wire       [31:0]   _zz_238;
+  reg                 _zz_239;
+  reg                 _zz_240;
+  reg                 _zz_241;
+  reg                 _zz_242;
+  reg        [1:0]    _zz_243;
+  reg        [31:0]   _zz_244;
+  reg                 _zz_245;
+  reg                 _zz_246;
+  reg                 _zz_247;
+  reg                 _zz_248;
+  reg        [1:0]    _zz_249;
+  reg        [31:0]   _zz_250;
+  reg                 _zz_251;
+  wire                _zz_252;
+  reg        [31:0]   _zz_253;
+  reg        [31:0]   _zz_254;
+  wire       [31:0]   _zz_255;
+  wire       [31:0]   _zz_256;
+  wire       [31:0]   _zz_257;
+  reg                 _zz_258;
+  reg                 _zz_259;
+  reg                 _zz_260;
+  reg                 _zz_261;
+  reg        [1:0]    _zz_262;
+  reg        [31:0]   _zz_263;
+  reg                 _zz_264;
+  reg                 _zz_265;
+  reg                 _zz_266;
+  reg                 _zz_267;
+  reg        [1:0]    _zz_268;
+  reg        [31:0]   _zz_269;
+  reg                 _zz_270;
+  wire                _zz_271;
+  reg        [31:0]   _zz_272;
+  reg        [31:0]   _zz_273;
+  wire       [31:0]   _zz_274;
+  wire       [31:0]   _zz_275;
+  wire       [31:0]   _zz_276;
+  reg                 _zz_277;
+  reg                 _zz_278;
+  reg                 _zz_279;
+  reg                 _zz_280;
+  reg        [1:0]    _zz_281;
+  reg        [31:0]   _zz_282;
+  reg                 _zz_283;
+  reg                 _zz_284;
+  reg                 _zz_285;
+  reg                 _zz_286;
+  reg        [1:0]    _zz_287;
+  reg        [31:0]   _zz_288;
+  reg                 _zz_289;
+  wire                _zz_290;
+  reg        [31:0]   _zz_291;
+  reg        [31:0]   _zz_292;
+  wire       [31:0]   _zz_293;
+  wire       [31:0]   _zz_294;
+  wire       [31:0]   _zz_295;
+  reg                 _zz_296;
+  reg                 _zz_297;
+  reg                 _zz_298;
+  reg                 _zz_299;
+  reg        [1:0]    _zz_300;
+  reg        [31:0]   _zz_301;
+  reg                 _zz_302;
+  reg                 _zz_303;
+  reg                 _zz_304;
+  reg                 _zz_305;
+  reg        [1:0]    _zz_306;
+  reg        [31:0]   _zz_307;
+  reg                 _zz_308;
+  wire                _zz_309;
+  reg        [31:0]   _zz_310;
+  reg        [31:0]   _zz_311;
+  wire       [31:0]   _zz_312;
+  wire       [31:0]   _zz_313;
+  wire       [31:0]   _zz_314;
+  reg                 _zz_315;
+  reg                 _zz_316;
+  reg                 _zz_317;
+  reg                 _zz_318;
+  reg        [1:0]    _zz_319;
+  reg        [31:0]   _zz_320;
+  reg                 _zz_321;
+  reg                 _zz_322;
+  reg                 _zz_323;
+  reg                 _zz_324;
+  reg        [1:0]    _zz_325;
+  reg        [31:0]   _zz_326;
+  reg                 _zz_327;
+  wire                _zz_328;
+  reg        [31:0]   _zz_329;
+  reg        [31:0]   _zz_330;
+  wire       [31:0]   _zz_331;
+  wire       [31:0]   _zz_332;
+  wire       [31:0]   _zz_333;
+  reg                 _zz_334;
+  reg                 _zz_335;
+  reg                 _zz_336;
+  reg                 _zz_337;
+  reg        [1:0]    _zz_338;
+  reg        [31:0]   _zz_339;
+  reg                 _zz_340;
+  reg                 _zz_341;
+  reg                 _zz_342;
+  reg                 _zz_343;
+  reg        [1:0]    _zz_344;
+  reg        [31:0]   _zz_345;
+  reg                 _zz_346;
+  wire                _zz_347;
+  reg        [31:0]   _zz_348;
+  reg        [31:0]   _zz_349;
+  wire       [31:0]   _zz_350;
+  wire       [31:0]   _zz_351;
+  wire       [31:0]   _zz_352;
+  reg                 _zz_353;
+  reg                 _zz_354;
+  reg                 _zz_355;
+  reg                 _zz_356;
+  reg        [1:0]    _zz_357;
+  reg        [31:0]   _zz_358;
+  reg                 _zz_359;
+  reg                 _zz_360;
+  reg                 _zz_361;
+  reg                 _zz_362;
+  reg        [1:0]    _zz_363;
+  reg        [31:0]   _zz_364;
+  reg                 _zz_365;
+  wire                _zz_366;
+  reg        [31:0]   _zz_367;
+  reg        [31:0]   _zz_368;
+  wire       [31:0]   _zz_369;
+  wire       [31:0]   _zz_370;
+  wire       [31:0]   _zz_371;
+  reg                 _zz_372;
+  reg                 _zz_373;
+  reg                 _zz_374;
+  reg                 _zz_375;
+  reg        [1:0]    _zz_376;
+  reg        [31:0]   _zz_377;
+  reg                 _zz_378;
+  reg                 _zz_379;
+  reg                 _zz_380;
+  reg                 _zz_381;
+  reg        [1:0]    _zz_382;
+  reg        [31:0]   _zz_383;
+  reg                 _zz_384;
+  wire                _zz_385;
+  reg        [31:0]   _zz_386;
+  reg        [31:0]   _zz_387;
+  wire       [31:0]   _zz_388;
+  wire       [31:0]   _zz_389;
+  wire       [31:0]   _zz_390;
   wire                PmpPlugin_ports_0_hits_0;
   wire                PmpPlugin_ports_0_hits_1;
   wire                PmpPlugin_ports_0_hits_2;
@@ -2394,57 +1452,65 @@ module VexRiscv (
   wire                PmpPlugin_ports_0_hits_13;
   wire                PmpPlugin_ports_0_hits_14;
   wire                PmpPlugin_ports_0_hits_15;
-  wire       [15:0]   _zz_346_;
-  wire       [15:0]   _zz_347_;
-  wire                _zz_348_;
-  wire                _zz_349_;
-  wire                _zz_350_;
-  wire                _zz_351_;
-  wire                _zz_352_;
-  wire                _zz_353_;
-  wire                _zz_354_;
-  wire                _zz_355_;
-  wire                _zz_356_;
-  wire                _zz_357_;
-  wire                _zz_358_;
-  wire                _zz_359_;
-  wire                _zz_360_;
-  wire                _zz_361_;
-  wire                _zz_362_;
-  wire       [15:0]   _zz_363_;
-  wire       [15:0]   _zz_364_;
-  wire                _zz_365_;
-  wire                _zz_366_;
-  wire                _zz_367_;
-  wire                _zz_368_;
-  wire                _zz_369_;
-  wire                _zz_370_;
-  wire                _zz_371_;
-  wire                _zz_372_;
-  wire                _zz_373_;
-  wire                _zz_374_;
-  wire                _zz_375_;
-  wire                _zz_376_;
-  wire                _zz_377_;
-  wire                _zz_378_;
-  wire                _zz_379_;
-  wire       [15:0]   _zz_380_;
-  wire       [15:0]   _zz_381_;
-  wire                _zz_382_;
-  wire                _zz_383_;
-  wire                _zz_384_;
-  wire                _zz_385_;
-  wire                _zz_386_;
-  wire                _zz_387_;
-  wire                _zz_388_;
-  wire                _zz_389_;
-  wire                _zz_390_;
-  wire                _zz_391_;
-  wire                _zz_392_;
-  wire                _zz_393_;
-  wire                _zz_394_;
-  wire                _zz_395_;
-  wire                _zz_396_;
+  wire       [4:0]    _zz_391;
+  wire       [4:0]    _zz_392;
+  wire       [4:0]    _zz_393;
+  wire       [4:0]    _zz_394;
+  wire       [4:0]    _zz_395;
+  wire       [4:0]    _zz_396;
+  wire       [4:0]    _zz_397;
+  wire       [4:0]    _zz_398;
+  wire       [15:0]   _zz_399;
+  wire       [15:0]   _zz_400;
+  wire                _zz_401;
+  wire                _zz_402;
+  wire                _zz_403;
+  wire                _zz_404;
+  wire                _zz_405;
+  wire                _zz_406;
+  wire                _zz_407;
+  wire                _zz_408;
+  wire                _zz_409;
+  wire                _zz_410;
+  wire                _zz_411;
+  wire                _zz_412;
+  wire                _zz_413;
+  wire                _zz_414;
+  wire                _zz_415;
+  wire       [15:0]   _zz_416;
+  wire       [15:0]   _zz_417;
+  wire                _zz_418;
+  wire                _zz_419;
+  wire                _zz_420;
+  wire                _zz_421;
+  wire                _zz_422;
+  wire                _zz_423;
+  wire                _zz_424;
+  wire                _zz_425;
+  wire                _zz_426;
+  wire                _zz_427;
+  wire                _zz_428;
+  wire                _zz_429;
+  wire                _zz_430;
+  wire                _zz_431;
+  wire                _zz_432;
+  wire       [15:0]   _zz_433;
+  wire       [15:0]   _zz_434;
+  wire                _zz_435;
+  wire                _zz_436;
+  wire                _zz_437;
+  wire                _zz_438;
+  wire                _zz_439;
+  wire                _zz_440;
+  wire                _zz_441;
+  wire                _zz_442;
+  wire                _zz_443;
+  wire                _zz_444;
+  wire                _zz_445;
+  wire                _zz_446;
+  wire                _zz_447;
+  wire                _zz_448;
+  wire                _zz_449;
   wire                PmpPlugin_ports_1_hits_0;
   wire                PmpPlugin_ports_1_hits_1;
   wire                PmpPlugin_ports_1_hits_2;
@@ -2461,124 +1527,132 @@ module VexRiscv (
   wire                PmpPlugin_ports_1_hits_13;
   wire                PmpPlugin_ports_1_hits_14;
   wire                PmpPlugin_ports_1_hits_15;
-  wire       [15:0]   _zz_397_;
-  wire       [15:0]   _zz_398_;
-  wire                _zz_399_;
-  wire                _zz_400_;
-  wire                _zz_401_;
-  wire                _zz_402_;
-  wire                _zz_403_;
-  wire                _zz_404_;
-  wire                _zz_405_;
-  wire                _zz_406_;
-  wire                _zz_407_;
-  wire                _zz_408_;
-  wire                _zz_409_;
-  wire                _zz_410_;
-  wire                _zz_411_;
-  wire                _zz_412_;
-  wire                _zz_413_;
-  wire       [15:0]   _zz_414_;
-  wire       [15:0]   _zz_415_;
-  wire                _zz_416_;
-  wire                _zz_417_;
-  wire                _zz_418_;
-  wire                _zz_419_;
-  wire                _zz_420_;
-  wire                _zz_421_;
-  wire                _zz_422_;
-  wire                _zz_423_;
-  wire                _zz_424_;
-  wire                _zz_425_;
-  wire                _zz_426_;
-  wire                _zz_427_;
-  wire                _zz_428_;
-  wire                _zz_429_;
-  wire                _zz_430_;
-  wire       [15:0]   _zz_431_;
-  wire       [15:0]   _zz_432_;
-  wire                _zz_433_;
-  wire                _zz_434_;
-  wire                _zz_435_;
-  wire                _zz_436_;
-  wire                _zz_437_;
-  wire                _zz_438_;
-  wire                _zz_439_;
-  wire                _zz_440_;
-  wire                _zz_441_;
-  wire                _zz_442_;
-  wire                _zz_443_;
-  wire                _zz_444_;
-  wire                _zz_445_;
-  wire                _zz_446_;
-  wire                _zz_447_;
-  wire       [32:0]   _zz_448_;
-  wire                _zz_449_;
-  wire                _zz_450_;
-  wire                _zz_451_;
-  wire                _zz_452_;
-  wire       `BranchCtrlEnum_defaultEncoding_type _zz_453_;
-  wire       `Src1CtrlEnum_defaultEncoding_type _zz_454_;
-  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_455_;
-  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_456_;
-  wire       `AluCtrlEnum_defaultEncoding_type _zz_457_;
-  wire       `Src2CtrlEnum_defaultEncoding_type _zz_458_;
-  wire       `EnvCtrlEnum_defaultEncoding_type _zz_459_;
+  wire       [4:0]    _zz_450;
+  wire       [4:0]    _zz_451;
+  wire       [4:0]    _zz_452;
+  wire       [4:0]    _zz_453;
+  wire       [4:0]    _zz_454;
+  wire       [4:0]    _zz_455;
+  wire       [4:0]    _zz_456;
+  wire       [4:0]    _zz_457;
+  wire       [15:0]   _zz_458;
+  wire       [15:0]   _zz_459;
+  wire                _zz_460;
+  wire                _zz_461;
+  wire                _zz_462;
+  wire                _zz_463;
+  wire                _zz_464;
+  wire                _zz_465;
+  wire                _zz_466;
+  wire                _zz_467;
+  wire                _zz_468;
+  wire                _zz_469;
+  wire                _zz_470;
+  wire                _zz_471;
+  wire                _zz_472;
+  wire                _zz_473;
+  wire                _zz_474;
+  wire       [15:0]   _zz_475;
+  wire       [15:0]   _zz_476;
+  wire                _zz_477;
+  wire                _zz_478;
+  wire                _zz_479;
+  wire                _zz_480;
+  wire                _zz_481;
+  wire                _zz_482;
+  wire                _zz_483;
+  wire                _zz_484;
+  wire                _zz_485;
+  wire                _zz_486;
+  wire                _zz_487;
+  wire                _zz_488;
+  wire                _zz_489;
+  wire                _zz_490;
+  wire                _zz_491;
+  wire       [15:0]   _zz_492;
+  wire       [15:0]   _zz_493;
+  wire                _zz_494;
+  wire                _zz_495;
+  wire                _zz_496;
+  wire                _zz_497;
+  wire                _zz_498;
+  wire                _zz_499;
+  wire                _zz_500;
+  wire                _zz_501;
+  wire                _zz_502;
+  wire                _zz_503;
+  wire                _zz_504;
+  wire                _zz_505;
+  wire                _zz_506;
+  wire                _zz_507;
+  wire                _zz_508;
+  wire       [32:0]   _zz_509;
+  wire                _zz_510;
+  wire                _zz_511;
+  wire                _zz_512;
+  wire                _zz_513;
+  wire       `Src1CtrlEnum_defaultEncoding_type _zz_514;
+  wire       `AluCtrlEnum_defaultEncoding_type _zz_515;
+  wire       `Src2CtrlEnum_defaultEncoding_type _zz_516;
+  wire       `AluBitwiseCtrlEnum_defaultEncoding_type _zz_517;
+  wire       `ShiftCtrlEnum_defaultEncoding_type _zz_518;
+  wire       `BranchCtrlEnum_defaultEncoding_type _zz_519;
+  wire       `EnvCtrlEnum_defaultEncoding_type _zz_520;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress1;
   wire       [4:0]    decode_RegFilePlugin_regFileReadAddress2;
   wire       [31:0]   decode_RegFilePlugin_rs1Data;
   wire       [31:0]   decode_RegFilePlugin_rs2Data;
   reg                 lastStageRegFileWrite_valid /* verilator public */ ;
-  wire       [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
-  wire       [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
-  reg                 _zz_460_;
+  reg        [4:0]    lastStageRegFileWrite_payload_address /* verilator public */ ;
+  reg        [31:0]   lastStageRegFileWrite_payload_data /* verilator public */ ;
+  reg                 _zz_521;
   reg        [31:0]   execute_IntAluPlugin_bitwise;
-  reg        [31:0]   _zz_461_;
-  reg        [31:0]   _zz_462_;
-  wire                _zz_463_;
-  reg        [19:0]   _zz_464_;
-  wire                _zz_465_;
-  reg        [19:0]   _zz_466_;
-  reg        [31:0]   _zz_467_;
+  reg        [31:0]   _zz_522;
+  reg        [31:0]   _zz_523;
+  wire                _zz_524;
+  reg        [19:0]   _zz_525;
+  wire                _zz_526;
+  reg        [19:0]   _zz_527;
+  reg        [31:0]   _zz_528;
   reg        [31:0]   execute_SrcPlugin_addSub;
   wire                execute_SrcPlugin_less;
   wire       [4:0]    execute_FullBarrelShifterPlugin_amplitude;
-  reg        [31:0]   _zz_468_;
+  reg        [31:0]   _zz_529;
   wire       [31:0]   execute_FullBarrelShifterPlugin_reversed;
-  reg        [31:0]   _zz_469_;
-  reg                 _zz_470_;
-  reg                 _zz_471_;
-  reg                 _zz_472_;
-  reg        [4:0]    _zz_473_;
-  reg        [31:0]   _zz_474_;
-  wire                _zz_475_;
-  wire                _zz_476_;
-  wire                _zz_477_;
-  wire                _zz_478_;
-  wire                _zz_479_;
-  wire                _zz_480_;
+  reg        [31:0]   _zz_530;
+  reg                 _zz_531;
+  reg                 _zz_532;
+  reg                 _zz_533;
+  reg        [4:0]    _zz_534;
+  reg        [31:0]   _zz_535;
+  wire                _zz_536;
+  wire                _zz_537;
+  wire                _zz_538;
+  wire                _zz_539;
+  wire                _zz_540;
+  wire                _zz_541;
   wire                execute_BranchPlugin_eq;
-  wire       [2:0]    _zz_481_;
-  reg                 _zz_482_;
-  reg                 _zz_483_;
-  wire                _zz_484_;
-  reg        [19:0]   _zz_485_;
-  wire                _zz_486_;
-  reg        [10:0]   _zz_487_;
-  wire                _zz_488_;
-  reg        [18:0]   _zz_489_;
-  reg                 _zz_490_;
+  wire       [2:0]    _zz_542;
+  reg                 _zz_543;
+  reg                 _zz_544;
+  wire                _zz_545;
+  reg        [19:0]   _zz_546;
+  wire                _zz_547;
+  reg        [10:0]   _zz_548;
+  wire                _zz_549;
+  reg        [18:0]   _zz_550;
+  reg                 _zz_551;
   wire                execute_BranchPlugin_missAlignedTarget;
   reg        [31:0]   execute_BranchPlugin_branch_src1;
   reg        [31:0]   execute_BranchPlugin_branch_src2;
-  wire                _zz_491_;
-  reg        [19:0]   _zz_492_;
-  wire                _zz_493_;
-  reg        [10:0]   _zz_494_;
-  wire                _zz_495_;
-  reg        [18:0]   _zz_496_;
+  wire                _zz_552;
+  reg        [19:0]   _zz_553;
+  wire                _zz_554;
+  reg        [10:0]   _zz_555;
+  wire                _zz_556;
+  reg        [18:0]   _zz_557;
   wire       [31:0]   execute_BranchPlugin_branchAdder;
-  reg        [1:0]    _zz_497_;
+  reg        [1:0]    _zz_558;
   reg        [1:0]    CsrPlugin_misa_base;
   reg        [25:0]   CsrPlugin_misa_extensions;
   reg        [1:0]    CsrPlugin_mtvec_mode;
@@ -2599,9 +1673,9 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_mtval;
   reg        [63:0]   CsrPlugin_mcycle = 64'b0000000000000000000000000000000000000000000000000000000000000000;
   reg        [63:0]   CsrPlugin_minstret = 64'b0000000000000000000000000000000000000000000000000000000000000000;
-  wire                _zz_498_;
-  wire                _zz_499_;
-  wire                _zz_500_;
+  wire                _zz_559;
+  wire                _zz_560;
+  wire                _zz_561;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_decode;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_execute;
   reg                 CsrPlugin_exceptionPortCtrl_exceptionValids_memory;
@@ -2614,8 +1688,8 @@ module VexRiscv (
   reg        [31:0]   CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped;
   wire       [1:0]    CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege;
-  wire       [1:0]    _zz_501_;
-  wire                _zz_502_;
+  wire       [1:0]    _zz_562;
+  wire                _zz_563;
   reg                 CsrPlugin_interrupt_valid;
   reg        [3:0]    CsrPlugin_interrupt_code /* verilator public */ ;
   reg        [1:0]    CsrPlugin_interrupt_targetPrivilege;
@@ -2627,7 +1701,7 @@ module VexRiscv (
   wire                CsrPlugin_pipelineLiberator_active;
   reg                 CsrPlugin_pipelineLiberator_done;
   wire                CsrPlugin_interruptJump /* verilator public */ ;
-  reg                 CsrPlugin_hadException;
+  reg                 CsrPlugin_hadException /* verilator public */ ;
   reg        [1:0]    CsrPlugin_targetPrivilege;
   reg        [3:0]    CsrPlugin_trapCause;
   reg        [1:0]    CsrPlugin_xtvec_mode;
@@ -2668,18 +1742,18 @@ module VexRiscv (
   wire                memory_DivPlugin_div_counter_willOverflow;
   reg                 memory_DivPlugin_div_done;
   reg        [31:0]   memory_DivPlugin_div_result;
-  wire       [31:0]   _zz_503_;
+  wire       [31:0]   _zz_564;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderShifted;
   wire       [32:0]   memory_DivPlugin_div_stage_0_remainderMinusDenominator;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outRemainder;
   wire       [31:0]   memory_DivPlugin_div_stage_0_outNumerator;
-  wire       [31:0]   _zz_504_;
-  wire                _zz_505_;
-  wire                _zz_506_;
-  reg        [32:0]   _zz_507_;
+  wire       [31:0]   _zz_565;
+  wire                _zz_566;
+  wire                _zz_567;
+  reg        [32:0]   _zz_568;
   reg        [31:0]   externalInterruptArray_regNext;
-  reg        [31:0]   _zz_508_;
-  wire       [31:0]   _zz_509_;
+  reg        [31:0]   _zz_569;
+  wire       [31:0]   _zz_570;
   reg                 DebugPlugin_firstCycle;
   reg                 DebugPlugin_secondCycle;
   reg                 DebugPlugin_resetIt;
@@ -2689,72 +1763,73 @@ module VexRiscv (
   reg                 DebugPlugin_godmode;
   reg                 DebugPlugin_haltedByBreak;
   reg        [31:0]   DebugPlugin_busReadDataReg;
-  reg                 _zz_510_;
+  reg                 _zz_571;
   wire                DebugPlugin_allowEBreak;
   reg                 DebugPlugin_resetIt_regNext;
-  reg                 decode_to_execute_IS_MUL;
-  reg                 execute_to_memory_IS_MUL;
-  reg                 memory_to_writeBack_IS_MUL;
-  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
-  reg                 decode_to_execute_CSR_READ_OPCODE;
-  reg        [31:0]   decode_to_execute_RS2;
-  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
-  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
-  reg        [33:0]   execute_to_memory_MUL_HH;
-  reg        [33:0]   memory_to_writeBack_MUL_HH;
-  reg        [33:0]   execute_to_memory_MUL_LH;
-  reg        [31:0]   execute_to_memory_BRANCH_CALC;
-  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
-  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
-  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
-  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
-  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
-  reg        [31:0]   decode_to_execute_RS1;
-  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg        [31:0]   decode_to_execute_PC;
+  reg        [31:0]   execute_to_memory_PC;
+  reg        [31:0]   memory_to_writeBack_PC;
   reg        [31:0]   decode_to_execute_INSTRUCTION;
   reg        [31:0]   execute_to_memory_INSTRUCTION;
   reg        [31:0]   memory_to_writeBack_INSTRUCTION;
   reg        [31:0]   decode_to_execute_FORMAL_PC_NEXT;
   reg        [31:0]   execute_to_memory_FORMAL_PC_NEXT;
   reg        [31:0]   memory_to_writeBack_FORMAL_PC_NEXT;
-  reg                 decode_to_execute_DO_EBREAK;
-  reg                 decode_to_execute_CSR_WRITE_OPCODE;
-  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
-  reg        [31:0]   decode_to_execute_PC;
-  reg        [31:0]   execute_to_memory_PC;
-  reg        [31:0]   memory_to_writeBack_PC;
-  reg                 decode_to_execute_SRC2_FORCE_ZERO;
-  reg                 decode_to_execute_IS_DIV;
-  reg                 execute_to_memory_IS_DIV;
-  reg                 decode_to_execute_IS_RS2_SIGNED;
-  reg                 execute_to_memory_BRANCH_DO;
-  reg                 decode_to_execute_REGFILE_WRITE_VALID;
-  reg                 execute_to_memory_REGFILE_WRITE_VALID;
-  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
-  reg                 decode_to_execute_MEMORY_MANAGMENT;
-  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
-  reg        [31:0]   execute_to_memory_MUL_LL;
-  reg        [33:0]   execute_to_memory_MUL_HL;
-  reg                 decode_to_execute_IS_CSR;
-  reg                 decode_to_execute_MEMORY_WR;
-  reg                 execute_to_memory_MEMORY_WR;
-  reg                 memory_to_writeBack_MEMORY_WR;
-  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
-  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
-  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
-  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  reg                 decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
+  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
+  reg                 decode_to_execute_SRC_USE_SUB_LESS;
   reg                 decode_to_execute_MEMORY_ENABLE;
   reg                 execute_to_memory_MEMORY_ENABLE;
   reg                 memory_to_writeBack_MEMORY_ENABLE;
-  reg                 decode_to_execute_IS_RS1_SIGNED;
-  reg        `Src1CtrlEnum_defaultEncoding_type decode_to_execute_SRC1_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
-  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
-  reg                 decode_to_execute_SRC_USE_SUB_LESS;
+  reg        `AluCtrlEnum_defaultEncoding_type decode_to_execute_ALU_CTRL;
+  reg        `Src2CtrlEnum_defaultEncoding_type decode_to_execute_SRC2_CTRL;
+  reg                 decode_to_execute_REGFILE_WRITE_VALID;
+  reg                 execute_to_memory_REGFILE_WRITE_VALID;
+  reg                 memory_to_writeBack_REGFILE_WRITE_VALID;
+  reg                 decode_to_execute_BYPASSABLE_EXECUTE_STAGE;
   reg                 decode_to_execute_BYPASSABLE_MEMORY_STAGE;
   reg                 execute_to_memory_BYPASSABLE_MEMORY_STAGE;
-  reg        [2:0]    _zz_511_;
+  reg                 decode_to_execute_MEMORY_WR;
+  reg                 execute_to_memory_MEMORY_WR;
+  reg                 memory_to_writeBack_MEMORY_WR;
+  reg                 decode_to_execute_MEMORY_MANAGMENT;
+  reg                 decode_to_execute_SRC_LESS_UNSIGNED;
+  reg        `AluBitwiseCtrlEnum_defaultEncoding_type decode_to_execute_ALU_BITWISE_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type decode_to_execute_SHIFT_CTRL;
+  reg        `ShiftCtrlEnum_defaultEncoding_type execute_to_memory_SHIFT_CTRL;
+  reg        `BranchCtrlEnum_defaultEncoding_type decode_to_execute_BRANCH_CTRL;
+  reg                 decode_to_execute_IS_CSR;
+  reg        `EnvCtrlEnum_defaultEncoding_type decode_to_execute_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type execute_to_memory_ENV_CTRL;
+  reg        `EnvCtrlEnum_defaultEncoding_type memory_to_writeBack_ENV_CTRL;
+  reg                 decode_to_execute_IS_MUL;
+  reg                 execute_to_memory_IS_MUL;
+  reg                 memory_to_writeBack_IS_MUL;
+  reg                 decode_to_execute_IS_DIV;
+  reg                 execute_to_memory_IS_DIV;
+  reg                 decode_to_execute_IS_RS1_SIGNED;
+  reg                 decode_to_execute_IS_RS2_SIGNED;
+  reg        [31:0]   decode_to_execute_RS1;
+  reg        [31:0]   decode_to_execute_RS2;
+  reg                 decode_to_execute_SRC2_FORCE_ZERO;
+  reg                 decode_to_execute_PREDICTION_HAD_BRANCHED2;
+  reg                 decode_to_execute_CSR_WRITE_OPCODE;
+  reg                 decode_to_execute_CSR_READ_OPCODE;
+  reg                 decode_to_execute_DO_EBREAK;
+  reg        [1:0]    execute_to_memory_MEMORY_ADDRESS_LOW;
+  reg        [1:0]    memory_to_writeBack_MEMORY_ADDRESS_LOW;
+  reg        [31:0]   execute_to_memory_REGFILE_WRITE_DATA;
+  reg        [31:0]   memory_to_writeBack_REGFILE_WRITE_DATA;
+  reg        [31:0]   execute_to_memory_SHIFT_RIGHT;
+  reg                 execute_to_memory_BRANCH_DO;
+  reg        [31:0]   execute_to_memory_BRANCH_CALC;
+  reg        [31:0]   execute_to_memory_MUL_LL;
+  reg        [33:0]   execute_to_memory_MUL_LH;
+  reg        [33:0]   execute_to_memory_MUL_HL;
+  reg        [33:0]   execute_to_memory_MUL_HH;
+  reg        [33:0]   memory_to_writeBack_MUL_HH;
+  reg        [51:0]   memory_to_writeBack_MUL_LOW;
+  reg        [2:0]    _zz_572;
   reg                 execute_CsrPlugin_csr_3264;
   reg                 execute_CsrPlugin_csr_944;
   reg                 execute_CsrPlugin_csr_945;
@@ -2799,1217 +1874,1505 @@ module VexRiscv (
   reg                 execute_CsrPlugin_csr_3202;
   reg                 execute_CsrPlugin_csr_3008;
   reg                 execute_CsrPlugin_csr_4032;
-  reg        [31:0]   _zz_512_;
-  reg        [31:0]   _zz_513_;
-  reg        [31:0]   _zz_514_;
-  reg        [31:0]   _zz_515_;
-  reg        [31:0]   _zz_516_;
-  reg        [31:0]   _zz_517_;
-  reg        [31:0]   _zz_518_;
-  reg        [31:0]   _zz_519_;
-  reg        [31:0]   _zz_520_;
-  reg        [31:0]   _zz_521_;
-  reg        [31:0]   _zz_522_;
-  reg        [31:0]   _zz_523_;
-  reg        [31:0]   _zz_524_;
-  reg        [31:0]   _zz_525_;
-  reg        [31:0]   _zz_526_;
-  reg        [31:0]   _zz_527_;
-  reg        [31:0]   _zz_528_;
-  reg        [31:0]   _zz_529_;
-  reg        [31:0]   _zz_530_;
-  reg        [31:0]   _zz_531_;
-  reg        [31:0]   _zz_532_;
-  reg        [31:0]   _zz_533_;
-  reg        [31:0]   _zz_534_;
-  reg        [31:0]   _zz_535_;
-  reg        [31:0]   _zz_536_;
-  reg        [31:0]   _zz_537_;
-  reg        [31:0]   _zz_538_;
-  reg        [31:0]   _zz_539_;
-  reg        [31:0]   _zz_540_;
-  reg        [31:0]   _zz_541_;
-  reg        [31:0]   _zz_542_;
-  reg        [31:0]   _zz_543_;
-  reg        [31:0]   _zz_544_;
-  reg        [31:0]   _zz_545_;
-  reg        [31:0]   _zz_546_;
-  reg        [31:0]   _zz_547_;
-  reg        [31:0]   _zz_548_;
-  reg        [31:0]   _zz_549_;
-  reg        [31:0]   _zz_550_;
-  reg        [31:0]   _zz_551_;
-  reg        [31:0]   _zz_552_;
-  reg        [31:0]   _zz_553_;
-  reg        [31:0]   _zz_554_;
-  reg        [2:0]    _zz_555_;
-  reg                 _zz_556_;
+  reg        [31:0]   _zz_573;
+  reg        [31:0]   _zz_574;
+  reg        [31:0]   _zz_575;
+  reg        [31:0]   _zz_576;
+  reg        [31:0]   _zz_577;
+  reg        [31:0]   _zz_578;
+  reg        [31:0]   _zz_579;
+  reg        [31:0]   _zz_580;
+  reg        [31:0]   _zz_581;
+  reg        [31:0]   _zz_582;
+  reg        [31:0]   _zz_583;
+  reg        [31:0]   _zz_584;
+  reg        [31:0]   _zz_585;
+  reg        [31:0]   _zz_586;
+  reg        [31:0]   _zz_587;
+  reg        [31:0]   _zz_588;
+  reg        [31:0]   _zz_589;
+  reg        [31:0]   _zz_590;
+  reg        [31:0]   _zz_591;
+  reg        [31:0]   _zz_592;
+  reg        [31:0]   _zz_593;
+  reg        [31:0]   _zz_594;
+  reg        [31:0]   _zz_595;
+  reg        [31:0]   _zz_596;
+  reg        [31:0]   _zz_597;
+  reg        [31:0]   _zz_598;
+  reg        [31:0]   _zz_599;
+  reg        [31:0]   _zz_600;
+  reg        [31:0]   _zz_601;
+  reg        [31:0]   _zz_602;
+  reg        [31:0]   _zz_603;
+  reg        [31:0]   _zz_604;
+  reg        [31:0]   _zz_605;
+  reg        [31:0]   _zz_606;
+  reg        [31:0]   _zz_607;
+  reg        [31:0]   _zz_608;
+  reg        [31:0]   _zz_609;
+  reg        [31:0]   _zz_610;
+  reg        [31:0]   _zz_611;
+  reg        [31:0]   _zz_612;
+  reg        [31:0]   _zz_613;
+  reg        [31:0]   _zz_614;
+  reg        [31:0]   _zz_615;
+  reg        [2:0]    _zz_616;
+  reg                 _zz_617;
   reg        [31:0]   iBusWishbone_DAT_MISO_regNext;
-  reg        [2:0]    _zz_557_;
-  wire                _zz_558_;
-  wire                _zz_559_;
-  wire                _zz_560_;
-  wire                _zz_561_;
-  wire                _zz_562_;
-  reg                 _zz_563_;
+  reg        [2:0]    _zz_618;
+  wire                _zz_619;
+  wire                _zz_620;
+  wire                _zz_621;
+  wire                _zz_622;
+  wire                _zz_623;
+  reg                 _zz_624;
   reg        [31:0]   dBusWishbone_DAT_MISO_regNext;
   `ifndef SYNTHESIS
-  reg [71:0] _zz_1__string;
-  reg [71:0] _zz_2__string;
-  reg [71:0] decode_SHIFT_CTRL_string;
-  reg [71:0] _zz_3__string;
-  reg [71:0] _zz_4__string;
-  reg [71:0] _zz_5__string;
-  reg [95:0] decode_SRC1_CTRL_string;
-  reg [95:0] _zz_6__string;
-  reg [95:0] _zz_7__string;
-  reg [95:0] _zz_8__string;
-  reg [39:0] _zz_9__string;
-  reg [39:0] _zz_10__string;
-  reg [39:0] _zz_11__string;
-  reg [39:0] _zz_12__string;
+  reg [39:0] _zz_1_string;
+  reg [39:0] _zz_2_string;
+  reg [39:0] _zz_3_string;
+  reg [39:0] _zz_4_string;
   reg [39:0] decode_ENV_CTRL_string;
-  reg [39:0] _zz_13__string;
-  reg [39:0] _zz_14__string;
-  reg [39:0] _zz_15__string;
-  reg [63:0] decode_ALU_CTRL_string;
-  reg [63:0] _zz_16__string;
-  reg [63:0] _zz_17__string;
-  reg [63:0] _zz_18__string;
+  reg [39:0] _zz_5_string;
+  reg [39:0] _zz_6_string;
+  reg [39:0] _zz_7_string;
+  reg [31:0] _zz_8_string;
+  reg [31:0] _zz_9_string;
+  reg [71:0] _zz_10_string;
+  reg [71:0] _zz_11_string;
+  reg [71:0] decode_SHIFT_CTRL_string;
+  reg [71:0] _zz_12_string;
+  reg [71:0] _zz_13_string;
+  reg [71:0] _zz_14_string;
   reg [39:0] decode_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_19__string;
-  reg [39:0] _zz_20__string;
-  reg [39:0] _zz_21__string;
+  reg [39:0] _zz_15_string;
+  reg [39:0] _zz_16_string;
+  reg [39:0] _zz_17_string;
   reg [23:0] decode_SRC2_CTRL_string;
-  reg [23:0] _zz_22__string;
-  reg [23:0] _zz_23__string;
-  reg [23:0] _zz_24__string;
-  reg [31:0] _zz_25__string;
-  reg [31:0] _zz_26__string;
+  reg [23:0] _zz_18_string;
+  reg [23:0] _zz_19_string;
+  reg [23:0] _zz_20_string;
+  reg [63:0] decode_ALU_CTRL_string;
+  reg [63:0] _zz_21_string;
+  reg [63:0] _zz_22_string;
+  reg [63:0] _zz_23_string;
+  reg [95:0] decode_SRC1_CTRL_string;
+  reg [95:0] _zz_24_string;
+  reg [95:0] _zz_25_string;
+  reg [95:0] _zz_26_string;
   reg [39:0] memory_ENV_CTRL_string;
-  reg [39:0] _zz_27__string;
+  reg [39:0] _zz_27_string;
   reg [39:0] execute_ENV_CTRL_string;
-  reg [39:0] _zz_28__string;
+  reg [39:0] _zz_28_string;
   reg [39:0] writeBack_ENV_CTRL_string;
-  reg [39:0] _zz_29__string;
+  reg [39:0] _zz_29_string;
   reg [31:0] execute_BRANCH_CTRL_string;
-  reg [31:0] _zz_30__string;
+  reg [31:0] _zz_30_string;
   reg [71:0] memory_SHIFT_CTRL_string;
-  reg [71:0] _zz_33__string;
+  reg [71:0] _zz_33_string;
   reg [71:0] execute_SHIFT_CTRL_string;
-  reg [71:0] _zz_34__string;
+  reg [71:0] _zz_34_string;
   reg [23:0] execute_SRC2_CTRL_string;
-  reg [23:0] _zz_36__string;
+  reg [23:0] _zz_36_string;
   reg [95:0] execute_SRC1_CTRL_string;
-  reg [95:0] _zz_37__string;
+  reg [95:0] _zz_37_string;
   reg [63:0] execute_ALU_CTRL_string;
-  reg [63:0] _zz_38__string;
+  reg [63:0] _zz_38_string;
   reg [39:0] execute_ALU_BITWISE_CTRL_string;
-  reg [39:0] _zz_39__string;
-  reg [39:0] _zz_43__string;
-  reg [23:0] _zz_44__string;
-  reg [63:0] _zz_45__string;
-  reg [71:0] _zz_46__string;
-  reg [39:0] _zz_47__string;
-  reg [95:0] _zz_48__string;
-  reg [31:0] _zz_49__string;
+  reg [39:0] _zz_39_string;
+  reg [39:0] _zz_43_string;
+  reg [31:0] _zz_44_string;
+  reg [71:0] _zz_45_string;
+  reg [39:0] _zz_46_string;
+  reg [23:0] _zz_47_string;
+  reg [63:0] _zz_48_string;
+  reg [95:0] _zz_49_string;
   reg [31:0] decode_BRANCH_CTRL_string;
-  reg [31:0] _zz_54__string;
-  reg [31:0] _zz_453__string;
-  reg [95:0] _zz_454__string;
-  reg [39:0] _zz_455__string;
-  reg [71:0] _zz_456__string;
-  reg [63:0] _zz_457__string;
-  reg [23:0] _zz_458__string;
-  reg [39:0] _zz_459__string;
-  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
+  reg [31:0] _zz_51_string;
+  reg [95:0] _zz_514_string;
+  reg [63:0] _zz_515_string;
+  reg [23:0] _zz_516_string;
+  reg [39:0] _zz_517_string;
+  reg [71:0] _zz_518_string;
+  reg [31:0] _zz_519_string;
+  reg [39:0] _zz_520_string;
+  reg [95:0] decode_to_execute_SRC1_CTRL_string;
+  reg [63:0] decode_to_execute_ALU_CTRL_string;
   reg [23:0] decode_to_execute_SRC2_CTRL_string;
   reg [39:0] decode_to_execute_ALU_BITWISE_CTRL_string;
-  reg [63:0] decode_to_execute_ALU_CTRL_string;
+  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
+  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
+  reg [31:0] decode_to_execute_BRANCH_CTRL_string;
   reg [39:0] decode_to_execute_ENV_CTRL_string;
   reg [39:0] execute_to_memory_ENV_CTRL_string;
   reg [39:0] memory_to_writeBack_ENV_CTRL_string;
-  reg [95:0] decode_to_execute_SRC1_CTRL_string;
-  reg [71:0] decode_to_execute_SHIFT_CTRL_string;
-  reg [71:0] execute_to_memory_SHIFT_CTRL_string;
   `endif
 
   (* ram_style = "block" *) reg [31:0] RegFilePlugin_regFile [0:31] /* verilator public */ ;
 
-  assign _zz_591_ = (execute_arbitration_isValid && execute_IS_CSR);
-  assign _zz_592_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_593_ = 1'b1;
-  assign _zz_594_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_595_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_596_ = (memory_arbitration_isValid && memory_IS_DIV);
-  assign _zz_597_ = ((_zz_568_ && IBusCachedPlugin_cache_io_cpu_decode_error) && (! _zz_53__2));
-  assign _zz_598_ = ((_zz_568_ && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! _zz_53__1));
-  assign _zz_599_ = ((_zz_568_ && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! _zz_53__0));
-  assign _zz_600_ = ((_zz_568_ && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
-  assign _zz_601_ = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != (2'b00));
-  assign _zz_602_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
-  assign _zz_603_ = (execute_arbitration_isValid && execute_DO_EBREAK);
-  assign _zz_604_ = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00)) == 1'b0);
-  assign _zz_605_ = (CsrPlugin_hadException || CsrPlugin_interruptJump);
-  assign _zz_606_ = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
-  assign _zz_607_ = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
-  assign _zz_608_ = writeBack_INSTRUCTION[29 : 28];
-  assign _zz_609_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_610_ = (_zz_51_ == 5'h0);
-  assign _zz_611_ = (_zz_50_ == 5'h0);
-  assign _zz_612_ = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
-  assign _zz_613_ = (1'b0 || (! 1'b1));
-  assign _zz_614_ = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
-  assign _zz_615_ = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
-  assign _zz_616_ = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
-  assign _zz_617_ = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
-  assign _zz_618_ = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
-  assign _zz_619_ = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
-  assign _zz_620_ = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
-  assign _zz_621_ = execute_INSTRUCTION[13 : 12];
-  assign _zz_622_ = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
-  assign _zz_623_ = (! memory_arbitration_isStuck);
-  assign _zz_624_ = debug_bus_cmd_payload_address[7 : 2];
-  assign _zz_625_ = (iBus_cmd_valid || (_zz_555_ != (3'b000)));
-  assign _zz_626_ = (_zz_581_ && (! dataCache_1__io_mem_cmd_s2mPipe_ready));
-  assign _zz_627_ = (! _zz_99_);
-  assign _zz_628_ = (! _zz_115_);
-  assign _zz_629_ = (! _zz_131_);
-  assign _zz_630_ = (! _zz_147_);
-  assign _zz_631_ = (! _zz_163_);
-  assign _zz_632_ = (! _zz_179_);
-  assign _zz_633_ = (! _zz_195_);
-  assign _zz_634_ = (! _zz_211_);
-  assign _zz_635_ = (! _zz_227_);
-  assign _zz_636_ = (! _zz_243_);
-  assign _zz_637_ = (! _zz_259_);
-  assign _zz_638_ = (! _zz_275_);
-  assign _zz_639_ = (! _zz_291_);
-  assign _zz_640_ = (! _zz_307_);
-  assign _zz_641_ = (! _zz_323_);
-  assign _zz_642_ = (! _zz_339_);
-  assign _zz_643_ = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < (2'b11)));
-  assign _zz_644_ = ((_zz_498_ && 1'b1) && (! 1'b0));
-  assign _zz_645_ = ((_zz_499_ && 1'b1) && (! 1'b0));
-  assign _zz_646_ = ((_zz_500_ && 1'b1) && (! 1'b0));
-  assign _zz_647_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_648_ = execute_INSTRUCTION[13];
-  assign _zz_649_ = writeBack_INSTRUCTION[13 : 12];
-  assign _zz_650_ = _zz_448_[2 : 2];
-  assign _zz_651_ = _zz_448_[15 : 15];
-  assign _zz_652_ = ($signed(_zz_653_) + $signed(_zz_658_));
-  assign _zz_653_ = ($signed(_zz_654_) + $signed(_zz_656_));
-  assign _zz_654_ = 52'h0;
-  assign _zz_655_ = {1'b0,memory_MUL_LL};
-  assign _zz_656_ = {{19{_zz_655_[32]}}, _zz_655_};
-  assign _zz_657_ = ({16'd0,memory_MUL_LH} <<< 16);
-  assign _zz_658_ = {{2{_zz_657_[49]}}, _zz_657_};
-  assign _zz_659_ = ({16'd0,memory_MUL_HL} <<< 16);
-  assign _zz_660_ = {{2{_zz_659_[49]}}, _zz_659_};
-  assign _zz_661_ = _zz_448_[17 : 17];
-  assign _zz_662_ = _zz_448_[9 : 9];
-  assign _zz_663_ = _zz_448_[28 : 28];
-  assign _zz_664_ = _zz_448_[18 : 18];
-  assign _zz_665_ = _zz_448_[16 : 16];
-  assign _zz_666_ = _zz_448_[24 : 24];
-  assign _zz_667_ = ($signed(_zz_669_) >>> execute_FullBarrelShifterPlugin_amplitude);
-  assign _zz_668_ = _zz_667_[31 : 0];
-  assign _zz_669_ = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
-  assign _zz_670_ = _zz_448_[5 : 5];
-  assign _zz_671_ = _zz_448_[11 : 11];
-  assign _zz_672_ = _zz_448_[12 : 12];
-  assign _zz_673_ = _zz_448_[29 : 29];
-  assign _zz_674_ = _zz_448_[21 : 21];
-  assign _zz_675_ = _zz_448_[10 : 10];
-  assign _zz_676_ = _zz_448_[20 : 20];
-  assign _zz_677_ = _zz_448_[19 : 19];
-  assign _zz_678_ = _zz_448_[8 : 8];
-  assign _zz_679_ = _zz_448_[27 : 27];
-  assign _zz_680_ = (_zz_58_ - (4'b0001));
-  assign _zz_681_ = {IBusCachedPlugin_fetchPc_inc,(2'b00)};
-  assign _zz_682_ = {29'd0, _zz_681_};
-  assign _zz_683_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_684_ = {{_zz_73_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_685_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_686_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_687_ = {{_zz_75_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_688_ = {{_zz_77_,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_689_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
-  assign _zz_690_ = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
-  assign _zz_691_ = (writeBack_MEMORY_WR ? (3'b111) : (3'b101));
-  assign _zz_692_ = (writeBack_MEMORY_WR ? (3'b110) : (3'b100));
-  assign _zz_693_ = (_zz_95_ + 32'h00000001);
-  assign _zz_694_ = (_zz_695_ <<< 3);
-  assign _zz_695_ = (_zz_104_ + 32'h00000001);
-  assign _zz_696_ = (_zz_111_ + 32'h00000001);
-  assign _zz_697_ = (_zz_698_ <<< 3);
-  assign _zz_698_ = (_zz_120_ + 32'h00000001);
-  assign _zz_699_ = (_zz_127_ + 32'h00000001);
-  assign _zz_700_ = (_zz_701_ <<< 3);
-  assign _zz_701_ = (_zz_136_ + 32'h00000001);
-  assign _zz_702_ = (_zz_143_ + 32'h00000001);
-  assign _zz_703_ = (_zz_704_ <<< 3);
-  assign _zz_704_ = (_zz_152_ + 32'h00000001);
-  assign _zz_705_ = (_zz_159_ + 32'h00000001);
-  assign _zz_706_ = (_zz_707_ <<< 3);
-  assign _zz_707_ = (_zz_168_ + 32'h00000001);
-  assign _zz_708_ = (_zz_175_ + 32'h00000001);
-  assign _zz_709_ = (_zz_710_ <<< 3);
-  assign _zz_710_ = (_zz_184_ + 32'h00000001);
-  assign _zz_711_ = (_zz_191_ + 32'h00000001);
-  assign _zz_712_ = (_zz_713_ <<< 3);
-  assign _zz_713_ = (_zz_200_ + 32'h00000001);
-  assign _zz_714_ = (_zz_207_ + 32'h00000001);
-  assign _zz_715_ = (_zz_716_ <<< 3);
-  assign _zz_716_ = (_zz_216_ + 32'h00000001);
-  assign _zz_717_ = (_zz_223_ + 32'h00000001);
-  assign _zz_718_ = (_zz_719_ <<< 3);
-  assign _zz_719_ = (_zz_232_ + 32'h00000001);
-  assign _zz_720_ = (_zz_239_ + 32'h00000001);
-  assign _zz_721_ = (_zz_722_ <<< 3);
-  assign _zz_722_ = (_zz_248_ + 32'h00000001);
-  assign _zz_723_ = (_zz_255_ + 32'h00000001);
-  assign _zz_724_ = (_zz_725_ <<< 3);
-  assign _zz_725_ = (_zz_264_ + 32'h00000001);
-  assign _zz_726_ = (_zz_271_ + 32'h00000001);
-  assign _zz_727_ = (_zz_728_ <<< 3);
-  assign _zz_728_ = (_zz_280_ + 32'h00000001);
-  assign _zz_729_ = (_zz_287_ + 32'h00000001);
-  assign _zz_730_ = (_zz_731_ <<< 3);
-  assign _zz_731_ = (_zz_296_ + 32'h00000001);
-  assign _zz_732_ = (_zz_303_ + 32'h00000001);
-  assign _zz_733_ = (_zz_734_ <<< 3);
-  assign _zz_734_ = (_zz_312_ + 32'h00000001);
-  assign _zz_735_ = (_zz_319_ + 32'h00000001);
-  assign _zz_736_ = (_zz_737_ <<< 3);
-  assign _zz_737_ = (_zz_328_ + 32'h00000001);
-  assign _zz_738_ = (_zz_335_ + 32'h00000001);
-  assign _zz_739_ = (_zz_740_ <<< 3);
-  assign _zz_740_ = (_zz_344_ + 32'h00000001);
-  assign _zz_741_ = (_zz_346_ - 16'h0001);
-  assign _zz_742_ = (_zz_363_ - 16'h0001);
-  assign _zz_743_ = (_zz_380_ - 16'h0001);
-  assign _zz_744_ = (_zz_397_ - 16'h0001);
-  assign _zz_745_ = (_zz_414_ - 16'h0001);
-  assign _zz_746_ = (_zz_431_ - 16'h0001);
-  assign _zz_747_ = execute_SRC_LESS;
-  assign _zz_748_ = (3'b100);
-  assign _zz_749_ = execute_INSTRUCTION[19 : 15];
-  assign _zz_750_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_751_ = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
-  assign _zz_752_ = ($signed(_zz_753_) + $signed(_zz_756_));
-  assign _zz_753_ = ($signed(_zz_754_) + $signed(_zz_755_));
-  assign _zz_754_ = execute_SRC1;
-  assign _zz_755_ = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
-  assign _zz_756_ = (execute_SRC_USE_SUB_LESS ? _zz_757_ : _zz_758_);
-  assign _zz_757_ = 32'h00000001;
-  assign _zz_758_ = 32'h0;
-  assign _zz_759_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_760_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_761_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_762_ = {_zz_485_,execute_INSTRUCTION[31 : 20]};
-  assign _zz_763_ = {{_zz_487_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
-  assign _zz_764_ = {{_zz_489_,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
-  assign _zz_765_ = execute_INSTRUCTION[31 : 20];
-  assign _zz_766_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
-  assign _zz_767_ = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
-  assign _zz_768_ = (3'b100);
-  assign _zz_769_ = (_zz_501_ & (~ _zz_770_));
-  assign _zz_770_ = (_zz_501_ - (2'b01));
-  assign _zz_771_ = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
-  assign _zz_772_ = ({32'd0,writeBack_MUL_HH} <<< 32);
-  assign _zz_773_ = writeBack_MUL_LOW[31 : 0];
-  assign _zz_774_ = writeBack_MulPlugin_result[63 : 32];
-  assign _zz_775_ = memory_DivPlugin_div_counter_willIncrement;
-  assign _zz_776_ = {5'd0, _zz_775_};
-  assign _zz_777_ = {1'd0, memory_DivPlugin_rs2};
-  assign _zz_778_ = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
-  assign _zz_779_ = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
-  assign _zz_780_ = {_zz_503_,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
-  assign _zz_781_ = _zz_782_;
-  assign _zz_782_ = _zz_783_;
-  assign _zz_783_ = ({1'b0,(memory_DivPlugin_div_needRevert ? (~ _zz_504_) : _zz_504_)} + _zz_785_);
-  assign _zz_784_ = memory_DivPlugin_div_needRevert;
-  assign _zz_785_ = {32'd0, _zz_784_};
-  assign _zz_786_ = _zz_506_;
-  assign _zz_787_ = {32'd0, _zz_786_};
-  assign _zz_788_ = _zz_505_;
-  assign _zz_789_ = {31'd0, _zz_788_};
-  assign _zz_790_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_791_ = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_792_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_793_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_794_ = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_795_ = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_796_ = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_797_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_798_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_799_ = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_800_ = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_801_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_802_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_803_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_804_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_805_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_806_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_807_ = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_808_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_809_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_810_ = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_811_ = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_812_ = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_813_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_814_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_815_ = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_816_ = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_817_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_818_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_819_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_820_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_821_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_822_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_823_ = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_824_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_825_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_826_ = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_827_ = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_828_ = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_829_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_830_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_831_ = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_832_ = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_833_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_834_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_835_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_836_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_837_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_838_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_839_ = execute_CsrPlugin_writeData[23 : 23];
-  assign _zz_840_ = execute_CsrPlugin_writeData[15 : 15];
-  assign _zz_841_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_842_ = execute_CsrPlugin_writeData[26 : 26];
-  assign _zz_843_ = execute_CsrPlugin_writeData[25 : 25];
-  assign _zz_844_ = execute_CsrPlugin_writeData[24 : 24];
-  assign _zz_845_ = execute_CsrPlugin_writeData[18 : 18];
-  assign _zz_846_ = execute_CsrPlugin_writeData[17 : 17];
-  assign _zz_847_ = execute_CsrPlugin_writeData[16 : 16];
-  assign _zz_848_ = execute_CsrPlugin_writeData[10 : 10];
-  assign _zz_849_ = execute_CsrPlugin_writeData[9 : 9];
-  assign _zz_850_ = execute_CsrPlugin_writeData[8 : 8];
-  assign _zz_851_ = execute_CsrPlugin_writeData[2 : 2];
-  assign _zz_852_ = execute_CsrPlugin_writeData[1 : 1];
-  assign _zz_853_ = execute_CsrPlugin_writeData[0 : 0];
-  assign _zz_854_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_855_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_856_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_857_ = execute_CsrPlugin_writeData[11 : 11];
-  assign _zz_858_ = execute_CsrPlugin_writeData[7 : 7];
-  assign _zz_859_ = execute_CsrPlugin_writeData[3 : 3];
-  assign _zz_860_ = execute_CsrPlugin_writeData[31 : 31];
-  assign _zz_861_ = (iBus_cmd_payload_address >>> 5);
-  assign _zz_862_ = 1'b1;
-  assign _zz_863_ = 1'b1;
-  assign _zz_864_ = {_zz_62_,_zz_61_};
-  assign _zz_865_ = {_zz_362_,{_zz_361_,{_zz_360_,_zz_359_}}};
-  assign _zz_866_ = {_zz_379_,{_zz_378_,{_zz_377_,_zz_376_}}};
-  assign _zz_867_ = {_zz_396_,{_zz_395_,{_zz_394_,_zz_393_}}};
-  assign _zz_868_ = {_zz_413_,{_zz_412_,{_zz_411_,_zz_410_}}};
-  assign _zz_869_ = {_zz_430_,{_zz_429_,{_zz_428_,_zz_427_}}};
-  assign _zz_870_ = {_zz_447_,{_zz_446_,{_zz_445_,_zz_444_}}};
-  assign _zz_871_ = 32'h0000107f;
-  assign _zz_872_ = (decode_INSTRUCTION & 32'h0000207f);
-  assign _zz_873_ = 32'h00002073;
-  assign _zz_874_ = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
-  assign _zz_875_ = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
-  assign _zz_876_ = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_877_) == 32'h00000003),{(_zz_878_ == _zz_879_),{_zz_880_,{_zz_881_,_zz_882_}}}}}};
-  assign _zz_877_ = 32'h0000505f;
-  assign _zz_878_ = (decode_INSTRUCTION & 32'h0000707b);
-  assign _zz_879_ = 32'h00000063;
-  assign _zz_880_ = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
-  assign _zz_881_ = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
-  assign _zz_882_ = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_883_) == 32'h00001013),{(_zz_884_ == _zz_885_),{_zz_886_,{_zz_887_,_zz_888_}}}}}};
-  assign _zz_883_ = 32'hfc00307f;
-  assign _zz_884_ = (decode_INSTRUCTION & 32'hbe00707f);
-  assign _zz_885_ = 32'h00005033;
-  assign _zz_886_ = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
-  assign _zz_887_ = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
-  assign _zz_888_ = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
-  assign _zz_889_ = decode_INSTRUCTION[31];
-  assign _zz_890_ = decode_INSTRUCTION[31];
-  assign _zz_891_ = decode_INSTRUCTION[7];
-  assign _zz_892_ = PmpPlugin_ports_0_hits_5;
-  assign _zz_893_ = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_894_ = PmpPlugin_ports_0_hits_5;
-  assign _zz_895_ = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_896_ = PmpPlugin_ports_0_hits_5;
-  assign _zz_897_ = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
-  assign _zz_898_ = PmpPlugin_ports_1_hits_5;
-  assign _zz_899_ = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_900_ = PmpPlugin_ports_1_hits_5;
-  assign _zz_901_ = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_902_ = PmpPlugin_ports_1_hits_5;
-  assign _zz_903_ = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
-  assign _zz_904_ = (decode_INSTRUCTION & 32'h00002040);
-  assign _zz_905_ = 32'h00002040;
-  assign _zz_906_ = ((decode_INSTRUCTION & _zz_917_) == 32'h00001040);
-  assign _zz_907_ = (_zz_918_ == _zz_919_);
-  assign _zz_908_ = {_zz_920_,_zz_921_};
-  assign _zz_909_ = ((decode_INSTRUCTION & _zz_922_) == 32'h10000050);
-  assign _zz_910_ = ((decode_INSTRUCTION & _zz_923_) == 32'h00000050);
-  assign _zz_911_ = ((decode_INSTRUCTION & _zz_924_) == 32'h00000050);
-  assign _zz_912_ = {_zz_925_,_zz_926_};
-  assign _zz_913_ = (2'b00);
-  assign _zz_914_ = ({_zz_927_,_zz_928_} != (2'b00));
-  assign _zz_915_ = (_zz_929_ != _zz_930_);
-  assign _zz_916_ = {_zz_931_,{_zz_932_,_zz_933_}};
-  assign _zz_917_ = 32'h00001040;
-  assign _zz_918_ = (decode_INSTRUCTION & 32'h00100040);
-  assign _zz_919_ = 32'h00000040;
-  assign _zz_920_ = ((decode_INSTRUCTION & _zz_934_) == 32'h00000040);
-  assign _zz_921_ = ((decode_INSTRUCTION & _zz_935_) == 32'h0);
-  assign _zz_922_ = 32'h10203050;
-  assign _zz_923_ = 32'h10103050;
-  assign _zz_924_ = 32'h00103050;
-  assign _zz_925_ = ((decode_INSTRUCTION & _zz_936_) == 32'h00000020);
-  assign _zz_926_ = ((decode_INSTRUCTION & _zz_937_) == 32'h00000020);
-  assign _zz_927_ = (_zz_938_ == _zz_939_);
-  assign _zz_928_ = (_zz_940_ == _zz_941_);
-  assign _zz_929_ = (_zz_942_ == _zz_943_);
-  assign _zz_930_ = (1'b0);
-  assign _zz_931_ = ({_zz_944_,_zz_945_} != (2'b00));
-  assign _zz_932_ = (_zz_946_ != _zz_947_);
-  assign _zz_933_ = {_zz_948_,{_zz_949_,_zz_950_}};
-  assign _zz_934_ = 32'h00000050;
-  assign _zz_935_ = 32'h00000038;
-  assign _zz_936_ = 32'h00000034;
-  assign _zz_937_ = 32'h00000064;
-  assign _zz_938_ = (decode_INSTRUCTION & 32'h00001050);
-  assign _zz_939_ = 32'h00001050;
-  assign _zz_940_ = (decode_INSTRUCTION & 32'h00002050);
-  assign _zz_941_ = 32'h00002050;
-  assign _zz_942_ = (decode_INSTRUCTION & 32'h00005048);
-  assign _zz_943_ = 32'h00001008;
-  assign _zz_944_ = _zz_450_;
-  assign _zz_945_ = ((decode_INSTRUCTION & _zz_951_) == 32'h00000020);
-  assign _zz_946_ = {_zz_450_,(_zz_952_ == _zz_953_)};
-  assign _zz_947_ = (2'b00);
-  assign _zz_948_ = ((_zz_954_ == _zz_955_) != (1'b0));
-  assign _zz_949_ = (_zz_956_ != (1'b0));
-  assign _zz_950_ = {(_zz_957_ != _zz_958_),{_zz_959_,{_zz_960_,_zz_961_}}};
-  assign _zz_951_ = 32'h00000070;
-  assign _zz_952_ = (decode_INSTRUCTION & 32'h00000020);
-  assign _zz_953_ = 32'h0;
-  assign _zz_954_ = (decode_INSTRUCTION & 32'h02004064);
-  assign _zz_955_ = 32'h02004020;
-  assign _zz_956_ = ((decode_INSTRUCTION & 32'h00004014) == 32'h00004010);
-  assign _zz_957_ = ((decode_INSTRUCTION & 32'h00006014) == 32'h00002010);
-  assign _zz_958_ = (1'b0);
-  assign _zz_959_ = ({(_zz_962_ == _zz_963_),{_zz_964_,{_zz_965_,_zz_966_}}} != (4'b0000));
-  assign _zz_960_ = ((_zz_967_ == _zz_968_) != (1'b0));
-  assign _zz_961_ = {({_zz_969_,_zz_970_} != 6'h0),{(_zz_971_ != _zz_972_),{_zz_973_,{_zz_974_,_zz_975_}}}};
-  assign _zz_962_ = (decode_INSTRUCTION & 32'h00000044);
-  assign _zz_963_ = 32'h0;
-  assign _zz_964_ = ((decode_INSTRUCTION & _zz_976_) == 32'h0);
-  assign _zz_965_ = (_zz_977_ == _zz_978_);
-  assign _zz_966_ = (_zz_979_ == _zz_980_);
-  assign _zz_967_ = (decode_INSTRUCTION & 32'h00000064);
-  assign _zz_968_ = 32'h00000024;
-  assign _zz_969_ = _zz_449_;
-  assign _zz_970_ = {_zz_981_,{_zz_982_,_zz_983_}};
-  assign _zz_971_ = (_zz_984_ == _zz_985_);
-  assign _zz_972_ = (1'b0);
-  assign _zz_973_ = ({_zz_986_,_zz_987_} != (2'b00));
-  assign _zz_974_ = (_zz_988_ != _zz_989_);
-  assign _zz_975_ = {_zz_990_,{_zz_991_,_zz_992_}};
-  assign _zz_976_ = 32'h00000018;
-  assign _zz_977_ = (decode_INSTRUCTION & 32'h00006004);
-  assign _zz_978_ = 32'h00002000;
-  assign _zz_979_ = (decode_INSTRUCTION & 32'h00005004);
-  assign _zz_980_ = 32'h00001000;
-  assign _zz_981_ = ((decode_INSTRUCTION & _zz_993_) == 32'h00001010);
-  assign _zz_982_ = (_zz_994_ == _zz_995_);
-  assign _zz_983_ = {_zz_996_,{_zz_997_,_zz_998_}};
-  assign _zz_984_ = (decode_INSTRUCTION & 32'h00004048);
-  assign _zz_985_ = 32'h00004008;
-  assign _zz_986_ = (_zz_999_ == _zz_1000_);
-  assign _zz_987_ = (_zz_1001_ == _zz_1002_);
-  assign _zz_988_ = _zz_452_;
-  assign _zz_989_ = (1'b0);
-  assign _zz_990_ = (_zz_452_ != (1'b0));
-  assign _zz_991_ = (_zz_1003_ != _zz_1004_);
-  assign _zz_992_ = {_zz_1005_,{_zz_1006_,_zz_1007_}};
-  assign _zz_993_ = 32'h00001010;
-  assign _zz_994_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_995_ = 32'h00002010;
-  assign _zz_996_ = ((decode_INSTRUCTION & 32'h00000050) == 32'h00000010);
-  assign _zz_997_ = ((decode_INSTRUCTION & _zz_1008_) == 32'h00000004);
-  assign _zz_998_ = ((decode_INSTRUCTION & _zz_1009_) == 32'h0);
-  assign _zz_999_ = (decode_INSTRUCTION & 32'h00002010);
-  assign _zz_1000_ = 32'h00002000;
-  assign _zz_1001_ = (decode_INSTRUCTION & 32'h00005000);
-  assign _zz_1002_ = 32'h00001000;
-  assign _zz_1003_ = {(_zz_1010_ == _zz_1011_),(_zz_1012_ == _zz_1013_)};
-  assign _zz_1004_ = (2'b00);
-  assign _zz_1005_ = ({_zz_1014_,{_zz_1015_,_zz_1016_}} != (3'b000));
-  assign _zz_1006_ = (_zz_1017_ != (1'b0));
-  assign _zz_1007_ = {(_zz_1018_ != _zz_1019_),{_zz_1020_,{_zz_1021_,_zz_1022_}}};
-  assign _zz_1008_ = 32'h0000000c;
-  assign _zz_1009_ = 32'h00000028;
-  assign _zz_1010_ = (decode_INSTRUCTION & 32'h00007034);
-  assign _zz_1011_ = 32'h00005010;
-  assign _zz_1012_ = (decode_INSTRUCTION & 32'h02007064);
-  assign _zz_1013_ = 32'h00005020;
-  assign _zz_1014_ = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
-  assign _zz_1015_ = ((decode_INSTRUCTION & _zz_1023_) == 32'h00001010);
-  assign _zz_1016_ = ((decode_INSTRUCTION & _zz_1024_) == 32'h00001010);
-  assign _zz_1017_ = ((decode_INSTRUCTION & 32'h10103050) == 32'h00100050);
-  assign _zz_1018_ = ((decode_INSTRUCTION & _zz_1025_) == 32'h02000030);
-  assign _zz_1019_ = (1'b0);
-  assign _zz_1020_ = ({_zz_1026_,{_zz_1027_,_zz_1028_}} != (3'b000));
-  assign _zz_1021_ = (_zz_1029_ != (1'b0));
-  assign _zz_1022_ = {(_zz_1030_ != _zz_1031_),{_zz_1032_,{_zz_1033_,_zz_1034_}}};
-  assign _zz_1023_ = 32'h00007034;
-  assign _zz_1024_ = 32'h02007054;
-  assign _zz_1025_ = 32'h02004074;
-  assign _zz_1026_ = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
-  assign _zz_1027_ = ((decode_INSTRUCTION & _zz_1035_) == 32'h00002010);
-  assign _zz_1028_ = ((decode_INSTRUCTION & _zz_1036_) == 32'h40000030);
-  assign _zz_1029_ = ((decode_INSTRUCTION & 32'h00000020) == 32'h00000020);
-  assign _zz_1030_ = ((decode_INSTRUCTION & _zz_1037_) == 32'h0);
-  assign _zz_1031_ = (1'b0);
-  assign _zz_1032_ = ((_zz_1038_ == _zz_1039_) != (1'b0));
-  assign _zz_1033_ = (_zz_1040_ != (1'b0));
-  assign _zz_1034_ = {(_zz_1041_ != _zz_1042_),{_zz_1043_,{_zz_1044_,_zz_1045_}}};
-  assign _zz_1035_ = 32'h00002014;
-  assign _zz_1036_ = 32'h40000034;
-  assign _zz_1037_ = 32'h00000058;
-  assign _zz_1038_ = (decode_INSTRUCTION & 32'h00001000);
-  assign _zz_1039_ = 32'h00001000;
-  assign _zz_1040_ = ((decode_INSTRUCTION & 32'h00003000) == 32'h00002000);
-  assign _zz_1041_ = {_zz_450_,{_zz_1046_,{_zz_1047_,_zz_1048_}}};
-  assign _zz_1042_ = 5'h0;
-  assign _zz_1043_ = ({_zz_1049_,_zz_451_} != (2'b00));
-  assign _zz_1044_ = ({_zz_1050_,_zz_1051_} != (2'b00));
-  assign _zz_1045_ = {(_zz_1052_ != _zz_1053_),{_zz_1054_,_zz_1055_}};
-  assign _zz_1046_ = ((decode_INSTRUCTION & 32'h00002030) == 32'h00002010);
-  assign _zz_1047_ = ((decode_INSTRUCTION & _zz_1056_) == 32'h00000010);
-  assign _zz_1048_ = {(_zz_1057_ == _zz_1058_),(_zz_1059_ == _zz_1060_)};
-  assign _zz_1049_ = ((decode_INSTRUCTION & 32'h00000014) == 32'h00000004);
-  assign _zz_1050_ = ((decode_INSTRUCTION & _zz_1061_) == 32'h00000004);
-  assign _zz_1051_ = _zz_451_;
-  assign _zz_1052_ = {(_zz_1062_ == _zz_1063_),{_zz_450_,{_zz_1064_,_zz_1065_}}};
-  assign _zz_1053_ = 5'h0;
-  assign _zz_1054_ = ({_zz_449_,_zz_1066_} != (2'b00));
-  assign _zz_1055_ = ((_zz_1067_ == _zz_1068_) != (1'b0));
-  assign _zz_1056_ = 32'h00001030;
-  assign _zz_1057_ = (decode_INSTRUCTION & 32'h02002060);
-  assign _zz_1058_ = 32'h00002020;
-  assign _zz_1059_ = (decode_INSTRUCTION & 32'h02003020);
-  assign _zz_1060_ = 32'h00000020;
-  assign _zz_1061_ = 32'h00000044;
-  assign _zz_1062_ = (decode_INSTRUCTION & 32'h00000040);
-  assign _zz_1063_ = 32'h00000040;
-  assign _zz_1064_ = ((decode_INSTRUCTION & 32'h00004020) == 32'h00004020);
-  assign _zz_1065_ = {((decode_INSTRUCTION & 32'h00000030) == 32'h00000010),((decode_INSTRUCTION & 32'h02000020) == 32'h00000020)};
-  assign _zz_1066_ = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
-  assign _zz_1067_ = (decode_INSTRUCTION & 32'h00000058);
-  assign _zz_1068_ = 32'h00000040;
-  assign _zz_1069_ = execute_INSTRUCTION[31];
-  assign _zz_1070_ = execute_INSTRUCTION[31];
-  assign _zz_1071_ = execute_INSTRUCTION[7];
-  assign _zz_1072_ = (_zz_512_ | _zz_513_);
-  assign _zz_1073_ = (_zz_514_ | _zz_515_);
-  assign _zz_1074_ = (_zz_516_ | _zz_517_);
-  assign _zz_1075_ = (_zz_518_ | _zz_519_);
-  assign _zz_1076_ = (_zz_520_ | _zz_521_);
-  assign _zz_1077_ = (_zz_522_ | _zz_523_);
-  assign _zz_1078_ = (_zz_524_ | _zz_525_);
-  assign _zz_1079_ = (_zz_526_ | _zz_527_);
-  assign _zz_1080_ = (_zz_528_ | _zz_529_);
-  assign _zz_1081_ = (_zz_530_ | _zz_531_);
-  assign _zz_1082_ = (_zz_532_ | _zz_533_);
-  assign _zz_1083_ = (_zz_534_ | _zz_535_);
-  assign _zz_1084_ = (_zz_1088_ | _zz_536_);
-  assign _zz_1085_ = (_zz_537_ | _zz_538_);
-  assign _zz_1086_ = (_zz_539_ | _zz_540_);
-  assign _zz_1087_ = (_zz_541_ | _zz_542_);
-  assign _zz_1088_ = 32'h0;
+  assign _zz_674 = (execute_arbitration_isValid && execute_IS_CSR);
+  assign _zz_675 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_676 = 1'b1;
+  assign _zz_677 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_678 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_679 = (memory_arbitration_isValid && memory_IS_DIV);
+  assign _zz_680 = ((_zz_630 && IBusCachedPlugin_cache_io_cpu_decode_error) && (! IBusCachedPlugin_rsp_issueDetected_3));
+  assign _zz_681 = ((_zz_630 && IBusCachedPlugin_cache_io_cpu_decode_cacheMiss) && (! IBusCachedPlugin_rsp_issueDetected_2));
+  assign _zz_682 = ((_zz_630 && IBusCachedPlugin_cache_io_cpu_decode_mmuException) && (! IBusCachedPlugin_rsp_issueDetected_1));
+  assign _zz_683 = ((_zz_630 && IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling) && (! IBusCachedPlugin_rsp_issueDetected));
+  assign _zz_684 = ({decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid} != 2'b00);
+  assign _zz_685 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_WFI));
+  assign _zz_686 = (execute_arbitration_isValid && execute_DO_EBREAK);
+  assign _zz_687 = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) == 1'b0);
+  assign _zz_688 = (CsrPlugin_hadException || CsrPlugin_interruptJump);
+  assign _zz_689 = (writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET));
+  assign _zz_690 = (DebugPlugin_stepIt && IBusCachedPlugin_incomingInstruction);
+  assign _zz_691 = writeBack_INSTRUCTION[29 : 28];
+  assign _zz_692 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_693 = (_zz_824 == 5'h0);
+  assign _zz_694 = (_zz_834 == 5'h0);
+  assign _zz_695 = (writeBack_arbitration_isValid && writeBack_REGFILE_WRITE_VALID);
+  assign _zz_696 = (1'b0 || (! 1'b1));
+  assign _zz_697 = (memory_arbitration_isValid && memory_REGFILE_WRITE_VALID);
+  assign _zz_698 = (1'b0 || (! memory_BYPASSABLE_MEMORY_STAGE));
+  assign _zz_699 = (execute_arbitration_isValid && execute_REGFILE_WRITE_VALID);
+  assign _zz_700 = (1'b0 || (! execute_BYPASSABLE_EXECUTE_STAGE));
+  assign _zz_701 = (CsrPlugin_privilege < execute_CsrPlugin_csrAddress[9 : 8]);
+  assign _zz_702 = (execute_CsrPlugin_illegalAccess || execute_CsrPlugin_illegalInstruction);
+  assign _zz_703 = (execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_ECALL));
+  assign _zz_704 = execute_INSTRUCTION[13 : 12];
+  assign _zz_705 = (memory_DivPlugin_frontendOk && (! memory_DivPlugin_div_done));
+  assign _zz_706 = (! memory_arbitration_isStuck);
+  assign _zz_707 = debug_bus_cmd_payload_address[7 : 2];
+  assign _zz_708 = (iBus_cmd_valid || (_zz_616 != 3'b000));
+  assign _zz_709 = (_zz_652 && (! dataCache_1_io_mem_cmd_s2mPipe_ready));
+  assign _zz_710 = (! _zz_90);
+  assign _zz_711 = (! _zz_109);
+  assign _zz_712 = (! _zz_128);
+  assign _zz_713 = (! _zz_147);
+  assign _zz_714 = (! _zz_166);
+  assign _zz_715 = (! _zz_185);
+  assign _zz_716 = (! _zz_204);
+  assign _zz_717 = (! _zz_223);
+  assign _zz_718 = (! _zz_242);
+  assign _zz_719 = (! _zz_261);
+  assign _zz_720 = (! _zz_280);
+  assign _zz_721 = (! _zz_299);
+  assign _zz_722 = (! _zz_318);
+  assign _zz_723 = (! _zz_337);
+  assign _zz_724 = (! _zz_356);
+  assign _zz_725 = (! _zz_375);
+  assign _zz_726 = (CsrPlugin_mstatus_MIE || (CsrPlugin_privilege < 2'b11));
+  assign _zz_727 = ((_zz_559 && 1'b1) && (! 1'b0));
+  assign _zz_728 = ((_zz_560 && 1'b1) && (! 1'b0));
+  assign _zz_729 = ((_zz_561 && 1'b1) && (! 1'b0));
+  assign _zz_730 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_731 = execute_INSTRUCTION[13];
+  assign _zz_732 = writeBack_INSTRUCTION[13 : 12];
+  assign _zz_733 = ($signed(_zz_734) + $signed(_zz_739));
+  assign _zz_734 = ($signed(_zz_735) + $signed(_zz_737));
+  assign _zz_735 = 52'h0;
+  assign _zz_736 = {1'b0,memory_MUL_LL};
+  assign _zz_737 = {{19{_zz_736[32]}}, _zz_736};
+  assign _zz_738 = ({16'd0,memory_MUL_LH} <<< 16);
+  assign _zz_739 = {{2{_zz_738[49]}}, _zz_738};
+  assign _zz_740 = ({16'd0,memory_MUL_HL} <<< 16);
+  assign _zz_741 = {{2{_zz_740[49]}}, _zz_740};
+  assign _zz_742 = ($signed(_zz_744) >>> execute_FullBarrelShifterPlugin_amplitude);
+  assign _zz_743 = _zz_742[31 : 0];
+  assign _zz_744 = {((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SRA_1) && execute_FullBarrelShifterPlugin_reversed[31]),execute_FullBarrelShifterPlugin_reversed};
+  assign _zz_745 = _zz_509[31 : 31];
+  assign _zz_746 = _zz_509[30 : 30];
+  assign _zz_747 = _zz_509[29 : 29];
+  assign _zz_748 = _zz_509[28 : 28];
+  assign _zz_749 = _zz_509[25 : 25];
+  assign _zz_750 = _zz_509[17 : 17];
+  assign _zz_751 = _zz_509[16 : 16];
+  assign _zz_752 = _zz_509[13 : 13];
+  assign _zz_753 = _zz_509[12 : 12];
+  assign _zz_754 = _zz_509[11 : 11];
+  assign _zz_755 = _zz_509[32 : 32];
+  assign _zz_756 = _zz_509[15 : 15];
+  assign _zz_757 = _zz_509[5 : 5];
+  assign _zz_758 = _zz_509[3 : 3];
+  assign _zz_759 = _zz_509[20 : 20];
+  assign _zz_760 = _zz_509[10 : 10];
+  assign _zz_761 = _zz_509[4 : 4];
+  assign _zz_762 = _zz_509[0 : 0];
+  assign _zz_763 = (_zz_55 - 4'b0001);
+  assign _zz_764 = {IBusCachedPlugin_fetchPc_inc,2'b00};
+  assign _zz_765 = {29'd0, _zz_764};
+  assign _zz_766 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_767 = {{_zz_70,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_768 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_769 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_770 = {{_zz_72,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_771 = {{_zz_74,{{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_772 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]};
+  assign _zz_773 = {{{decode_INSTRUCTION[31],decode_INSTRUCTION[7]},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]};
+  assign _zz_774 = (writeBack_MEMORY_WR ? 3'b111 : 3'b101);
+  assign _zz_775 = (writeBack_MEMORY_WR ? 3'b110 : 3'b100);
+  assign _zz_776 = (_zz_92 + 32'h00000001);
+  assign _zz_777 = (_zz_778 <<< 3);
+  assign _zz_778 = (_zz_104 + 32'h00000001);
+  assign _zz_779 = (_zz_111 + 32'h00000001);
+  assign _zz_780 = (_zz_781 <<< 3);
+  assign _zz_781 = (_zz_123 + 32'h00000001);
+  assign _zz_782 = (_zz_130 + 32'h00000001);
+  assign _zz_783 = (_zz_784 <<< 3);
+  assign _zz_784 = (_zz_142 + 32'h00000001);
+  assign _zz_785 = (_zz_149 + 32'h00000001);
+  assign _zz_786 = (_zz_787 <<< 3);
+  assign _zz_787 = (_zz_161 + 32'h00000001);
+  assign _zz_788 = (_zz_168 + 32'h00000001);
+  assign _zz_789 = (_zz_790 <<< 3);
+  assign _zz_790 = (_zz_180 + 32'h00000001);
+  assign _zz_791 = (_zz_187 + 32'h00000001);
+  assign _zz_792 = (_zz_793 <<< 3);
+  assign _zz_793 = (_zz_199 + 32'h00000001);
+  assign _zz_794 = (_zz_206 + 32'h00000001);
+  assign _zz_795 = (_zz_796 <<< 3);
+  assign _zz_796 = (_zz_218 + 32'h00000001);
+  assign _zz_797 = (_zz_225 + 32'h00000001);
+  assign _zz_798 = (_zz_799 <<< 3);
+  assign _zz_799 = (_zz_237 + 32'h00000001);
+  assign _zz_800 = (_zz_244 + 32'h00000001);
+  assign _zz_801 = (_zz_802 <<< 3);
+  assign _zz_802 = (_zz_256 + 32'h00000001);
+  assign _zz_803 = (_zz_263 + 32'h00000001);
+  assign _zz_804 = (_zz_805 <<< 3);
+  assign _zz_805 = (_zz_275 + 32'h00000001);
+  assign _zz_806 = (_zz_282 + 32'h00000001);
+  assign _zz_807 = (_zz_808 <<< 3);
+  assign _zz_808 = (_zz_294 + 32'h00000001);
+  assign _zz_809 = (_zz_301 + 32'h00000001);
+  assign _zz_810 = (_zz_811 <<< 3);
+  assign _zz_811 = (_zz_313 + 32'h00000001);
+  assign _zz_812 = (_zz_320 + 32'h00000001);
+  assign _zz_813 = (_zz_814 <<< 3);
+  assign _zz_814 = (_zz_332 + 32'h00000001);
+  assign _zz_815 = (_zz_339 + 32'h00000001);
+  assign _zz_816 = (_zz_817 <<< 3);
+  assign _zz_817 = (_zz_351 + 32'h00000001);
+  assign _zz_818 = (_zz_358 + 32'h00000001);
+  assign _zz_819 = (_zz_820 <<< 3);
+  assign _zz_820 = (_zz_370 + 32'h00000001);
+  assign _zz_821 = (_zz_377 + 32'h00000001);
+  assign _zz_822 = (_zz_823 <<< 3);
+  assign _zz_823 = (_zz_389 + 32'h00000001);
+  assign _zz_824 = (_zz_825 + _zz_828);
+  assign _zz_825 = (_zz_826 + _zz_827);
+  assign _zz_826 = (_zz_656 + _zz_657);
+  assign _zz_827 = (_zz_658 + _zz_659);
+  assign _zz_828 = (_zz_660 + _zz_661);
+  assign _zz_829 = PmpPlugin_ports_0_hits_15;
+  assign _zz_830 = {2'd0, _zz_829};
+  assign _zz_831 = (_zz_399 - 16'h0001);
+  assign _zz_832 = (_zz_416 - 16'h0001);
+  assign _zz_833 = (_zz_433 - 16'h0001);
+  assign _zz_834 = (_zz_835 + _zz_838);
+  assign _zz_835 = (_zz_836 + _zz_837);
+  assign _zz_836 = (_zz_665 + _zz_666);
+  assign _zz_837 = (_zz_667 + _zz_668);
+  assign _zz_838 = (_zz_669 + _zz_670);
+  assign _zz_839 = PmpPlugin_ports_1_hits_15;
+  assign _zz_840 = {2'd0, _zz_839};
+  assign _zz_841 = (_zz_458 - 16'h0001);
+  assign _zz_842 = (_zz_475 - 16'h0001);
+  assign _zz_843 = (_zz_492 - 16'h0001);
+  assign _zz_844 = execute_SRC_LESS;
+  assign _zz_845 = 3'b100;
+  assign _zz_846 = execute_INSTRUCTION[19 : 15];
+  assign _zz_847 = execute_INSTRUCTION[31 : 20];
+  assign _zz_848 = {execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]};
+  assign _zz_849 = ($signed(_zz_850) + $signed(_zz_853));
+  assign _zz_850 = ($signed(_zz_851) + $signed(_zz_852));
+  assign _zz_851 = execute_SRC1;
+  assign _zz_852 = (execute_SRC_USE_SUB_LESS ? (~ execute_SRC2) : execute_SRC2);
+  assign _zz_853 = (execute_SRC_USE_SUB_LESS ? _zz_854 : _zz_855);
+  assign _zz_854 = 32'h00000001;
+  assign _zz_855 = 32'h0;
+  assign _zz_856 = execute_INSTRUCTION[31 : 20];
+  assign _zz_857 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_858 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_859 = {_zz_546,execute_INSTRUCTION[31 : 20]};
+  assign _zz_860 = {{_zz_548,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0};
+  assign _zz_861 = {{_zz_550,{{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0};
+  assign _zz_862 = execute_INSTRUCTION[31 : 20];
+  assign _zz_863 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]};
+  assign _zz_864 = {{{execute_INSTRUCTION[31],execute_INSTRUCTION[7]},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]};
+  assign _zz_865 = 3'b100;
+  assign _zz_866 = (_zz_562 & (~ _zz_867));
+  assign _zz_867 = (_zz_562 - 2'b01);
+  assign _zz_868 = {{14{writeBack_MUL_LOW[51]}}, writeBack_MUL_LOW};
+  assign _zz_869 = ({32'd0,writeBack_MUL_HH} <<< 32);
+  assign _zz_870 = writeBack_MUL_LOW[31 : 0];
+  assign _zz_871 = writeBack_MulPlugin_result[63 : 32];
+  assign _zz_872 = memory_DivPlugin_div_counter_willIncrement;
+  assign _zz_873 = {5'd0, _zz_872};
+  assign _zz_874 = {1'd0, memory_DivPlugin_rs2};
+  assign _zz_875 = memory_DivPlugin_div_stage_0_remainderMinusDenominator[31:0];
+  assign _zz_876 = memory_DivPlugin_div_stage_0_remainderShifted[31:0];
+  assign _zz_877 = {_zz_564,(! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32])};
+  assign _zz_878 = _zz_879;
+  assign _zz_879 = _zz_880;
+  assign _zz_880 = ({memory_DivPlugin_div_needRevert,(memory_DivPlugin_div_needRevert ? (~ _zz_565) : _zz_565)} + _zz_882);
+  assign _zz_881 = memory_DivPlugin_div_needRevert;
+  assign _zz_882 = {32'd0, _zz_881};
+  assign _zz_883 = _zz_567;
+  assign _zz_884 = {32'd0, _zz_883};
+  assign _zz_885 = _zz_566;
+  assign _zz_886 = {31'd0, _zz_885};
+  assign _zz_887 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_888 = execute_CsrPlugin_writeData[23 : 23];
+  assign _zz_889 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_890 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_891 = execute_CsrPlugin_writeData[26 : 26];
+  assign _zz_892 = execute_CsrPlugin_writeData[25 : 25];
+  assign _zz_893 = execute_CsrPlugin_writeData[24 : 24];
+  assign _zz_894 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_895 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_896 = execute_CsrPlugin_writeData[16 : 16];
+  assign _zz_897 = execute_CsrPlugin_writeData[10 : 10];
+  assign _zz_898 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_899 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_900 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_901 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_902 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_903 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_904 = execute_CsrPlugin_writeData[23 : 23];
+  assign _zz_905 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_906 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_907 = execute_CsrPlugin_writeData[26 : 26];
+  assign _zz_908 = execute_CsrPlugin_writeData[25 : 25];
+  assign _zz_909 = execute_CsrPlugin_writeData[24 : 24];
+  assign _zz_910 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_911 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_912 = execute_CsrPlugin_writeData[16 : 16];
+  assign _zz_913 = execute_CsrPlugin_writeData[10 : 10];
+  assign _zz_914 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_915 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_916 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_917 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_918 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_919 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_920 = execute_CsrPlugin_writeData[23 : 23];
+  assign _zz_921 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_922 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_923 = execute_CsrPlugin_writeData[26 : 26];
+  assign _zz_924 = execute_CsrPlugin_writeData[25 : 25];
+  assign _zz_925 = execute_CsrPlugin_writeData[24 : 24];
+  assign _zz_926 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_927 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_928 = execute_CsrPlugin_writeData[16 : 16];
+  assign _zz_929 = execute_CsrPlugin_writeData[10 : 10];
+  assign _zz_930 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_931 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_932 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_933 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_934 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_935 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_936 = execute_CsrPlugin_writeData[23 : 23];
+  assign _zz_937 = execute_CsrPlugin_writeData[15 : 15];
+  assign _zz_938 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_939 = execute_CsrPlugin_writeData[26 : 26];
+  assign _zz_940 = execute_CsrPlugin_writeData[25 : 25];
+  assign _zz_941 = execute_CsrPlugin_writeData[24 : 24];
+  assign _zz_942 = execute_CsrPlugin_writeData[18 : 18];
+  assign _zz_943 = execute_CsrPlugin_writeData[17 : 17];
+  assign _zz_944 = execute_CsrPlugin_writeData[16 : 16];
+  assign _zz_945 = execute_CsrPlugin_writeData[10 : 10];
+  assign _zz_946 = execute_CsrPlugin_writeData[9 : 9];
+  assign _zz_947 = execute_CsrPlugin_writeData[8 : 8];
+  assign _zz_948 = execute_CsrPlugin_writeData[2 : 2];
+  assign _zz_949 = execute_CsrPlugin_writeData[1 : 1];
+  assign _zz_950 = execute_CsrPlugin_writeData[0 : 0];
+  assign _zz_951 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_952 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_953 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_954 = execute_CsrPlugin_writeData[11 : 11];
+  assign _zz_955 = execute_CsrPlugin_writeData[7 : 7];
+  assign _zz_956 = execute_CsrPlugin_writeData[3 : 3];
+  assign _zz_957 = execute_CsrPlugin_writeData[31 : 31];
+  assign _zz_958 = (iBus_cmd_payload_address >>> 5);
+  assign _zz_959 = 1'b1;
+  assign _zz_960 = 1'b1;
+  assign _zz_961 = {_zz_59,_zz_58};
+  assign _zz_962 = {PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}};
+  assign _zz_963 = {PmpPlugin_ports_0_hits_5,{PmpPlugin_ports_0_hits_4,PmpPlugin_ports_0_hits_3}};
+  assign _zz_964 = {PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,PmpPlugin_ports_0_hits_6}};
+  assign _zz_965 = {PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,PmpPlugin_ports_0_hits_9}};
+  assign _zz_966 = {PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,PmpPlugin_ports_0_hits_12}};
+  assign _zz_967 = {_zz_415,{_zz_414,{_zz_413,_zz_412}}};
+  assign _zz_968 = {_zz_432,{_zz_431,{_zz_430,_zz_429}}};
+  assign _zz_969 = {_zz_449,{_zz_448,{_zz_447,_zz_446}}};
+  assign _zz_970 = {PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}};
+  assign _zz_971 = {PmpPlugin_ports_1_hits_5,{PmpPlugin_ports_1_hits_4,PmpPlugin_ports_1_hits_3}};
+  assign _zz_972 = {PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,PmpPlugin_ports_1_hits_6}};
+  assign _zz_973 = {PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,PmpPlugin_ports_1_hits_9}};
+  assign _zz_974 = {PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,PmpPlugin_ports_1_hits_12}};
+  assign _zz_975 = {_zz_474,{_zz_473,{_zz_472,_zz_471}}};
+  assign _zz_976 = {_zz_491,{_zz_490,{_zz_489,_zz_488}}};
+  assign _zz_977 = {_zz_508,{_zz_507,{_zz_506,_zz_505}}};
+  assign _zz_978 = 32'h0000107f;
+  assign _zz_979 = (decode_INSTRUCTION & 32'h0000207f);
+  assign _zz_980 = 32'h00002073;
+  assign _zz_981 = ((decode_INSTRUCTION & 32'h0000407f) == 32'h00004063);
+  assign _zz_982 = ((decode_INSTRUCTION & 32'h0000207f) == 32'h00002013);
+  assign _zz_983 = {((decode_INSTRUCTION & 32'h0000603f) == 32'h00000023),{((decode_INSTRUCTION & 32'h0000207f) == 32'h00000003),{((decode_INSTRUCTION & _zz_984) == 32'h00000003),{(_zz_985 == _zz_986),{_zz_987,{_zz_988,_zz_989}}}}}};
+  assign _zz_984 = 32'h0000505f;
+  assign _zz_985 = (decode_INSTRUCTION & 32'h0000707b);
+  assign _zz_986 = 32'h00000063;
+  assign _zz_987 = ((decode_INSTRUCTION & 32'h0000607f) == 32'h0000000f);
+  assign _zz_988 = ((decode_INSTRUCTION & 32'hfc00007f) == 32'h00000033);
+  assign _zz_989 = {((decode_INSTRUCTION & 32'h01f0707f) == 32'h0000500f),{((decode_INSTRUCTION & 32'hbc00707f) == 32'h00005013),{((decode_INSTRUCTION & _zz_990) == 32'h00001013),{(_zz_991 == _zz_992),{_zz_993,{_zz_994,_zz_995}}}}}};
+  assign _zz_990 = 32'hfc00307f;
+  assign _zz_991 = (decode_INSTRUCTION & 32'hbe00707f);
+  assign _zz_992 = 32'h00005033;
+  assign _zz_993 = ((decode_INSTRUCTION & 32'hbe00707f) == 32'h00000033);
+  assign _zz_994 = ((decode_INSTRUCTION & 32'hdfffffff) == 32'h10200073);
+  assign _zz_995 = {((decode_INSTRUCTION & 32'hffefffff) == 32'h00000073),((decode_INSTRUCTION & 32'hffffffff) == 32'h10500073)};
+  assign _zz_996 = decode_INSTRUCTION[31];
+  assign _zz_997 = decode_INSTRUCTION[31];
+  assign _zz_998 = decode_INSTRUCTION[7];
+  assign _zz_999 = PmpPlugin_ports_0_hits_5;
+  assign _zz_1000 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz_1001 = PmpPlugin_ports_0_hits_5;
+  assign _zz_1002 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz_1003 = PmpPlugin_ports_0_hits_5;
+  assign _zz_1004 = {PmpPlugin_ports_0_hits_4,{PmpPlugin_ports_0_hits_3,{PmpPlugin_ports_0_hits_2,{PmpPlugin_ports_0_hits_1,PmpPlugin_ports_0_hits_0}}}};
+  assign _zz_1005 = PmpPlugin_ports_1_hits_5;
+  assign _zz_1006 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz_1007 = PmpPlugin_ports_1_hits_5;
+  assign _zz_1008 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz_1009 = PmpPlugin_ports_1_hits_5;
+  assign _zz_1010 = {PmpPlugin_ports_1_hits_4,{PmpPlugin_ports_1_hits_3,{PmpPlugin_ports_1_hits_2,{PmpPlugin_ports_1_hits_1,PmpPlugin_ports_1_hits_0}}}};
+  assign _zz_1011 = 32'h10103050;
+  assign _zz_1012 = ((decode_INSTRUCTION & 32'h02004064) == 32'h02004020);
+  assign _zz_1013 = 1'b0;
+  assign _zz_1014 = (((decode_INSTRUCTION & _zz_1017) == 32'h02000030) != 1'b0);
+  assign _zz_1015 = ({_zz_1018,_zz_1019} != 2'b00);
+  assign _zz_1016 = {(_zz_1020 != 1'b0),{(_zz_1021 != _zz_1022),{_zz_1023,{_zz_1024,_zz_1025}}}};
+  assign _zz_1017 = 32'h02004074;
+  assign _zz_1018 = ((decode_INSTRUCTION & 32'h10203050) == 32'h10000050);
+  assign _zz_1019 = ((decode_INSTRUCTION & 32'h10103050) == 32'h00000050);
+  assign _zz_1020 = ((decode_INSTRUCTION & 32'h00103050) == 32'h00000050);
+  assign _zz_1021 = {(_zz_1026 == _zz_1027),(_zz_1028 == _zz_1029)};
+  assign _zz_1022 = 2'b00;
+  assign _zz_1023 = ({_zz_512,_zz_1030} != 2'b00);
+  assign _zz_1024 = (_zz_1031 != 1'b0);
+  assign _zz_1025 = {(_zz_1032 != _zz_1033),{_zz_1034,{_zz_1035,_zz_1036}}};
+  assign _zz_1026 = (decode_INSTRUCTION & 32'h00001050);
+  assign _zz_1027 = 32'h00001050;
+  assign _zz_1028 = (decode_INSTRUCTION & 32'h00002050);
+  assign _zz_1029 = 32'h00002050;
+  assign _zz_1030 = ((decode_INSTRUCTION & 32'h0000001c) == 32'h00000004);
+  assign _zz_1031 = ((decode_INSTRUCTION & 32'h00000058) == 32'h00000040);
+  assign _zz_1032 = {(_zz_1037 == _zz_1038),(_zz_1039 == _zz_1040)};
+  assign _zz_1033 = 2'b00;
+  assign _zz_1034 = ({_zz_1041,{_zz_1042,_zz_1043}} != 3'b000);
+  assign _zz_1035 = (_zz_1044 != 1'b0);
+  assign _zz_1036 = {(_zz_1045 != _zz_1046),{_zz_1047,{_zz_1048,_zz_1049}}};
+  assign _zz_1037 = (decode_INSTRUCTION & 32'h00007034);
+  assign _zz_1038 = 32'h00005010;
+  assign _zz_1039 = (decode_INSTRUCTION & 32'h02007064);
+  assign _zz_1040 = 32'h00005020;
+  assign _zz_1041 = ((decode_INSTRUCTION & 32'h40003054) == 32'h40001010);
+  assign _zz_1042 = ((decode_INSTRUCTION & _zz_1050) == 32'h00001010);
+  assign _zz_1043 = ((decode_INSTRUCTION & _zz_1051) == 32'h00001010);
+  assign _zz_1044 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000024);
+  assign _zz_1045 = ((decode_INSTRUCTION & _zz_1052) == 32'h00001000);
+  assign _zz_1046 = 1'b0;
+  assign _zz_1047 = ((_zz_1053 == _zz_1054) != 1'b0);
+  assign _zz_1048 = ({_zz_1055,_zz_1056} != 2'b00);
+  assign _zz_1049 = {(_zz_1057 != _zz_1058),{_zz_1059,{_zz_1060,_zz_1061}}};
+  assign _zz_1050 = 32'h00007034;
+  assign _zz_1051 = 32'h02007054;
+  assign _zz_1052 = 32'h00001000;
+  assign _zz_1053 = (decode_INSTRUCTION & 32'h00003000);
+  assign _zz_1054 = 32'h00002000;
+  assign _zz_1055 = ((decode_INSTRUCTION & _zz_1062) == 32'h00002000);
+  assign _zz_1056 = ((decode_INSTRUCTION & _zz_1063) == 32'h00001000);
+  assign _zz_1057 = ((decode_INSTRUCTION & _zz_1064) == 32'h00004008);
+  assign _zz_1058 = 1'b0;
+  assign _zz_1059 = ({_zz_1065,_zz_1066} != 2'b00);
+  assign _zz_1060 = ({_zz_1067,_zz_1068} != 5'h0);
+  assign _zz_1061 = {(_zz_1069 != _zz_1070),{_zz_1071,{_zz_1072,_zz_1073}}};
+  assign _zz_1062 = 32'h00002010;
+  assign _zz_1063 = 32'h00005000;
+  assign _zz_1064 = 32'h00004048;
+  assign _zz_1065 = ((decode_INSTRUCTION & 32'h00000034) == 32'h00000020);
+  assign _zz_1066 = ((decode_INSTRUCTION & 32'h00000064) == 32'h00000020);
+  assign _zz_1067 = ((decode_INSTRUCTION & _zz_1074) == 32'h00002040);
+  assign _zz_1068 = {(_zz_1075 == _zz_1076),{_zz_1077,{_zz_1078,_zz_1079}}};
+  assign _zz_1069 = ((decode_INSTRUCTION & _zz_1080) == 32'h00000020);
+  assign _zz_1070 = 1'b0;
+  assign _zz_1071 = ({_zz_1081,{_zz_1082,_zz_1083}} != 5'h0);
+  assign _zz_1072 = ({_zz_1084,_zz_1085} != 5'h0);
+  assign _zz_1073 = {(_zz_1086 != _zz_1087),{_zz_1088,{_zz_1089,_zz_1090}}};
+  assign _zz_1074 = 32'h00002040;
+  assign _zz_1075 = (decode_INSTRUCTION & 32'h00001040);
+  assign _zz_1076 = 32'h00001040;
+  assign _zz_1077 = ((decode_INSTRUCTION & _zz_1091) == 32'h00000040);
+  assign _zz_1078 = (_zz_1092 == _zz_1093);
+  assign _zz_1079 = (_zz_1094 == _zz_1095);
+  assign _zz_1080 = 32'h00000020;
+  assign _zz_1081 = ((decode_INSTRUCTION & _zz_1096) == 32'h00000040);
+  assign _zz_1082 = _zz_511;
+  assign _zz_1083 = {_zz_1097,{_zz_1098,_zz_1099}};
+  assign _zz_1084 = _zz_511;
+  assign _zz_1085 = {_zz_1100,{_zz_1101,_zz_1102}};
+  assign _zz_1086 = {_zz_512,{_zz_1103,_zz_1104}};
+  assign _zz_1087 = 6'h0;
+  assign _zz_1088 = ({_zz_1105,_zz_1106} != 2'b00);
+  assign _zz_1089 = (_zz_1107 != _zz_1108);
+  assign _zz_1090 = {_zz_1109,{_zz_1110,_zz_1111}};
+  assign _zz_1091 = 32'h00100040;
+  assign _zz_1092 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_1093 = 32'h00000040;
+  assign _zz_1094 = (decode_INSTRUCTION & 32'h00000038);
+  assign _zz_1095 = 32'h0;
+  assign _zz_1096 = 32'h00000040;
+  assign _zz_1097 = ((decode_INSTRUCTION & _zz_1112) == 32'h00004020);
+  assign _zz_1098 = (_zz_1113 == _zz_1114);
+  assign _zz_1099 = (_zz_1115 == _zz_1116);
+  assign _zz_1100 = ((decode_INSTRUCTION & _zz_1117) == 32'h00002010);
+  assign _zz_1101 = (_zz_1118 == _zz_1119);
+  assign _zz_1102 = {_zz_1120,_zz_1121};
+  assign _zz_1103 = (_zz_1122 == _zz_1123);
+  assign _zz_1104 = {_zz_1124,{_zz_1125,_zz_1126}};
+  assign _zz_1105 = _zz_511;
+  assign _zz_1106 = (_zz_1127 == _zz_1128);
+  assign _zz_1107 = {_zz_511,_zz_1129};
+  assign _zz_1108 = 2'b00;
+  assign _zz_1109 = (_zz_1130 != 1'b0);
+  assign _zz_1110 = (_zz_1131 != _zz_1132);
+  assign _zz_1111 = {_zz_1133,{_zz_1134,_zz_1135}};
+  assign _zz_1112 = 32'h00004020;
+  assign _zz_1113 = (decode_INSTRUCTION & 32'h00000030);
+  assign _zz_1114 = 32'h00000010;
+  assign _zz_1115 = (decode_INSTRUCTION & 32'h02000020);
+  assign _zz_1116 = 32'h00000020;
+  assign _zz_1117 = 32'h00002030;
+  assign _zz_1118 = (decode_INSTRUCTION & 32'h00001030);
+  assign _zz_1119 = 32'h00000010;
+  assign _zz_1120 = ((decode_INSTRUCTION & _zz_1136) == 32'h00002020);
+  assign _zz_1121 = ((decode_INSTRUCTION & _zz_1137) == 32'h00000020);
+  assign _zz_1122 = (decode_INSTRUCTION & 32'h00001010);
+  assign _zz_1123 = 32'h00001010;
+  assign _zz_1124 = ((decode_INSTRUCTION & _zz_1138) == 32'h00002010);
+  assign _zz_1125 = (_zz_1139 == _zz_1140);
+  assign _zz_1126 = {_zz_1141,_zz_1142};
+  assign _zz_1127 = (decode_INSTRUCTION & 32'h00000070);
+  assign _zz_1128 = 32'h00000020;
+  assign _zz_1129 = ((decode_INSTRUCTION & _zz_1143) == 32'h0);
+  assign _zz_1130 = ((decode_INSTRUCTION & _zz_1144) == 32'h00004010);
+  assign _zz_1131 = (_zz_1145 == _zz_1146);
+  assign _zz_1132 = 1'b0;
+  assign _zz_1133 = ({_zz_1147,_zz_1148} != 4'b0000);
+  assign _zz_1134 = (_zz_1149 != _zz_1150);
+  assign _zz_1135 = {_zz_1151,{_zz_1152,_zz_1153}};
+  assign _zz_1136 = 32'h02002060;
+  assign _zz_1137 = 32'h02003020;
+  assign _zz_1138 = 32'h00002010;
+  assign _zz_1139 = (decode_INSTRUCTION & 32'h00000050);
+  assign _zz_1140 = 32'h00000010;
+  assign _zz_1141 = ((decode_INSTRUCTION & 32'h0000000c) == 32'h00000004);
+  assign _zz_1142 = ((decode_INSTRUCTION & 32'h00000028) == 32'h0);
+  assign _zz_1143 = 32'h00000020;
+  assign _zz_1144 = 32'h00004014;
+  assign _zz_1145 = (decode_INSTRUCTION & 32'h00006014);
+  assign _zz_1146 = 32'h00002010;
+  assign _zz_1147 = ((decode_INSTRUCTION & _zz_1154) == 32'h0);
+  assign _zz_1148 = {(_zz_1155 == _zz_1156),{_zz_1157,_zz_1158}};
+  assign _zz_1149 = ((decode_INSTRUCTION & _zz_1159) == 32'h0);
+  assign _zz_1150 = 1'b0;
+  assign _zz_1151 = ({_zz_1160,{_zz_1161,_zz_1162}} != 3'b000);
+  assign _zz_1152 = ({_zz_1163,_zz_1164} != 2'b00);
+  assign _zz_1153 = {(_zz_1165 != _zz_1166),(_zz_1167 != _zz_1168)};
+  assign _zz_1154 = 32'h00000044;
+  assign _zz_1155 = (decode_INSTRUCTION & 32'h00000018);
+  assign _zz_1156 = 32'h0;
+  assign _zz_1157 = ((decode_INSTRUCTION & 32'h00006004) == 32'h00002000);
+  assign _zz_1158 = ((decode_INSTRUCTION & 32'h00005004) == 32'h00001000);
+  assign _zz_1159 = 32'h00000058;
+  assign _zz_1160 = ((decode_INSTRUCTION & 32'h00000044) == 32'h00000040);
+  assign _zz_1161 = ((decode_INSTRUCTION & _zz_1169) == 32'h00002010);
+  assign _zz_1162 = ((decode_INSTRUCTION & _zz_1170) == 32'h40000030);
+  assign _zz_1163 = ((decode_INSTRUCTION & _zz_1171) == 32'h00000004);
+  assign _zz_1164 = _zz_510;
+  assign _zz_1165 = {(_zz_1172 == _zz_1173),_zz_510};
+  assign _zz_1166 = 2'b00;
+  assign _zz_1167 = ((decode_INSTRUCTION & _zz_1174) == 32'h00001008);
+  assign _zz_1168 = 1'b0;
+  assign _zz_1169 = 32'h00002014;
+  assign _zz_1170 = 32'h40000034;
+  assign _zz_1171 = 32'h00000014;
+  assign _zz_1172 = (decode_INSTRUCTION & 32'h00000044);
+  assign _zz_1173 = 32'h00000004;
+  assign _zz_1174 = 32'h00005048;
+  assign _zz_1175 = execute_INSTRUCTION[31];
+  assign _zz_1176 = execute_INSTRUCTION[31];
+  assign _zz_1177 = execute_INSTRUCTION[7];
+  assign _zz_1178 = (_zz_573 | _zz_574);
+  assign _zz_1179 = (_zz_575 | _zz_576);
+  assign _zz_1180 = (_zz_577 | _zz_578);
+  assign _zz_1181 = (_zz_579 | _zz_580);
+  assign _zz_1182 = (_zz_581 | _zz_582);
+  assign _zz_1183 = (_zz_583 | _zz_584);
+  assign _zz_1184 = (_zz_585 | _zz_586);
+  assign _zz_1185 = (_zz_587 | _zz_588);
+  assign _zz_1186 = (_zz_589 | _zz_590);
+  assign _zz_1187 = (_zz_591 | _zz_592);
+  assign _zz_1188 = (_zz_593 | _zz_594);
+  assign _zz_1189 = (_zz_595 | _zz_596);
+  assign _zz_1190 = (_zz_1194 | _zz_597);
+  assign _zz_1191 = (_zz_598 | _zz_599);
+  assign _zz_1192 = (_zz_600 | _zz_601);
+  assign _zz_1193 = (_zz_602 | _zz_603);
+  assign _zz_1194 = 32'h0;
   always @ (posedge clk) begin
-    if(_zz_862_) begin
-      _zz_582_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
+    if(_zz_959) begin
+      _zz_653 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress1];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_863_) begin
-      _zz_583_ <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
+    if(_zz_960) begin
+      _zz_654 <= RegFilePlugin_regFile[decode_RegFilePlugin_regFileReadAddress2];
     end
   end
 
   always @ (posedge clk) begin
-    if(_zz_42_) begin
+    if(_zz_42) begin
       RegFilePlugin_regFile[lastStageRegFileWrite_payload_address] <= lastStageRegFileWrite_payload_data;
     end
   end
 
-  InstructionCache IBusCachedPlugin_cache ( 
-    .io_flush                                     (_zz_564_                                                             ), //i
-    .io_cpu_prefetch_isValid                      (_zz_565_                                                             ), //i
-    .io_cpu_prefetch_haltIt                       (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt                        ), //o
-    .io_cpu_prefetch_pc                           (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]                ), //i
-    .io_cpu_fetch_isValid                         (_zz_566_                                                             ), //i
-    .io_cpu_fetch_isStuck                         (_zz_567_                                                             ), //i
-    .io_cpu_fetch_isRemoved                       (IBusCachedPlugin_externalFlush                                       ), //i
-    .io_cpu_fetch_pc                              (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]                ), //i
-    .io_cpu_fetch_data                            (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]                       ), //o
-    .io_cpu_fetch_mmuBus_cmd_isValid              (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid               ), //o
-    .io_cpu_fetch_mmuBus_cmd_virtualAddress       (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_fetch_mmuBus_cmd_bypassTranslation    (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_fetch_mmuBus_rsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]                    ), //i
-    .io_cpu_fetch_mmuBus_rsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                               ), //i
-    .io_cpu_fetch_mmuBus_rsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                             ), //i
-    .io_cpu_fetch_mmuBus_rsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                                ), //i
-    .io_cpu_fetch_mmuBus_rsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                                ), //i
-    .io_cpu_fetch_mmuBus_end                      (IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end                       ), //o
-    .io_cpu_fetch_mmuBus_busy                     (IBusCachedPlugin_mmuBus_busy                                         ), //i
-    .io_cpu_fetch_physicalAddress                 (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]            ), //o
-    .io_cpu_fetch_haltIt                          (IBusCachedPlugin_cache_io_cpu_fetch_haltIt                           ), //o
-    .io_cpu_decode_isValid                        (_zz_568_                                                             ), //i
-    .io_cpu_decode_isStuck                        (_zz_569_                                                             ), //i
-    .io_cpu_decode_pc                             (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]                ), //i
-    .io_cpu_decode_physicalAddress                (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //o
-    .io_cpu_decode_data                           (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]                      ), //o
-    .io_cpu_decode_cacheMiss                      (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss                       ), //o
-    .io_cpu_decode_error                          (IBusCachedPlugin_cache_io_cpu_decode_error                           ), //o
-    .io_cpu_decode_mmuRefilling                   (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling                    ), //o
-    .io_cpu_decode_mmuException                   (IBusCachedPlugin_cache_io_cpu_decode_mmuException                    ), //o
-    .io_cpu_decode_isUser                         (_zz_570_                                                             ), //i
-    .io_cpu_fill_valid                            (_zz_571_                                                             ), //i
-    .io_cpu_fill_payload                          (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]           ), //i
-    .io_mem_cmd_valid                             (IBusCachedPlugin_cache_io_mem_cmd_valid                              ), //o
-    .io_mem_cmd_ready                             (iBus_cmd_ready                                                       ), //i
-    .io_mem_cmd_payload_address                   (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]              ), //o
-    .io_mem_cmd_payload_size                      (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]                  ), //o
-    .io_mem_rsp_valid                             (iBus_rsp_valid                                                       ), //i
-    .io_mem_rsp_payload_data                      (iBus_rsp_payload_data[31:0]                                          ), //i
-    .io_mem_rsp_payload_error                     (iBus_rsp_payload_error                                               ), //i
-    ._zz_10_                                      (_zz_511_[2:0]                                                        ), //i
-    ._zz_11_                                      (IBusCachedPlugin_injectionPort_payload[31:0]                         ), //i
-    .clk                                          (clk                                                                  ), //i
-    .reset                                        (reset                                                                )  //i
+  InstructionCache IBusCachedPlugin_cache (
+    .io_flush                                 (_zz_625                                                     ), //i
+    .io_cpu_prefetch_isValid                  (_zz_626                                                     ), //i
+    .io_cpu_prefetch_haltIt                   (IBusCachedPlugin_cache_io_cpu_prefetch_haltIt               ), //o
+    .io_cpu_prefetch_pc                       (IBusCachedPlugin_iBusRsp_stages_0_input_payload[31:0]       ), //i
+    .io_cpu_fetch_isValid                     (_zz_627                                                     ), //i
+    .io_cpu_fetch_isStuck                     (_zz_628                                                     ), //i
+    .io_cpu_fetch_isRemoved                   (_zz_629                                                     ), //i
+    .io_cpu_fetch_pc                          (IBusCachedPlugin_iBusRsp_stages_1_input_payload[31:0]       ), //i
+    .io_cpu_fetch_data                        (IBusCachedPlugin_cache_io_cpu_fetch_data[31:0]              ), //o
+    .io_cpu_fetch_mmuRsp_physicalAddress      (IBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
+    .io_cpu_fetch_mmuRsp_isIoAccess           (IBusCachedPlugin_mmuBus_rsp_isIoAccess                      ), //i
+    .io_cpu_fetch_mmuRsp_isPaging             (IBusCachedPlugin_mmuBus_rsp_isPaging                        ), //i
+    .io_cpu_fetch_mmuRsp_allowRead            (IBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
+    .io_cpu_fetch_mmuRsp_allowWrite           (IBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
+    .io_cpu_fetch_mmuRsp_allowExecute         (IBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
+    .io_cpu_fetch_mmuRsp_exception            (IBusCachedPlugin_mmuBus_rsp_exception                       ), //i
+    .io_cpu_fetch_mmuRsp_refilling            (IBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
+    .io_cpu_fetch_mmuRsp_bypassTranslation    (IBusCachedPlugin_mmuBus_rsp_bypassTranslation               ), //i
+    .io_cpu_fetch_physicalAddress             (IBusCachedPlugin_cache_io_cpu_fetch_physicalAddress[31:0]   ), //o
+    .io_cpu_decode_isValid                    (_zz_630                                                     ), //i
+    .io_cpu_decode_isStuck                    (_zz_631                                                     ), //i
+    .io_cpu_decode_pc                         (IBusCachedPlugin_iBusRsp_stages_2_input_payload[31:0]       ), //i
+    .io_cpu_decode_physicalAddress            (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //o
+    .io_cpu_decode_data                       (IBusCachedPlugin_cache_io_cpu_decode_data[31:0]             ), //o
+    .io_cpu_decode_cacheMiss                  (IBusCachedPlugin_cache_io_cpu_decode_cacheMiss              ), //o
+    .io_cpu_decode_error                      (IBusCachedPlugin_cache_io_cpu_decode_error                  ), //o
+    .io_cpu_decode_mmuRefilling               (IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling           ), //o
+    .io_cpu_decode_mmuException               (IBusCachedPlugin_cache_io_cpu_decode_mmuException           ), //o
+    .io_cpu_decode_isUser                     (_zz_632                                                     ), //i
+    .io_cpu_fill_valid                        (_zz_633                                                     ), //i
+    .io_cpu_fill_payload                      (IBusCachedPlugin_cache_io_cpu_decode_physicalAddress[31:0]  ), //i
+    .io_mem_cmd_valid                         (IBusCachedPlugin_cache_io_mem_cmd_valid                     ), //o
+    .io_mem_cmd_ready                         (iBus_cmd_ready                                              ), //i
+    .io_mem_cmd_payload_address               (IBusCachedPlugin_cache_io_mem_cmd_payload_address[31:0]     ), //o
+    .io_mem_cmd_payload_size                  (IBusCachedPlugin_cache_io_mem_cmd_payload_size[2:0]         ), //o
+    .io_mem_rsp_valid                         (iBus_rsp_valid                                              ), //i
+    .io_mem_rsp_payload_data                  (iBus_rsp_payload_data[31:0]                                 ), //i
+    .io_mem_rsp_payload_error                 (iBus_rsp_payload_error                                      ), //i
+    ._zz_9                                    (_zz_572[2:0]                                                ), //i
+    ._zz_10                                   (IBusCachedPlugin_injectionPort_payload[31:0]                ), //i
+    .clk                                      (clk                                                         ), //i
+    .reset                                    (reset                                                       )  //i
   );
-  DataCache dataCache_1_ ( 
-    .io_cpu_execute_isValid                        (_zz_572_                                                    ), //i
-    .io_cpu_execute_address                        (_zz_573_[31:0]                                              ), //i
-    .io_cpu_execute_args_wr                        (execute_MEMORY_WR                                           ), //i
-    .io_cpu_execute_args_data                      (_zz_85_[31:0]                                               ), //i
-    .io_cpu_execute_args_size                      (execute_DBusCachedPlugin_size[1:0]                          ), //i
-    .io_cpu_memory_isValid                         (_zz_574_                                                    ), //i
-    .io_cpu_memory_isStuck                         (memory_arbitration_isStuck                                  ), //i
-    .io_cpu_memory_isRemoved                       (memory_arbitration_removeIt                                 ), //i
-    .io_cpu_memory_isWrite                         (dataCache_1__io_cpu_memory_isWrite                          ), //o
-    .io_cpu_memory_address                         (_zz_575_[31:0]                                              ), //i
-    .io_cpu_memory_mmuBus_cmd_isValid              (dataCache_1__io_cpu_memory_mmuBus_cmd_isValid               ), //o
-    .io_cpu_memory_mmuBus_cmd_virtualAddress       (dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress[31:0]  ), //o
-    .io_cpu_memory_mmuBus_cmd_bypassTranslation    (dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation     ), //o
-    .io_cpu_memory_mmuBus_rsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]           ), //i
-    .io_cpu_memory_mmuBus_rsp_isIoAccess           (_zz_576_                                                    ), //i
-    .io_cpu_memory_mmuBus_rsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead                       ), //i
-    .io_cpu_memory_mmuBus_rsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite                      ), //i
-    .io_cpu_memory_mmuBus_rsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute                    ), //i
-    .io_cpu_memory_mmuBus_rsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception                       ), //i
-    .io_cpu_memory_mmuBus_rsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling                       ), //i
-    .io_cpu_memory_mmuBus_end                      (dataCache_1__io_cpu_memory_mmuBus_end                       ), //o
-    .io_cpu_memory_mmuBus_busy                     (DBusCachedPlugin_mmuBus_busy                                ), //i
-    .io_cpu_writeBack_isValid                      (_zz_577_                                                    ), //i
-    .io_cpu_writeBack_isStuck                      (writeBack_arbitration_isStuck                               ), //i
-    .io_cpu_writeBack_isUser                       (_zz_578_                                                    ), //i
-    .io_cpu_writeBack_haltIt                       (dataCache_1__io_cpu_writeBack_haltIt                        ), //o
-    .io_cpu_writeBack_isWrite                      (dataCache_1__io_cpu_writeBack_isWrite                       ), //o
-    .io_cpu_writeBack_data                         (dataCache_1__io_cpu_writeBack_data[31:0]                    ), //o
-    .io_cpu_writeBack_address                      (_zz_579_[31:0]                                              ), //i
-    .io_cpu_writeBack_mmuException                 (dataCache_1__io_cpu_writeBack_mmuException                  ), //o
-    .io_cpu_writeBack_unalignedAccess              (dataCache_1__io_cpu_writeBack_unalignedAccess               ), //o
-    .io_cpu_writeBack_accessError                  (dataCache_1__io_cpu_writeBack_accessError                   ), //o
-    .io_cpu_redo                                   (dataCache_1__io_cpu_redo                                    ), //o
-    .io_cpu_flush_valid                            (_zz_580_                                                    ), //i
-    .io_cpu_flush_ready                            (dataCache_1__io_cpu_flush_ready                             ), //o
-    .io_mem_cmd_valid                              (dataCache_1__io_mem_cmd_valid                               ), //o
-    .io_mem_cmd_ready                              (_zz_581_                                                    ), //i
-    .io_mem_cmd_payload_wr                         (dataCache_1__io_mem_cmd_payload_wr                          ), //o
-    .io_mem_cmd_payload_address                    (dataCache_1__io_mem_cmd_payload_address[31:0]               ), //o
-    .io_mem_cmd_payload_data                       (dataCache_1__io_mem_cmd_payload_data[31:0]                  ), //o
-    .io_mem_cmd_payload_mask                       (dataCache_1__io_mem_cmd_payload_mask[3:0]                   ), //o
-    .io_mem_cmd_payload_length                     (dataCache_1__io_mem_cmd_payload_length[2:0]                 ), //o
-    .io_mem_cmd_payload_last                       (dataCache_1__io_mem_cmd_payload_last                        ), //o
-    .io_mem_rsp_valid                              (dBus_rsp_valid                                              ), //i
-    .io_mem_rsp_payload_data                       (dBus_rsp_payload_data[31:0]                                 ), //i
-    .io_mem_rsp_payload_error                      (dBus_rsp_payload_error                                      ), //i
-    .clk                                           (clk                                                         ), //i
-    .reset                                         (reset                                                       )  //i
+  DataCache dataCache_1 (
+    .io_cpu_execute_isValid                    (_zz_634                                            ), //i
+    .io_cpu_execute_address                    (_zz_635[31:0]                                      ), //i
+    .io_cpu_execute_haltIt                     (dataCache_1_io_cpu_execute_haltIt                  ), //o
+    .io_cpu_execute_args_wr                    (execute_MEMORY_WR                                  ), //i
+    .io_cpu_execute_args_data                  (_zz_82[31:0]                                       ), //i
+    .io_cpu_execute_args_size                  (execute_DBusCachedPlugin_size[1:0]                 ), //i
+    .io_cpu_execute_args_totalyConsistent      (execute_MEMORY_FORCE_CONSTISTENCY                  ), //i
+    .io_cpu_execute_refilling                  (dataCache_1_io_cpu_execute_refilling               ), //o
+    .io_cpu_memory_isValid                     (_zz_636                                            ), //i
+    .io_cpu_memory_isStuck                     (memory_arbitration_isStuck                         ), //i
+    .io_cpu_memory_isWrite                     (dataCache_1_io_cpu_memory_isWrite                  ), //o
+    .io_cpu_memory_address                     (_zz_637[31:0]                                      ), //i
+    .io_cpu_memory_mmuRsp_physicalAddress      (DBusCachedPlugin_mmuBus_rsp_physicalAddress[31:0]  ), //i
+    .io_cpu_memory_mmuRsp_isIoAccess           (_zz_638                                            ), //i
+    .io_cpu_memory_mmuRsp_isPaging             (DBusCachedPlugin_mmuBus_rsp_isPaging               ), //i
+    .io_cpu_memory_mmuRsp_allowRead            (DBusCachedPlugin_mmuBus_rsp_allowRead              ), //i
+    .io_cpu_memory_mmuRsp_allowWrite           (DBusCachedPlugin_mmuBus_rsp_allowWrite             ), //i
+    .io_cpu_memory_mmuRsp_allowExecute         (DBusCachedPlugin_mmuBus_rsp_allowExecute           ), //i
+    .io_cpu_memory_mmuRsp_exception            (DBusCachedPlugin_mmuBus_rsp_exception              ), //i
+    .io_cpu_memory_mmuRsp_refilling            (DBusCachedPlugin_mmuBus_rsp_refilling              ), //i
+    .io_cpu_memory_mmuRsp_bypassTranslation    (DBusCachedPlugin_mmuBus_rsp_bypassTranslation      ), //i
+    .io_cpu_writeBack_isValid                  (_zz_639                                            ), //i
+    .io_cpu_writeBack_isStuck                  (writeBack_arbitration_isStuck                      ), //i
+    .io_cpu_writeBack_isUser                   (_zz_640                                            ), //i
+    .io_cpu_writeBack_haltIt                   (dataCache_1_io_cpu_writeBack_haltIt                ), //o
+    .io_cpu_writeBack_isWrite                  (dataCache_1_io_cpu_writeBack_isWrite               ), //o
+    .io_cpu_writeBack_data                     (dataCache_1_io_cpu_writeBack_data[31:0]            ), //o
+    .io_cpu_writeBack_address                  (_zz_641[31:0]                                      ), //i
+    .io_cpu_writeBack_mmuException             (dataCache_1_io_cpu_writeBack_mmuException          ), //o
+    .io_cpu_writeBack_unalignedAccess          (dataCache_1_io_cpu_writeBack_unalignedAccess       ), //o
+    .io_cpu_writeBack_accessError              (dataCache_1_io_cpu_writeBack_accessError           ), //o
+    .io_cpu_writeBack_keepMemRspData           (dataCache_1_io_cpu_writeBack_keepMemRspData        ), //o
+    .io_cpu_writeBack_fence_SW                 (_zz_642                                            ), //i
+    .io_cpu_writeBack_fence_SR                 (_zz_643                                            ), //i
+    .io_cpu_writeBack_fence_SO                 (_zz_644                                            ), //i
+    .io_cpu_writeBack_fence_SI                 (_zz_645                                            ), //i
+    .io_cpu_writeBack_fence_PW                 (_zz_646                                            ), //i
+    .io_cpu_writeBack_fence_PR                 (_zz_647                                            ), //i
+    .io_cpu_writeBack_fence_PO                 (_zz_648                                            ), //i
+    .io_cpu_writeBack_fence_PI                 (_zz_649                                            ), //i
+    .io_cpu_writeBack_fence_FM                 (_zz_650[3:0]                                       ), //i
+    .io_cpu_redo                               (dataCache_1_io_cpu_redo                            ), //o
+    .io_cpu_flush_valid                        (_zz_651                                            ), //i
+    .io_cpu_flush_ready                        (dataCache_1_io_cpu_flush_ready                     ), //o
+    .io_mem_cmd_valid                          (dataCache_1_io_mem_cmd_valid                       ), //o
+    .io_mem_cmd_ready                          (_zz_652                                            ), //i
+    .io_mem_cmd_payload_wr                     (dataCache_1_io_mem_cmd_payload_wr                  ), //o
+    .io_mem_cmd_payload_uncached               (dataCache_1_io_mem_cmd_payload_uncached            ), //o
+    .io_mem_cmd_payload_address                (dataCache_1_io_mem_cmd_payload_address[31:0]       ), //o
+    .io_mem_cmd_payload_data                   (dataCache_1_io_mem_cmd_payload_data[31:0]          ), //o
+    .io_mem_cmd_payload_mask                   (dataCache_1_io_mem_cmd_payload_mask[3:0]           ), //o
+    .io_mem_cmd_payload_length                 (dataCache_1_io_mem_cmd_payload_length[2:0]         ), //o
+    .io_mem_cmd_payload_last                   (dataCache_1_io_mem_cmd_payload_last                ), //o
+    .io_mem_rsp_valid                          (dBus_rsp_valid                                     ), //i
+    .io_mem_rsp_payload_last                   (dBus_rsp_payload_last                              ), //i
+    .io_mem_rsp_payload_data                   (dBus_rsp_payload_data[31:0]                        ), //i
+    .io_mem_rsp_payload_error                  (dBus_rsp_payload_error                             ), //i
+    .clk                                       (clk                                                ), //i
+    .reset                                     (reset                                              )  //i
   );
   always @(*) begin
-    case(_zz_864_)
+    case(_zz_961)
       2'b00 : begin
-        _zz_584_ = DBusCachedPlugin_redoBranch_payload;
+        _zz_655 = DBusCachedPlugin_redoBranch_payload;
       end
       2'b01 : begin
-        _zz_584_ = CsrPlugin_jumpInterface_payload;
+        _zz_655 = CsrPlugin_jumpInterface_payload;
       end
       2'b10 : begin
-        _zz_584_ = BranchPlugin_jumpInterface_payload;
+        _zz_655 = BranchPlugin_jumpInterface_payload;
       end
       default : begin
-        _zz_584_ = IBusCachedPlugin_predictionJumpInterface_payload;
+        _zz_655 = IBusCachedPlugin_predictionJumpInterface_payload;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_865_)
-      4'b0000 : begin
-        _zz_585_ = _zz_96_;
+    case(_zz_962)
+      3'b000 : begin
+        _zz_656 = _zz_391;
       end
-      4'b0001 : begin
-        _zz_585_ = _zz_112_;
+      3'b001 : begin
+        _zz_656 = _zz_392;
       end
-      4'b0010 : begin
-        _zz_585_ = _zz_128_;
+      3'b010 : begin
+        _zz_656 = _zz_393;
       end
-      4'b0011 : begin
-        _zz_585_ = _zz_144_;
+      3'b011 : begin
+        _zz_656 = _zz_394;
       end
-      4'b0100 : begin
-        _zz_585_ = _zz_160_;
+      3'b100 : begin
+        _zz_656 = _zz_395;
       end
-      4'b0101 : begin
-        _zz_585_ = _zz_176_;
+      3'b101 : begin
+        _zz_656 = _zz_396;
       end
-      4'b0110 : begin
-        _zz_585_ = _zz_192_;
-      end
-      4'b0111 : begin
-        _zz_585_ = _zz_208_;
-      end
-      4'b1000 : begin
-        _zz_585_ = _zz_224_;
-      end
-      4'b1001 : begin
-        _zz_585_ = _zz_240_;
-      end
-      4'b1010 : begin
-        _zz_585_ = _zz_256_;
-      end
-      4'b1011 : begin
-        _zz_585_ = _zz_272_;
-      end
-      4'b1100 : begin
-        _zz_585_ = _zz_288_;
-      end
-      4'b1101 : begin
-        _zz_585_ = _zz_304_;
-      end
-      4'b1110 : begin
-        _zz_585_ = _zz_320_;
+      3'b110 : begin
+        _zz_656 = _zz_397;
       end
       default : begin
-        _zz_585_ = _zz_336_;
+        _zz_656 = _zz_398;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_866_)
-      4'b0000 : begin
-        _zz_586_ = _zz_97_;
+    case(_zz_963)
+      3'b000 : begin
+        _zz_657 = _zz_391;
       end
-      4'b0001 : begin
-        _zz_586_ = _zz_113_;
+      3'b001 : begin
+        _zz_657 = _zz_392;
       end
-      4'b0010 : begin
-        _zz_586_ = _zz_129_;
+      3'b010 : begin
+        _zz_657 = _zz_393;
       end
-      4'b0011 : begin
-        _zz_586_ = _zz_145_;
+      3'b011 : begin
+        _zz_657 = _zz_394;
       end
-      4'b0100 : begin
-        _zz_586_ = _zz_161_;
+      3'b100 : begin
+        _zz_657 = _zz_395;
       end
-      4'b0101 : begin
-        _zz_586_ = _zz_177_;
+      3'b101 : begin
+        _zz_657 = _zz_396;
       end
-      4'b0110 : begin
-        _zz_586_ = _zz_193_;
-      end
-      4'b0111 : begin
-        _zz_586_ = _zz_209_;
-      end
-      4'b1000 : begin
-        _zz_586_ = _zz_225_;
-      end
-      4'b1001 : begin
-        _zz_586_ = _zz_241_;
-      end
-      4'b1010 : begin
-        _zz_586_ = _zz_257_;
-      end
-      4'b1011 : begin
-        _zz_586_ = _zz_273_;
-      end
-      4'b1100 : begin
-        _zz_586_ = _zz_289_;
-      end
-      4'b1101 : begin
-        _zz_586_ = _zz_305_;
-      end
-      4'b1110 : begin
-        _zz_586_ = _zz_321_;
+      3'b110 : begin
+        _zz_657 = _zz_397;
       end
       default : begin
-        _zz_586_ = _zz_337_;
+        _zz_657 = _zz_398;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_867_)
-      4'b0000 : begin
-        _zz_587_ = _zz_98_;
+    case(_zz_964)
+      3'b000 : begin
+        _zz_658 = _zz_391;
       end
-      4'b0001 : begin
-        _zz_587_ = _zz_114_;
+      3'b001 : begin
+        _zz_658 = _zz_392;
       end
-      4'b0010 : begin
-        _zz_587_ = _zz_130_;
+      3'b010 : begin
+        _zz_658 = _zz_393;
       end
-      4'b0011 : begin
-        _zz_587_ = _zz_146_;
+      3'b011 : begin
+        _zz_658 = _zz_394;
       end
-      4'b0100 : begin
-        _zz_587_ = _zz_162_;
+      3'b100 : begin
+        _zz_658 = _zz_395;
       end
-      4'b0101 : begin
-        _zz_587_ = _zz_178_;
+      3'b101 : begin
+        _zz_658 = _zz_396;
       end
-      4'b0110 : begin
-        _zz_587_ = _zz_194_;
-      end
-      4'b0111 : begin
-        _zz_587_ = _zz_210_;
-      end
-      4'b1000 : begin
-        _zz_587_ = _zz_226_;
-      end
-      4'b1001 : begin
-        _zz_587_ = _zz_242_;
-      end
-      4'b1010 : begin
-        _zz_587_ = _zz_258_;
-      end
-      4'b1011 : begin
-        _zz_587_ = _zz_274_;
-      end
-      4'b1100 : begin
-        _zz_587_ = _zz_290_;
-      end
-      4'b1101 : begin
-        _zz_587_ = _zz_306_;
-      end
-      4'b1110 : begin
-        _zz_587_ = _zz_322_;
+      3'b110 : begin
+        _zz_658 = _zz_397;
       end
       default : begin
-        _zz_587_ = _zz_338_;
+        _zz_658 = _zz_398;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_868_)
-      4'b0000 : begin
-        _zz_588_ = _zz_96_;
+    case(_zz_965)
+      3'b000 : begin
+        _zz_659 = _zz_391;
       end
-      4'b0001 : begin
-        _zz_588_ = _zz_112_;
+      3'b001 : begin
+        _zz_659 = _zz_392;
       end
-      4'b0010 : begin
-        _zz_588_ = _zz_128_;
+      3'b010 : begin
+        _zz_659 = _zz_393;
       end
-      4'b0011 : begin
-        _zz_588_ = _zz_144_;
+      3'b011 : begin
+        _zz_659 = _zz_394;
       end
-      4'b0100 : begin
-        _zz_588_ = _zz_160_;
+      3'b100 : begin
+        _zz_659 = _zz_395;
       end
-      4'b0101 : begin
-        _zz_588_ = _zz_176_;
+      3'b101 : begin
+        _zz_659 = _zz_396;
       end
-      4'b0110 : begin
-        _zz_588_ = _zz_192_;
-      end
-      4'b0111 : begin
-        _zz_588_ = _zz_208_;
-      end
-      4'b1000 : begin
-        _zz_588_ = _zz_224_;
-      end
-      4'b1001 : begin
-        _zz_588_ = _zz_240_;
-      end
-      4'b1010 : begin
-        _zz_588_ = _zz_256_;
-      end
-      4'b1011 : begin
-        _zz_588_ = _zz_272_;
-      end
-      4'b1100 : begin
-        _zz_588_ = _zz_288_;
-      end
-      4'b1101 : begin
-        _zz_588_ = _zz_304_;
-      end
-      4'b1110 : begin
-        _zz_588_ = _zz_320_;
+      3'b110 : begin
+        _zz_659 = _zz_397;
       end
       default : begin
-        _zz_588_ = _zz_336_;
+        _zz_659 = _zz_398;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_869_)
-      4'b0000 : begin
-        _zz_589_ = _zz_97_;
+    case(_zz_966)
+      3'b000 : begin
+        _zz_660 = _zz_391;
       end
-      4'b0001 : begin
-        _zz_589_ = _zz_113_;
+      3'b001 : begin
+        _zz_660 = _zz_392;
       end
-      4'b0010 : begin
-        _zz_589_ = _zz_129_;
+      3'b010 : begin
+        _zz_660 = _zz_393;
       end
-      4'b0011 : begin
-        _zz_589_ = _zz_145_;
+      3'b011 : begin
+        _zz_660 = _zz_394;
       end
-      4'b0100 : begin
-        _zz_589_ = _zz_161_;
+      3'b100 : begin
+        _zz_660 = _zz_395;
       end
-      4'b0101 : begin
-        _zz_589_ = _zz_177_;
+      3'b101 : begin
+        _zz_660 = _zz_396;
       end
-      4'b0110 : begin
-        _zz_589_ = _zz_193_;
-      end
-      4'b0111 : begin
-        _zz_589_ = _zz_209_;
-      end
-      4'b1000 : begin
-        _zz_589_ = _zz_225_;
-      end
-      4'b1001 : begin
-        _zz_589_ = _zz_241_;
-      end
-      4'b1010 : begin
-        _zz_589_ = _zz_257_;
-      end
-      4'b1011 : begin
-        _zz_589_ = _zz_273_;
-      end
-      4'b1100 : begin
-        _zz_589_ = _zz_289_;
-      end
-      4'b1101 : begin
-        _zz_589_ = _zz_305_;
-      end
-      4'b1110 : begin
-        _zz_589_ = _zz_321_;
+      3'b110 : begin
+        _zz_660 = _zz_397;
       end
       default : begin
-        _zz_589_ = _zz_337_;
+        _zz_660 = _zz_398;
       end
     endcase
   end
 
   always @(*) begin
-    case(_zz_870_)
-      4'b0000 : begin
-        _zz_590_ = _zz_98_;
+    case(_zz_830)
+      3'b000 : begin
+        _zz_661 = _zz_391;
       end
-      4'b0001 : begin
-        _zz_590_ = _zz_114_;
+      3'b001 : begin
+        _zz_661 = _zz_392;
       end
-      4'b0010 : begin
-        _zz_590_ = _zz_130_;
+      3'b010 : begin
+        _zz_661 = _zz_393;
       end
-      4'b0011 : begin
-        _zz_590_ = _zz_146_;
+      3'b011 : begin
+        _zz_661 = _zz_394;
       end
-      4'b0100 : begin
-        _zz_590_ = _zz_162_;
+      3'b100 : begin
+        _zz_661 = _zz_395;
       end
-      4'b0101 : begin
-        _zz_590_ = _zz_178_;
+      3'b101 : begin
+        _zz_661 = _zz_396;
       end
-      4'b0110 : begin
-        _zz_590_ = _zz_194_;
-      end
-      4'b0111 : begin
-        _zz_590_ = _zz_210_;
-      end
-      4'b1000 : begin
-        _zz_590_ = _zz_226_;
-      end
-      4'b1001 : begin
-        _zz_590_ = _zz_242_;
-      end
-      4'b1010 : begin
-        _zz_590_ = _zz_258_;
-      end
-      4'b1011 : begin
-        _zz_590_ = _zz_274_;
-      end
-      4'b1100 : begin
-        _zz_590_ = _zz_290_;
-      end
-      4'b1101 : begin
-        _zz_590_ = _zz_306_;
-      end
-      4'b1110 : begin
-        _zz_590_ = _zz_322_;
+      3'b110 : begin
+        _zz_661 = _zz_397;
       end
       default : begin
-        _zz_590_ = _zz_338_;
+        _zz_661 = _zz_398;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_967)
+      4'b0000 : begin
+        _zz_662 = _zz_87;
+      end
+      4'b0001 : begin
+        _zz_662 = _zz_106;
+      end
+      4'b0010 : begin
+        _zz_662 = _zz_125;
+      end
+      4'b0011 : begin
+        _zz_662 = _zz_144;
+      end
+      4'b0100 : begin
+        _zz_662 = _zz_163;
+      end
+      4'b0101 : begin
+        _zz_662 = _zz_182;
+      end
+      4'b0110 : begin
+        _zz_662 = _zz_201;
+      end
+      4'b0111 : begin
+        _zz_662 = _zz_220;
+      end
+      4'b1000 : begin
+        _zz_662 = _zz_239;
+      end
+      4'b1001 : begin
+        _zz_662 = _zz_258;
+      end
+      4'b1010 : begin
+        _zz_662 = _zz_277;
+      end
+      4'b1011 : begin
+        _zz_662 = _zz_296;
+      end
+      4'b1100 : begin
+        _zz_662 = _zz_315;
+      end
+      4'b1101 : begin
+        _zz_662 = _zz_334;
+      end
+      4'b1110 : begin
+        _zz_662 = _zz_353;
+      end
+      default : begin
+        _zz_662 = _zz_372;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_968)
+      4'b0000 : begin
+        _zz_663 = _zz_88;
+      end
+      4'b0001 : begin
+        _zz_663 = _zz_107;
+      end
+      4'b0010 : begin
+        _zz_663 = _zz_126;
+      end
+      4'b0011 : begin
+        _zz_663 = _zz_145;
+      end
+      4'b0100 : begin
+        _zz_663 = _zz_164;
+      end
+      4'b0101 : begin
+        _zz_663 = _zz_183;
+      end
+      4'b0110 : begin
+        _zz_663 = _zz_202;
+      end
+      4'b0111 : begin
+        _zz_663 = _zz_221;
+      end
+      4'b1000 : begin
+        _zz_663 = _zz_240;
+      end
+      4'b1001 : begin
+        _zz_663 = _zz_259;
+      end
+      4'b1010 : begin
+        _zz_663 = _zz_278;
+      end
+      4'b1011 : begin
+        _zz_663 = _zz_297;
+      end
+      4'b1100 : begin
+        _zz_663 = _zz_316;
+      end
+      4'b1101 : begin
+        _zz_663 = _zz_335;
+      end
+      4'b1110 : begin
+        _zz_663 = _zz_354;
+      end
+      default : begin
+        _zz_663 = _zz_373;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_969)
+      4'b0000 : begin
+        _zz_664 = _zz_89;
+      end
+      4'b0001 : begin
+        _zz_664 = _zz_108;
+      end
+      4'b0010 : begin
+        _zz_664 = _zz_127;
+      end
+      4'b0011 : begin
+        _zz_664 = _zz_146;
+      end
+      4'b0100 : begin
+        _zz_664 = _zz_165;
+      end
+      4'b0101 : begin
+        _zz_664 = _zz_184;
+      end
+      4'b0110 : begin
+        _zz_664 = _zz_203;
+      end
+      4'b0111 : begin
+        _zz_664 = _zz_222;
+      end
+      4'b1000 : begin
+        _zz_664 = _zz_241;
+      end
+      4'b1001 : begin
+        _zz_664 = _zz_260;
+      end
+      4'b1010 : begin
+        _zz_664 = _zz_279;
+      end
+      4'b1011 : begin
+        _zz_664 = _zz_298;
+      end
+      4'b1100 : begin
+        _zz_664 = _zz_317;
+      end
+      4'b1101 : begin
+        _zz_664 = _zz_336;
+      end
+      4'b1110 : begin
+        _zz_664 = _zz_355;
+      end
+      default : begin
+        _zz_664 = _zz_374;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_970)
+      3'b000 : begin
+        _zz_665 = _zz_450;
+      end
+      3'b001 : begin
+        _zz_665 = _zz_451;
+      end
+      3'b010 : begin
+        _zz_665 = _zz_452;
+      end
+      3'b011 : begin
+        _zz_665 = _zz_453;
+      end
+      3'b100 : begin
+        _zz_665 = _zz_454;
+      end
+      3'b101 : begin
+        _zz_665 = _zz_455;
+      end
+      3'b110 : begin
+        _zz_665 = _zz_456;
+      end
+      default : begin
+        _zz_665 = _zz_457;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_971)
+      3'b000 : begin
+        _zz_666 = _zz_450;
+      end
+      3'b001 : begin
+        _zz_666 = _zz_451;
+      end
+      3'b010 : begin
+        _zz_666 = _zz_452;
+      end
+      3'b011 : begin
+        _zz_666 = _zz_453;
+      end
+      3'b100 : begin
+        _zz_666 = _zz_454;
+      end
+      3'b101 : begin
+        _zz_666 = _zz_455;
+      end
+      3'b110 : begin
+        _zz_666 = _zz_456;
+      end
+      default : begin
+        _zz_666 = _zz_457;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_972)
+      3'b000 : begin
+        _zz_667 = _zz_450;
+      end
+      3'b001 : begin
+        _zz_667 = _zz_451;
+      end
+      3'b010 : begin
+        _zz_667 = _zz_452;
+      end
+      3'b011 : begin
+        _zz_667 = _zz_453;
+      end
+      3'b100 : begin
+        _zz_667 = _zz_454;
+      end
+      3'b101 : begin
+        _zz_667 = _zz_455;
+      end
+      3'b110 : begin
+        _zz_667 = _zz_456;
+      end
+      default : begin
+        _zz_667 = _zz_457;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_973)
+      3'b000 : begin
+        _zz_668 = _zz_450;
+      end
+      3'b001 : begin
+        _zz_668 = _zz_451;
+      end
+      3'b010 : begin
+        _zz_668 = _zz_452;
+      end
+      3'b011 : begin
+        _zz_668 = _zz_453;
+      end
+      3'b100 : begin
+        _zz_668 = _zz_454;
+      end
+      3'b101 : begin
+        _zz_668 = _zz_455;
+      end
+      3'b110 : begin
+        _zz_668 = _zz_456;
+      end
+      default : begin
+        _zz_668 = _zz_457;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_974)
+      3'b000 : begin
+        _zz_669 = _zz_450;
+      end
+      3'b001 : begin
+        _zz_669 = _zz_451;
+      end
+      3'b010 : begin
+        _zz_669 = _zz_452;
+      end
+      3'b011 : begin
+        _zz_669 = _zz_453;
+      end
+      3'b100 : begin
+        _zz_669 = _zz_454;
+      end
+      3'b101 : begin
+        _zz_669 = _zz_455;
+      end
+      3'b110 : begin
+        _zz_669 = _zz_456;
+      end
+      default : begin
+        _zz_669 = _zz_457;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_840)
+      3'b000 : begin
+        _zz_670 = _zz_450;
+      end
+      3'b001 : begin
+        _zz_670 = _zz_451;
+      end
+      3'b010 : begin
+        _zz_670 = _zz_452;
+      end
+      3'b011 : begin
+        _zz_670 = _zz_453;
+      end
+      3'b100 : begin
+        _zz_670 = _zz_454;
+      end
+      3'b101 : begin
+        _zz_670 = _zz_455;
+      end
+      3'b110 : begin
+        _zz_670 = _zz_456;
+      end
+      default : begin
+        _zz_670 = _zz_457;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_975)
+      4'b0000 : begin
+        _zz_671 = _zz_87;
+      end
+      4'b0001 : begin
+        _zz_671 = _zz_106;
+      end
+      4'b0010 : begin
+        _zz_671 = _zz_125;
+      end
+      4'b0011 : begin
+        _zz_671 = _zz_144;
+      end
+      4'b0100 : begin
+        _zz_671 = _zz_163;
+      end
+      4'b0101 : begin
+        _zz_671 = _zz_182;
+      end
+      4'b0110 : begin
+        _zz_671 = _zz_201;
+      end
+      4'b0111 : begin
+        _zz_671 = _zz_220;
+      end
+      4'b1000 : begin
+        _zz_671 = _zz_239;
+      end
+      4'b1001 : begin
+        _zz_671 = _zz_258;
+      end
+      4'b1010 : begin
+        _zz_671 = _zz_277;
+      end
+      4'b1011 : begin
+        _zz_671 = _zz_296;
+      end
+      4'b1100 : begin
+        _zz_671 = _zz_315;
+      end
+      4'b1101 : begin
+        _zz_671 = _zz_334;
+      end
+      4'b1110 : begin
+        _zz_671 = _zz_353;
+      end
+      default : begin
+        _zz_671 = _zz_372;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_976)
+      4'b0000 : begin
+        _zz_672 = _zz_88;
+      end
+      4'b0001 : begin
+        _zz_672 = _zz_107;
+      end
+      4'b0010 : begin
+        _zz_672 = _zz_126;
+      end
+      4'b0011 : begin
+        _zz_672 = _zz_145;
+      end
+      4'b0100 : begin
+        _zz_672 = _zz_164;
+      end
+      4'b0101 : begin
+        _zz_672 = _zz_183;
+      end
+      4'b0110 : begin
+        _zz_672 = _zz_202;
+      end
+      4'b0111 : begin
+        _zz_672 = _zz_221;
+      end
+      4'b1000 : begin
+        _zz_672 = _zz_240;
+      end
+      4'b1001 : begin
+        _zz_672 = _zz_259;
+      end
+      4'b1010 : begin
+        _zz_672 = _zz_278;
+      end
+      4'b1011 : begin
+        _zz_672 = _zz_297;
+      end
+      4'b1100 : begin
+        _zz_672 = _zz_316;
+      end
+      4'b1101 : begin
+        _zz_672 = _zz_335;
+      end
+      4'b1110 : begin
+        _zz_672 = _zz_354;
+      end
+      default : begin
+        _zz_672 = _zz_373;
+      end
+    endcase
+  end
+
+  always @(*) begin
+    case(_zz_977)
+      4'b0000 : begin
+        _zz_673 = _zz_89;
+      end
+      4'b0001 : begin
+        _zz_673 = _zz_108;
+      end
+      4'b0010 : begin
+        _zz_673 = _zz_127;
+      end
+      4'b0011 : begin
+        _zz_673 = _zz_146;
+      end
+      4'b0100 : begin
+        _zz_673 = _zz_165;
+      end
+      4'b0101 : begin
+        _zz_673 = _zz_184;
+      end
+      4'b0110 : begin
+        _zz_673 = _zz_203;
+      end
+      4'b0111 : begin
+        _zz_673 = _zz_222;
+      end
+      4'b1000 : begin
+        _zz_673 = _zz_241;
+      end
+      4'b1001 : begin
+        _zz_673 = _zz_260;
+      end
+      4'b1010 : begin
+        _zz_673 = _zz_279;
+      end
+      4'b1011 : begin
+        _zz_673 = _zz_298;
+      end
+      4'b1100 : begin
+        _zz_673 = _zz_317;
+      end
+      4'b1101 : begin
+        _zz_673 = _zz_336;
+      end
+      4'b1110 : begin
+        _zz_673 = _zz_355;
+      end
+      default : begin
+        _zz_673 = _zz_374;
       end
     endcase
   end
 
   `ifndef SYNTHESIS
   always @(*) begin
-    case(_zz_1_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_1__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_1__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_1__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_1__string = "SRA_1    ";
-      default : _zz_1__string = "?????????";
+    case(_zz_1)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_1_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_1_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_1_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_1_string = "ECALL";
+      default : _zz_1_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_2_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_2__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_2__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_2__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_2__string = "SRA_1    ";
-      default : _zz_2__string = "?????????";
+    case(_zz_2)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_2_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_2_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_2_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_2_string = "ECALL";
+      default : _zz_2_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_SHIFT_CTRL_string = "?????????";
+    case(_zz_3)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_3_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_3_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_3_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_3_string = "ECALL";
+      default : _zz_3_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_3_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_3__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_3__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_3__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_3__string = "SRA_1    ";
-      default : _zz_3__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_4_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_4__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_4__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_4__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_4__string = "SRA_1    ";
-      default : _zz_4__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_5_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_5__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_5__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_5__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_5__string = "SRA_1    ";
-      default : _zz_5__string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
-      default : decode_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_6_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_6__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_6__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_6__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_6__string = "URS1        ";
-      default : _zz_6__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_7_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_7__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_7__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_7__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_7__string = "URS1        ";
-      default : _zz_7__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_8_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_8__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_8__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_8__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_8__string = "URS1        ";
-      default : _zz_8__string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_9_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_9__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_9__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_9__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_9__string = "ECALL";
-      default : _zz_9__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_10_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_10__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_10__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_10__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_10__string = "ECALL";
-      default : _zz_10__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_11_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_11__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_11__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_11__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_11__string = "ECALL";
-      default : _zz_11__string = "?????";
-    endcase
-  end
-  always @(*) begin
-    case(_zz_12_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_12__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_12__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_12__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_12__string = "ECALL";
-      default : _zz_12__string = "?????";
+    case(_zz_4)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_4_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_4_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_4_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_4_string = "ECALL";
+      default : _zz_4_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4022,62 +3385,102 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_13_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_13__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_13__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_13__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_13__string = "ECALL";
-      default : _zz_13__string = "?????";
+    case(_zz_5)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_5_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_5_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_5_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_5_string = "ECALL";
+      default : _zz_5_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_14_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_14__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_14__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_14__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_14__string = "ECALL";
-      default : _zz_14__string = "?????";
+    case(_zz_6)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_6_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_6_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_6_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_6_string = "ECALL";
+      default : _zz_6_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_15_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_15__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_15__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_15__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_15__string = "ECALL";
-      default : _zz_15__string = "?????";
+    case(_zz_7)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_7_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_7_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_7_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_7_string = "ECALL";
+      default : _zz_7_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
-      default : decode_ALU_CTRL_string = "????????";
+    case(_zz_8)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_8_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_8_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_8_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_8_string = "JALR";
+      default : _zz_8_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_16_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_16__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_16__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_16__string = "BITWISE ";
-      default : _zz_16__string = "????????";
+    case(_zz_9)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_9_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_9_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_9_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_9_string = "JALR";
+      default : _zz_9_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_17_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_17__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_17__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_17__string = "BITWISE ";
-      default : _zz_17__string = "????????";
+    case(_zz_10)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_10_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_10_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_10_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_10_string = "SRA_1    ";
+      default : _zz_10_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_18_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_18__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_18__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_18__string = "BITWISE ";
-      default : _zz_18__string = "????????";
+    case(_zz_11)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_11_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_11_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_11_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_11_string = "SRA_1    ";
+      default : _zz_11_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_12)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_12_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_12_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_12_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_12_string = "SRA_1    ";
+      default : _zz_12_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_13)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_13_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_13_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_13_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_13_string = "SRA_1    ";
+      default : _zz_13_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_14)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_14_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_14_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_14_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_14_string = "SRA_1    ";
+      default : _zz_14_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -4089,27 +3492,27 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_19_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_19__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_19__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_19__string = "AND_1";
-      default : _zz_19__string = "?????";
+    case(_zz_15)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_15_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_15_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_15_string = "AND_1";
+      default : _zz_15_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_20_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_20__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_20__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_20__string = "AND_1";
-      default : _zz_20__string = "?????";
+    case(_zz_16)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_16_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_16_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_16_string = "AND_1";
+      default : _zz_16_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_21_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_21__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_21__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_21__string = "AND_1";
-      default : _zz_21__string = "?????";
+    case(_zz_17)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_17_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_17_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_17_string = "AND_1";
+      default : _zz_17_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4122,48 +3525,98 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_22_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_22__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_22__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_22__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_22__string = "PC ";
-      default : _zz_22__string = "???";
+    case(_zz_18)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_18_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_18_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_18_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_18_string = "PC ";
+      default : _zz_18_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_23_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_23__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_23__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_23__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_23__string = "PC ";
-      default : _zz_23__string = "???";
+    case(_zz_19)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_19_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_19_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_19_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_19_string = "PC ";
+      default : _zz_19_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_24_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_24__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_24__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_24__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_24__string = "PC ";
-      default : _zz_24__string = "???";
+    case(_zz_20)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_20_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_20_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_20_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_20_string = "PC ";
+      default : _zz_20_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_25_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_25__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_25__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_25__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_25__string = "JALR";
-      default : _zz_25__string = "????";
+    case(decode_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_ALU_CTRL_string = "BITWISE ";
+      default : decode_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_26_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_26__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_26__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_26__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_26__string = "JALR";
-      default : _zz_26__string = "????";
+    case(_zz_21)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_21_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_21_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_21_string = "BITWISE ";
+      default : _zz_21_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_22)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_22_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_22_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_22_string = "BITWISE ";
+      default : _zz_22_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_23)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_23_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_23_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_23_string = "BITWISE ";
+      default : _zz_23_string = "????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_SRC1_CTRL_string = "URS1        ";
+      default : decode_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_24)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_24_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_24_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_24_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_24_string = "URS1        ";
+      default : _zz_24_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_25)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_25_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_25_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_25_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_25_string = "URS1        ";
+      default : _zz_25_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(_zz_26)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_26_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_26_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_26_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_26_string = "URS1        ";
+      default : _zz_26_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4176,12 +3629,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_27_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27__string = "ECALL";
-      default : _zz_27__string = "?????";
+    case(_zz_27)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_27_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_27_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_27_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_27_string = "ECALL";
+      default : _zz_27_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4194,12 +3647,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_28_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28__string = "ECALL";
-      default : _zz_28__string = "?????";
+    case(_zz_28)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_28_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_28_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_28_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_28_string = "ECALL";
+      default : _zz_28_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4212,12 +3665,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_29_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29__string = "ECALL";
-      default : _zz_29__string = "?????";
+    case(_zz_29)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_29_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_29_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_29_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_29_string = "ECALL";
+      default : _zz_29_string = "?????";
     endcase
   end
   always @(*) begin
@@ -4230,12 +3683,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_30_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_30__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_30__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30__string = "JALR";
-      default : _zz_30__string = "????";
+    case(_zz_30)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_30_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_30_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_30_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_30_string = "JALR";
+      default : _zz_30_string = "????";
     endcase
   end
   always @(*) begin
@@ -4248,12 +3701,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_33_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33__string = "SRA_1    ";
-      default : _zz_33__string = "?????????";
+    case(_zz_33)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_33_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_33_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_33_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_33_string = "SRA_1    ";
+      default : _zz_33_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -4266,12 +3719,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_34_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34__string = "SRA_1    ";
-      default : _zz_34__string = "?????????";
+    case(_zz_34)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_34_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_34_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_34_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_34_string = "SRA_1    ";
+      default : _zz_34_string = "?????????";
     endcase
   end
   always @(*) begin
@@ -4284,12 +3737,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_36_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_36__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_36__string = "PC ";
-      default : _zz_36__string = "???";
+    case(_zz_36)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_36_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_36_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_36_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_36_string = "PC ";
+      default : _zz_36_string = "???";
     endcase
   end
   always @(*) begin
@@ -4302,12 +3755,12 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_37_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_37__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37__string = "URS1        ";
-      default : _zz_37__string = "????????????";
+    case(_zz_37)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_37_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_37_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_37_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_37_string = "URS1        ";
+      default : _zz_37_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4319,11 +3772,11 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_38_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38__string = "BITWISE ";
-      default : _zz_38__string = "????????";
+    case(_zz_38)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_38_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_38_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_38_string = "BITWISE ";
+      default : _zz_38_string = "????????";
     endcase
   end
   always @(*) begin
@@ -4335,72 +3788,72 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_39_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39__string = "AND_1";
-      default : _zz_39__string = "?????";
+    case(_zz_39)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_39_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_39_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_39_string = "AND_1";
+      default : _zz_39_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_43_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43__string = "ECALL";
-      default : _zz_43__string = "?????";
+    case(_zz_43)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_43_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_43_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_43_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_43_string = "ECALL";
+      default : _zz_43_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_44_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_44__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_44__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_44__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_44__string = "PC ";
-      default : _zz_44__string = "???";
+    case(_zz_44)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_44_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_44_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_44_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_44_string = "JALR";
+      default : _zz_44_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_45_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_45__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_45__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_45__string = "BITWISE ";
-      default : _zz_45__string = "????????";
+    case(_zz_45)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_45_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_45_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_45_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_45_string = "SRA_1    ";
+      default : _zz_45_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_46_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_46__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_46__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_46__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_46__string = "SRA_1    ";
-      default : _zz_46__string = "?????????";
+    case(_zz_46)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_46_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_46_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_46_string = "AND_1";
+      default : _zz_46_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_47_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_47__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_47__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_47__string = "AND_1";
-      default : _zz_47__string = "?????";
+    case(_zz_47)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_47_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_47_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_47_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_47_string = "PC ";
+      default : _zz_47_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_48_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_48__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_48__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_48__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_48__string = "URS1        ";
-      default : _zz_48__string = "????????????";
+    case(_zz_48)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_48_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_48_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_48_string = "BITWISE ";
+      default : _zz_48_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_49_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_49__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_49__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_49__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_49__string = "JALR";
-      default : _zz_49__string = "????";
+    case(_zz_49)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_49_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_49_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_49_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_49_string = "URS1        ";
+      default : _zz_49_string = "????????????";
     endcase
   end
   always @(*) begin
@@ -4413,82 +3866,90 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(_zz_54_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_54__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_54__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_54__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_54__string = "JALR";
-      default : _zz_54__string = "????";
+    case(_zz_51)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_51_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_51_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_51_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_51_string = "JALR";
+      default : _zz_51_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_453_)
-      `BranchCtrlEnum_defaultEncoding_INC : _zz_453__string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : _zz_453__string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : _zz_453__string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : _zz_453__string = "JALR";
-      default : _zz_453__string = "????";
+    case(_zz_514)
+      `Src1CtrlEnum_defaultEncoding_RS : _zz_514_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : _zz_514_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_514_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_514_string = "URS1        ";
+      default : _zz_514_string = "????????????";
     endcase
   end
   always @(*) begin
-    case(_zz_454_)
-      `Src1CtrlEnum_defaultEncoding_RS : _zz_454__string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : _zz_454__string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : _zz_454__string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : _zz_454__string = "URS1        ";
-      default : _zz_454__string = "????????????";
+    case(_zz_515)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_515_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_515_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_515_string = "BITWISE ";
+      default : _zz_515_string = "????????";
     endcase
   end
   always @(*) begin
-    case(_zz_455_)
-      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_455__string = "XOR_1";
-      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_455__string = "OR_1 ";
-      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_455__string = "AND_1";
-      default : _zz_455__string = "?????";
+    case(_zz_516)
+      `Src2CtrlEnum_defaultEncoding_RS : _zz_516_string = "RS ";
+      `Src2CtrlEnum_defaultEncoding_IMI : _zz_516_string = "IMI";
+      `Src2CtrlEnum_defaultEncoding_IMS : _zz_516_string = "IMS";
+      `Src2CtrlEnum_defaultEncoding_PC : _zz_516_string = "PC ";
+      default : _zz_516_string = "???";
     endcase
   end
   always @(*) begin
-    case(_zz_456_)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_456__string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_456__string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_456__string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_456__string = "SRA_1    ";
-      default : _zz_456__string = "?????????";
+    case(_zz_517)
+      `AluBitwiseCtrlEnum_defaultEncoding_XOR_1 : _zz_517_string = "XOR_1";
+      `AluBitwiseCtrlEnum_defaultEncoding_OR_1 : _zz_517_string = "OR_1 ";
+      `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : _zz_517_string = "AND_1";
+      default : _zz_517_string = "?????";
     endcase
   end
   always @(*) begin
-    case(_zz_457_)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : _zz_457__string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : _zz_457__string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : _zz_457__string = "BITWISE ";
-      default : _zz_457__string = "????????";
+    case(_zz_518)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : _zz_518_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : _zz_518_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : _zz_518_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : _zz_518_string = "SRA_1    ";
+      default : _zz_518_string = "?????????";
     endcase
   end
   always @(*) begin
-    case(_zz_458_)
-      `Src2CtrlEnum_defaultEncoding_RS : _zz_458__string = "RS ";
-      `Src2CtrlEnum_defaultEncoding_IMI : _zz_458__string = "IMI";
-      `Src2CtrlEnum_defaultEncoding_IMS : _zz_458__string = "IMS";
-      `Src2CtrlEnum_defaultEncoding_PC : _zz_458__string = "PC ";
-      default : _zz_458__string = "???";
+    case(_zz_519)
+      `BranchCtrlEnum_defaultEncoding_INC : _zz_519_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : _zz_519_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : _zz_519_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : _zz_519_string = "JALR";
+      default : _zz_519_string = "????";
     endcase
   end
   always @(*) begin
-    case(_zz_459_)
-      `EnvCtrlEnum_defaultEncoding_NONE : _zz_459__string = "NONE ";
-      `EnvCtrlEnum_defaultEncoding_XRET : _zz_459__string = "XRET ";
-      `EnvCtrlEnum_defaultEncoding_WFI : _zz_459__string = "WFI  ";
-      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_459__string = "ECALL";
-      default : _zz_459__string = "?????";
+    case(_zz_520)
+      `EnvCtrlEnum_defaultEncoding_NONE : _zz_520_string = "NONE ";
+      `EnvCtrlEnum_defaultEncoding_XRET : _zz_520_string = "XRET ";
+      `EnvCtrlEnum_defaultEncoding_WFI : _zz_520_string = "WFI  ";
+      `EnvCtrlEnum_defaultEncoding_ECALL : _zz_520_string = "ECALL";
+      default : _zz_520_string = "?????";
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_BRANCH_CTRL)
-      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
-      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
-      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
-      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
-      default : decode_to_execute_BRANCH_CTRL_string = "????";
+    case(decode_to_execute_SRC1_CTRL)
+      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
+      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
+      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
+      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
+      default : decode_to_execute_SRC1_CTRL_string = "????????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_ALU_CTRL)
+      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
+      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
+      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
+      default : decode_to_execute_ALU_CTRL_string = "????????";
     endcase
   end
   always @(*) begin
@@ -4509,11 +3970,30 @@ module VexRiscv (
     endcase
   end
   always @(*) begin
-    case(decode_to_execute_ALU_CTRL)
-      `AluCtrlEnum_defaultEncoding_ADD_SUB : decode_to_execute_ALU_CTRL_string = "ADD_SUB ";
-      `AluCtrlEnum_defaultEncoding_SLT_SLTU : decode_to_execute_ALU_CTRL_string = "SLT_SLTU";
-      `AluCtrlEnum_defaultEncoding_BITWISE : decode_to_execute_ALU_CTRL_string = "BITWISE ";
-      default : decode_to_execute_ALU_CTRL_string = "????????";
+    case(decode_to_execute_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
+      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(execute_to_memory_SHIFT_CTRL)
+      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
+      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
+      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
+      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
+    endcase
+  end
+  always @(*) begin
+    case(decode_to_execute_BRANCH_CTRL)
+      `BranchCtrlEnum_defaultEncoding_INC : decode_to_execute_BRANCH_CTRL_string = "INC ";
+      `BranchCtrlEnum_defaultEncoding_B : decode_to_execute_BRANCH_CTRL_string = "B   ";
+      `BranchCtrlEnum_defaultEncoding_JAL : decode_to_execute_BRANCH_CTRL_string = "JAL ";
+      `BranchCtrlEnum_defaultEncoding_JALR : decode_to_execute_BRANCH_CTRL_string = "JALR";
+      default : decode_to_execute_BRANCH_CTRL_string = "????";
     endcase
   end
   always @(*) begin
@@ -4543,89 +4023,63 @@ module VexRiscv (
       default : memory_to_writeBack_ENV_CTRL_string = "?????";
     endcase
   end
-  always @(*) begin
-    case(decode_to_execute_SRC1_CTRL)
-      `Src1CtrlEnum_defaultEncoding_RS : decode_to_execute_SRC1_CTRL_string = "RS          ";
-      `Src1CtrlEnum_defaultEncoding_IMU : decode_to_execute_SRC1_CTRL_string = "IMU         ";
-      `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : decode_to_execute_SRC1_CTRL_string = "PC_INCREMENT";
-      `Src1CtrlEnum_defaultEncoding_URS1 : decode_to_execute_SRC1_CTRL_string = "URS1        ";
-      default : decode_to_execute_SRC1_CTRL_string = "????????????";
-    endcase
-  end
-  always @(*) begin
-    case(decode_to_execute_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : decode_to_execute_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : decode_to_execute_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : decode_to_execute_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : decode_to_execute_SHIFT_CTRL_string = "SRA_1    ";
-      default : decode_to_execute_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
-  always @(*) begin
-    case(execute_to_memory_SHIFT_CTRL)
-      `ShiftCtrlEnum_defaultEncoding_DISABLE_1 : execute_to_memory_SHIFT_CTRL_string = "DISABLE_1";
-      `ShiftCtrlEnum_defaultEncoding_SLL_1 : execute_to_memory_SHIFT_CTRL_string = "SLL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRL_1 : execute_to_memory_SHIFT_CTRL_string = "SRL_1    ";
-      `ShiftCtrlEnum_defaultEncoding_SRA_1 : execute_to_memory_SHIFT_CTRL_string = "SRA_1    ";
-      default : execute_to_memory_SHIFT_CTRL_string = "?????????";
-    endcase
-  end
   `endif
 
-  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
-  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_650_[0];
-  assign _zz_1_ = _zz_2_;
-  assign decode_SHIFT_CTRL = _zz_3_;
-  assign _zz_4_ = _zz_5_;
-  assign decode_SRC1_CTRL = _zz_6_;
-  assign _zz_7_ = _zz_8_;
-  assign decode_IS_RS1_SIGNED = _zz_651_[0];
-  assign memory_MUL_LOW = ($signed(_zz_652_) + $signed(_zz_660_));
-  assign _zz_9_ = _zz_10_;
-  assign _zz_11_ = _zz_12_;
-  assign decode_ENV_CTRL = _zz_13_;
-  assign _zz_14_ = _zz_15_;
-  assign decode_SRC_LESS_UNSIGNED = _zz_661_[0];
-  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
-  assign decode_MEMORY_WR = _zz_662_[0];
-  assign decode_IS_CSR = _zz_663_[0];
+  assign memory_MUL_LOW = ($signed(_zz_733) + $signed(_zz_741));
+  assign memory_MUL_HH = execute_to_memory_MUL_HH;
+  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_HL = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bSLow));
+  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
   assign execute_MUL_LL = (execute_MulPlugin_aULow * execute_MulPlugin_bULow);
-  assign decode_ALU_CTRL = _zz_16_;
-  assign _zz_17_ = _zz_18_;
-  assign decode_MEMORY_MANAGMENT = _zz_664_[0];
+  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],1'b0};
   assign execute_BRANCH_DO = ((execute_PREDICTION_HAD_BRANCHED2 != execute_BRANCH_COND_RESULT) || execute_BranchPlugin_missAlignedTarget);
-  assign decode_IS_RS2_SIGNED = _zz_665_[0];
-  assign decode_IS_DIV = _zz_666_[0];
-  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
-  assign memory_PC = execute_to_memory_PC;
-  assign decode_ALU_BITWISE_CTRL = _zz_19_;
-  assign _zz_20_ = _zz_21_;
-  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == (2'b01)) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == (2'b11)) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign execute_SHIFT_RIGHT = _zz_743;
+  assign execute_REGFILE_WRITE_DATA = _zz_522;
+  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
+  assign execute_MEMORY_ADDRESS_LOW = _zz_635[1 : 0];
   assign decode_DO_EBREAK = (((! DebugPlugin_haltIt) && (decode_IS_EBREAK || 1'b0)) && DebugPlugin_allowEBreak);
+  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
+  assign decode_CSR_WRITE_OPCODE = (! (((decode_INSTRUCTION[14 : 13] == 2'b01) && (decode_INSTRUCTION[19 : 15] == 5'h0)) || ((decode_INSTRUCTION[14 : 13] == 2'b11) && (decode_INSTRUCTION[19 : 15] == 5'h0))));
+  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
+  assign decode_SRC2_FORCE_ZERO = (decode_SRC_ADD_ZERO && (! decode_SRC_USE_SUB_LESS));
+  assign decode_IS_RS2_SIGNED = _zz_745[0];
+  assign decode_IS_RS1_SIGNED = _zz_746[0];
+  assign decode_IS_DIV = _zz_747[0];
+  assign memory_IS_MUL = execute_to_memory_IS_MUL;
+  assign execute_IS_MUL = decode_to_execute_IS_MUL;
+  assign decode_IS_MUL = _zz_748[0];
+  assign _zz_1 = _zz_2;
+  assign _zz_3 = _zz_4;
+  assign decode_ENV_CTRL = _zz_5;
+  assign _zz_6 = _zz_7;
+  assign decode_IS_CSR = _zz_749[0];
+  assign _zz_8 = _zz_9;
+  assign _zz_10 = _zz_11;
+  assign decode_SHIFT_CTRL = _zz_12;
+  assign _zz_13 = _zz_14;
+  assign decode_ALU_BITWISE_CTRL = _zz_15;
+  assign _zz_16 = _zz_17;
+  assign decode_SRC_LESS_UNSIGNED = _zz_750[0];
+  assign decode_MEMORY_MANAGMENT = _zz_751[0];
+  assign memory_MEMORY_WR = execute_to_memory_MEMORY_WR;
+  assign decode_MEMORY_WR = _zz_752[0];
+  assign execute_BYPASSABLE_MEMORY_STAGE = decode_to_execute_BYPASSABLE_MEMORY_STAGE;
+  assign decode_BYPASSABLE_MEMORY_STAGE = _zz_753[0];
+  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_754[0];
+  assign decode_SRC2_CTRL = _zz_18;
+  assign _zz_19 = _zz_20;
+  assign decode_ALU_CTRL = _zz_21;
+  assign _zz_22 = _zz_23;
+  assign decode_SRC1_CTRL = _zz_24;
+  assign _zz_25 = _zz_26;
+  assign decode_MEMORY_FORCE_CONSTISTENCY = 1'b0;
   assign writeBack_FORMAL_PC_NEXT = memory_to_writeBack_FORMAL_PC_NEXT;
   assign memory_FORMAL_PC_NEXT = execute_to_memory_FORMAL_PC_NEXT;
   assign execute_FORMAL_PC_NEXT = decode_to_execute_FORMAL_PC_NEXT;
   assign decode_FORMAL_PC_NEXT = (decode_PC + 32'h00000004);
-  assign execute_SHIFT_RIGHT = _zz_668_;
-  assign memory_MEMORY_ADDRESS_LOW = execute_to_memory_MEMORY_ADDRESS_LOW;
-  assign execute_MEMORY_ADDRESS_LOW = _zz_573_[1 : 0];
-  assign execute_REGFILE_WRITE_DATA = _zz_461_;
-  assign decode_BYPASSABLE_EXECUTE_STAGE = _zz_670_[0];
-  assign execute_BRANCH_CALC = {execute_BranchPlugin_branchAdder[31 : 1],(1'b0)};
-  assign execute_MUL_LH = ($signed(execute_MulPlugin_aSLow) * $signed(execute_MulPlugin_bHigh));
-  assign memory_MUL_HH = execute_to_memory_MUL_HH;
-  assign execute_MUL_HH = ($signed(execute_MulPlugin_aHigh) * $signed(execute_MulPlugin_bHigh));
-  assign decode_PREDICTION_HAD_BRANCHED2 = IBusCachedPlugin_decodePrediction_cmd_hadBranch;
-  assign decode_SRC2_CTRL = _zz_22_;
-  assign _zz_23_ = _zz_24_;
-  assign decode_CSR_READ_OPCODE = (decode_INSTRUCTION[13 : 7] != 7'h20);
-  assign _zz_25_ = _zz_26_;
-  assign memory_IS_MUL = execute_to_memory_IS_MUL;
-  assign execute_IS_MUL = decode_to_execute_IS_MUL;
-  assign decode_IS_MUL = _zz_671_[0];
+  assign memory_PC = execute_to_memory_PC;
   assign execute_DO_EBREAK = decode_to_execute_DO_EBREAK;
-  assign decode_IS_EBREAK = _zz_672_[0];
+  assign decode_IS_EBREAK = _zz_755[0];
   assign execute_IS_RS1_SIGNED = decode_to_execute_IS_RS1_SIGNED;
   assign execute_IS_DIV = decode_to_execute_IS_DIV;
   assign execute_IS_RS2_SIGNED = decode_to_execute_IS_RS2_SIGNED;
@@ -4639,22 +4093,22 @@ module VexRiscv (
   assign execute_CSR_READ_OPCODE = decode_to_execute_CSR_READ_OPCODE;
   assign execute_CSR_WRITE_OPCODE = decode_to_execute_CSR_WRITE_OPCODE;
   assign execute_IS_CSR = decode_to_execute_IS_CSR;
-  assign memory_ENV_CTRL = _zz_27_;
-  assign execute_ENV_CTRL = _zz_28_;
-  assign writeBack_ENV_CTRL = _zz_29_;
+  assign memory_ENV_CTRL = _zz_27;
+  assign execute_ENV_CTRL = _zz_28;
+  assign writeBack_ENV_CTRL = _zz_29;
   assign memory_BRANCH_CALC = execute_to_memory_BRANCH_CALC;
   assign memory_BRANCH_DO = execute_to_memory_BRANCH_DO;
   assign execute_PC = decode_to_execute_PC;
   assign execute_PREDICTION_HAD_BRANCHED2 = decode_to_execute_PREDICTION_HAD_BRANCHED2;
   assign execute_RS1 = decode_to_execute_RS1;
-  assign execute_BRANCH_COND_RESULT = _zz_483_;
-  assign execute_BRANCH_CTRL = _zz_30_;
-  assign decode_RS2_USE = _zz_673_[0];
-  assign decode_RS1_USE = _zz_674_[0];
+  assign execute_BRANCH_COND_RESULT = _zz_544;
+  assign execute_BRANCH_CTRL = _zz_30;
+  assign decode_RS2_USE = _zz_756[0];
+  assign decode_RS1_USE = _zz_757[0];
   always @ (*) begin
-    _zz_31_ = execute_REGFILE_WRITE_DATA;
-    if(_zz_591_)begin
-      _zz_31_ = execute_CsrPlugin_readData;
+    _zz_31 = execute_REGFILE_WRITE_DATA;
+    if(_zz_674)begin
+      _zz_31 = execute_CsrPlugin_readData;
     end
   end
 
@@ -4666,29 +4120,29 @@ module VexRiscv (
   assign writeBack_REGFILE_WRITE_VALID = memory_to_writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
     decode_RS2 = decode_RegFilePlugin_rs2Data;
-    if(_zz_472_)begin
-      if((_zz_473_ == decode_INSTRUCTION[24 : 20]))begin
-        decode_RS2 = _zz_474_;
+    if(_zz_533)begin
+      if((_zz_534 == decode_INSTRUCTION[24 : 20]))begin
+        decode_RS2 = _zz_535;
       end
     end
-    if(_zz_592_)begin
-      if(_zz_593_)begin
-        if(_zz_476_)begin
-          decode_RS2 = _zz_52_;
+    if(_zz_675)begin
+      if(_zz_676)begin
+        if(_zz_537)begin
+          decode_RS2 = _zz_50;
         end
       end
     end
-    if(_zz_594_)begin
+    if(_zz_677)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_478_)begin
-          decode_RS2 = _zz_32_;
+        if(_zz_539)begin
+          decode_RS2 = _zz_32;
         end
       end
     end
-    if(_zz_595_)begin
+    if(_zz_678)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_480_)begin
-          decode_RS2 = _zz_31_;
+        if(_zz_541)begin
+          decode_RS2 = _zz_31;
         end
       end
     end
@@ -4696,29 +4150,29 @@ module VexRiscv (
 
   always @ (*) begin
     decode_RS1 = decode_RegFilePlugin_rs1Data;
-    if(_zz_472_)begin
-      if((_zz_473_ == decode_INSTRUCTION[19 : 15]))begin
-        decode_RS1 = _zz_474_;
+    if(_zz_533)begin
+      if((_zz_534 == decode_INSTRUCTION[19 : 15]))begin
+        decode_RS1 = _zz_535;
       end
     end
-    if(_zz_592_)begin
-      if(_zz_593_)begin
-        if(_zz_475_)begin
-          decode_RS1 = _zz_52_;
+    if(_zz_675)begin
+      if(_zz_676)begin
+        if(_zz_536)begin
+          decode_RS1 = _zz_50;
         end
       end
     end
-    if(_zz_594_)begin
+    if(_zz_677)begin
       if(memory_BYPASSABLE_MEMORY_STAGE)begin
-        if(_zz_477_)begin
-          decode_RS1 = _zz_32_;
+        if(_zz_538)begin
+          decode_RS1 = _zz_32;
         end
       end
     end
-    if(_zz_595_)begin
+    if(_zz_678)begin
       if(execute_BYPASSABLE_EXECUTE_STAGE)begin
-        if(_zz_479_)begin
-          decode_RS1 = _zz_31_;
+        if(_zz_540)begin
+          decode_RS1 = _zz_31;
         end
       end
     end
@@ -4726,294 +4180,70 @@ module VexRiscv (
 
   assign memory_SHIFT_RIGHT = execute_to_memory_SHIFT_RIGHT;
   always @ (*) begin
-    _zz_32_ = memory_REGFILE_WRITE_DATA;
+    _zz_32 = memory_REGFILE_WRITE_DATA;
     if(memory_arbitration_isValid)begin
       case(memory_SHIFT_CTRL)
         `ShiftCtrlEnum_defaultEncoding_SLL_1 : begin
-          _zz_32_ = _zz_469_;
+          _zz_32 = _zz_530;
         end
         `ShiftCtrlEnum_defaultEncoding_SRL_1, `ShiftCtrlEnum_defaultEncoding_SRA_1 : begin
-          _zz_32_ = memory_SHIFT_RIGHT;
+          _zz_32 = memory_SHIFT_RIGHT;
         end
         default : begin
         end
       endcase
     end
-    if(_zz_596_)begin
-      _zz_32_ = memory_DivPlugin_div_result;
+    if(_zz_679)begin
+      _zz_32 = memory_DivPlugin_div_result;
     end
   end
 
-  assign memory_SHIFT_CTRL = _zz_33_;
-  assign execute_SHIFT_CTRL = _zz_34_;
+  assign memory_SHIFT_CTRL = _zz_33;
+  assign execute_SHIFT_CTRL = _zz_34;
   assign execute_SRC_LESS_UNSIGNED = decode_to_execute_SRC_LESS_UNSIGNED;
   assign execute_SRC2_FORCE_ZERO = decode_to_execute_SRC2_FORCE_ZERO;
   assign execute_SRC_USE_SUB_LESS = decode_to_execute_SRC_USE_SUB_LESS;
-  assign _zz_35_ = execute_PC;
-  assign execute_SRC2_CTRL = _zz_36_;
-  assign execute_SRC1_CTRL = _zz_37_;
-  assign decode_SRC_USE_SUB_LESS = _zz_675_[0];
-  assign decode_SRC_ADD_ZERO = _zz_676_[0];
+  assign _zz_35 = execute_PC;
+  assign execute_SRC2_CTRL = _zz_36;
+  assign execute_SRC1_CTRL = _zz_37;
+  assign decode_SRC_USE_SUB_LESS = _zz_758[0];
+  assign decode_SRC_ADD_ZERO = _zz_759[0];
   assign execute_SRC_ADD_SUB = execute_SrcPlugin_addSub;
   assign execute_SRC_LESS = execute_SrcPlugin_less;
-  assign execute_ALU_CTRL = _zz_38_;
-  assign execute_SRC2 = _zz_467_;
-  assign execute_SRC1 = _zz_462_;
-  assign execute_ALU_BITWISE_CTRL = _zz_39_;
-  assign _zz_40_ = writeBack_INSTRUCTION;
-  assign _zz_41_ = writeBack_REGFILE_WRITE_VALID;
+  assign execute_ALU_CTRL = _zz_38;
+  assign execute_SRC2 = _zz_528;
+  assign execute_SRC1 = _zz_523;
+  assign execute_ALU_BITWISE_CTRL = _zz_39;
+  assign _zz_40 = writeBack_INSTRUCTION;
+  assign _zz_41 = writeBack_REGFILE_WRITE_VALID;
   always @ (*) begin
-    _zz_42_ = 1'b0;
+    _zz_42 = 1'b0;
     if(lastStageRegFileWrite_valid)begin
-      _zz_42_ = 1'b1;
+      _zz_42 = 1'b1;
     end
   end
 
   assign decode_INSTRUCTION_ANTICIPATED = (decode_arbitration_isStuck ? decode_INSTRUCTION : IBusCachedPlugin_cache_io_cpu_fetch_data);
   always @ (*) begin
-    decode_REGFILE_WRITE_VALID = _zz_677_[0];
+    decode_REGFILE_WRITE_VALID = _zz_760[0];
     if((decode_INSTRUCTION[11 : 7] == 5'h0))begin
       decode_REGFILE_WRITE_VALID = 1'b0;
     end
   end
 
-  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_871_) == 32'h00001073),{(_zz_872_ == _zz_873_),{_zz_874_,{_zz_875_,_zz_876_}}}}}}} != 21'h0);
+  assign decode_LEGAL_INSTRUCTION = ({((decode_INSTRUCTION & 32'h0000005f) == 32'h00000017),{((decode_INSTRUCTION & 32'h0000007f) == 32'h0000006f),{((decode_INSTRUCTION & 32'h0000106f) == 32'h00000003),{((decode_INSTRUCTION & _zz_978) == 32'h00001073),{(_zz_979 == _zz_980),{_zz_981,{_zz_982,_zz_983}}}}}}} != 21'h0);
   always @ (*) begin
-    _zz_50_ = _zz_50__14;
-    if(PmpPlugin_ports_1_hits_15)begin
-      _zz_50_ = (_zz_50__14 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__14 = _zz_50__13;
-    if(PmpPlugin_ports_1_hits_14)begin
-      _zz_50__14 = (_zz_50__13 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__13 = _zz_50__12;
-    if(PmpPlugin_ports_1_hits_13)begin
-      _zz_50__13 = (_zz_50__12 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__12 = _zz_50__11;
-    if(PmpPlugin_ports_1_hits_12)begin
-      _zz_50__12 = (_zz_50__11 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__11 = _zz_50__10;
-    if(PmpPlugin_ports_1_hits_11)begin
-      _zz_50__11 = (_zz_50__10 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__10 = _zz_50__9;
-    if(PmpPlugin_ports_1_hits_10)begin
-      _zz_50__10 = (_zz_50__9 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__9 = _zz_50__8;
-    if(PmpPlugin_ports_1_hits_9)begin
-      _zz_50__9 = (_zz_50__8 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__8 = _zz_50__7;
-    if(PmpPlugin_ports_1_hits_8)begin
-      _zz_50__8 = (_zz_50__7 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__7 = _zz_50__6;
-    if(PmpPlugin_ports_1_hits_7)begin
-      _zz_50__7 = (_zz_50__6 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__6 = _zz_50__5;
-    if(PmpPlugin_ports_1_hits_6)begin
-      _zz_50__6 = (_zz_50__5 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__5 = _zz_50__4;
-    if(PmpPlugin_ports_1_hits_5)begin
-      _zz_50__5 = (_zz_50__4 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__4 = _zz_50__3;
-    if(PmpPlugin_ports_1_hits_4)begin
-      _zz_50__4 = (_zz_50__3 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__3 = _zz_50__2;
-    if(PmpPlugin_ports_1_hits_3)begin
-      _zz_50__3 = (_zz_50__2 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__2 = _zz_50__1;
-    if(PmpPlugin_ports_1_hits_2)begin
-      _zz_50__2 = (_zz_50__1 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__1 = _zz_50__0;
-    if(PmpPlugin_ports_1_hits_1)begin
-      _zz_50__1 = (_zz_50__0 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_50__0 = 5'h0;
-    if(PmpPlugin_ports_1_hits_0)begin
-      _zz_50__0 = (5'h0 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51_ = _zz_51__14;
-    if(PmpPlugin_ports_0_hits_15)begin
-      _zz_51_ = (_zz_51__14 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__14 = _zz_51__13;
-    if(PmpPlugin_ports_0_hits_14)begin
-      _zz_51__14 = (_zz_51__13 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__13 = _zz_51__12;
-    if(PmpPlugin_ports_0_hits_13)begin
-      _zz_51__13 = (_zz_51__12 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__12 = _zz_51__11;
-    if(PmpPlugin_ports_0_hits_12)begin
-      _zz_51__12 = (_zz_51__11 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__11 = _zz_51__10;
-    if(PmpPlugin_ports_0_hits_11)begin
-      _zz_51__11 = (_zz_51__10 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__10 = _zz_51__9;
-    if(PmpPlugin_ports_0_hits_10)begin
-      _zz_51__10 = (_zz_51__9 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__9 = _zz_51__8;
-    if(PmpPlugin_ports_0_hits_9)begin
-      _zz_51__9 = (_zz_51__8 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__8 = _zz_51__7;
-    if(PmpPlugin_ports_0_hits_8)begin
-      _zz_51__8 = (_zz_51__7 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__7 = _zz_51__6;
-    if(PmpPlugin_ports_0_hits_7)begin
-      _zz_51__7 = (_zz_51__6 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__6 = _zz_51__5;
-    if(PmpPlugin_ports_0_hits_6)begin
-      _zz_51__6 = (_zz_51__5 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__5 = _zz_51__4;
-    if(PmpPlugin_ports_0_hits_5)begin
-      _zz_51__5 = (_zz_51__4 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__4 = _zz_51__3;
-    if(PmpPlugin_ports_0_hits_4)begin
-      _zz_51__4 = (_zz_51__3 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__3 = _zz_51__2;
-    if(PmpPlugin_ports_0_hits_3)begin
-      _zz_51__3 = (_zz_51__2 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__2 = _zz_51__1;
-    if(PmpPlugin_ports_0_hits_2)begin
-      _zz_51__2 = (_zz_51__1 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__1 = _zz_51__0;
-    if(PmpPlugin_ports_0_hits_1)begin
-      _zz_51__1 = (_zz_51__0 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_51__0 = 5'h0;
-    if(PmpPlugin_ports_0_hits_0)begin
-      _zz_51__0 = (5'h0 + 5'h01);
-    end
-  end
-
-  always @ (*) begin
-    _zz_52_ = writeBack_REGFILE_WRITE_DATA;
+    _zz_50 = writeBack_REGFILE_WRITE_DATA;
     if((writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE))begin
-      _zz_52_ = writeBack_DBusCachedPlugin_rspFormated;
+      _zz_50 = writeBack_DBusCachedPlugin_rspFormated;
     end
     if((writeBack_arbitration_isValid && writeBack_IS_MUL))begin
-      case(_zz_649_)
+      case(_zz_732)
         2'b00 : begin
-          _zz_52_ = _zz_773_;
+          _zz_50 = _zz_870;
         end
         default : begin
-          _zz_52_ = _zz_774_;
+          _zz_50 = _zz_871;
         end
       endcase
     end
@@ -5025,55 +4255,56 @@ module VexRiscv (
   assign writeBack_MEMORY_ENABLE = memory_to_writeBack_MEMORY_ENABLE;
   assign memory_REGFILE_WRITE_DATA = execute_to_memory_REGFILE_WRITE_DATA;
   assign memory_MEMORY_ENABLE = execute_to_memory_MEMORY_ENABLE;
+  assign execute_MEMORY_FORCE_CONSTISTENCY = decode_to_execute_MEMORY_FORCE_CONSTISTENCY;
   assign execute_MEMORY_MANAGMENT = decode_to_execute_MEMORY_MANAGMENT;
   assign execute_RS2 = decode_to_execute_RS2;
   assign execute_MEMORY_WR = decode_to_execute_MEMORY_WR;
   assign execute_SRC_ADD = execute_SrcPlugin_addSub;
   assign execute_MEMORY_ENABLE = decode_to_execute_MEMORY_ENABLE;
   assign execute_INSTRUCTION = decode_to_execute_INSTRUCTION;
-  assign decode_MEMORY_ENABLE = _zz_678_[0];
-  assign decode_FLUSH_ALL = _zz_679_[0];
+  assign decode_MEMORY_ENABLE = _zz_761[0];
+  assign decode_FLUSH_ALL = _zz_762[0];
   always @ (*) begin
-    _zz_53_ = _zz_53__2;
-    if(_zz_597_)begin
-      _zz_53_ = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_4 = IBusCachedPlugin_rsp_issueDetected_3;
+    if(_zz_680)begin
+      IBusCachedPlugin_rsp_issueDetected_4 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_53__2 = _zz_53__1;
-    if(_zz_598_)begin
-      _zz_53__2 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_3 = IBusCachedPlugin_rsp_issueDetected_2;
+    if(_zz_681)begin
+      IBusCachedPlugin_rsp_issueDetected_3 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_53__1 = _zz_53__0;
-    if(_zz_599_)begin
-      _zz_53__1 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_2 = IBusCachedPlugin_rsp_issueDetected_1;
+    if(_zz_682)begin
+      IBusCachedPlugin_rsp_issueDetected_2 = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_53__0 = IBusCachedPlugin_rsp_issueDetected;
-    if(_zz_600_)begin
-      _zz_53__0 = 1'b1;
+    IBusCachedPlugin_rsp_issueDetected_1 = IBusCachedPlugin_rsp_issueDetected;
+    if(_zz_683)begin
+      IBusCachedPlugin_rsp_issueDetected_1 = 1'b1;
     end
   end
 
-  assign decode_BRANCH_CTRL = _zz_54_;
+  assign decode_BRANCH_CTRL = _zz_51;
   assign decode_INSTRUCTION = IBusCachedPlugin_iBusRsp_output_payload_rsp_inst;
   always @ (*) begin
-    _zz_55_ = memory_FORMAL_PC_NEXT;
+    _zz_52 = memory_FORMAL_PC_NEXT;
     if(BranchPlugin_jumpInterface_valid)begin
-      _zz_55_ = BranchPlugin_jumpInterface_payload;
+      _zz_52 = BranchPlugin_jumpInterface_payload;
     end
   end
 
   always @ (*) begin
-    _zz_56_ = decode_FORMAL_PC_NEXT;
+    _zz_53 = decode_FORMAL_PC_NEXT;
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
-      _zz_56_ = IBusCachedPlugin_predictionJumpInterface_payload;
+      _zz_53 = IBusCachedPlugin_predictionJumpInterface_payload;
     end
   end
 
@@ -5085,17 +4316,9 @@ module VexRiscv (
     if(((DBusCachedPlugin_mmuBus_busy && decode_arbitration_isValid) && decode_MEMORY_ENABLE))begin
       decode_arbitration_haltItself = 1'b1;
     end
-    case(_zz_511_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_572)
       3'b010 : begin
         decode_arbitration_haltItself = 1'b1;
-      end
-      3'b011 : begin
-      end
-      3'b100 : begin
       end
       default : begin
       end
@@ -5104,20 +4327,20 @@ module VexRiscv (
 
   always @ (*) begin
     decode_arbitration_haltByOther = 1'b0;
-    if((decode_arbitration_isValid && (_zz_470_ || _zz_471_)))begin
+    if((decode_arbitration_isValid && (_zz_531 || _zz_532)))begin
       decode_arbitration_haltByOther = 1'b1;
     end
     if(CsrPlugin_pipelineLiberator_active)begin
       decode_arbitration_haltByOther = 1'b1;
     end
-    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != (3'b000)))begin
+    if(({(writeBack_arbitration_isValid && (writeBack_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),{(memory_arbitration_isValid && (memory_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET)),(execute_arbitration_isValid && (execute_ENV_CTRL == `EnvCtrlEnum_defaultEncoding_XRET))}} != 3'b000))begin
       decode_arbitration_haltByOther = 1'b1;
     end
   end
 
   always @ (*) begin
     decode_arbitration_removeIt = 1'b0;
-    if(_zz_601_)begin
+    if(_zz_684)begin
       decode_arbitration_removeIt = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -5131,25 +4354,22 @@ module VexRiscv (
     if(IBusCachedPlugin_predictionJumpInterface_valid)begin
       decode_arbitration_flushNext = 1'b1;
     end
-    if(_zz_601_)begin
+    if(_zz_684)begin
       decode_arbitration_flushNext = 1'b1;
     end
   end
 
   always @ (*) begin
     execute_arbitration_haltItself = 1'b0;
-    if((_zz_580_ && (! dataCache_1__io_cpu_flush_ready)))begin
+    if(((_zz_651 && (! dataCache_1_io_cpu_flush_ready)) || dataCache_1_io_cpu_execute_haltIt))begin
       execute_arbitration_haltItself = 1'b1;
     end
-    if(((dataCache_1__io_cpu_redo && execute_arbitration_isValid) && execute_MEMORY_ENABLE))begin
-      execute_arbitration_haltItself = 1'b1;
-    end
-    if(_zz_602_)begin
+    if(_zz_685)begin
       if((! execute_CsrPlugin_wfiWake))begin
         execute_arbitration_haltItself = 1'b1;
       end
     end
-    if(_zz_591_)begin
+    if(_zz_674)begin
       if(execute_CsrPlugin_blockedBySideEffects)begin
         execute_arbitration_haltItself = 1'b1;
       end
@@ -5158,7 +4378,10 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_haltByOther = 1'b0;
-    if(_zz_603_)begin
+    if((dataCache_1_io_cpu_execute_refilling && execute_arbitration_isValid))begin
+      execute_arbitration_haltByOther = 1'b1;
+    end
+    if(_zz_686)begin
       execute_arbitration_haltByOther = 1'b1;
     end
   end
@@ -5175,8 +4398,8 @@ module VexRiscv (
 
   always @ (*) begin
     execute_arbitration_flushIt = 1'b0;
-    if(_zz_603_)begin
-      if(_zz_604_)begin
+    if(_zz_686)begin
+      if(_zz_687)begin
         execute_arbitration_flushIt = 1'b1;
       end
     end
@@ -5187,8 +4410,8 @@ module VexRiscv (
     if(CsrPlugin_selfException_valid)begin
       execute_arbitration_flushNext = 1'b1;
     end
-    if(_zz_603_)begin
-      if(_zz_604_)begin
+    if(_zz_686)begin
+      if(_zz_687)begin
         execute_arbitration_flushNext = 1'b1;
       end
     end
@@ -5196,7 +4419,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_arbitration_haltItself = 1'b0;
-    if(_zz_596_)begin
+    if(_zz_679)begin
       if(((! memory_DivPlugin_frontendOk) || (! memory_DivPlugin_div_done)))begin
         memory_arbitration_haltItself = 1'b1;
       end
@@ -5227,7 +4450,7 @@ module VexRiscv (
 
   always @ (*) begin
     writeBack_arbitration_haltItself = 1'b0;
-    if(dataCache_1__io_cpu_writeBack_haltIt)begin
+    if(dataCache_1_io_cpu_writeBack_haltIt)begin
       writeBack_arbitration_haltItself = 1'b1;
     end
   end
@@ -5258,10 +4481,10 @@ module VexRiscv (
     if(DBusCachedPlugin_exceptionBus_valid)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_605_)begin
+    if(_zz_688)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
-    if(_zz_606_)begin
+    if(_zz_689)begin
       writeBack_arbitration_flushNext = 1'b1;
     end
   end
@@ -5272,24 +4495,24 @@ module VexRiscv (
   assign lastStageIsFiring = writeBack_arbitration_isFiring;
   always @ (*) begin
     IBusCachedPlugin_fetcherHalt = 1'b0;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != (4'b0000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValids_memory,{CsrPlugin_exceptionPortCtrl_exceptionValids_execute,CsrPlugin_exceptionPortCtrl_exceptionValids_decode}}} != 4'b0000))begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_605_)begin
+    if(_zz_688)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_606_)begin
+    if(_zz_689)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_603_)begin
-      if(_zz_604_)begin
+    if(_zz_686)begin
+      if(_zz_687)begin
         IBusCachedPlugin_fetcherHalt = 1'b1;
       end
     end
     if(DebugPlugin_haltIt)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
-    if(_zz_607_)begin
+    if(_zz_690)begin
       IBusCachedPlugin_fetcherHalt = 1'b1;
     end
   end
@@ -5302,15 +4525,15 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_57_ = 1'b0;
+    _zz_54 = 1'b0;
     if(DebugPlugin_godmode)begin
-      _zz_57_ = 1'b1;
+      _zz_54 = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_inWfi = 1'b0;
-    if(_zz_602_)begin
+    if(_zz_685)begin
       CsrPlugin_inWfi = 1'b1;
     end
   end
@@ -5324,21 +4547,21 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_jumpInterface_valid = 1'b0;
-    if(_zz_605_)begin
+    if(_zz_688)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
-    if(_zz_606_)begin
+    if(_zz_689)begin
       CsrPlugin_jumpInterface_valid = 1'b1;
     end
   end
 
   always @ (*) begin
     CsrPlugin_jumpInterface_payload = 32'h0;
-    if(_zz_605_)begin
-      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,(2'b00)};
+    if(_zz_688)begin
+      CsrPlugin_jumpInterface_payload = {CsrPlugin_xtvec_base,2'b00};
     end
-    if(_zz_606_)begin
-      case(_zz_608_)
+    if(_zz_689)begin
+      case(_zz_691)
         2'b11 : begin
           CsrPlugin_jumpInterface_payload = CsrPlugin_mepc;
         end
@@ -5369,14 +4592,14 @@ module VexRiscv (
     end
   end
 
-  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != (4'b0000));
-  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != (4'b0000));
-  assign _zz_58_ = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
-  assign _zz_59_ = (_zz_58_ & (~ _zz_680_));
-  assign _zz_60_ = _zz_59_[3];
-  assign _zz_61_ = (_zz_59_[1] || _zz_60_);
-  assign _zz_62_ = (_zz_59_[2] || _zz_60_);
-  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_584_;
+  assign IBusCachedPlugin_externalFlush = ({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,{execute_arbitration_flushNext,decode_arbitration_flushNext}}} != 4'b0000);
+  assign IBusCachedPlugin_jump_pcLoad_valid = ({CsrPlugin_jumpInterface_valid,{BranchPlugin_jumpInterface_valid,{DBusCachedPlugin_redoBranch_valid,IBusCachedPlugin_predictionJumpInterface_valid}}} != 4'b0000);
+  assign _zz_55 = {IBusCachedPlugin_predictionJumpInterface_valid,{BranchPlugin_jumpInterface_valid,{CsrPlugin_jumpInterface_valid,DBusCachedPlugin_redoBranch_valid}}};
+  assign _zz_56 = (_zz_55 & (~ _zz_763));
+  assign _zz_57 = _zz_56[3];
+  assign _zz_58 = (_zz_56[1] || _zz_57);
+  assign _zz_59 = (_zz_56[2] || _zz_57);
+  assign IBusCachedPlugin_jump_pcLoad_payload = _zz_655;
   always @ (*) begin
     IBusCachedPlugin_fetchPc_correction = 1'b0;
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
@@ -5396,7 +4619,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_682_);
+    IBusCachedPlugin_fetchPc_pc = (IBusCachedPlugin_fetchPc_pcReg + _zz_765);
     if(IBusCachedPlugin_fetchPc_redo_valid)begin
       IBusCachedPlugin_fetchPc_pc = IBusCachedPlugin_fetchPc_redo_payload;
     end
@@ -5436,44 +4659,44 @@ module VexRiscv (
     end
   end
 
-  assign _zz_63_ = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_63_);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_63_);
+  assign _zz_60 = (! IBusCachedPlugin_iBusRsp_stages_0_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_0_input_ready = (IBusCachedPlugin_iBusRsp_stages_0_output_ready && _zz_60);
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_valid = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && _zz_60);
   assign IBusCachedPlugin_iBusRsp_stages_0_output_payload = IBusCachedPlugin_iBusRsp_stages_0_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b0;
-    if(IBusCachedPlugin_cache_io_cpu_fetch_haltIt)begin
+    if(IBusCachedPlugin_mmuBus_busy)begin
       IBusCachedPlugin_iBusRsp_stages_1_halt = 1'b1;
     end
   end
 
-  assign _zz_64_ = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_64_);
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_64_);
+  assign _zz_61 = (! IBusCachedPlugin_iBusRsp_stages_1_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_ready = (IBusCachedPlugin_iBusRsp_stages_1_output_ready && _zz_61);
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_valid = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && _zz_61);
   assign IBusCachedPlugin_iBusRsp_stages_1_output_payload = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b0;
-    if((_zz_53_ || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
+    if((IBusCachedPlugin_rsp_issueDetected_4 || IBusCachedPlugin_rsp_iBusRspOutputHalt))begin
       IBusCachedPlugin_iBusRsp_stages_2_halt = 1'b1;
     end
   end
 
-  assign _zz_65_ = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_65_);
-  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_65_);
+  assign _zz_62 = (! IBusCachedPlugin_iBusRsp_stages_2_halt);
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_ready = (IBusCachedPlugin_iBusRsp_stages_2_output_ready && _zz_62);
+  assign IBusCachedPlugin_iBusRsp_stages_2_output_valid = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && _zz_62);
   assign IBusCachedPlugin_iBusRsp_stages_2_output_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_fetchPc_redo_valid = IBusCachedPlugin_iBusRsp_redoFetch;
   assign IBusCachedPlugin_fetchPc_redo_payload = IBusCachedPlugin_iBusRsp_stages_2_input_payload;
   assign IBusCachedPlugin_iBusRsp_flush = ((decode_arbitration_removeIt || (decode_arbitration_flushNext && (! decode_arbitration_isStuck))) || IBusCachedPlugin_iBusRsp_redoFetch);
-  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_66_;
-  assign _zz_66_ = ((1'b0 && (! _zz_67_)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_67_ = _zz_68_;
-  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_67_;
+  assign IBusCachedPlugin_iBusRsp_stages_0_output_ready = _zz_63;
+  assign _zz_63 = ((1'b0 && (! _zz_64)) || IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign _zz_64 = _zz_65;
+  assign IBusCachedPlugin_iBusRsp_stages_1_input_valid = _zz_64;
   assign IBusCachedPlugin_iBusRsp_stages_1_input_payload = IBusCachedPlugin_fetchPc_pcReg;
-  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_69_)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_69_ = _zz_70_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_69_;
-  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_71_;
+  assign IBusCachedPlugin_iBusRsp_stages_1_output_ready = ((1'b0 && (! _zz_66)) || IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_66 = _zz_67;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_valid = _zz_66;
+  assign IBusCachedPlugin_iBusRsp_stages_2_input_payload = _zz_68;
   always @ (*) begin
     IBusCachedPlugin_iBusRsp_readyForError = 1'b1;
     if((! IBusCachedPlugin_pcValids_0))begin
@@ -5488,143 +4711,137 @@ module VexRiscv (
   assign IBusCachedPlugin_iBusRsp_output_ready = (! decode_arbitration_isStuck);
   always @ (*) begin
     decode_arbitration_isValid = IBusCachedPlugin_iBusRsp_output_valid;
-    case(_zz_511_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
+    case(_zz_572)
       3'b010 : begin
         decode_arbitration_isValid = 1'b1;
       end
       3'b011 : begin
         decode_arbitration_isValid = 1'b1;
       end
-      3'b100 : begin
-      end
       default : begin
       end
     endcase
   end
 
-  assign _zz_72_ = _zz_683_[11];
+  assign _zz_69 = _zz_766[11];
   always @ (*) begin
-    _zz_73_[18] = _zz_72_;
-    _zz_73_[17] = _zz_72_;
-    _zz_73_[16] = _zz_72_;
-    _zz_73_[15] = _zz_72_;
-    _zz_73_[14] = _zz_72_;
-    _zz_73_[13] = _zz_72_;
-    _zz_73_[12] = _zz_72_;
-    _zz_73_[11] = _zz_72_;
-    _zz_73_[10] = _zz_72_;
-    _zz_73_[9] = _zz_72_;
-    _zz_73_[8] = _zz_72_;
-    _zz_73_[7] = _zz_72_;
-    _zz_73_[6] = _zz_72_;
-    _zz_73_[5] = _zz_72_;
-    _zz_73_[4] = _zz_72_;
-    _zz_73_[3] = _zz_72_;
-    _zz_73_[2] = _zz_72_;
-    _zz_73_[1] = _zz_72_;
-    _zz_73_[0] = _zz_72_;
+    _zz_70[18] = _zz_69;
+    _zz_70[17] = _zz_69;
+    _zz_70[16] = _zz_69;
+    _zz_70[15] = _zz_69;
+    _zz_70[14] = _zz_69;
+    _zz_70[13] = _zz_69;
+    _zz_70[12] = _zz_69;
+    _zz_70[11] = _zz_69;
+    _zz_70[10] = _zz_69;
+    _zz_70[9] = _zz_69;
+    _zz_70[8] = _zz_69;
+    _zz_70[7] = _zz_69;
+    _zz_70[6] = _zz_69;
+    _zz_70[5] = _zz_69;
+    _zz_70[4] = _zz_69;
+    _zz_70[3] = _zz_69;
+    _zz_70[2] = _zz_69;
+    _zz_70[1] = _zz_69;
+    _zz_70[0] = _zz_69;
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_684_[31]));
-    if(_zz_78_)begin
+    IBusCachedPlugin_decodePrediction_cmd_hadBranch = ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) || ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_B) && _zz_767[31]));
+    if(_zz_75)begin
       IBusCachedPlugin_decodePrediction_cmd_hadBranch = 1'b0;
     end
   end
 
-  assign _zz_74_ = _zz_685_[19];
+  assign _zz_71 = _zz_768[19];
   always @ (*) begin
-    _zz_75_[10] = _zz_74_;
-    _zz_75_[9] = _zz_74_;
-    _zz_75_[8] = _zz_74_;
-    _zz_75_[7] = _zz_74_;
-    _zz_75_[6] = _zz_74_;
-    _zz_75_[5] = _zz_74_;
-    _zz_75_[4] = _zz_74_;
-    _zz_75_[3] = _zz_74_;
-    _zz_75_[2] = _zz_74_;
-    _zz_75_[1] = _zz_74_;
-    _zz_75_[0] = _zz_74_;
+    _zz_72[10] = _zz_71;
+    _zz_72[9] = _zz_71;
+    _zz_72[8] = _zz_71;
+    _zz_72[7] = _zz_71;
+    _zz_72[6] = _zz_71;
+    _zz_72[5] = _zz_71;
+    _zz_72[4] = _zz_71;
+    _zz_72[3] = _zz_71;
+    _zz_72[2] = _zz_71;
+    _zz_72[1] = _zz_71;
+    _zz_72[0] = _zz_71;
   end
 
-  assign _zz_76_ = _zz_686_[11];
+  assign _zz_73 = _zz_769[11];
   always @ (*) begin
-    _zz_77_[18] = _zz_76_;
-    _zz_77_[17] = _zz_76_;
-    _zz_77_[16] = _zz_76_;
-    _zz_77_[15] = _zz_76_;
-    _zz_77_[14] = _zz_76_;
-    _zz_77_[13] = _zz_76_;
-    _zz_77_[12] = _zz_76_;
-    _zz_77_[11] = _zz_76_;
-    _zz_77_[10] = _zz_76_;
-    _zz_77_[9] = _zz_76_;
-    _zz_77_[8] = _zz_76_;
-    _zz_77_[7] = _zz_76_;
-    _zz_77_[6] = _zz_76_;
-    _zz_77_[5] = _zz_76_;
-    _zz_77_[4] = _zz_76_;
-    _zz_77_[3] = _zz_76_;
-    _zz_77_[2] = _zz_76_;
-    _zz_77_[1] = _zz_76_;
-    _zz_77_[0] = _zz_76_;
+    _zz_74[18] = _zz_73;
+    _zz_74[17] = _zz_73;
+    _zz_74[16] = _zz_73;
+    _zz_74[15] = _zz_73;
+    _zz_74[14] = _zz_73;
+    _zz_74[13] = _zz_73;
+    _zz_74[12] = _zz_73;
+    _zz_74[11] = _zz_73;
+    _zz_74[10] = _zz_73;
+    _zz_74[9] = _zz_73;
+    _zz_74[8] = _zz_73;
+    _zz_74[7] = _zz_73;
+    _zz_74[6] = _zz_73;
+    _zz_74[5] = _zz_73;
+    _zz_74[4] = _zz_73;
+    _zz_74[3] = _zz_73;
+    _zz_74[2] = _zz_73;
+    _zz_74[1] = _zz_73;
+    _zz_74[0] = _zz_73;
   end
 
   always @ (*) begin
     case(decode_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_78_ = _zz_687_[1];
+        _zz_75 = _zz_770[1];
       end
       default : begin
-        _zz_78_ = _zz_688_[1];
+        _zz_75 = _zz_771[1];
       end
     endcase
   end
 
   assign IBusCachedPlugin_predictionJumpInterface_valid = (decode_arbitration_isValid && IBusCachedPlugin_decodePrediction_cmd_hadBranch);
-  assign _zz_79_ = _zz_689_[19];
+  assign _zz_76 = _zz_772[19];
   always @ (*) begin
-    _zz_80_[10] = _zz_79_;
-    _zz_80_[9] = _zz_79_;
-    _zz_80_[8] = _zz_79_;
-    _zz_80_[7] = _zz_79_;
-    _zz_80_[6] = _zz_79_;
-    _zz_80_[5] = _zz_79_;
-    _zz_80_[4] = _zz_79_;
-    _zz_80_[3] = _zz_79_;
-    _zz_80_[2] = _zz_79_;
-    _zz_80_[1] = _zz_79_;
-    _zz_80_[0] = _zz_79_;
+    _zz_77[10] = _zz_76;
+    _zz_77[9] = _zz_76;
+    _zz_77[8] = _zz_76;
+    _zz_77[7] = _zz_76;
+    _zz_77[6] = _zz_76;
+    _zz_77[5] = _zz_76;
+    _zz_77[4] = _zz_76;
+    _zz_77[3] = _zz_76;
+    _zz_77[2] = _zz_76;
+    _zz_77[1] = _zz_76;
+    _zz_77[0] = _zz_76;
   end
 
-  assign _zz_81_ = _zz_690_[11];
+  assign _zz_78 = _zz_773[11];
   always @ (*) begin
-    _zz_82_[18] = _zz_81_;
-    _zz_82_[17] = _zz_81_;
-    _zz_82_[16] = _zz_81_;
-    _zz_82_[15] = _zz_81_;
-    _zz_82_[14] = _zz_81_;
-    _zz_82_[13] = _zz_81_;
-    _zz_82_[12] = _zz_81_;
-    _zz_82_[11] = _zz_81_;
-    _zz_82_[10] = _zz_81_;
-    _zz_82_[9] = _zz_81_;
-    _zz_82_[8] = _zz_81_;
-    _zz_82_[7] = _zz_81_;
-    _zz_82_[6] = _zz_81_;
-    _zz_82_[5] = _zz_81_;
-    _zz_82_[4] = _zz_81_;
-    _zz_82_[3] = _zz_81_;
-    _zz_82_[2] = _zz_81_;
-    _zz_82_[1] = _zz_81_;
-    _zz_82_[0] = _zz_81_;
+    _zz_79[18] = _zz_78;
+    _zz_79[17] = _zz_78;
+    _zz_79[16] = _zz_78;
+    _zz_79[15] = _zz_78;
+    _zz_79[14] = _zz_78;
+    _zz_79[13] = _zz_78;
+    _zz_79[12] = _zz_78;
+    _zz_79[11] = _zz_78;
+    _zz_79[10] = _zz_78;
+    _zz_79[9] = _zz_78;
+    _zz_79[8] = _zz_78;
+    _zz_79[7] = _zz_78;
+    _zz_79[6] = _zz_78;
+    _zz_79[5] = _zz_78;
+    _zz_79[4] = _zz_78;
+    _zz_79[3] = _zz_78;
+    _zz_79[2] = _zz_78;
+    _zz_79[1] = _zz_78;
+    _zz_79[0] = _zz_78;
   end
 
-  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_80_,{{{_zz_889_,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_82_,{{{_zz_890_,_zz_891_},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
+  assign IBusCachedPlugin_predictionJumpInterface_payload = (decode_PC + ((decode_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_77,{{{_zz_996,decode_INSTRUCTION[19 : 12]},decode_INSTRUCTION[20]},decode_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_79,{{{_zz_997,_zz_998},decode_INSTRUCTION[30 : 25]},decode_INSTRUCTION[11 : 8]}},1'b0}));
   assign iBus_cmd_valid = IBusCachedPlugin_cache_io_mem_cmd_valid;
   always @ (*) begin
     iBus_cmd_payload_address = IBusCachedPlugin_cache_io_mem_cmd_payload_address;
@@ -5633,123 +4850,128 @@ module VexRiscv (
 
   assign iBus_cmd_payload_size = IBusCachedPlugin_cache_io_mem_cmd_payload_size;
   assign IBusCachedPlugin_s0_tightlyCoupledHit = 1'b0;
-  assign _zz_565_ = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
-  assign _zz_566_ = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
-  assign _zz_567_ = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
-  assign _zz_568_ = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
-  assign _zz_569_ = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
-  assign _zz_570_ = (CsrPlugin_privilege == (2'b00));
+  assign _zz_626 = (IBusCachedPlugin_iBusRsp_stages_0_input_valid && (! IBusCachedPlugin_s0_tightlyCoupledHit));
+  assign _zz_627 = (IBusCachedPlugin_iBusRsp_stages_1_input_valid && (! IBusCachedPlugin_s1_tightlyCoupledHit));
+  assign _zz_628 = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_627;
+  assign IBusCachedPlugin_mmuBus_cmd_0_isStuck = (! IBusCachedPlugin_iBusRsp_stages_1_input_ready);
+  assign IBusCachedPlugin_mmuBus_cmd_0_virtualAddress = IBusCachedPlugin_iBusRsp_stages_1_input_payload;
+  assign IBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign IBusCachedPlugin_mmuBus_end = (IBusCachedPlugin_iBusRsp_stages_1_input_ready || IBusCachedPlugin_externalFlush);
+  assign _zz_630 = (IBusCachedPlugin_iBusRsp_stages_2_input_valid && (! IBusCachedPlugin_s2_tightlyCoupledHit));
+  assign _zz_631 = (! IBusCachedPlugin_iBusRsp_stages_2_input_ready);
+  assign _zz_632 = (CsrPlugin_privilege == 2'b00);
   assign IBusCachedPlugin_rsp_iBusRspOutputHalt = 1'b0;
   assign IBusCachedPlugin_rsp_issueDetected = 1'b0;
   always @ (*) begin
     IBusCachedPlugin_rsp_redoFetch = 1'b0;
-    if(_zz_600_)begin
+    if(_zz_683)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
-    if(_zz_598_)begin
+    if(_zz_681)begin
       IBusCachedPlugin_rsp_redoFetch = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_571_ = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
-    if(_zz_598_)begin
-      _zz_571_ = 1'b1;
+    _zz_633 = (IBusCachedPlugin_rsp_redoFetch && (! IBusCachedPlugin_cache_io_cpu_decode_mmuRefilling));
+    if(_zz_681)begin
+      _zz_633 = 1'b1;
     end
   end
 
   always @ (*) begin
     IBusCachedPlugin_decodeExceptionPort_valid = 1'b0;
-    if(_zz_599_)begin
+    if(_zz_682)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
-    if(_zz_597_)begin
+    if(_zz_680)begin
       IBusCachedPlugin_decodeExceptionPort_valid = IBusCachedPlugin_iBusRsp_readyForError;
     end
   end
 
   always @ (*) begin
-    IBusCachedPlugin_decodeExceptionPort_payload_code = (4'bxxxx);
-    if(_zz_599_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b1100);
+    IBusCachedPlugin_decodeExceptionPort_payload_code = 4'bxxxx;
+    if(_zz_682)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b1100;
     end
-    if(_zz_597_)begin
-      IBusCachedPlugin_decodeExceptionPort_payload_code = (4'b0001);
+    if(_zz_680)begin
+      IBusCachedPlugin_decodeExceptionPort_payload_code = 4'b0001;
     end
   end
 
-  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],(2'b00)};
+  assign IBusCachedPlugin_decodeExceptionPort_payload_badAddr = {IBusCachedPlugin_iBusRsp_stages_2_input_payload[31 : 2],2'b00};
   assign IBusCachedPlugin_iBusRsp_output_valid = IBusCachedPlugin_iBusRsp_stages_2_output_valid;
   assign IBusCachedPlugin_iBusRsp_stages_2_output_ready = IBusCachedPlugin_iBusRsp_output_ready;
   assign IBusCachedPlugin_iBusRsp_output_payload_rsp_inst = IBusCachedPlugin_cache_io_cpu_decode_data;
   assign IBusCachedPlugin_iBusRsp_output_payload_pc = IBusCachedPlugin_iBusRsp_stages_2_output_payload;
-  assign IBusCachedPlugin_mmuBus_cmd_isValid = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_isValid;
-  assign IBusCachedPlugin_mmuBus_cmd_virtualAddress = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_virtualAddress;
-  assign IBusCachedPlugin_mmuBus_cmd_bypassTranslation = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_cmd_bypassTranslation;
-  assign IBusCachedPlugin_mmuBus_end = IBusCachedPlugin_cache_io_cpu_fetch_mmuBus_end;
-  assign _zz_564_ = (decode_arbitration_isValid && decode_FLUSH_ALL);
-  assign dataCache_1__io_mem_cmd_s2mPipe_valid = (dataCache_1__io_mem_cmd_valid || dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign _zz_581_ = (! dataCache_1__io_mem_cmd_s2mPipe_rValid);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_wr = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_wr : dataCache_1__io_mem_cmd_payload_wr);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_address = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_address : dataCache_1__io_mem_cmd_payload_address);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_data = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_data : dataCache_1__io_mem_cmd_payload_data);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_mask = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_mask : dataCache_1__io_mem_cmd_payload_mask);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_length = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_length : dataCache_1__io_mem_cmd_payload_length);
-  assign dataCache_1__io_mem_cmd_s2mPipe_payload_last = (dataCache_1__io_mem_cmd_s2mPipe_rValid ? dataCache_1__io_mem_cmd_s2mPipe_rData_last : dataCache_1__io_mem_cmd_payload_last);
-  assign dataCache_1__io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready);
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last;
-  assign dBus_cmd_valid = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_valid;
-  assign dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
-  assign dBus_cmd_payload_wr = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
-  assign dBus_cmd_payload_address = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_address;
-  assign dBus_cmd_payload_data = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_data;
-  assign dBus_cmd_payload_mask = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
-  assign dBus_cmd_payload_length = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_length;
-  assign dBus_cmd_payload_last = dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_payload_last;
+  assign _zz_625 = (decode_arbitration_isValid && decode_FLUSH_ALL);
+  assign dataCache_1_io_mem_cmd_s2mPipe_valid = (dataCache_1_io_mem_cmd_valid || dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign _zz_652 = (! dataCache_1_io_mem_cmd_s2mPipe_rValid);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_wr = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_wr : dataCache_1_io_mem_cmd_payload_wr);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_uncached = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_uncached : dataCache_1_io_mem_cmd_payload_uncached);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_address = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_address : dataCache_1_io_mem_cmd_payload_address);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_data = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_data : dataCache_1_io_mem_cmd_payload_data);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_mask = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_mask : dataCache_1_io_mem_cmd_payload_mask);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_length = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_length : dataCache_1_io_mem_cmd_payload_length);
+  assign dataCache_1_io_mem_cmd_s2mPipe_payload_last = (dataCache_1_io_mem_cmd_s2mPipe_rValid ? dataCache_1_io_mem_cmd_s2mPipe_rData_last : dataCache_1_io_mem_cmd_payload_last);
+  assign dataCache_1_io_mem_cmd_s2mPipe_ready = ((1'b1 && (! dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid)) || dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready);
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last;
+  assign dBus_cmd_valid = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_valid;
+  assign dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_ready = dBus_cmd_ready;
+  assign dBus_cmd_payload_wr = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_wr;
+  assign dBus_cmd_payload_uncached = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_uncached;
+  assign dBus_cmd_payload_address = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_address;
+  assign dBus_cmd_payload_data = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_data;
+  assign dBus_cmd_payload_mask = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_mask;
+  assign dBus_cmd_payload_length = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_length;
+  assign dBus_cmd_payload_last = dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_payload_last;
   assign execute_DBusCachedPlugin_size = execute_INSTRUCTION[13 : 12];
-  assign _zz_572_ = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
-  assign _zz_573_ = execute_SRC_ADD;
+  assign _zz_634 = (execute_arbitration_isValid && execute_MEMORY_ENABLE);
+  assign _zz_635 = execute_SRC_ADD;
   always @ (*) begin
     case(execute_DBusCachedPlugin_size)
       2'b00 : begin
-        _zz_85_ = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
+        _zz_82 = {{{execute_RS2[7 : 0],execute_RS2[7 : 0]},execute_RS2[7 : 0]},execute_RS2[7 : 0]};
       end
       2'b01 : begin
-        _zz_85_ = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
+        _zz_82 = {execute_RS2[15 : 0],execute_RS2[15 : 0]};
       end
       default : begin
-        _zz_85_ = execute_RS2[31 : 0];
+        _zz_82 = execute_RS2[31 : 0];
       end
     endcase
   end
 
-  assign _zz_580_ = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
-  assign _zz_574_ = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
-  assign _zz_575_ = memory_REGFILE_WRITE_DATA;
-  assign DBusCachedPlugin_mmuBus_cmd_isValid = dataCache_1__io_cpu_memory_mmuBus_cmd_isValid;
-  assign DBusCachedPlugin_mmuBus_cmd_virtualAddress = dataCache_1__io_cpu_memory_mmuBus_cmd_virtualAddress;
-  assign DBusCachedPlugin_mmuBus_cmd_bypassTranslation = dataCache_1__io_cpu_memory_mmuBus_cmd_bypassTranslation;
+  assign _zz_651 = (execute_arbitration_isValid && execute_MEMORY_MANAGMENT);
+  assign _zz_636 = (memory_arbitration_isValid && memory_MEMORY_ENABLE);
+  assign _zz_637 = memory_REGFILE_WRITE_DATA;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isValid = _zz_636;
+  assign DBusCachedPlugin_mmuBus_cmd_0_isStuck = memory_arbitration_isStuck;
+  assign DBusCachedPlugin_mmuBus_cmd_0_virtualAddress = _zz_637;
+  assign DBusCachedPlugin_mmuBus_cmd_0_bypassTranslation = 1'b0;
+  assign DBusCachedPlugin_mmuBus_end = ((! memory_arbitration_isStuck) || memory_arbitration_removeIt);
   always @ (*) begin
-    _zz_576_ = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
-    if((_zz_57_ && (! dataCache_1__io_cpu_memory_isWrite)))begin
-      _zz_576_ = 1'b1;
+    _zz_638 = DBusCachedPlugin_mmuBus_rsp_isIoAccess;
+    if((_zz_54 && (! dataCache_1_io_cpu_memory_isWrite)))begin
+      _zz_638 = 1'b1;
     end
   end
 
-  assign DBusCachedPlugin_mmuBus_end = dataCache_1__io_cpu_memory_mmuBus_end;
-  assign _zz_577_ = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
-  assign _zz_578_ = (CsrPlugin_privilege == (2'b00));
-  assign _zz_579_ = writeBack_REGFILE_WRITE_DATA;
+  assign _zz_639 = (writeBack_arbitration_isValid && writeBack_MEMORY_ENABLE);
+  assign _zz_640 = (CsrPlugin_privilege == 2'b00);
+  assign _zz_641 = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
     DBusCachedPlugin_redoBranch_valid = 1'b0;
-    if(_zz_609_)begin
-      if(dataCache_1__io_cpu_redo)begin
+    if(_zz_692)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_redoBranch_valid = 1'b1;
       end
     end
@@ -5758,17 +4980,17 @@ module VexRiscv (
   assign DBusCachedPlugin_redoBranch_payload = writeBack_PC;
   always @ (*) begin
     DBusCachedPlugin_exceptionBus_valid = 1'b0;
-    if(_zz_609_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
+    if(_zz_692)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b1;
       end
-      if(dataCache_1__io_cpu_redo)begin
+      if(dataCache_1_io_cpu_redo)begin
         DBusCachedPlugin_exceptionBus_valid = 1'b0;
       end
     end
@@ -5776,94 +4998,94 @@ module VexRiscv (
 
   assign DBusCachedPlugin_exceptionBus_payload_badAddr = writeBack_REGFILE_WRITE_DATA;
   always @ (*) begin
-    DBusCachedPlugin_exceptionBus_payload_code = (4'bxxxx);
-    if(_zz_609_)begin
-      if(dataCache_1__io_cpu_writeBack_accessError)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_691_};
+    DBusCachedPlugin_exceptionBus_payload_code = 4'bxxxx;
+    if(_zz_692)begin
+      if(dataCache_1_io_cpu_writeBack_accessError)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_774};
       end
-      if(dataCache_1__io_cpu_writeBack_unalignedAccess)begin
-        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_692_};
+      if(dataCache_1_io_cpu_writeBack_mmuException)begin
+        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? 4'b1111 : 4'b1101);
       end
-      if(dataCache_1__io_cpu_writeBack_mmuException)begin
-        DBusCachedPlugin_exceptionBus_payload_code = (writeBack_MEMORY_WR ? (4'b1111) : (4'b1101));
+      if(dataCache_1_io_cpu_writeBack_unalignedAccess)begin
+        DBusCachedPlugin_exceptionBus_payload_code = {1'd0, _zz_775};
       end
     end
   end
 
   always @ (*) begin
-    writeBack_DBusCachedPlugin_rspShifted = dataCache_1__io_cpu_writeBack_data;
+    writeBack_DBusCachedPlugin_rspShifted = dataCache_1_io_cpu_writeBack_data;
     case(writeBack_MEMORY_ADDRESS_LOW)
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[15 : 8];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[15 : 8];
       end
       2'b10 : begin
-        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 16];
+        writeBack_DBusCachedPlugin_rspShifted[15 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 16];
       end
       2'b11 : begin
-        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1__io_cpu_writeBack_data[31 : 24];
+        writeBack_DBusCachedPlugin_rspShifted[7 : 0] = dataCache_1_io_cpu_writeBack_data[31 : 24];
       end
       default : begin
       end
     endcase
   end
 
-  assign _zz_86_ = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_83 = (writeBack_DBusCachedPlugin_rspShifted[7] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_87_[31] = _zz_86_;
-    _zz_87_[30] = _zz_86_;
-    _zz_87_[29] = _zz_86_;
-    _zz_87_[28] = _zz_86_;
-    _zz_87_[27] = _zz_86_;
-    _zz_87_[26] = _zz_86_;
-    _zz_87_[25] = _zz_86_;
-    _zz_87_[24] = _zz_86_;
-    _zz_87_[23] = _zz_86_;
-    _zz_87_[22] = _zz_86_;
-    _zz_87_[21] = _zz_86_;
-    _zz_87_[20] = _zz_86_;
-    _zz_87_[19] = _zz_86_;
-    _zz_87_[18] = _zz_86_;
-    _zz_87_[17] = _zz_86_;
-    _zz_87_[16] = _zz_86_;
-    _zz_87_[15] = _zz_86_;
-    _zz_87_[14] = _zz_86_;
-    _zz_87_[13] = _zz_86_;
-    _zz_87_[12] = _zz_86_;
-    _zz_87_[11] = _zz_86_;
-    _zz_87_[10] = _zz_86_;
-    _zz_87_[9] = _zz_86_;
-    _zz_87_[8] = _zz_86_;
-    _zz_87_[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
+    _zz_84[31] = _zz_83;
+    _zz_84[30] = _zz_83;
+    _zz_84[29] = _zz_83;
+    _zz_84[28] = _zz_83;
+    _zz_84[27] = _zz_83;
+    _zz_84[26] = _zz_83;
+    _zz_84[25] = _zz_83;
+    _zz_84[24] = _zz_83;
+    _zz_84[23] = _zz_83;
+    _zz_84[22] = _zz_83;
+    _zz_84[21] = _zz_83;
+    _zz_84[20] = _zz_83;
+    _zz_84[19] = _zz_83;
+    _zz_84[18] = _zz_83;
+    _zz_84[17] = _zz_83;
+    _zz_84[16] = _zz_83;
+    _zz_84[15] = _zz_83;
+    _zz_84[14] = _zz_83;
+    _zz_84[13] = _zz_83;
+    _zz_84[12] = _zz_83;
+    _zz_84[11] = _zz_83;
+    _zz_84[10] = _zz_83;
+    _zz_84[9] = _zz_83;
+    _zz_84[8] = _zz_83;
+    _zz_84[7 : 0] = writeBack_DBusCachedPlugin_rspShifted[7 : 0];
   end
 
-  assign _zz_88_ = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
+  assign _zz_85 = (writeBack_DBusCachedPlugin_rspShifted[15] && (! writeBack_INSTRUCTION[14]));
   always @ (*) begin
-    _zz_89_[31] = _zz_88_;
-    _zz_89_[30] = _zz_88_;
-    _zz_89_[29] = _zz_88_;
-    _zz_89_[28] = _zz_88_;
-    _zz_89_[27] = _zz_88_;
-    _zz_89_[26] = _zz_88_;
-    _zz_89_[25] = _zz_88_;
-    _zz_89_[24] = _zz_88_;
-    _zz_89_[23] = _zz_88_;
-    _zz_89_[22] = _zz_88_;
-    _zz_89_[21] = _zz_88_;
-    _zz_89_[20] = _zz_88_;
-    _zz_89_[19] = _zz_88_;
-    _zz_89_[18] = _zz_88_;
-    _zz_89_[17] = _zz_88_;
-    _zz_89_[16] = _zz_88_;
-    _zz_89_[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
+    _zz_86[31] = _zz_85;
+    _zz_86[30] = _zz_85;
+    _zz_86[29] = _zz_85;
+    _zz_86[28] = _zz_85;
+    _zz_86[27] = _zz_85;
+    _zz_86[26] = _zz_85;
+    _zz_86[25] = _zz_85;
+    _zz_86[24] = _zz_85;
+    _zz_86[23] = _zz_85;
+    _zz_86[22] = _zz_85;
+    _zz_86[21] = _zz_85;
+    _zz_86[20] = _zz_85;
+    _zz_86[19] = _zz_85;
+    _zz_86[18] = _zz_85;
+    _zz_86[17] = _zz_85;
+    _zz_86[16] = _zz_85;
+    _zz_86[15 : 0] = writeBack_DBusCachedPlugin_rspShifted[15 : 0];
   end
 
   always @ (*) begin
-    case(_zz_647_)
+    case(_zz_730)
       2'b00 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_87_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_84;
       end
       2'b01 : begin
-        writeBack_DBusCachedPlugin_rspFormated = _zz_89_;
+        writeBack_DBusCachedPlugin_rspFormated = _zz_86;
       end
       default : begin
         writeBack_DBusCachedPlugin_rspFormated = writeBack_DBusCachedPlugin_rspShifted;
@@ -5871,281 +5093,1975 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_103_ = (_zz_95_ <<< 2);
-  assign _zz_104_ = (_zz_95_ & (~ _zz_693_));
-  assign _zz_105_ = ((_zz_95_ & (~ _zz_104_)) <<< 2);
-  assign _zz_119_ = (_zz_111_ <<< 2);
-  assign _zz_120_ = (_zz_111_ & (~ _zz_696_));
-  assign _zz_121_ = ((_zz_111_ & (~ _zz_120_)) <<< 2);
-  assign _zz_135_ = (_zz_127_ <<< 2);
-  assign _zz_136_ = (_zz_127_ & (~ _zz_699_));
-  assign _zz_137_ = ((_zz_127_ & (~ _zz_136_)) <<< 2);
-  assign _zz_151_ = (_zz_143_ <<< 2);
-  assign _zz_152_ = (_zz_143_ & (~ _zz_702_));
-  assign _zz_153_ = ((_zz_143_ & (~ _zz_152_)) <<< 2);
-  assign _zz_167_ = (_zz_159_ <<< 2);
-  assign _zz_168_ = (_zz_159_ & (~ _zz_705_));
-  assign _zz_169_ = ((_zz_159_ & (~ _zz_168_)) <<< 2);
-  assign _zz_183_ = (_zz_175_ <<< 2);
-  assign _zz_184_ = (_zz_175_ & (~ _zz_708_));
-  assign _zz_185_ = ((_zz_175_ & (~ _zz_184_)) <<< 2);
-  assign _zz_199_ = (_zz_191_ <<< 2);
-  assign _zz_200_ = (_zz_191_ & (~ _zz_711_));
-  assign _zz_201_ = ((_zz_191_ & (~ _zz_200_)) <<< 2);
-  assign _zz_215_ = (_zz_207_ <<< 2);
-  assign _zz_216_ = (_zz_207_ & (~ _zz_714_));
-  assign _zz_217_ = ((_zz_207_ & (~ _zz_216_)) <<< 2);
-  assign _zz_231_ = (_zz_223_ <<< 2);
-  assign _zz_232_ = (_zz_223_ & (~ _zz_717_));
-  assign _zz_233_ = ((_zz_223_ & (~ _zz_232_)) <<< 2);
-  assign _zz_247_ = (_zz_239_ <<< 2);
-  assign _zz_248_ = (_zz_239_ & (~ _zz_720_));
-  assign _zz_249_ = ((_zz_239_ & (~ _zz_248_)) <<< 2);
-  assign _zz_263_ = (_zz_255_ <<< 2);
-  assign _zz_264_ = (_zz_255_ & (~ _zz_723_));
-  assign _zz_265_ = ((_zz_255_ & (~ _zz_264_)) <<< 2);
-  assign _zz_279_ = (_zz_271_ <<< 2);
-  assign _zz_280_ = (_zz_271_ & (~ _zz_726_));
-  assign _zz_281_ = ((_zz_271_ & (~ _zz_280_)) <<< 2);
-  assign _zz_295_ = (_zz_287_ <<< 2);
-  assign _zz_296_ = (_zz_287_ & (~ _zz_729_));
-  assign _zz_297_ = ((_zz_287_ & (~ _zz_296_)) <<< 2);
-  assign _zz_311_ = (_zz_303_ <<< 2);
-  assign _zz_312_ = (_zz_303_ & (~ _zz_732_));
-  assign _zz_313_ = ((_zz_303_ & (~ _zz_312_)) <<< 2);
-  assign _zz_327_ = (_zz_319_ <<< 2);
-  assign _zz_328_ = (_zz_319_ & (~ _zz_735_));
-  assign _zz_329_ = ((_zz_319_ & (~ _zz_328_)) <<< 2);
-  assign _zz_343_ = (_zz_335_ <<< 2);
-  assign _zz_344_ = (_zz_335_ & (~ _zz_738_));
-  assign _zz_345_ = ((_zz_335_ & (~ _zz_344_)) <<< 2);
-  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  assign PmpPlugin_ports_0_hits_0 = (((_zz_100_ && (_zz_101_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_102_)) && (_zz_99_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_1 = (((_zz_116_ && (_zz_117_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_118_)) && (_zz_115_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_2 = (((_zz_132_ && (_zz_133_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_134_)) && (_zz_131_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_3 = (((_zz_148_ && (_zz_149_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_150_)) && (_zz_147_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_4 = (((_zz_164_ && (_zz_165_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_166_)) && (_zz_163_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_5 = (((_zz_180_ && (_zz_181_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_182_)) && (_zz_179_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_6 = (((_zz_196_ && (_zz_197_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_198_)) && (_zz_195_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_7 = (((_zz_212_ && (_zz_213_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_214_)) && (_zz_211_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_8 = (((_zz_228_ && (_zz_229_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_230_)) && (_zz_227_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_9 = (((_zz_244_ && (_zz_245_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_246_)) && (_zz_243_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_10 = (((_zz_260_ && (_zz_261_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_262_)) && (_zz_259_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_11 = (((_zz_276_ && (_zz_277_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_278_)) && (_zz_275_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_12 = (((_zz_292_ && (_zz_293_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_294_)) && (_zz_291_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_13 = (((_zz_308_ && (_zz_309_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_310_)) && (_zz_307_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_14 = (((_zz_324_ && (_zz_325_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_326_)) && (_zz_323_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_0_hits_15 = (((_zz_340_ && (_zz_341_ <= IBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_342_)) && (_zz_339_ || (! (CsrPlugin_privilege == (2'b11)))));
   always @ (*) begin
-    if(_zz_610_)begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == (2'b11));
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowRead = _zz_585_;
+    _zz_93 = _zz_87;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_93 = _zz_902[0];
+      end
     end
   end
 
   always @ (*) begin
-    if(_zz_610_)begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == (2'b11));
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_586_;
+    _zz_94 = _zz_88;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_94 = _zz_901[0];
+      end
     end
   end
 
   always @ (*) begin
-    if(_zz_610_)begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == (2'b11));
-    end else begin
-      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_587_;
+    _zz_95 = _zz_89;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_95 = _zz_900[0];
+      end
     end
   end
 
-  assign _zz_346_ = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_892_,_zz_893_}}}}}}}}}}};
-  assign _zz_347_ = (_zz_346_ & (~ _zz_741_));
-  assign _zz_348_ = _zz_347_[3];
-  assign _zz_349_ = _zz_347_[5];
-  assign _zz_350_ = _zz_347_[6];
-  assign _zz_351_ = _zz_347_[7];
-  assign _zz_352_ = _zz_347_[9];
-  assign _zz_353_ = _zz_347_[10];
-  assign _zz_354_ = _zz_347_[11];
-  assign _zz_355_ = _zz_347_[12];
-  assign _zz_356_ = _zz_347_[13];
-  assign _zz_357_ = _zz_347_[14];
-  assign _zz_358_ = _zz_347_[15];
-  assign _zz_359_ = (((((((_zz_347_[1] || _zz_348_) || _zz_349_) || _zz_351_) || _zz_352_) || _zz_354_) || _zz_356_) || _zz_358_);
-  assign _zz_360_ = (((((((_zz_347_[2] || _zz_348_) || _zz_350_) || _zz_351_) || _zz_353_) || _zz_354_) || _zz_357_) || _zz_358_);
-  assign _zz_361_ = (((((((_zz_347_[4] || _zz_349_) || _zz_350_) || _zz_351_) || _zz_355_) || _zz_356_) || _zz_357_) || _zz_358_);
-  assign _zz_362_ = (((((((_zz_347_[8] || _zz_352_) || _zz_353_) || _zz_354_) || _zz_355_) || _zz_356_) || _zz_357_) || _zz_358_);
-  assign _zz_363_ = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_894_,_zz_895_}}}}}}}}}}};
-  assign _zz_364_ = (_zz_363_ & (~ _zz_742_));
-  assign _zz_365_ = _zz_364_[3];
-  assign _zz_366_ = _zz_364_[5];
-  assign _zz_367_ = _zz_364_[6];
-  assign _zz_368_ = _zz_364_[7];
-  assign _zz_369_ = _zz_364_[9];
-  assign _zz_370_ = _zz_364_[10];
-  assign _zz_371_ = _zz_364_[11];
-  assign _zz_372_ = _zz_364_[12];
-  assign _zz_373_ = _zz_364_[13];
-  assign _zz_374_ = _zz_364_[14];
-  assign _zz_375_ = _zz_364_[15];
-  assign _zz_376_ = (((((((_zz_364_[1] || _zz_365_) || _zz_366_) || _zz_368_) || _zz_369_) || _zz_371_) || _zz_373_) || _zz_375_);
-  assign _zz_377_ = (((((((_zz_364_[2] || _zz_365_) || _zz_367_) || _zz_368_) || _zz_370_) || _zz_371_) || _zz_374_) || _zz_375_);
-  assign _zz_378_ = (((((((_zz_364_[4] || _zz_366_) || _zz_367_) || _zz_368_) || _zz_372_) || _zz_373_) || _zz_374_) || _zz_375_);
-  assign _zz_379_ = (((((((_zz_364_[8] || _zz_369_) || _zz_370_) || _zz_371_) || _zz_372_) || _zz_373_) || _zz_374_) || _zz_375_);
-  assign _zz_380_ = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_896_,_zz_897_}}}}}}}}}}};
-  assign _zz_381_ = (_zz_380_ & (~ _zz_743_));
-  assign _zz_382_ = _zz_381_[3];
-  assign _zz_383_ = _zz_381_[5];
-  assign _zz_384_ = _zz_381_[6];
-  assign _zz_385_ = _zz_381_[7];
-  assign _zz_386_ = _zz_381_[9];
-  assign _zz_387_ = _zz_381_[10];
-  assign _zz_388_ = _zz_381_[11];
-  assign _zz_389_ = _zz_381_[12];
-  assign _zz_390_ = _zz_381_[13];
-  assign _zz_391_ = _zz_381_[14];
-  assign _zz_392_ = _zz_381_[15];
-  assign _zz_393_ = (((((((_zz_381_[1] || _zz_382_) || _zz_383_) || _zz_385_) || _zz_386_) || _zz_388_) || _zz_390_) || _zz_392_);
-  assign _zz_394_ = (((((((_zz_381_[2] || _zz_382_) || _zz_384_) || _zz_385_) || _zz_387_) || _zz_388_) || _zz_391_) || _zz_392_);
-  assign _zz_395_ = (((((((_zz_381_[4] || _zz_383_) || _zz_384_) || _zz_385_) || _zz_389_) || _zz_390_) || _zz_391_) || _zz_392_);
-  assign _zz_396_ = (((((((_zz_381_[8] || _zz_386_) || _zz_387_) || _zz_388_) || _zz_389_) || _zz_390_) || _zz_391_) || _zz_392_);
+  always @ (*) begin
+    _zz_96 = _zz_90;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_96 = _zz_890[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_97 = _zz_91;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_97 = execute_CsrPlugin_writeData[4 : 3];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_98 = _zz_92;
+    if(execute_CsrPlugin_csr_944)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_98 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_103 = (_zz_92 <<< 2);
+  assign _zz_104 = (_zz_92 & (~ _zz_776));
+  assign _zz_105 = ((_zz_92 & (~ _zz_104)) <<< 2);
+  assign _zz_100 = _zz_90;
+  always @ (*) begin
+    _zz_99 = 1'b1;
+    case(_zz_97)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_99 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_97)
+      2'b01 : begin
+        _zz_101 = 32'h0;
+      end
+      2'b10 : begin
+        _zz_101 = _zz_103;
+      end
+      2'b11 : begin
+        _zz_101 = _zz_105;
+      end
+      default : begin
+        _zz_101 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_97)
+      2'b01 : begin
+        _zz_102 = _zz_103;
+      end
+      2'b10 : begin
+        _zz_102 = (_zz_103 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_102 = (_zz_105 + _zz_777);
+      end
+      default : begin
+        _zz_102 = _zz_103;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_112 = _zz_106;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_112 = _zz_899[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_113 = _zz_107;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_113 = _zz_898[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_114 = _zz_108;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_114 = _zz_897[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_115 = _zz_109;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_115 = _zz_889[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_116 = _zz_110;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_116 = execute_CsrPlugin_writeData[12 : 11];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_117 = _zz_111;
+    if(execute_CsrPlugin_csr_945)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_117 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_122 = (_zz_111 <<< 2);
+  assign _zz_123 = (_zz_111 & (~ _zz_779));
+  assign _zz_124 = ((_zz_111 & (~ _zz_123)) <<< 2);
+  assign _zz_119 = _zz_109;
+  always @ (*) begin
+    _zz_118 = 1'b1;
+    case(_zz_116)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_118 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_116)
+      2'b01 : begin
+        _zz_120 = _zz_102;
+      end
+      2'b10 : begin
+        _zz_120 = _zz_122;
+      end
+      2'b11 : begin
+        _zz_120 = _zz_124;
+      end
+      default : begin
+        _zz_120 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_116)
+      2'b01 : begin
+        _zz_121 = _zz_122;
+      end
+      2'b10 : begin
+        _zz_121 = (_zz_122 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_121 = (_zz_124 + _zz_780);
+      end
+      default : begin
+        _zz_121 = _zz_122;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_131 = _zz_125;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_131 = _zz_896[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_132 = _zz_126;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_132 = _zz_895[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_133 = _zz_127;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_133 = _zz_894[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_134 = _zz_128;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_134 = _zz_888[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_135 = _zz_129;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_135 = execute_CsrPlugin_writeData[20 : 19];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_136 = _zz_130;
+    if(execute_CsrPlugin_csr_946)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_136 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_141 = (_zz_130 <<< 2);
+  assign _zz_142 = (_zz_130 & (~ _zz_782));
+  assign _zz_143 = ((_zz_130 & (~ _zz_142)) <<< 2);
+  assign _zz_138 = _zz_128;
+  always @ (*) begin
+    _zz_137 = 1'b1;
+    case(_zz_135)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_137 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_135)
+      2'b01 : begin
+        _zz_139 = _zz_121;
+      end
+      2'b10 : begin
+        _zz_139 = _zz_141;
+      end
+      2'b11 : begin
+        _zz_139 = _zz_143;
+      end
+      default : begin
+        _zz_139 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_135)
+      2'b01 : begin
+        _zz_140 = _zz_141;
+      end
+      2'b10 : begin
+        _zz_140 = (_zz_141 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_140 = (_zz_143 + _zz_783);
+      end
+      default : begin
+        _zz_140 = _zz_141;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_150 = _zz_144;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_150 = _zz_893[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_151 = _zz_145;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_151 = _zz_892[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_152 = _zz_146;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_152 = _zz_891[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_153 = _zz_147;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_153 = _zz_887[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_154 = _zz_148;
+    if(execute_CsrPlugin_csr_928)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_154 = execute_CsrPlugin_writeData[28 : 27];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_155 = _zz_149;
+    if(execute_CsrPlugin_csr_947)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_155 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_160 = (_zz_149 <<< 2);
+  assign _zz_161 = (_zz_149 & (~ _zz_785));
+  assign _zz_162 = ((_zz_149 & (~ _zz_161)) <<< 2);
+  assign _zz_157 = _zz_147;
+  always @ (*) begin
+    _zz_156 = 1'b1;
+    case(_zz_154)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_156 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_154)
+      2'b01 : begin
+        _zz_158 = _zz_140;
+      end
+      2'b10 : begin
+        _zz_158 = _zz_160;
+      end
+      2'b11 : begin
+        _zz_158 = _zz_162;
+      end
+      default : begin
+        _zz_158 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_154)
+      2'b01 : begin
+        _zz_159 = _zz_160;
+      end
+      2'b10 : begin
+        _zz_159 = (_zz_160 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_159 = (_zz_162 + _zz_786);
+      end
+      default : begin
+        _zz_159 = _zz_160;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_169 = _zz_163;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_169 = _zz_918[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_170 = _zz_164;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_170 = _zz_917[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_171 = _zz_165;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_171 = _zz_916[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_172 = _zz_166;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_172 = _zz_906[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_173 = _zz_167;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_173 = execute_CsrPlugin_writeData[4 : 3];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_174 = _zz_168;
+    if(execute_CsrPlugin_csr_948)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_174 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_179 = (_zz_168 <<< 2);
+  assign _zz_180 = (_zz_168 & (~ _zz_788));
+  assign _zz_181 = ((_zz_168 & (~ _zz_180)) <<< 2);
+  assign _zz_176 = _zz_166;
+  always @ (*) begin
+    _zz_175 = 1'b1;
+    case(_zz_173)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_175 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_173)
+      2'b01 : begin
+        _zz_177 = _zz_159;
+      end
+      2'b10 : begin
+        _zz_177 = _zz_179;
+      end
+      2'b11 : begin
+        _zz_177 = _zz_181;
+      end
+      default : begin
+        _zz_177 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_173)
+      2'b01 : begin
+        _zz_178 = _zz_179;
+      end
+      2'b10 : begin
+        _zz_178 = (_zz_179 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_178 = (_zz_181 + _zz_789);
+      end
+      default : begin
+        _zz_178 = _zz_179;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_188 = _zz_182;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_188 = _zz_915[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_189 = _zz_183;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_189 = _zz_914[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_190 = _zz_184;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_190 = _zz_913[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_191 = _zz_185;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_191 = _zz_905[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_192 = _zz_186;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_192 = execute_CsrPlugin_writeData[12 : 11];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_193 = _zz_187;
+    if(execute_CsrPlugin_csr_949)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_193 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_198 = (_zz_187 <<< 2);
+  assign _zz_199 = (_zz_187 & (~ _zz_791));
+  assign _zz_200 = ((_zz_187 & (~ _zz_199)) <<< 2);
+  assign _zz_195 = _zz_185;
+  always @ (*) begin
+    _zz_194 = 1'b1;
+    case(_zz_192)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_194 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_192)
+      2'b01 : begin
+        _zz_196 = _zz_178;
+      end
+      2'b10 : begin
+        _zz_196 = _zz_198;
+      end
+      2'b11 : begin
+        _zz_196 = _zz_200;
+      end
+      default : begin
+        _zz_196 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_192)
+      2'b01 : begin
+        _zz_197 = _zz_198;
+      end
+      2'b10 : begin
+        _zz_197 = (_zz_198 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_197 = (_zz_200 + _zz_792);
+      end
+      default : begin
+        _zz_197 = _zz_198;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_207 = _zz_201;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_207 = _zz_912[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_208 = _zz_202;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_208 = _zz_911[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_209 = _zz_203;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_209 = _zz_910[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_210 = _zz_204;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_210 = _zz_904[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_211 = _zz_205;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_211 = execute_CsrPlugin_writeData[20 : 19];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_212 = _zz_206;
+    if(execute_CsrPlugin_csr_950)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_212 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_217 = (_zz_206 <<< 2);
+  assign _zz_218 = (_zz_206 & (~ _zz_794));
+  assign _zz_219 = ((_zz_206 & (~ _zz_218)) <<< 2);
+  assign _zz_214 = _zz_204;
+  always @ (*) begin
+    _zz_213 = 1'b1;
+    case(_zz_211)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_213 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_211)
+      2'b01 : begin
+        _zz_215 = _zz_197;
+      end
+      2'b10 : begin
+        _zz_215 = _zz_217;
+      end
+      2'b11 : begin
+        _zz_215 = _zz_219;
+      end
+      default : begin
+        _zz_215 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_211)
+      2'b01 : begin
+        _zz_216 = _zz_217;
+      end
+      2'b10 : begin
+        _zz_216 = (_zz_217 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_216 = (_zz_219 + _zz_795);
+      end
+      default : begin
+        _zz_216 = _zz_217;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_226 = _zz_220;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_226 = _zz_909[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_227 = _zz_221;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_227 = _zz_908[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_228 = _zz_222;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_228 = _zz_907[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_229 = _zz_223;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_229 = _zz_903[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_230 = _zz_224;
+    if(execute_CsrPlugin_csr_929)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_230 = execute_CsrPlugin_writeData[28 : 27];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_231 = _zz_225;
+    if(execute_CsrPlugin_csr_951)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_231 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_236 = (_zz_225 <<< 2);
+  assign _zz_237 = (_zz_225 & (~ _zz_797));
+  assign _zz_238 = ((_zz_225 & (~ _zz_237)) <<< 2);
+  assign _zz_233 = _zz_223;
+  always @ (*) begin
+    _zz_232 = 1'b1;
+    case(_zz_230)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_232 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_230)
+      2'b01 : begin
+        _zz_234 = _zz_216;
+      end
+      2'b10 : begin
+        _zz_234 = _zz_236;
+      end
+      2'b11 : begin
+        _zz_234 = _zz_238;
+      end
+      default : begin
+        _zz_234 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_230)
+      2'b01 : begin
+        _zz_235 = _zz_236;
+      end
+      2'b10 : begin
+        _zz_235 = (_zz_236 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_235 = (_zz_238 + _zz_798);
+      end
+      default : begin
+        _zz_235 = _zz_236;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_245 = _zz_239;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_245 = _zz_934[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_246 = _zz_240;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_246 = _zz_933[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_247 = _zz_241;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_247 = _zz_932[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_248 = _zz_242;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_248 = _zz_922[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_249 = _zz_243;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_249 = execute_CsrPlugin_writeData[4 : 3];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_250 = _zz_244;
+    if(execute_CsrPlugin_csr_952)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_250 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_255 = (_zz_244 <<< 2);
+  assign _zz_256 = (_zz_244 & (~ _zz_800));
+  assign _zz_257 = ((_zz_244 & (~ _zz_256)) <<< 2);
+  assign _zz_252 = _zz_242;
+  always @ (*) begin
+    _zz_251 = 1'b1;
+    case(_zz_249)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_251 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_249)
+      2'b01 : begin
+        _zz_253 = _zz_235;
+      end
+      2'b10 : begin
+        _zz_253 = _zz_255;
+      end
+      2'b11 : begin
+        _zz_253 = _zz_257;
+      end
+      default : begin
+        _zz_253 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_249)
+      2'b01 : begin
+        _zz_254 = _zz_255;
+      end
+      2'b10 : begin
+        _zz_254 = (_zz_255 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_254 = (_zz_257 + _zz_801);
+      end
+      default : begin
+        _zz_254 = _zz_255;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_264 = _zz_258;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_264 = _zz_931[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_265 = _zz_259;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_265 = _zz_930[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_266 = _zz_260;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_266 = _zz_929[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_267 = _zz_261;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_267 = _zz_921[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_268 = _zz_262;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_268 = execute_CsrPlugin_writeData[12 : 11];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_269 = _zz_263;
+    if(execute_CsrPlugin_csr_953)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_269 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_274 = (_zz_263 <<< 2);
+  assign _zz_275 = (_zz_263 & (~ _zz_803));
+  assign _zz_276 = ((_zz_263 & (~ _zz_275)) <<< 2);
+  assign _zz_271 = _zz_261;
+  always @ (*) begin
+    _zz_270 = 1'b1;
+    case(_zz_268)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_270 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_268)
+      2'b01 : begin
+        _zz_272 = _zz_254;
+      end
+      2'b10 : begin
+        _zz_272 = _zz_274;
+      end
+      2'b11 : begin
+        _zz_272 = _zz_276;
+      end
+      default : begin
+        _zz_272 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_268)
+      2'b01 : begin
+        _zz_273 = _zz_274;
+      end
+      2'b10 : begin
+        _zz_273 = (_zz_274 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_273 = (_zz_276 + _zz_804);
+      end
+      default : begin
+        _zz_273 = _zz_274;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_283 = _zz_277;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_283 = _zz_928[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_284 = _zz_278;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_284 = _zz_927[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_285 = _zz_279;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_285 = _zz_926[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_286 = _zz_280;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_286 = _zz_920[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_287 = _zz_281;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_287 = execute_CsrPlugin_writeData[20 : 19];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_288 = _zz_282;
+    if(execute_CsrPlugin_csr_954)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_288 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_293 = (_zz_282 <<< 2);
+  assign _zz_294 = (_zz_282 & (~ _zz_806));
+  assign _zz_295 = ((_zz_282 & (~ _zz_294)) <<< 2);
+  assign _zz_290 = _zz_280;
+  always @ (*) begin
+    _zz_289 = 1'b1;
+    case(_zz_287)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_289 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_287)
+      2'b01 : begin
+        _zz_291 = _zz_273;
+      end
+      2'b10 : begin
+        _zz_291 = _zz_293;
+      end
+      2'b11 : begin
+        _zz_291 = _zz_295;
+      end
+      default : begin
+        _zz_291 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_287)
+      2'b01 : begin
+        _zz_292 = _zz_293;
+      end
+      2'b10 : begin
+        _zz_292 = (_zz_293 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_292 = (_zz_295 + _zz_807);
+      end
+      default : begin
+        _zz_292 = _zz_293;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_302 = _zz_296;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_302 = _zz_925[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_303 = _zz_297;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_303 = _zz_924[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_304 = _zz_298;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_304 = _zz_923[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_305 = _zz_299;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_305 = _zz_919[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_306 = _zz_300;
+    if(execute_CsrPlugin_csr_930)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_306 = execute_CsrPlugin_writeData[28 : 27];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_307 = _zz_301;
+    if(execute_CsrPlugin_csr_955)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_307 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_312 = (_zz_301 <<< 2);
+  assign _zz_313 = (_zz_301 & (~ _zz_809));
+  assign _zz_314 = ((_zz_301 & (~ _zz_313)) <<< 2);
+  assign _zz_309 = _zz_299;
+  always @ (*) begin
+    _zz_308 = 1'b1;
+    case(_zz_306)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_308 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_306)
+      2'b01 : begin
+        _zz_310 = _zz_292;
+      end
+      2'b10 : begin
+        _zz_310 = _zz_312;
+      end
+      2'b11 : begin
+        _zz_310 = _zz_314;
+      end
+      default : begin
+        _zz_310 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_306)
+      2'b01 : begin
+        _zz_311 = _zz_312;
+      end
+      2'b10 : begin
+        _zz_311 = (_zz_312 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_311 = (_zz_314 + _zz_810);
+      end
+      default : begin
+        _zz_311 = _zz_312;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_321 = _zz_315;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_321 = _zz_950[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_322 = _zz_316;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_322 = _zz_949[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_323 = _zz_317;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_323 = _zz_948[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_324 = _zz_318;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_324 = _zz_938[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_325 = _zz_319;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_325 = execute_CsrPlugin_writeData[4 : 3];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_326 = _zz_320;
+    if(execute_CsrPlugin_csr_956)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_326 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_331 = (_zz_320 <<< 2);
+  assign _zz_332 = (_zz_320 & (~ _zz_812));
+  assign _zz_333 = ((_zz_320 & (~ _zz_332)) <<< 2);
+  assign _zz_328 = _zz_318;
+  always @ (*) begin
+    _zz_327 = 1'b1;
+    case(_zz_325)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_327 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_325)
+      2'b01 : begin
+        _zz_329 = _zz_311;
+      end
+      2'b10 : begin
+        _zz_329 = _zz_331;
+      end
+      2'b11 : begin
+        _zz_329 = _zz_333;
+      end
+      default : begin
+        _zz_329 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_325)
+      2'b01 : begin
+        _zz_330 = _zz_331;
+      end
+      2'b10 : begin
+        _zz_330 = (_zz_331 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_330 = (_zz_333 + _zz_813);
+      end
+      default : begin
+        _zz_330 = _zz_331;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_340 = _zz_334;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_340 = _zz_947[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_341 = _zz_335;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_341 = _zz_946[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_342 = _zz_336;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_342 = _zz_945[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_343 = _zz_337;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_343 = _zz_937[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_344 = _zz_338;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_344 = execute_CsrPlugin_writeData[12 : 11];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_345 = _zz_339;
+    if(execute_CsrPlugin_csr_957)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_345 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_350 = (_zz_339 <<< 2);
+  assign _zz_351 = (_zz_339 & (~ _zz_815));
+  assign _zz_352 = ((_zz_339 & (~ _zz_351)) <<< 2);
+  assign _zz_347 = _zz_337;
+  always @ (*) begin
+    _zz_346 = 1'b1;
+    case(_zz_344)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_346 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_344)
+      2'b01 : begin
+        _zz_348 = _zz_330;
+      end
+      2'b10 : begin
+        _zz_348 = _zz_350;
+      end
+      2'b11 : begin
+        _zz_348 = _zz_352;
+      end
+      default : begin
+        _zz_348 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_344)
+      2'b01 : begin
+        _zz_349 = _zz_350;
+      end
+      2'b10 : begin
+        _zz_349 = (_zz_350 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_349 = (_zz_352 + _zz_816);
+      end
+      default : begin
+        _zz_349 = _zz_350;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_359 = _zz_353;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_359 = _zz_944[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_360 = _zz_354;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_360 = _zz_943[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_361 = _zz_355;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_361 = _zz_942[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_362 = _zz_356;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_362 = _zz_936[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_363 = _zz_357;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_363 = execute_CsrPlugin_writeData[20 : 19];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_364 = _zz_358;
+    if(execute_CsrPlugin_csr_958)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_364 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_369 = (_zz_358 <<< 2);
+  assign _zz_370 = (_zz_358 & (~ _zz_818));
+  assign _zz_371 = ((_zz_358 & (~ _zz_370)) <<< 2);
+  assign _zz_366 = _zz_356;
+  always @ (*) begin
+    _zz_365 = 1'b1;
+    case(_zz_363)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_365 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_363)
+      2'b01 : begin
+        _zz_367 = _zz_349;
+      end
+      2'b10 : begin
+        _zz_367 = _zz_369;
+      end
+      2'b11 : begin
+        _zz_367 = _zz_371;
+      end
+      default : begin
+        _zz_367 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_363)
+      2'b01 : begin
+        _zz_368 = _zz_369;
+      end
+      2'b10 : begin
+        _zz_368 = (_zz_369 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_368 = (_zz_371 + _zz_819);
+      end
+      default : begin
+        _zz_368 = _zz_369;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    _zz_378 = _zz_372;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_378 = _zz_941[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_379 = _zz_373;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_379 = _zz_940[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_380 = _zz_374;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_380 = _zz_939[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_381 = _zz_375;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_381 = _zz_935[0];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_382 = _zz_376;
+    if(execute_CsrPlugin_csr_931)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_382 = execute_CsrPlugin_writeData[28 : 27];
+      end
+    end
+  end
+
+  always @ (*) begin
+    _zz_383 = _zz_377;
+    if(execute_CsrPlugin_csr_959)begin
+      if(execute_CsrPlugin_writeEnable)begin
+        _zz_383 = execute_CsrPlugin_writeData[31 : 0];
+      end
+    end
+  end
+
+  assign _zz_388 = (_zz_377 <<< 2);
+  assign _zz_389 = (_zz_377 & (~ _zz_821));
+  assign _zz_390 = ((_zz_377 & (~ _zz_389)) <<< 2);
+  assign _zz_385 = _zz_375;
+  always @ (*) begin
+    _zz_384 = 1'b1;
+    case(_zz_382)
+      2'b01 : begin
+      end
+      2'b10 : begin
+      end
+      2'b11 : begin
+      end
+      default : begin
+        _zz_384 = 1'b0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_382)
+      2'b01 : begin
+        _zz_386 = _zz_368;
+      end
+      2'b10 : begin
+        _zz_386 = _zz_388;
+      end
+      2'b11 : begin
+        _zz_386 = _zz_390;
+      end
+      default : begin
+        _zz_386 = 32'h0;
+      end
+    endcase
+  end
+
+  always @ (*) begin
+    case(_zz_382)
+      2'b01 : begin
+        _zz_387 = _zz_388;
+      end
+      2'b10 : begin
+        _zz_387 = (_zz_388 + 32'h00000004);
+      end
+      2'b11 : begin
+        _zz_387 = (_zz_390 + _zz_822);
+      end
+      default : begin
+        _zz_387 = _zz_388;
+      end
+    endcase
+  end
+
+  assign IBusCachedPlugin_mmuBus_rsp_physicalAddress = IBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign PmpPlugin_ports_0_hits_0 = (((_zz_99 && (_zz_101 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_102)) && (_zz_100 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_1 = (((_zz_118 && (_zz_120 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_121)) && (_zz_119 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_2 = (((_zz_137 && (_zz_139 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_140)) && (_zz_138 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_3 = (((_zz_156 && (_zz_158 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_159)) && (_zz_157 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_4 = (((_zz_175 && (_zz_177 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_178)) && (_zz_176 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_5 = (((_zz_194 && (_zz_196 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_197)) && (_zz_195 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_6 = (((_zz_213 && (_zz_215 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_216)) && (_zz_214 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_7 = (((_zz_232 && (_zz_234 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_235)) && (_zz_233 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_8 = (((_zz_251 && (_zz_253 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_254)) && (_zz_252 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_9 = (((_zz_270 && (_zz_272 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_273)) && (_zz_271 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_10 = (((_zz_289 && (_zz_291 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_292)) && (_zz_290 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_11 = (((_zz_308 && (_zz_310 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_311)) && (_zz_309 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_12 = (((_zz_327 && (_zz_329 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_330)) && (_zz_328 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_13 = (((_zz_346 && (_zz_348 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_349)) && (_zz_347 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_14 = (((_zz_365 && (_zz_367 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_368)) && (_zz_366 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_0_hits_15 = (((_zz_384 && (_zz_386 <= IBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (IBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_387)) && (_zz_385 || (! (CsrPlugin_privilege == 2'b11))));
+  assign _zz_391 = 5'h0;
+  assign _zz_392 = 5'h01;
+  assign _zz_393 = 5'h01;
+  assign _zz_394 = 5'h02;
+  assign _zz_395 = 5'h01;
+  assign _zz_396 = 5'h02;
+  assign _zz_397 = 5'h02;
+  assign _zz_398 = 5'h03;
+  always @ (*) begin
+    if(_zz_693)begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowRead = _zz_662;
+    end
+  end
+
+  always @ (*) begin
+    if(_zz_693)begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_663;
+    end
+  end
+
+  always @ (*) begin
+    if(_zz_693)begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
+    end else begin
+      IBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_664;
+    end
+  end
+
+  assign _zz_399 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_999,_zz_1000}}}}}}}}}}};
+  assign _zz_400 = (_zz_399 & (~ _zz_831));
+  assign _zz_401 = _zz_400[3];
+  assign _zz_402 = _zz_400[5];
+  assign _zz_403 = _zz_400[6];
+  assign _zz_404 = _zz_400[7];
+  assign _zz_405 = _zz_400[9];
+  assign _zz_406 = _zz_400[10];
+  assign _zz_407 = _zz_400[11];
+  assign _zz_408 = _zz_400[12];
+  assign _zz_409 = _zz_400[13];
+  assign _zz_410 = _zz_400[14];
+  assign _zz_411 = _zz_400[15];
+  assign _zz_412 = (((((((_zz_400[1] || _zz_401) || _zz_402) || _zz_404) || _zz_405) || _zz_407) || _zz_409) || _zz_411);
+  assign _zz_413 = (((((((_zz_400[2] || _zz_401) || _zz_403) || _zz_404) || _zz_406) || _zz_407) || _zz_410) || _zz_411);
+  assign _zz_414 = (((((((_zz_400[4] || _zz_402) || _zz_403) || _zz_404) || _zz_408) || _zz_409) || _zz_410) || _zz_411);
+  assign _zz_415 = (((((((_zz_400[8] || _zz_405) || _zz_406) || _zz_407) || _zz_408) || _zz_409) || _zz_410) || _zz_411);
+  assign _zz_416 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_1001,_zz_1002}}}}}}}}}}};
+  assign _zz_417 = (_zz_416 & (~ _zz_832));
+  assign _zz_418 = _zz_417[3];
+  assign _zz_419 = _zz_417[5];
+  assign _zz_420 = _zz_417[6];
+  assign _zz_421 = _zz_417[7];
+  assign _zz_422 = _zz_417[9];
+  assign _zz_423 = _zz_417[10];
+  assign _zz_424 = _zz_417[11];
+  assign _zz_425 = _zz_417[12];
+  assign _zz_426 = _zz_417[13];
+  assign _zz_427 = _zz_417[14];
+  assign _zz_428 = _zz_417[15];
+  assign _zz_429 = (((((((_zz_417[1] || _zz_418) || _zz_419) || _zz_421) || _zz_422) || _zz_424) || _zz_426) || _zz_428);
+  assign _zz_430 = (((((((_zz_417[2] || _zz_418) || _zz_420) || _zz_421) || _zz_423) || _zz_424) || _zz_427) || _zz_428);
+  assign _zz_431 = (((((((_zz_417[4] || _zz_419) || _zz_420) || _zz_421) || _zz_425) || _zz_426) || _zz_427) || _zz_428);
+  assign _zz_432 = (((((((_zz_417[8] || _zz_422) || _zz_423) || _zz_424) || _zz_425) || _zz_426) || _zz_427) || _zz_428);
+  assign _zz_433 = {PmpPlugin_ports_0_hits_15,{PmpPlugin_ports_0_hits_14,{PmpPlugin_ports_0_hits_13,{PmpPlugin_ports_0_hits_12,{PmpPlugin_ports_0_hits_11,{PmpPlugin_ports_0_hits_10,{PmpPlugin_ports_0_hits_9,{PmpPlugin_ports_0_hits_8,{PmpPlugin_ports_0_hits_7,{PmpPlugin_ports_0_hits_6,{_zz_1003,_zz_1004}}}}}}}}}}};
+  assign _zz_434 = (_zz_433 & (~ _zz_833));
+  assign _zz_435 = _zz_434[3];
+  assign _zz_436 = _zz_434[5];
+  assign _zz_437 = _zz_434[6];
+  assign _zz_438 = _zz_434[7];
+  assign _zz_439 = _zz_434[9];
+  assign _zz_440 = _zz_434[10];
+  assign _zz_441 = _zz_434[11];
+  assign _zz_442 = _zz_434[12];
+  assign _zz_443 = _zz_434[13];
+  assign _zz_444 = _zz_434[14];
+  assign _zz_445 = _zz_434[15];
+  assign _zz_446 = (((((((_zz_434[1] || _zz_435) || _zz_436) || _zz_438) || _zz_439) || _zz_441) || _zz_443) || _zz_445);
+  assign _zz_447 = (((((((_zz_434[2] || _zz_435) || _zz_437) || _zz_438) || _zz_440) || _zz_441) || _zz_444) || _zz_445);
+  assign _zz_448 = (((((((_zz_434[4] || _zz_436) || _zz_437) || _zz_438) || _zz_442) || _zz_443) || _zz_444) || _zz_445);
+  assign _zz_449 = (((((((_zz_434[8] || _zz_439) || _zz_440) || _zz_441) || _zz_442) || _zz_443) || _zz_444) || _zz_445);
   assign IBusCachedPlugin_mmuBus_rsp_isIoAccess = IBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign IBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign IBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign IBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_virtualAddress;
-  assign PmpPlugin_ports_1_hits_0 = (((_zz_100_ && (_zz_101_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_102_)) && (_zz_99_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_1 = (((_zz_116_ && (_zz_117_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_118_)) && (_zz_115_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_2 = (((_zz_132_ && (_zz_133_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_134_)) && (_zz_131_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_3 = (((_zz_148_ && (_zz_149_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_150_)) && (_zz_147_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_4 = (((_zz_164_ && (_zz_165_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_166_)) && (_zz_163_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_5 = (((_zz_180_ && (_zz_181_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_182_)) && (_zz_179_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_6 = (((_zz_196_ && (_zz_197_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_198_)) && (_zz_195_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_7 = (((_zz_212_ && (_zz_213_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_214_)) && (_zz_211_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_8 = (((_zz_228_ && (_zz_229_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_230_)) && (_zz_227_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_9 = (((_zz_244_ && (_zz_245_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_246_)) && (_zz_243_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_10 = (((_zz_260_ && (_zz_261_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_262_)) && (_zz_259_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_11 = (((_zz_276_ && (_zz_277_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_278_)) && (_zz_275_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_12 = (((_zz_292_ && (_zz_293_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_294_)) && (_zz_291_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_13 = (((_zz_308_ && (_zz_309_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_310_)) && (_zz_307_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_14 = (((_zz_324_ && (_zz_325_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_326_)) && (_zz_323_ || (! (CsrPlugin_privilege == (2'b11)))));
-  assign PmpPlugin_ports_1_hits_15 = (((_zz_340_ && (_zz_341_ <= DBusCachedPlugin_mmuBus_cmd_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_virtualAddress < _zz_342_)) && (_zz_339_ || (! (CsrPlugin_privilege == (2'b11)))));
+  assign DBusCachedPlugin_mmuBus_rsp_physicalAddress = DBusCachedPlugin_mmuBus_cmd_0_virtualAddress;
+  assign PmpPlugin_ports_1_hits_0 = (((_zz_99 && (_zz_101 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_102)) && (_zz_100 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_1 = (((_zz_118 && (_zz_120 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_121)) && (_zz_119 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_2 = (((_zz_137 && (_zz_139 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_140)) && (_zz_138 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_3 = (((_zz_156 && (_zz_158 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_159)) && (_zz_157 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_4 = (((_zz_175 && (_zz_177 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_178)) && (_zz_176 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_5 = (((_zz_194 && (_zz_196 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_197)) && (_zz_195 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_6 = (((_zz_213 && (_zz_215 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_216)) && (_zz_214 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_7 = (((_zz_232 && (_zz_234 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_235)) && (_zz_233 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_8 = (((_zz_251 && (_zz_253 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_254)) && (_zz_252 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_9 = (((_zz_270 && (_zz_272 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_273)) && (_zz_271 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_10 = (((_zz_289 && (_zz_291 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_292)) && (_zz_290 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_11 = (((_zz_308 && (_zz_310 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_311)) && (_zz_309 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_12 = (((_zz_327 && (_zz_329 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_330)) && (_zz_328 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_13 = (((_zz_346 && (_zz_348 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_349)) && (_zz_347 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_14 = (((_zz_365 && (_zz_367 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_368)) && (_zz_366 || (! (CsrPlugin_privilege == 2'b11))));
+  assign PmpPlugin_ports_1_hits_15 = (((_zz_384 && (_zz_386 <= DBusCachedPlugin_mmuBus_cmd_0_virtualAddress)) && (DBusCachedPlugin_mmuBus_cmd_0_virtualAddress < _zz_387)) && (_zz_385 || (! (CsrPlugin_privilege == 2'b11))));
+  assign _zz_450 = 5'h0;
+  assign _zz_451 = 5'h01;
+  assign _zz_452 = 5'h01;
+  assign _zz_453 = 5'h02;
+  assign _zz_454 = 5'h01;
+  assign _zz_455 = 5'h02;
+  assign _zz_456 = 5'h02;
+  assign _zz_457 = 5'h03;
   always @ (*) begin
-    if(_zz_611_)begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == (2'b11));
+    if(_zz_694)begin
+      DBusCachedPlugin_mmuBus_rsp_allowRead = (CsrPlugin_privilege == 2'b11);
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowRead = _zz_588_;
+      DBusCachedPlugin_mmuBus_rsp_allowRead = _zz_671;
     end
   end
 
   always @ (*) begin
-    if(_zz_611_)begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == (2'b11));
+    if(_zz_694)begin
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = (CsrPlugin_privilege == 2'b11);
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_589_;
+      DBusCachedPlugin_mmuBus_rsp_allowWrite = _zz_672;
     end
   end
 
   always @ (*) begin
-    if(_zz_611_)begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == (2'b11));
+    if(_zz_694)begin
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = (CsrPlugin_privilege == 2'b11);
     end else begin
-      DBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_590_;
+      DBusCachedPlugin_mmuBus_rsp_allowExecute = _zz_673;
     end
   end
 
-  assign _zz_397_ = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_898_,_zz_899_}}}}}}}}}}};
-  assign _zz_398_ = (_zz_397_ & (~ _zz_744_));
-  assign _zz_399_ = _zz_398_[3];
-  assign _zz_400_ = _zz_398_[5];
-  assign _zz_401_ = _zz_398_[6];
-  assign _zz_402_ = _zz_398_[7];
-  assign _zz_403_ = _zz_398_[9];
-  assign _zz_404_ = _zz_398_[10];
-  assign _zz_405_ = _zz_398_[11];
-  assign _zz_406_ = _zz_398_[12];
-  assign _zz_407_ = _zz_398_[13];
-  assign _zz_408_ = _zz_398_[14];
-  assign _zz_409_ = _zz_398_[15];
-  assign _zz_410_ = (((((((_zz_398_[1] || _zz_399_) || _zz_400_) || _zz_402_) || _zz_403_) || _zz_405_) || _zz_407_) || _zz_409_);
-  assign _zz_411_ = (((((((_zz_398_[2] || _zz_399_) || _zz_401_) || _zz_402_) || _zz_404_) || _zz_405_) || _zz_408_) || _zz_409_);
-  assign _zz_412_ = (((((((_zz_398_[4] || _zz_400_) || _zz_401_) || _zz_402_) || _zz_406_) || _zz_407_) || _zz_408_) || _zz_409_);
-  assign _zz_413_ = (((((((_zz_398_[8] || _zz_403_) || _zz_404_) || _zz_405_) || _zz_406_) || _zz_407_) || _zz_408_) || _zz_409_);
-  assign _zz_414_ = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_900_,_zz_901_}}}}}}}}}}};
-  assign _zz_415_ = (_zz_414_ & (~ _zz_745_));
-  assign _zz_416_ = _zz_415_[3];
-  assign _zz_417_ = _zz_415_[5];
-  assign _zz_418_ = _zz_415_[6];
-  assign _zz_419_ = _zz_415_[7];
-  assign _zz_420_ = _zz_415_[9];
-  assign _zz_421_ = _zz_415_[10];
-  assign _zz_422_ = _zz_415_[11];
-  assign _zz_423_ = _zz_415_[12];
-  assign _zz_424_ = _zz_415_[13];
-  assign _zz_425_ = _zz_415_[14];
-  assign _zz_426_ = _zz_415_[15];
-  assign _zz_427_ = (((((((_zz_415_[1] || _zz_416_) || _zz_417_) || _zz_419_) || _zz_420_) || _zz_422_) || _zz_424_) || _zz_426_);
-  assign _zz_428_ = (((((((_zz_415_[2] || _zz_416_) || _zz_418_) || _zz_419_) || _zz_421_) || _zz_422_) || _zz_425_) || _zz_426_);
-  assign _zz_429_ = (((((((_zz_415_[4] || _zz_417_) || _zz_418_) || _zz_419_) || _zz_423_) || _zz_424_) || _zz_425_) || _zz_426_);
-  assign _zz_430_ = (((((((_zz_415_[8] || _zz_420_) || _zz_421_) || _zz_422_) || _zz_423_) || _zz_424_) || _zz_425_) || _zz_426_);
-  assign _zz_431_ = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_902_,_zz_903_}}}}}}}}}}};
-  assign _zz_432_ = (_zz_431_ & (~ _zz_746_));
-  assign _zz_433_ = _zz_432_[3];
-  assign _zz_434_ = _zz_432_[5];
-  assign _zz_435_ = _zz_432_[6];
-  assign _zz_436_ = _zz_432_[7];
-  assign _zz_437_ = _zz_432_[9];
-  assign _zz_438_ = _zz_432_[10];
-  assign _zz_439_ = _zz_432_[11];
-  assign _zz_440_ = _zz_432_[12];
-  assign _zz_441_ = _zz_432_[13];
-  assign _zz_442_ = _zz_432_[14];
-  assign _zz_443_ = _zz_432_[15];
-  assign _zz_444_ = (((((((_zz_432_[1] || _zz_433_) || _zz_434_) || _zz_436_) || _zz_437_) || _zz_439_) || _zz_441_) || _zz_443_);
-  assign _zz_445_ = (((((((_zz_432_[2] || _zz_433_) || _zz_435_) || _zz_436_) || _zz_438_) || _zz_439_) || _zz_442_) || _zz_443_);
-  assign _zz_446_ = (((((((_zz_432_[4] || _zz_434_) || _zz_435_) || _zz_436_) || _zz_440_) || _zz_441_) || _zz_442_) || _zz_443_);
-  assign _zz_447_ = (((((((_zz_432_[8] || _zz_437_) || _zz_438_) || _zz_439_) || _zz_440_) || _zz_441_) || _zz_442_) || _zz_443_);
+  assign _zz_458 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_1005,_zz_1006}}}}}}}}}}};
+  assign _zz_459 = (_zz_458 & (~ _zz_841));
+  assign _zz_460 = _zz_459[3];
+  assign _zz_461 = _zz_459[5];
+  assign _zz_462 = _zz_459[6];
+  assign _zz_463 = _zz_459[7];
+  assign _zz_464 = _zz_459[9];
+  assign _zz_465 = _zz_459[10];
+  assign _zz_466 = _zz_459[11];
+  assign _zz_467 = _zz_459[12];
+  assign _zz_468 = _zz_459[13];
+  assign _zz_469 = _zz_459[14];
+  assign _zz_470 = _zz_459[15];
+  assign _zz_471 = (((((((_zz_459[1] || _zz_460) || _zz_461) || _zz_463) || _zz_464) || _zz_466) || _zz_468) || _zz_470);
+  assign _zz_472 = (((((((_zz_459[2] || _zz_460) || _zz_462) || _zz_463) || _zz_465) || _zz_466) || _zz_469) || _zz_470);
+  assign _zz_473 = (((((((_zz_459[4] || _zz_461) || _zz_462) || _zz_463) || _zz_467) || _zz_468) || _zz_469) || _zz_470);
+  assign _zz_474 = (((((((_zz_459[8] || _zz_464) || _zz_465) || _zz_466) || _zz_467) || _zz_468) || _zz_469) || _zz_470);
+  assign _zz_475 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_1007,_zz_1008}}}}}}}}}}};
+  assign _zz_476 = (_zz_475 & (~ _zz_842));
+  assign _zz_477 = _zz_476[3];
+  assign _zz_478 = _zz_476[5];
+  assign _zz_479 = _zz_476[6];
+  assign _zz_480 = _zz_476[7];
+  assign _zz_481 = _zz_476[9];
+  assign _zz_482 = _zz_476[10];
+  assign _zz_483 = _zz_476[11];
+  assign _zz_484 = _zz_476[12];
+  assign _zz_485 = _zz_476[13];
+  assign _zz_486 = _zz_476[14];
+  assign _zz_487 = _zz_476[15];
+  assign _zz_488 = (((((((_zz_476[1] || _zz_477) || _zz_478) || _zz_480) || _zz_481) || _zz_483) || _zz_485) || _zz_487);
+  assign _zz_489 = (((((((_zz_476[2] || _zz_477) || _zz_479) || _zz_480) || _zz_482) || _zz_483) || _zz_486) || _zz_487);
+  assign _zz_490 = (((((((_zz_476[4] || _zz_478) || _zz_479) || _zz_480) || _zz_484) || _zz_485) || _zz_486) || _zz_487);
+  assign _zz_491 = (((((((_zz_476[8] || _zz_481) || _zz_482) || _zz_483) || _zz_484) || _zz_485) || _zz_486) || _zz_487);
+  assign _zz_492 = {PmpPlugin_ports_1_hits_15,{PmpPlugin_ports_1_hits_14,{PmpPlugin_ports_1_hits_13,{PmpPlugin_ports_1_hits_12,{PmpPlugin_ports_1_hits_11,{PmpPlugin_ports_1_hits_10,{PmpPlugin_ports_1_hits_9,{PmpPlugin_ports_1_hits_8,{PmpPlugin_ports_1_hits_7,{PmpPlugin_ports_1_hits_6,{_zz_1009,_zz_1010}}}}}}}}}}};
+  assign _zz_493 = (_zz_492 & (~ _zz_843));
+  assign _zz_494 = _zz_493[3];
+  assign _zz_495 = _zz_493[5];
+  assign _zz_496 = _zz_493[6];
+  assign _zz_497 = _zz_493[7];
+  assign _zz_498 = _zz_493[9];
+  assign _zz_499 = _zz_493[10];
+  assign _zz_500 = _zz_493[11];
+  assign _zz_501 = _zz_493[12];
+  assign _zz_502 = _zz_493[13];
+  assign _zz_503 = _zz_493[14];
+  assign _zz_504 = _zz_493[15];
+  assign _zz_505 = (((((((_zz_493[1] || _zz_494) || _zz_495) || _zz_497) || _zz_498) || _zz_500) || _zz_502) || _zz_504);
+  assign _zz_506 = (((((((_zz_493[2] || _zz_494) || _zz_496) || _zz_497) || _zz_499) || _zz_500) || _zz_503) || _zz_504);
+  assign _zz_507 = (((((((_zz_493[4] || _zz_495) || _zz_496) || _zz_497) || _zz_501) || _zz_502) || _zz_503) || _zz_504);
+  assign _zz_508 = (((((((_zz_493[8] || _zz_498) || _zz_499) || _zz_500) || _zz_501) || _zz_502) || _zz_503) || _zz_504);
   assign DBusCachedPlugin_mmuBus_rsp_isIoAccess = DBusCachedPlugin_mmuBus_rsp_physicalAddress[31];
+  assign DBusCachedPlugin_mmuBus_rsp_isPaging = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_exception = 1'b0;
   assign DBusCachedPlugin_mmuBus_rsp_refilling = 1'b0;
   assign DBusCachedPlugin_mmuBus_busy = 1'b0;
-  assign _zz_449_ = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
-  assign _zz_450_ = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
-  assign _zz_451_ = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
-  assign _zz_452_ = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
-  assign _zz_448_ = {({(_zz_904_ == _zz_905_),{_zz_906_,{_zz_907_,_zz_908_}}} != 5'h0),{({_zz_909_,_zz_910_} != (2'b00)),{(_zz_911_ != (1'b0)),{(_zz_912_ != _zz_913_),{_zz_914_,{_zz_915_,_zz_916_}}}}}};
-  assign _zz_453_ = _zz_448_[1 : 0];
-  assign _zz_49_ = _zz_453_;
-  assign _zz_454_ = _zz_448_[4 : 3];
-  assign _zz_48_ = _zz_454_;
-  assign _zz_455_ = _zz_448_[7 : 6];
-  assign _zz_47_ = _zz_455_;
-  assign _zz_456_ = _zz_448_[14 : 13];
-  assign _zz_46_ = _zz_456_;
-  assign _zz_457_ = _zz_448_[23 : 22];
-  assign _zz_45_ = _zz_457_;
-  assign _zz_458_ = _zz_448_[26 : 25];
-  assign _zz_44_ = _zz_458_;
-  assign _zz_459_ = _zz_448_[31 : 30];
-  assign _zz_43_ = _zz_459_;
+  assign _zz_510 = ((decode_INSTRUCTION & 32'h00004050) == 32'h00004050);
+  assign _zz_511 = ((decode_INSTRUCTION & 32'h00000004) == 32'h00000004);
+  assign _zz_512 = ((decode_INSTRUCTION & 32'h00000048) == 32'h00000048);
+  assign _zz_513 = ((decode_INSTRUCTION & 32'h00001000) == 32'h0);
+  assign _zz_509 = {(((decode_INSTRUCTION & _zz_1011) == 32'h00100050) != 1'b0),{(_zz_513 != 1'b0),{(_zz_513 != 1'b0),{(_zz_1012 != _zz_1013),{_zz_1014,{_zz_1015,_zz_1016}}}}}};
+  assign _zz_514 = _zz_509[2 : 1];
+  assign _zz_49 = _zz_514;
+  assign _zz_515 = _zz_509[7 : 6];
+  assign _zz_48 = _zz_515;
+  assign _zz_516 = _zz_509[9 : 8];
+  assign _zz_47 = _zz_516;
+  assign _zz_517 = _zz_509[19 : 18];
+  assign _zz_46 = _zz_517;
+  assign _zz_518 = _zz_509[22 : 21];
+  assign _zz_45 = _zz_518;
+  assign _zz_519 = _zz_509[24 : 23];
+  assign _zz_44 = _zz_519;
+  assign _zz_520 = _zz_509[27 : 26];
+  assign _zz_43 = _zz_520;
   assign decodeExceptionPort_valid = (decode_arbitration_isValid && (! decode_LEGAL_INSTRUCTION));
-  assign decodeExceptionPort_payload_code = (4'b0010);
+  assign decodeExceptionPort_payload_code = 4'b0010;
   assign decodeExceptionPort_payload_badAddr = decode_INSTRUCTION;
   assign decode_RegFilePlugin_regFileReadAddress1 = decode_INSTRUCTION_ANTICIPATED[19 : 15];
   assign decode_RegFilePlugin_regFileReadAddress2 = decode_INSTRUCTION_ANTICIPATED[24 : 20];
-  assign decode_RegFilePlugin_rs1Data = _zz_582_;
-  assign decode_RegFilePlugin_rs2Data = _zz_583_;
+  assign decode_RegFilePlugin_rs1Data = _zz_653;
+  assign decode_RegFilePlugin_rs2Data = _zz_654;
   always @ (*) begin
-    lastStageRegFileWrite_valid = (_zz_41_ && writeBack_arbitration_isFiring);
-    if(_zz_460_)begin
+    lastStageRegFileWrite_valid = (_zz_41 && writeBack_arbitration_isFiring);
+    if(_zz_521)begin
       lastStageRegFileWrite_valid = 1'b1;
     end
   end
 
-  assign lastStageRegFileWrite_payload_address = _zz_40_[11 : 7];
-  assign lastStageRegFileWrite_payload_data = _zz_52_;
+  always @ (*) begin
+    lastStageRegFileWrite_payload_address = _zz_40[11 : 7];
+    if(_zz_521)begin
+      lastStageRegFileWrite_payload_address = 5'h0;
+    end
+  end
+
+  always @ (*) begin
+    lastStageRegFileWrite_payload_data = _zz_50;
+    if(_zz_521)begin
+      lastStageRegFileWrite_payload_data = 32'h0;
+    end
+  end
+
   always @ (*) begin
     case(execute_ALU_BITWISE_CTRL)
       `AluBitwiseCtrlEnum_defaultEncoding_AND_1 : begin
@@ -6163,13 +7079,13 @@ module VexRiscv (
   always @ (*) begin
     case(execute_ALU_CTRL)
       `AluCtrlEnum_defaultEncoding_BITWISE : begin
-        _zz_461_ = execute_IntAluPlugin_bitwise;
+        _zz_522 = execute_IntAluPlugin_bitwise;
       end
       `AluCtrlEnum_defaultEncoding_SLT_SLTU : begin
-        _zz_461_ = {31'd0, _zz_747_};
+        _zz_522 = {31'd0, _zz_844};
       end
       default : begin
-        _zz_461_ = execute_SRC_ADD_SUB;
+        _zz_522 = execute_SRC_ADD_SUB;
       end
     endcase
   end
@@ -6177,87 +7093,87 @@ module VexRiscv (
   always @ (*) begin
     case(execute_SRC1_CTRL)
       `Src1CtrlEnum_defaultEncoding_RS : begin
-        _zz_462_ = execute_RS1;
+        _zz_523 = execute_RS1;
       end
       `Src1CtrlEnum_defaultEncoding_PC_INCREMENT : begin
-        _zz_462_ = {29'd0, _zz_748_};
+        _zz_523 = {29'd0, _zz_845};
       end
       `Src1CtrlEnum_defaultEncoding_IMU : begin
-        _zz_462_ = {execute_INSTRUCTION[31 : 12],12'h0};
+        _zz_523 = {execute_INSTRUCTION[31 : 12],12'h0};
       end
       default : begin
-        _zz_462_ = {27'd0, _zz_749_};
+        _zz_523 = {27'd0, _zz_846};
       end
     endcase
   end
 
-  assign _zz_463_ = _zz_750_[11];
+  assign _zz_524 = _zz_847[11];
   always @ (*) begin
-    _zz_464_[19] = _zz_463_;
-    _zz_464_[18] = _zz_463_;
-    _zz_464_[17] = _zz_463_;
-    _zz_464_[16] = _zz_463_;
-    _zz_464_[15] = _zz_463_;
-    _zz_464_[14] = _zz_463_;
-    _zz_464_[13] = _zz_463_;
-    _zz_464_[12] = _zz_463_;
-    _zz_464_[11] = _zz_463_;
-    _zz_464_[10] = _zz_463_;
-    _zz_464_[9] = _zz_463_;
-    _zz_464_[8] = _zz_463_;
-    _zz_464_[7] = _zz_463_;
-    _zz_464_[6] = _zz_463_;
-    _zz_464_[5] = _zz_463_;
-    _zz_464_[4] = _zz_463_;
-    _zz_464_[3] = _zz_463_;
-    _zz_464_[2] = _zz_463_;
-    _zz_464_[1] = _zz_463_;
-    _zz_464_[0] = _zz_463_;
+    _zz_525[19] = _zz_524;
+    _zz_525[18] = _zz_524;
+    _zz_525[17] = _zz_524;
+    _zz_525[16] = _zz_524;
+    _zz_525[15] = _zz_524;
+    _zz_525[14] = _zz_524;
+    _zz_525[13] = _zz_524;
+    _zz_525[12] = _zz_524;
+    _zz_525[11] = _zz_524;
+    _zz_525[10] = _zz_524;
+    _zz_525[9] = _zz_524;
+    _zz_525[8] = _zz_524;
+    _zz_525[7] = _zz_524;
+    _zz_525[6] = _zz_524;
+    _zz_525[5] = _zz_524;
+    _zz_525[4] = _zz_524;
+    _zz_525[3] = _zz_524;
+    _zz_525[2] = _zz_524;
+    _zz_525[1] = _zz_524;
+    _zz_525[0] = _zz_524;
   end
 
-  assign _zz_465_ = _zz_751_[11];
+  assign _zz_526 = _zz_848[11];
   always @ (*) begin
-    _zz_466_[19] = _zz_465_;
-    _zz_466_[18] = _zz_465_;
-    _zz_466_[17] = _zz_465_;
-    _zz_466_[16] = _zz_465_;
-    _zz_466_[15] = _zz_465_;
-    _zz_466_[14] = _zz_465_;
-    _zz_466_[13] = _zz_465_;
-    _zz_466_[12] = _zz_465_;
-    _zz_466_[11] = _zz_465_;
-    _zz_466_[10] = _zz_465_;
-    _zz_466_[9] = _zz_465_;
-    _zz_466_[8] = _zz_465_;
-    _zz_466_[7] = _zz_465_;
-    _zz_466_[6] = _zz_465_;
-    _zz_466_[5] = _zz_465_;
-    _zz_466_[4] = _zz_465_;
-    _zz_466_[3] = _zz_465_;
-    _zz_466_[2] = _zz_465_;
-    _zz_466_[1] = _zz_465_;
-    _zz_466_[0] = _zz_465_;
+    _zz_527[19] = _zz_526;
+    _zz_527[18] = _zz_526;
+    _zz_527[17] = _zz_526;
+    _zz_527[16] = _zz_526;
+    _zz_527[15] = _zz_526;
+    _zz_527[14] = _zz_526;
+    _zz_527[13] = _zz_526;
+    _zz_527[12] = _zz_526;
+    _zz_527[11] = _zz_526;
+    _zz_527[10] = _zz_526;
+    _zz_527[9] = _zz_526;
+    _zz_527[8] = _zz_526;
+    _zz_527[7] = _zz_526;
+    _zz_527[6] = _zz_526;
+    _zz_527[5] = _zz_526;
+    _zz_527[4] = _zz_526;
+    _zz_527[3] = _zz_526;
+    _zz_527[2] = _zz_526;
+    _zz_527[1] = _zz_526;
+    _zz_527[0] = _zz_526;
   end
 
   always @ (*) begin
     case(execute_SRC2_CTRL)
       `Src2CtrlEnum_defaultEncoding_RS : begin
-        _zz_467_ = execute_RS2;
+        _zz_528 = execute_RS2;
       end
       `Src2CtrlEnum_defaultEncoding_IMI : begin
-        _zz_467_ = {_zz_464_,execute_INSTRUCTION[31 : 20]};
+        _zz_528 = {_zz_525,execute_INSTRUCTION[31 : 20]};
       end
       `Src2CtrlEnum_defaultEncoding_IMS : begin
-        _zz_467_ = {_zz_466_,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
+        _zz_528 = {_zz_527,{execute_INSTRUCTION[31 : 25],execute_INSTRUCTION[11 : 7]}};
       end
       default : begin
-        _zz_467_ = _zz_35_;
+        _zz_528 = _zz_35;
       end
     endcase
   end
 
   always @ (*) begin
-    execute_SrcPlugin_addSub = _zz_752_;
+    execute_SrcPlugin_addSub = _zz_849;
     if(execute_SRC2_FORCE_ZERO)begin
       execute_SrcPlugin_addSub = execute_SRC1;
     end
@@ -6266,246 +7182,246 @@ module VexRiscv (
   assign execute_SrcPlugin_less = ((execute_SRC1[31] == execute_SRC2[31]) ? execute_SrcPlugin_addSub[31] : (execute_SRC_LESS_UNSIGNED ? execute_SRC2[31] : execute_SRC1[31]));
   assign execute_FullBarrelShifterPlugin_amplitude = execute_SRC2[4 : 0];
   always @ (*) begin
-    _zz_468_[0] = execute_SRC1[31];
-    _zz_468_[1] = execute_SRC1[30];
-    _zz_468_[2] = execute_SRC1[29];
-    _zz_468_[3] = execute_SRC1[28];
-    _zz_468_[4] = execute_SRC1[27];
-    _zz_468_[5] = execute_SRC1[26];
-    _zz_468_[6] = execute_SRC1[25];
-    _zz_468_[7] = execute_SRC1[24];
-    _zz_468_[8] = execute_SRC1[23];
-    _zz_468_[9] = execute_SRC1[22];
-    _zz_468_[10] = execute_SRC1[21];
-    _zz_468_[11] = execute_SRC1[20];
-    _zz_468_[12] = execute_SRC1[19];
-    _zz_468_[13] = execute_SRC1[18];
-    _zz_468_[14] = execute_SRC1[17];
-    _zz_468_[15] = execute_SRC1[16];
-    _zz_468_[16] = execute_SRC1[15];
-    _zz_468_[17] = execute_SRC1[14];
-    _zz_468_[18] = execute_SRC1[13];
-    _zz_468_[19] = execute_SRC1[12];
-    _zz_468_[20] = execute_SRC1[11];
-    _zz_468_[21] = execute_SRC1[10];
-    _zz_468_[22] = execute_SRC1[9];
-    _zz_468_[23] = execute_SRC1[8];
-    _zz_468_[24] = execute_SRC1[7];
-    _zz_468_[25] = execute_SRC1[6];
-    _zz_468_[26] = execute_SRC1[5];
-    _zz_468_[27] = execute_SRC1[4];
-    _zz_468_[28] = execute_SRC1[3];
-    _zz_468_[29] = execute_SRC1[2];
-    _zz_468_[30] = execute_SRC1[1];
-    _zz_468_[31] = execute_SRC1[0];
+    _zz_529[0] = execute_SRC1[31];
+    _zz_529[1] = execute_SRC1[30];
+    _zz_529[2] = execute_SRC1[29];
+    _zz_529[3] = execute_SRC1[28];
+    _zz_529[4] = execute_SRC1[27];
+    _zz_529[5] = execute_SRC1[26];
+    _zz_529[6] = execute_SRC1[25];
+    _zz_529[7] = execute_SRC1[24];
+    _zz_529[8] = execute_SRC1[23];
+    _zz_529[9] = execute_SRC1[22];
+    _zz_529[10] = execute_SRC1[21];
+    _zz_529[11] = execute_SRC1[20];
+    _zz_529[12] = execute_SRC1[19];
+    _zz_529[13] = execute_SRC1[18];
+    _zz_529[14] = execute_SRC1[17];
+    _zz_529[15] = execute_SRC1[16];
+    _zz_529[16] = execute_SRC1[15];
+    _zz_529[17] = execute_SRC1[14];
+    _zz_529[18] = execute_SRC1[13];
+    _zz_529[19] = execute_SRC1[12];
+    _zz_529[20] = execute_SRC1[11];
+    _zz_529[21] = execute_SRC1[10];
+    _zz_529[22] = execute_SRC1[9];
+    _zz_529[23] = execute_SRC1[8];
+    _zz_529[24] = execute_SRC1[7];
+    _zz_529[25] = execute_SRC1[6];
+    _zz_529[26] = execute_SRC1[5];
+    _zz_529[27] = execute_SRC1[4];
+    _zz_529[28] = execute_SRC1[3];
+    _zz_529[29] = execute_SRC1[2];
+    _zz_529[30] = execute_SRC1[1];
+    _zz_529[31] = execute_SRC1[0];
   end
 
-  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_468_ : execute_SRC1);
+  assign execute_FullBarrelShifterPlugin_reversed = ((execute_SHIFT_CTRL == `ShiftCtrlEnum_defaultEncoding_SLL_1) ? _zz_529 : execute_SRC1);
   always @ (*) begin
-    _zz_469_[0] = memory_SHIFT_RIGHT[31];
-    _zz_469_[1] = memory_SHIFT_RIGHT[30];
-    _zz_469_[2] = memory_SHIFT_RIGHT[29];
-    _zz_469_[3] = memory_SHIFT_RIGHT[28];
-    _zz_469_[4] = memory_SHIFT_RIGHT[27];
-    _zz_469_[5] = memory_SHIFT_RIGHT[26];
-    _zz_469_[6] = memory_SHIFT_RIGHT[25];
-    _zz_469_[7] = memory_SHIFT_RIGHT[24];
-    _zz_469_[8] = memory_SHIFT_RIGHT[23];
-    _zz_469_[9] = memory_SHIFT_RIGHT[22];
-    _zz_469_[10] = memory_SHIFT_RIGHT[21];
-    _zz_469_[11] = memory_SHIFT_RIGHT[20];
-    _zz_469_[12] = memory_SHIFT_RIGHT[19];
-    _zz_469_[13] = memory_SHIFT_RIGHT[18];
-    _zz_469_[14] = memory_SHIFT_RIGHT[17];
-    _zz_469_[15] = memory_SHIFT_RIGHT[16];
-    _zz_469_[16] = memory_SHIFT_RIGHT[15];
-    _zz_469_[17] = memory_SHIFT_RIGHT[14];
-    _zz_469_[18] = memory_SHIFT_RIGHT[13];
-    _zz_469_[19] = memory_SHIFT_RIGHT[12];
-    _zz_469_[20] = memory_SHIFT_RIGHT[11];
-    _zz_469_[21] = memory_SHIFT_RIGHT[10];
-    _zz_469_[22] = memory_SHIFT_RIGHT[9];
-    _zz_469_[23] = memory_SHIFT_RIGHT[8];
-    _zz_469_[24] = memory_SHIFT_RIGHT[7];
-    _zz_469_[25] = memory_SHIFT_RIGHT[6];
-    _zz_469_[26] = memory_SHIFT_RIGHT[5];
-    _zz_469_[27] = memory_SHIFT_RIGHT[4];
-    _zz_469_[28] = memory_SHIFT_RIGHT[3];
-    _zz_469_[29] = memory_SHIFT_RIGHT[2];
-    _zz_469_[30] = memory_SHIFT_RIGHT[1];
-    _zz_469_[31] = memory_SHIFT_RIGHT[0];
+    _zz_530[0] = memory_SHIFT_RIGHT[31];
+    _zz_530[1] = memory_SHIFT_RIGHT[30];
+    _zz_530[2] = memory_SHIFT_RIGHT[29];
+    _zz_530[3] = memory_SHIFT_RIGHT[28];
+    _zz_530[4] = memory_SHIFT_RIGHT[27];
+    _zz_530[5] = memory_SHIFT_RIGHT[26];
+    _zz_530[6] = memory_SHIFT_RIGHT[25];
+    _zz_530[7] = memory_SHIFT_RIGHT[24];
+    _zz_530[8] = memory_SHIFT_RIGHT[23];
+    _zz_530[9] = memory_SHIFT_RIGHT[22];
+    _zz_530[10] = memory_SHIFT_RIGHT[21];
+    _zz_530[11] = memory_SHIFT_RIGHT[20];
+    _zz_530[12] = memory_SHIFT_RIGHT[19];
+    _zz_530[13] = memory_SHIFT_RIGHT[18];
+    _zz_530[14] = memory_SHIFT_RIGHT[17];
+    _zz_530[15] = memory_SHIFT_RIGHT[16];
+    _zz_530[16] = memory_SHIFT_RIGHT[15];
+    _zz_530[17] = memory_SHIFT_RIGHT[14];
+    _zz_530[18] = memory_SHIFT_RIGHT[13];
+    _zz_530[19] = memory_SHIFT_RIGHT[12];
+    _zz_530[20] = memory_SHIFT_RIGHT[11];
+    _zz_530[21] = memory_SHIFT_RIGHT[10];
+    _zz_530[22] = memory_SHIFT_RIGHT[9];
+    _zz_530[23] = memory_SHIFT_RIGHT[8];
+    _zz_530[24] = memory_SHIFT_RIGHT[7];
+    _zz_530[25] = memory_SHIFT_RIGHT[6];
+    _zz_530[26] = memory_SHIFT_RIGHT[5];
+    _zz_530[27] = memory_SHIFT_RIGHT[4];
+    _zz_530[28] = memory_SHIFT_RIGHT[3];
+    _zz_530[29] = memory_SHIFT_RIGHT[2];
+    _zz_530[30] = memory_SHIFT_RIGHT[1];
+    _zz_530[31] = memory_SHIFT_RIGHT[0];
   end
 
   always @ (*) begin
-    _zz_470_ = 1'b0;
-    if(_zz_612_)begin
-      if(_zz_613_)begin
-        if(_zz_475_)begin
-          _zz_470_ = 1'b1;
+    _zz_531 = 1'b0;
+    if(_zz_695)begin
+      if(_zz_696)begin
+        if(_zz_536)begin
+          _zz_531 = 1'b1;
         end
       end
     end
-    if(_zz_614_)begin
-      if(_zz_615_)begin
-        if(_zz_477_)begin
-          _zz_470_ = 1'b1;
+    if(_zz_697)begin
+      if(_zz_698)begin
+        if(_zz_538)begin
+          _zz_531 = 1'b1;
         end
       end
     end
-    if(_zz_616_)begin
-      if(_zz_617_)begin
-        if(_zz_479_)begin
-          _zz_470_ = 1'b1;
+    if(_zz_699)begin
+      if(_zz_700)begin
+        if(_zz_540)begin
+          _zz_531 = 1'b1;
         end
       end
     end
     if((! decode_RS1_USE))begin
-      _zz_470_ = 1'b0;
+      _zz_531 = 1'b0;
     end
   end
 
   always @ (*) begin
-    _zz_471_ = 1'b0;
-    if(_zz_612_)begin
-      if(_zz_613_)begin
-        if(_zz_476_)begin
-          _zz_471_ = 1'b1;
+    _zz_532 = 1'b0;
+    if(_zz_695)begin
+      if(_zz_696)begin
+        if(_zz_537)begin
+          _zz_532 = 1'b1;
         end
       end
     end
-    if(_zz_614_)begin
-      if(_zz_615_)begin
-        if(_zz_478_)begin
-          _zz_471_ = 1'b1;
+    if(_zz_697)begin
+      if(_zz_698)begin
+        if(_zz_539)begin
+          _zz_532 = 1'b1;
         end
       end
     end
-    if(_zz_616_)begin
-      if(_zz_617_)begin
-        if(_zz_480_)begin
-          _zz_471_ = 1'b1;
+    if(_zz_699)begin
+      if(_zz_700)begin
+        if(_zz_541)begin
+          _zz_532 = 1'b1;
         end
       end
     end
     if((! decode_RS2_USE))begin
-      _zz_471_ = 1'b0;
+      _zz_532 = 1'b0;
     end
   end
 
-  assign _zz_475_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_476_ = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_477_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_478_ = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
-  assign _zz_479_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
-  assign _zz_480_ = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_536 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_537 = (writeBack_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_538 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_539 = (memory_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
+  assign _zz_540 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[19 : 15]);
+  assign _zz_541 = (execute_INSTRUCTION[11 : 7] == decode_INSTRUCTION[24 : 20]);
   assign execute_BranchPlugin_eq = (execute_SRC1 == execute_SRC2);
-  assign _zz_481_ = execute_INSTRUCTION[14 : 12];
+  assign _zz_542 = execute_INSTRUCTION[14 : 12];
   always @ (*) begin
-    if((_zz_481_ == (3'b000))) begin
-        _zz_482_ = execute_BranchPlugin_eq;
-    end else if((_zz_481_ == (3'b001))) begin
-        _zz_482_ = (! execute_BranchPlugin_eq);
-    end else if((((_zz_481_ & (3'b101)) == (3'b101)))) begin
-        _zz_482_ = (! execute_SRC_LESS);
+    if((_zz_542 == 3'b000)) begin
+        _zz_543 = execute_BranchPlugin_eq;
+    end else if((_zz_542 == 3'b001)) begin
+        _zz_543 = (! execute_BranchPlugin_eq);
+    end else if((((_zz_542 & 3'b101) == 3'b101))) begin
+        _zz_543 = (! execute_SRC_LESS);
     end else begin
-        _zz_482_ = execute_SRC_LESS;
+        _zz_543 = execute_SRC_LESS;
     end
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_INC : begin
-        _zz_483_ = 1'b0;
+        _zz_544 = 1'b0;
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_483_ = 1'b1;
+        _zz_544 = 1'b1;
       end
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_483_ = 1'b1;
+        _zz_544 = 1'b1;
       end
       default : begin
-        _zz_483_ = _zz_482_;
+        _zz_544 = _zz_543;
       end
     endcase
   end
 
-  assign _zz_484_ = _zz_759_[11];
+  assign _zz_545 = _zz_856[11];
   always @ (*) begin
-    _zz_485_[19] = _zz_484_;
-    _zz_485_[18] = _zz_484_;
-    _zz_485_[17] = _zz_484_;
-    _zz_485_[16] = _zz_484_;
-    _zz_485_[15] = _zz_484_;
-    _zz_485_[14] = _zz_484_;
-    _zz_485_[13] = _zz_484_;
-    _zz_485_[12] = _zz_484_;
-    _zz_485_[11] = _zz_484_;
-    _zz_485_[10] = _zz_484_;
-    _zz_485_[9] = _zz_484_;
-    _zz_485_[8] = _zz_484_;
-    _zz_485_[7] = _zz_484_;
-    _zz_485_[6] = _zz_484_;
-    _zz_485_[5] = _zz_484_;
-    _zz_485_[4] = _zz_484_;
-    _zz_485_[3] = _zz_484_;
-    _zz_485_[2] = _zz_484_;
-    _zz_485_[1] = _zz_484_;
-    _zz_485_[0] = _zz_484_;
+    _zz_546[19] = _zz_545;
+    _zz_546[18] = _zz_545;
+    _zz_546[17] = _zz_545;
+    _zz_546[16] = _zz_545;
+    _zz_546[15] = _zz_545;
+    _zz_546[14] = _zz_545;
+    _zz_546[13] = _zz_545;
+    _zz_546[12] = _zz_545;
+    _zz_546[11] = _zz_545;
+    _zz_546[10] = _zz_545;
+    _zz_546[9] = _zz_545;
+    _zz_546[8] = _zz_545;
+    _zz_546[7] = _zz_545;
+    _zz_546[6] = _zz_545;
+    _zz_546[5] = _zz_545;
+    _zz_546[4] = _zz_545;
+    _zz_546[3] = _zz_545;
+    _zz_546[2] = _zz_545;
+    _zz_546[1] = _zz_545;
+    _zz_546[0] = _zz_545;
   end
 
-  assign _zz_486_ = _zz_760_[19];
+  assign _zz_547 = _zz_857[19];
   always @ (*) begin
-    _zz_487_[10] = _zz_486_;
-    _zz_487_[9] = _zz_486_;
-    _zz_487_[8] = _zz_486_;
-    _zz_487_[7] = _zz_486_;
-    _zz_487_[6] = _zz_486_;
-    _zz_487_[5] = _zz_486_;
-    _zz_487_[4] = _zz_486_;
-    _zz_487_[3] = _zz_486_;
-    _zz_487_[2] = _zz_486_;
-    _zz_487_[1] = _zz_486_;
-    _zz_487_[0] = _zz_486_;
+    _zz_548[10] = _zz_547;
+    _zz_548[9] = _zz_547;
+    _zz_548[8] = _zz_547;
+    _zz_548[7] = _zz_547;
+    _zz_548[6] = _zz_547;
+    _zz_548[5] = _zz_547;
+    _zz_548[4] = _zz_547;
+    _zz_548[3] = _zz_547;
+    _zz_548[2] = _zz_547;
+    _zz_548[1] = _zz_547;
+    _zz_548[0] = _zz_547;
   end
 
-  assign _zz_488_ = _zz_761_[11];
+  assign _zz_549 = _zz_858[11];
   always @ (*) begin
-    _zz_489_[18] = _zz_488_;
-    _zz_489_[17] = _zz_488_;
-    _zz_489_[16] = _zz_488_;
-    _zz_489_[15] = _zz_488_;
-    _zz_489_[14] = _zz_488_;
-    _zz_489_[13] = _zz_488_;
-    _zz_489_[12] = _zz_488_;
-    _zz_489_[11] = _zz_488_;
-    _zz_489_[10] = _zz_488_;
-    _zz_489_[9] = _zz_488_;
-    _zz_489_[8] = _zz_488_;
-    _zz_489_[7] = _zz_488_;
-    _zz_489_[6] = _zz_488_;
-    _zz_489_[5] = _zz_488_;
-    _zz_489_[4] = _zz_488_;
-    _zz_489_[3] = _zz_488_;
-    _zz_489_[2] = _zz_488_;
-    _zz_489_[1] = _zz_488_;
-    _zz_489_[0] = _zz_488_;
+    _zz_550[18] = _zz_549;
+    _zz_550[17] = _zz_549;
+    _zz_550[16] = _zz_549;
+    _zz_550[15] = _zz_549;
+    _zz_550[14] = _zz_549;
+    _zz_550[13] = _zz_549;
+    _zz_550[12] = _zz_549;
+    _zz_550[11] = _zz_549;
+    _zz_550[10] = _zz_549;
+    _zz_550[9] = _zz_549;
+    _zz_550[8] = _zz_549;
+    _zz_550[7] = _zz_549;
+    _zz_550[6] = _zz_549;
+    _zz_550[5] = _zz_549;
+    _zz_550[4] = _zz_549;
+    _zz_550[3] = _zz_549;
+    _zz_550[2] = _zz_549;
+    _zz_550[1] = _zz_549;
+    _zz_550[0] = _zz_549;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        _zz_490_ = (_zz_762_[1] ^ execute_RS1[1]);
+        _zz_551 = (_zz_859[1] ^ execute_RS1[1]);
       end
       `BranchCtrlEnum_defaultEncoding_JAL : begin
-        _zz_490_ = _zz_763_[1];
+        _zz_551 = _zz_860[1];
       end
       default : begin
-        _zz_490_ = _zz_764_[1];
+        _zz_551 = _zz_861[1];
       end
     endcase
   end
 
-  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_490_);
+  assign execute_BranchPlugin_missAlignedTarget = (execute_BRANCH_COND_RESULT && _zz_551);
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
@@ -6517,106 +7433,106 @@ module VexRiscv (
     endcase
   end
 
-  assign _zz_491_ = _zz_765_[11];
+  assign _zz_552 = _zz_862[11];
   always @ (*) begin
-    _zz_492_[19] = _zz_491_;
-    _zz_492_[18] = _zz_491_;
-    _zz_492_[17] = _zz_491_;
-    _zz_492_[16] = _zz_491_;
-    _zz_492_[15] = _zz_491_;
-    _zz_492_[14] = _zz_491_;
-    _zz_492_[13] = _zz_491_;
-    _zz_492_[12] = _zz_491_;
-    _zz_492_[11] = _zz_491_;
-    _zz_492_[10] = _zz_491_;
-    _zz_492_[9] = _zz_491_;
-    _zz_492_[8] = _zz_491_;
-    _zz_492_[7] = _zz_491_;
-    _zz_492_[6] = _zz_491_;
-    _zz_492_[5] = _zz_491_;
-    _zz_492_[4] = _zz_491_;
-    _zz_492_[3] = _zz_491_;
-    _zz_492_[2] = _zz_491_;
-    _zz_492_[1] = _zz_491_;
-    _zz_492_[0] = _zz_491_;
+    _zz_553[19] = _zz_552;
+    _zz_553[18] = _zz_552;
+    _zz_553[17] = _zz_552;
+    _zz_553[16] = _zz_552;
+    _zz_553[15] = _zz_552;
+    _zz_553[14] = _zz_552;
+    _zz_553[13] = _zz_552;
+    _zz_553[12] = _zz_552;
+    _zz_553[11] = _zz_552;
+    _zz_553[10] = _zz_552;
+    _zz_553[9] = _zz_552;
+    _zz_553[8] = _zz_552;
+    _zz_553[7] = _zz_552;
+    _zz_553[6] = _zz_552;
+    _zz_553[5] = _zz_552;
+    _zz_553[4] = _zz_552;
+    _zz_553[3] = _zz_552;
+    _zz_553[2] = _zz_552;
+    _zz_553[1] = _zz_552;
+    _zz_553[0] = _zz_552;
   end
 
   always @ (*) begin
     case(execute_BRANCH_CTRL)
       `BranchCtrlEnum_defaultEncoding_JALR : begin
-        execute_BranchPlugin_branch_src2 = {_zz_492_,execute_INSTRUCTION[31 : 20]};
+        execute_BranchPlugin_branch_src2 = {_zz_553,execute_INSTRUCTION[31 : 20]};
       end
       default : begin
-        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_494_,{{{_zz_1069_,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_496_,{{{_zz_1070_,_zz_1071_},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
+        execute_BranchPlugin_branch_src2 = ((execute_BRANCH_CTRL == `BranchCtrlEnum_defaultEncoding_JAL) ? {{_zz_555,{{{_zz_1175,execute_INSTRUCTION[19 : 12]},execute_INSTRUCTION[20]},execute_INSTRUCTION[30 : 21]}},1'b0} : {{_zz_557,{{{_zz_1176,_zz_1177},execute_INSTRUCTION[30 : 25]},execute_INSTRUCTION[11 : 8]}},1'b0});
         if(execute_PREDICTION_HAD_BRANCHED2)begin
-          execute_BranchPlugin_branch_src2 = {29'd0, _zz_768_};
+          execute_BranchPlugin_branch_src2 = {29'd0, _zz_865};
         end
       end
     endcase
   end
 
-  assign _zz_493_ = _zz_766_[19];
+  assign _zz_554 = _zz_863[19];
   always @ (*) begin
-    _zz_494_[10] = _zz_493_;
-    _zz_494_[9] = _zz_493_;
-    _zz_494_[8] = _zz_493_;
-    _zz_494_[7] = _zz_493_;
-    _zz_494_[6] = _zz_493_;
-    _zz_494_[5] = _zz_493_;
-    _zz_494_[4] = _zz_493_;
-    _zz_494_[3] = _zz_493_;
-    _zz_494_[2] = _zz_493_;
-    _zz_494_[1] = _zz_493_;
-    _zz_494_[0] = _zz_493_;
+    _zz_555[10] = _zz_554;
+    _zz_555[9] = _zz_554;
+    _zz_555[8] = _zz_554;
+    _zz_555[7] = _zz_554;
+    _zz_555[6] = _zz_554;
+    _zz_555[5] = _zz_554;
+    _zz_555[4] = _zz_554;
+    _zz_555[3] = _zz_554;
+    _zz_555[2] = _zz_554;
+    _zz_555[1] = _zz_554;
+    _zz_555[0] = _zz_554;
   end
 
-  assign _zz_495_ = _zz_767_[11];
+  assign _zz_556 = _zz_864[11];
   always @ (*) begin
-    _zz_496_[18] = _zz_495_;
-    _zz_496_[17] = _zz_495_;
-    _zz_496_[16] = _zz_495_;
-    _zz_496_[15] = _zz_495_;
-    _zz_496_[14] = _zz_495_;
-    _zz_496_[13] = _zz_495_;
-    _zz_496_[12] = _zz_495_;
-    _zz_496_[11] = _zz_495_;
-    _zz_496_[10] = _zz_495_;
-    _zz_496_[9] = _zz_495_;
-    _zz_496_[8] = _zz_495_;
-    _zz_496_[7] = _zz_495_;
-    _zz_496_[6] = _zz_495_;
-    _zz_496_[5] = _zz_495_;
-    _zz_496_[4] = _zz_495_;
-    _zz_496_[3] = _zz_495_;
-    _zz_496_[2] = _zz_495_;
-    _zz_496_[1] = _zz_495_;
-    _zz_496_[0] = _zz_495_;
+    _zz_557[18] = _zz_556;
+    _zz_557[17] = _zz_556;
+    _zz_557[16] = _zz_556;
+    _zz_557[15] = _zz_556;
+    _zz_557[14] = _zz_556;
+    _zz_557[13] = _zz_556;
+    _zz_557[12] = _zz_556;
+    _zz_557[11] = _zz_556;
+    _zz_557[10] = _zz_556;
+    _zz_557[9] = _zz_556;
+    _zz_557[8] = _zz_556;
+    _zz_557[7] = _zz_556;
+    _zz_557[6] = _zz_556;
+    _zz_557[5] = _zz_556;
+    _zz_557[4] = _zz_556;
+    _zz_557[3] = _zz_556;
+    _zz_557[2] = _zz_556;
+    _zz_557[1] = _zz_556;
+    _zz_557[0] = _zz_556;
   end
 
   assign execute_BranchPlugin_branchAdder = (execute_BranchPlugin_branch_src1 + execute_BranchPlugin_branch_src2);
   assign BranchPlugin_jumpInterface_valid = ((memory_arbitration_isValid && memory_BRANCH_DO) && (! 1'b0));
   assign BranchPlugin_jumpInterface_payload = memory_BRANCH_CALC;
   assign BranchPlugin_branchExceptionPort_valid = (memory_arbitration_isValid && (memory_BRANCH_DO && memory_BRANCH_CALC[1]));
-  assign BranchPlugin_branchExceptionPort_payload_code = (4'b0000);
+  assign BranchPlugin_branchExceptionPort_payload_code = 4'b0000;
   assign BranchPlugin_branchExceptionPort_payload_badAddr = memory_BRANCH_CALC;
   assign IBusCachedPlugin_decodePrediction_rsp_wasWrong = BranchPlugin_jumpInterface_valid;
   always @ (*) begin
-    CsrPlugin_privilege = _zz_497_;
+    CsrPlugin_privilege = _zz_558;
     if(CsrPlugin_forceMachineWire)begin
-      CsrPlugin_privilege = (2'b11);
+      CsrPlugin_privilege = 2'b11;
     end
   end
 
-  assign _zz_498_ = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
-  assign _zz_499_ = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
-  assign _zz_500_ = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
-  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = (2'b11);
+  assign _zz_559 = (CsrPlugin_mip_MTIP && CsrPlugin_mie_MTIE);
+  assign _zz_560 = (CsrPlugin_mip_MSIP && CsrPlugin_mie_MSIE);
+  assign _zz_561 = (CsrPlugin_mip_MEIP && CsrPlugin_mie_MEIE);
+  assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped = 2'b11;
   assign CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilege = ((CsrPlugin_privilege < CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped) ? CsrPlugin_exceptionPortCtrl_exceptionTargetPrivilegeUncapped : CsrPlugin_privilege);
-  assign _zz_501_ = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
-  assign _zz_502_ = _zz_769_[0];
+  assign _zz_562 = {decodeExceptionPort_valid,IBusCachedPlugin_decodeExceptionPort_valid};
+  assign _zz_563 = _zz_866[0];
   always @ (*) begin
     CsrPlugin_exceptionPortCtrl_exceptionValids_decode = CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode;
-    if(_zz_601_)begin
+    if(_zz_684)begin
       CsrPlugin_exceptionPortCtrl_exceptionValids_decode = 1'b1;
     end
     if(decode_arbitration_isFlushed)begin
@@ -6662,7 +7578,7 @@ module VexRiscv (
   assign CsrPlugin_pipelineLiberator_active = ((CsrPlugin_interrupt_valid && CsrPlugin_allowInterrupts) && decode_arbitration_isValid);
   always @ (*) begin
     CsrPlugin_pipelineLiberator_done = CsrPlugin_pipelineLiberator_pcValids_2;
-    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != (3'b000)))begin
+    if(({CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack,{CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_memory,CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_execute}} != 3'b000))begin
       CsrPlugin_pipelineLiberator_done = 1'b0;
     end
     if(CsrPlugin_hadException)begin
@@ -6686,7 +7602,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    CsrPlugin_xtvec_mode = (2'bxx);
+    CsrPlugin_xtvec_mode = 2'bxx;
     case(CsrPlugin_targetPrivilege)
       2'b11 : begin
         CsrPlugin_xtvec_mode = CsrPlugin_mtvec_mode;
@@ -6708,7 +7624,7 @@ module VexRiscv (
   end
 
   assign contextSwitching = CsrPlugin_jumpInterface_valid;
-  assign execute_CsrPlugin_blockedBySideEffects = ({writeBack_arbitration_isValid,memory_arbitration_isValid} != (2'b00));
+  assign execute_CsrPlugin_blockedBySideEffects = (({writeBack_arbitration_isValid,memory_arbitration_isValid} != 2'b00) || 1'b0);
   always @ (*) begin
     execute_CsrPlugin_illegalAccess = 1'b1;
     if(execute_CsrPlugin_csr_3264)begin
@@ -6863,7 +7779,7 @@ module VexRiscv (
         execute_CsrPlugin_illegalAccess = 1'b0;
       end
     end
-    if(_zz_618_)begin
+    if(_zz_701)begin
       execute_CsrPlugin_illegalAccess = 1'b1;
     end
     if(((! execute_arbitration_isValid) || (! execute_IS_CSR)))begin
@@ -6882,26 +7798,26 @@ module VexRiscv (
 
   always @ (*) begin
     CsrPlugin_selfException_valid = 1'b0;
-    if(_zz_619_)begin
+    if(_zz_702)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
-    if(_zz_620_)begin
+    if(_zz_703)begin
       CsrPlugin_selfException_valid = 1'b1;
     end
   end
 
   always @ (*) begin
-    CsrPlugin_selfException_payload_code = (4'bxxxx);
-    if(_zz_619_)begin
-      CsrPlugin_selfException_payload_code = (4'b0010);
+    CsrPlugin_selfException_payload_code = 4'bxxxx;
+    if(_zz_702)begin
+      CsrPlugin_selfException_payload_code = 4'b0010;
     end
-    if(_zz_620_)begin
+    if(_zz_703)begin
       case(CsrPlugin_privilege)
         2'b00 : begin
-          CsrPlugin_selfException_payload_code = (4'b1000);
+          CsrPlugin_selfException_payload_code = 4'b1000;
         end
         default : begin
-          CsrPlugin_selfException_payload_code = (4'b1011);
+          CsrPlugin_selfException_payload_code = 4'b1011;
         end
       endcase
     end
@@ -6910,14 +7826,14 @@ module VexRiscv (
   assign CsrPlugin_selfException_payload_badAddr = execute_INSTRUCTION;
   always @ (*) begin
     execute_CsrPlugin_writeInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_WRITE_OPCODE);
-    if(_zz_618_)begin
+    if(_zz_701)begin
       execute_CsrPlugin_writeInstruction = 1'b0;
     end
   end
 
   always @ (*) begin
     execute_CsrPlugin_readInstruction = ((execute_arbitration_isValid && execute_IS_CSR) && execute_CSR_READ_OPCODE);
-    if(_zz_618_)begin
+    if(_zz_701)begin
       execute_CsrPlugin_readInstruction = 1'b0;
     end
   end
@@ -6926,7 +7842,7 @@ module VexRiscv (
   assign execute_CsrPlugin_readEnable = (execute_CsrPlugin_readInstruction && (! execute_arbitration_isStuck));
   assign execute_CsrPlugin_readToWriteData = execute_CsrPlugin_readData;
   always @ (*) begin
-    case(_zz_648_)
+    case(_zz_731)
       1'b0 : begin
         execute_CsrPlugin_writeData = execute_SRC1;
       end
@@ -6940,7 +7856,7 @@ module VexRiscv (
   assign execute_MulPlugin_a = execute_RS1;
   assign execute_MulPlugin_b = execute_RS2;
   always @ (*) begin
-    case(_zz_621_)
+    case(_zz_704)
       2'b01 : begin
         execute_MulPlugin_aSigned = 1'b1;
       end
@@ -6954,7 +7870,7 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    case(_zz_621_)
+    case(_zz_704)
       2'b01 : begin
         execute_MulPlugin_bSigned = 1'b1;
       end
@@ -6973,12 +7889,12 @@ module VexRiscv (
   assign execute_MulPlugin_bSLow = {1'b0,execute_MulPlugin_b[15 : 0]};
   assign execute_MulPlugin_aHigh = {(execute_MulPlugin_aSigned && execute_MulPlugin_a[31]),execute_MulPlugin_a[31 : 16]};
   assign execute_MulPlugin_bHigh = {(execute_MulPlugin_bSigned && execute_MulPlugin_b[31]),execute_MulPlugin_b[31 : 16]};
-  assign writeBack_MulPlugin_result = ($signed(_zz_771_) + $signed(_zz_772_));
+  assign writeBack_MulPlugin_result = ($signed(_zz_868) + $signed(_zz_869));
   assign memory_DivPlugin_frontendOk = 1'b1;
   always @ (*) begin
     memory_DivPlugin_div_counter_willIncrement = 1'b0;
-    if(_zz_596_)begin
-      if(_zz_622_)begin
+    if(_zz_679)begin
+      if(_zz_705)begin
         memory_DivPlugin_div_counter_willIncrement = 1'b1;
       end
     end
@@ -6986,7 +7902,7 @@ module VexRiscv (
 
   always @ (*) begin
     memory_DivPlugin_div_counter_willClear = 1'b0;
-    if(_zz_623_)begin
+    if(_zz_706)begin
       memory_DivPlugin_div_counter_willClear = 1'b1;
     end
   end
@@ -6997,35 +7913,33 @@ module VexRiscv (
     if(memory_DivPlugin_div_counter_willOverflow)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end else begin
-      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_776_);
+      memory_DivPlugin_div_counter_valueNext = (memory_DivPlugin_div_counter_value + _zz_873);
     end
     if(memory_DivPlugin_div_counter_willClear)begin
       memory_DivPlugin_div_counter_valueNext = 6'h0;
     end
   end
 
-  assign _zz_503_ = memory_DivPlugin_rs1[31 : 0];
-  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_503_[31]};
-  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_777_);
-  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_778_ : _zz_779_);
-  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_780_[31:0];
-  assign _zz_504_ = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
-  assign _zz_505_ = (execute_RS2[31] && execute_IS_RS2_SIGNED);
-  assign _zz_506_ = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
+  assign _zz_564 = memory_DivPlugin_rs1[31 : 0];
+  assign memory_DivPlugin_div_stage_0_remainderShifted = {memory_DivPlugin_accumulator[31 : 0],_zz_564[31]};
+  assign memory_DivPlugin_div_stage_0_remainderMinusDenominator = (memory_DivPlugin_div_stage_0_remainderShifted - _zz_874);
+  assign memory_DivPlugin_div_stage_0_outRemainder = ((! memory_DivPlugin_div_stage_0_remainderMinusDenominator[32]) ? _zz_875 : _zz_876);
+  assign memory_DivPlugin_div_stage_0_outNumerator = _zz_877[31:0];
+  assign _zz_565 = (memory_INSTRUCTION[13] ? memory_DivPlugin_accumulator[31 : 0] : memory_DivPlugin_rs1[31 : 0]);
+  assign _zz_566 = (execute_RS2[31] && execute_IS_RS2_SIGNED);
+  assign _zz_567 = (1'b0 || ((execute_IS_DIV && execute_RS1[31]) && execute_IS_RS1_SIGNED));
   always @ (*) begin
-    _zz_507_[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
-    _zz_507_[31 : 0] = execute_RS1;
+    _zz_568[32] = (execute_IS_RS1_SIGNED && execute_RS1[31]);
+    _zz_568[31 : 0] = execute_RS1;
   end
 
-  assign _zz_509_ = (_zz_508_ & externalInterruptArray_regNext);
-  assign externalInterrupt = (_zz_509_ != 32'h0);
+  assign _zz_570 = (_zz_569 & externalInterruptArray_regNext);
+  assign externalInterrupt = (_zz_570 != 32'h0);
   always @ (*) begin
     debug_bus_cmd_ready = 1'b1;
     if(debug_bus_cmd_valid)begin
-      case(_zz_624_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_707)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             debug_bus_cmd_ready = IBusCachedPlugin_injectionPort_ready;
           end
@@ -7038,7 +7952,7 @@ module VexRiscv (
 
   always @ (*) begin
     debug_bus_rsp_data = DebugPlugin_busReadDataReg;
-    if((! _zz_510_))begin
+    if((! _zz_571))begin
       debug_bus_rsp_data[0] = DebugPlugin_resetIt;
       debug_bus_rsp_data[1] = DebugPlugin_haltIt;
       debug_bus_rsp_data[2] = DebugPlugin_isPipBusy;
@@ -7050,10 +7964,8 @@ module VexRiscv (
   always @ (*) begin
     IBusCachedPlugin_injectionPort_valid = 1'b0;
     if(debug_bus_cmd_valid)begin
-      case(_zz_624_)
-        6'b000000 : begin
-        end
-        6'b000001 : begin
+      case(_zz_707)
+        6'h01 : begin
           if(debug_bus_cmd_payload_wr)begin
             IBusCachedPlugin_injectionPort_valid = 1'b1;
           end
@@ -7065,39 +7977,39 @@ module VexRiscv (
   end
 
   assign IBusCachedPlugin_injectionPort_payload = debug_bus_cmd_payload_data;
-  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == (2'b11));
+  assign DebugPlugin_allowEBreak = (CsrPlugin_privilege == 2'b11);
   assign debug_resetOut = DebugPlugin_resetIt_regNext;
-  assign _zz_26_ = decode_BRANCH_CTRL;
-  assign _zz_54_ = _zz_49_;
-  assign _zz_30_ = decode_to_execute_BRANCH_CTRL;
-  assign _zz_24_ = decode_SRC2_CTRL;
-  assign _zz_22_ = _zz_44_;
-  assign _zz_36_ = decode_to_execute_SRC2_CTRL;
-  assign _zz_21_ = decode_ALU_BITWISE_CTRL;
-  assign _zz_19_ = _zz_47_;
-  assign _zz_39_ = decode_to_execute_ALU_BITWISE_CTRL;
-  assign _zz_18_ = decode_ALU_CTRL;
-  assign _zz_16_ = _zz_45_;
-  assign _zz_38_ = decode_to_execute_ALU_CTRL;
-  assign _zz_15_ = decode_ENV_CTRL;
-  assign _zz_12_ = execute_ENV_CTRL;
-  assign _zz_10_ = memory_ENV_CTRL;
-  assign _zz_13_ = _zz_43_;
-  assign _zz_28_ = decode_to_execute_ENV_CTRL;
-  assign _zz_27_ = execute_to_memory_ENV_CTRL;
-  assign _zz_29_ = memory_to_writeBack_ENV_CTRL;
-  assign _zz_8_ = decode_SRC1_CTRL;
-  assign _zz_6_ = _zz_48_;
-  assign _zz_37_ = decode_to_execute_SRC1_CTRL;
-  assign _zz_5_ = decode_SHIFT_CTRL;
-  assign _zz_2_ = execute_SHIFT_CTRL;
-  assign _zz_3_ = _zz_46_;
-  assign _zz_34_ = decode_to_execute_SHIFT_CTRL;
-  assign _zz_33_ = execute_to_memory_SHIFT_CTRL;
-  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != (3'b000)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != (4'b0000)));
-  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != (2'b00)) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != (3'b000)));
-  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != (1'b0)) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != (2'b00)));
-  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != (1'b0)));
+  assign _zz_26 = decode_SRC1_CTRL;
+  assign _zz_24 = _zz_49;
+  assign _zz_37 = decode_to_execute_SRC1_CTRL;
+  assign _zz_23 = decode_ALU_CTRL;
+  assign _zz_21 = _zz_48;
+  assign _zz_38 = decode_to_execute_ALU_CTRL;
+  assign _zz_20 = decode_SRC2_CTRL;
+  assign _zz_18 = _zz_47;
+  assign _zz_36 = decode_to_execute_SRC2_CTRL;
+  assign _zz_17 = decode_ALU_BITWISE_CTRL;
+  assign _zz_15 = _zz_46;
+  assign _zz_39 = decode_to_execute_ALU_BITWISE_CTRL;
+  assign _zz_14 = decode_SHIFT_CTRL;
+  assign _zz_11 = execute_SHIFT_CTRL;
+  assign _zz_12 = _zz_45;
+  assign _zz_34 = decode_to_execute_SHIFT_CTRL;
+  assign _zz_33 = execute_to_memory_SHIFT_CTRL;
+  assign _zz_9 = decode_BRANCH_CTRL;
+  assign _zz_51 = _zz_44;
+  assign _zz_30 = decode_to_execute_BRANCH_CTRL;
+  assign _zz_7 = decode_ENV_CTRL;
+  assign _zz_4 = execute_ENV_CTRL;
+  assign _zz_2 = memory_ENV_CTRL;
+  assign _zz_5 = _zz_43;
+  assign _zz_28 = decode_to_execute_ENV_CTRL;
+  assign _zz_27 = execute_to_memory_ENV_CTRL;
+  assign _zz_29 = memory_to_writeBack_ENV_CTRL;
+  assign decode_arbitration_isFlushed = (({writeBack_arbitration_flushNext,{memory_arbitration_flushNext,execute_arbitration_flushNext}} != 3'b000) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,{execute_arbitration_flushIt,decode_arbitration_flushIt}}} != 4'b0000));
+  assign execute_arbitration_isFlushed = (({writeBack_arbitration_flushNext,memory_arbitration_flushNext} != 2'b00) || ({writeBack_arbitration_flushIt,{memory_arbitration_flushIt,execute_arbitration_flushIt}} != 3'b000));
+  assign memory_arbitration_isFlushed = ((writeBack_arbitration_flushNext != 1'b0) || ({writeBack_arbitration_flushIt,memory_arbitration_flushIt} != 2'b00));
+  assign writeBack_arbitration_isFlushed = (1'b0 || (writeBack_arbitration_flushIt != 1'b0));
   assign decode_arbitration_isStuckByOthers = (decode_arbitration_haltByOther || (((1'b0 || execute_arbitration_isStuck) || memory_arbitration_isStuck) || writeBack_arbitration_isStuck));
   assign decode_arbitration_isStuck = (decode_arbitration_haltItself || decode_arbitration_isStuckByOthers);
   assign decode_arbitration_isMoving = ((! decode_arbitration_isStuck) && (! decode_arbitration_removeIt));
@@ -7116,15 +8028,7 @@ module VexRiscv (
   assign writeBack_arbitration_isFiring = ((writeBack_arbitration_isValid && (! writeBack_arbitration_isStuck)) && (! writeBack_arbitration_removeIt));
   always @ (*) begin
     IBusCachedPlugin_injectionPort_ready = 1'b0;
-    case(_zz_511_)
-      3'b000 : begin
-      end
-      3'b001 : begin
-      end
-      3'b010 : begin
-      end
-      3'b011 : begin
-      end
+    case(_zz_572)
       3'b100 : begin
         IBusCachedPlugin_injectionPort_ready = 1'b1;
       end
@@ -7134,432 +8038,432 @@ module VexRiscv (
   end
 
   always @ (*) begin
-    _zz_512_ = 32'h0;
+    _zz_573 = 32'h0;
     if(execute_CsrPlugin_csr_3264)begin
-      _zz_512_[12 : 0] = 13'h1000;
-      _zz_512_[25 : 20] = 6'h20;
+      _zz_573[12 : 0] = 13'h1000;
+      _zz_573[25 : 20] = 6'h20;
     end
   end
 
   always @ (*) begin
-    _zz_513_ = 32'h0;
+    _zz_574 = 32'h0;
     if(execute_CsrPlugin_csr_944)begin
-      _zz_513_[31 : 0] = _zz_95_;
+      _zz_574[31 : 0] = _zz_92;
     end
   end
 
   always @ (*) begin
-    _zz_514_ = 32'h0;
+    _zz_575 = 32'h0;
     if(execute_CsrPlugin_csr_945)begin
-      _zz_514_[31 : 0] = _zz_111_;
+      _zz_575[31 : 0] = _zz_111;
     end
   end
 
   always @ (*) begin
-    _zz_515_ = 32'h0;
+    _zz_576 = 32'h0;
     if(execute_CsrPlugin_csr_946)begin
-      _zz_515_[31 : 0] = _zz_127_;
+      _zz_576[31 : 0] = _zz_130;
     end
   end
 
   always @ (*) begin
-    _zz_516_ = 32'h0;
+    _zz_577 = 32'h0;
     if(execute_CsrPlugin_csr_947)begin
-      _zz_516_[31 : 0] = _zz_143_;
+      _zz_577[31 : 0] = _zz_149;
     end
   end
 
   always @ (*) begin
-    _zz_517_ = 32'h0;
+    _zz_578 = 32'h0;
     if(execute_CsrPlugin_csr_948)begin
-      _zz_517_[31 : 0] = _zz_159_;
+      _zz_578[31 : 0] = _zz_168;
     end
   end
 
   always @ (*) begin
-    _zz_518_ = 32'h0;
+    _zz_579 = 32'h0;
     if(execute_CsrPlugin_csr_949)begin
-      _zz_518_[31 : 0] = _zz_175_;
+      _zz_579[31 : 0] = _zz_187;
     end
   end
 
   always @ (*) begin
-    _zz_519_ = 32'h0;
+    _zz_580 = 32'h0;
     if(execute_CsrPlugin_csr_950)begin
-      _zz_519_[31 : 0] = _zz_191_;
+      _zz_580[31 : 0] = _zz_206;
     end
   end
 
   always @ (*) begin
-    _zz_520_ = 32'h0;
+    _zz_581 = 32'h0;
     if(execute_CsrPlugin_csr_951)begin
-      _zz_520_[31 : 0] = _zz_207_;
+      _zz_581[31 : 0] = _zz_225;
     end
   end
 
   always @ (*) begin
-    _zz_521_ = 32'h0;
+    _zz_582 = 32'h0;
     if(execute_CsrPlugin_csr_952)begin
-      _zz_521_[31 : 0] = _zz_223_;
+      _zz_582[31 : 0] = _zz_244;
     end
   end
 
   always @ (*) begin
-    _zz_522_ = 32'h0;
+    _zz_583 = 32'h0;
     if(execute_CsrPlugin_csr_953)begin
-      _zz_522_[31 : 0] = _zz_239_;
+      _zz_583[31 : 0] = _zz_263;
     end
   end
 
   always @ (*) begin
-    _zz_523_ = 32'h0;
+    _zz_584 = 32'h0;
     if(execute_CsrPlugin_csr_954)begin
-      _zz_523_[31 : 0] = _zz_255_;
+      _zz_584[31 : 0] = _zz_282;
     end
   end
 
   always @ (*) begin
-    _zz_524_ = 32'h0;
+    _zz_585 = 32'h0;
     if(execute_CsrPlugin_csr_955)begin
-      _zz_524_[31 : 0] = _zz_271_;
+      _zz_585[31 : 0] = _zz_301;
     end
   end
 
   always @ (*) begin
-    _zz_525_ = 32'h0;
+    _zz_586 = 32'h0;
     if(execute_CsrPlugin_csr_956)begin
-      _zz_525_[31 : 0] = _zz_287_;
+      _zz_586[31 : 0] = _zz_320;
     end
   end
 
   always @ (*) begin
-    _zz_526_ = 32'h0;
+    _zz_587 = 32'h0;
     if(execute_CsrPlugin_csr_957)begin
-      _zz_526_[31 : 0] = _zz_303_;
+      _zz_587[31 : 0] = _zz_339;
     end
   end
 
   always @ (*) begin
-    _zz_527_ = 32'h0;
+    _zz_588 = 32'h0;
     if(execute_CsrPlugin_csr_958)begin
-      _zz_527_[31 : 0] = _zz_319_;
+      _zz_588[31 : 0] = _zz_358;
     end
   end
 
   always @ (*) begin
-    _zz_528_ = 32'h0;
+    _zz_589 = 32'h0;
     if(execute_CsrPlugin_csr_959)begin
-      _zz_528_[31 : 0] = _zz_335_;
+      _zz_589[31 : 0] = _zz_377;
     end
   end
 
   always @ (*) begin
-    _zz_529_ = 32'h0;
+    _zz_590 = 32'h0;
     if(execute_CsrPlugin_csr_928)begin
-      _zz_529_[31 : 31] = _zz_141_;
-      _zz_529_[23 : 23] = _zz_125_;
-      _zz_529_[15 : 15] = _zz_109_;
-      _zz_529_[7 : 7] = _zz_93_;
-      _zz_529_[28 : 27] = _zz_142_;
-      _zz_529_[26 : 26] = _zz_140_;
-      _zz_529_[25 : 25] = _zz_139_;
-      _zz_529_[24 : 24] = _zz_138_;
-      _zz_529_[20 : 19] = _zz_126_;
-      _zz_529_[18 : 18] = _zz_124_;
-      _zz_529_[17 : 17] = _zz_123_;
-      _zz_529_[16 : 16] = _zz_122_;
-      _zz_529_[12 : 11] = _zz_110_;
-      _zz_529_[10 : 10] = _zz_108_;
-      _zz_529_[9 : 9] = _zz_107_;
-      _zz_529_[8 : 8] = _zz_106_;
-      _zz_529_[4 : 3] = _zz_94_;
-      _zz_529_[2 : 2] = _zz_92_;
-      _zz_529_[1 : 1] = _zz_91_;
-      _zz_529_[0 : 0] = _zz_90_;
+      _zz_590[31 : 31] = _zz_147;
+      _zz_590[23 : 23] = _zz_128;
+      _zz_590[15 : 15] = _zz_109;
+      _zz_590[7 : 7] = _zz_90;
+      _zz_590[28 : 27] = _zz_148;
+      _zz_590[26 : 26] = _zz_146;
+      _zz_590[25 : 25] = _zz_145;
+      _zz_590[24 : 24] = _zz_144;
+      _zz_590[20 : 19] = _zz_129;
+      _zz_590[18 : 18] = _zz_127;
+      _zz_590[17 : 17] = _zz_126;
+      _zz_590[16 : 16] = _zz_125;
+      _zz_590[12 : 11] = _zz_110;
+      _zz_590[10 : 10] = _zz_108;
+      _zz_590[9 : 9] = _zz_107;
+      _zz_590[8 : 8] = _zz_106;
+      _zz_590[4 : 3] = _zz_91;
+      _zz_590[2 : 2] = _zz_89;
+      _zz_590[1 : 1] = _zz_88;
+      _zz_590[0 : 0] = _zz_87;
     end
   end
 
   always @ (*) begin
-    _zz_530_ = 32'h0;
+    _zz_591 = 32'h0;
     if(execute_CsrPlugin_csr_929)begin
-      _zz_530_[31 : 31] = _zz_205_;
-      _zz_530_[23 : 23] = _zz_189_;
-      _zz_530_[15 : 15] = _zz_173_;
-      _zz_530_[7 : 7] = _zz_157_;
-      _zz_530_[28 : 27] = _zz_206_;
-      _zz_530_[26 : 26] = _zz_204_;
-      _zz_530_[25 : 25] = _zz_203_;
-      _zz_530_[24 : 24] = _zz_202_;
-      _zz_530_[20 : 19] = _zz_190_;
-      _zz_530_[18 : 18] = _zz_188_;
-      _zz_530_[17 : 17] = _zz_187_;
-      _zz_530_[16 : 16] = _zz_186_;
-      _zz_530_[12 : 11] = _zz_174_;
-      _zz_530_[10 : 10] = _zz_172_;
-      _zz_530_[9 : 9] = _zz_171_;
-      _zz_530_[8 : 8] = _zz_170_;
-      _zz_530_[4 : 3] = _zz_158_;
-      _zz_530_[2 : 2] = _zz_156_;
-      _zz_530_[1 : 1] = _zz_155_;
-      _zz_530_[0 : 0] = _zz_154_;
+      _zz_591[31 : 31] = _zz_223;
+      _zz_591[23 : 23] = _zz_204;
+      _zz_591[15 : 15] = _zz_185;
+      _zz_591[7 : 7] = _zz_166;
+      _zz_591[28 : 27] = _zz_224;
+      _zz_591[26 : 26] = _zz_222;
+      _zz_591[25 : 25] = _zz_221;
+      _zz_591[24 : 24] = _zz_220;
+      _zz_591[20 : 19] = _zz_205;
+      _zz_591[18 : 18] = _zz_203;
+      _zz_591[17 : 17] = _zz_202;
+      _zz_591[16 : 16] = _zz_201;
+      _zz_591[12 : 11] = _zz_186;
+      _zz_591[10 : 10] = _zz_184;
+      _zz_591[9 : 9] = _zz_183;
+      _zz_591[8 : 8] = _zz_182;
+      _zz_591[4 : 3] = _zz_167;
+      _zz_591[2 : 2] = _zz_165;
+      _zz_591[1 : 1] = _zz_164;
+      _zz_591[0 : 0] = _zz_163;
     end
   end
 
   always @ (*) begin
-    _zz_531_ = 32'h0;
+    _zz_592 = 32'h0;
     if(execute_CsrPlugin_csr_930)begin
-      _zz_531_[31 : 31] = _zz_269_;
-      _zz_531_[23 : 23] = _zz_253_;
-      _zz_531_[15 : 15] = _zz_237_;
-      _zz_531_[7 : 7] = _zz_221_;
-      _zz_531_[28 : 27] = _zz_270_;
-      _zz_531_[26 : 26] = _zz_268_;
-      _zz_531_[25 : 25] = _zz_267_;
-      _zz_531_[24 : 24] = _zz_266_;
-      _zz_531_[20 : 19] = _zz_254_;
-      _zz_531_[18 : 18] = _zz_252_;
-      _zz_531_[17 : 17] = _zz_251_;
-      _zz_531_[16 : 16] = _zz_250_;
-      _zz_531_[12 : 11] = _zz_238_;
-      _zz_531_[10 : 10] = _zz_236_;
-      _zz_531_[9 : 9] = _zz_235_;
-      _zz_531_[8 : 8] = _zz_234_;
-      _zz_531_[4 : 3] = _zz_222_;
-      _zz_531_[2 : 2] = _zz_220_;
-      _zz_531_[1 : 1] = _zz_219_;
-      _zz_531_[0 : 0] = _zz_218_;
+      _zz_592[31 : 31] = _zz_299;
+      _zz_592[23 : 23] = _zz_280;
+      _zz_592[15 : 15] = _zz_261;
+      _zz_592[7 : 7] = _zz_242;
+      _zz_592[28 : 27] = _zz_300;
+      _zz_592[26 : 26] = _zz_298;
+      _zz_592[25 : 25] = _zz_297;
+      _zz_592[24 : 24] = _zz_296;
+      _zz_592[20 : 19] = _zz_281;
+      _zz_592[18 : 18] = _zz_279;
+      _zz_592[17 : 17] = _zz_278;
+      _zz_592[16 : 16] = _zz_277;
+      _zz_592[12 : 11] = _zz_262;
+      _zz_592[10 : 10] = _zz_260;
+      _zz_592[9 : 9] = _zz_259;
+      _zz_592[8 : 8] = _zz_258;
+      _zz_592[4 : 3] = _zz_243;
+      _zz_592[2 : 2] = _zz_241;
+      _zz_592[1 : 1] = _zz_240;
+      _zz_592[0 : 0] = _zz_239;
     end
   end
 
   always @ (*) begin
-    _zz_532_ = 32'h0;
+    _zz_593 = 32'h0;
     if(execute_CsrPlugin_csr_931)begin
-      _zz_532_[31 : 31] = _zz_333_;
-      _zz_532_[23 : 23] = _zz_317_;
-      _zz_532_[15 : 15] = _zz_301_;
-      _zz_532_[7 : 7] = _zz_285_;
-      _zz_532_[28 : 27] = _zz_334_;
-      _zz_532_[26 : 26] = _zz_332_;
-      _zz_532_[25 : 25] = _zz_331_;
-      _zz_532_[24 : 24] = _zz_330_;
-      _zz_532_[20 : 19] = _zz_318_;
-      _zz_532_[18 : 18] = _zz_316_;
-      _zz_532_[17 : 17] = _zz_315_;
-      _zz_532_[16 : 16] = _zz_314_;
-      _zz_532_[12 : 11] = _zz_302_;
-      _zz_532_[10 : 10] = _zz_300_;
-      _zz_532_[9 : 9] = _zz_299_;
-      _zz_532_[8 : 8] = _zz_298_;
-      _zz_532_[4 : 3] = _zz_286_;
-      _zz_532_[2 : 2] = _zz_284_;
-      _zz_532_[1 : 1] = _zz_283_;
-      _zz_532_[0 : 0] = _zz_282_;
+      _zz_593[31 : 31] = _zz_375;
+      _zz_593[23 : 23] = _zz_356;
+      _zz_593[15 : 15] = _zz_337;
+      _zz_593[7 : 7] = _zz_318;
+      _zz_593[28 : 27] = _zz_376;
+      _zz_593[26 : 26] = _zz_374;
+      _zz_593[25 : 25] = _zz_373;
+      _zz_593[24 : 24] = _zz_372;
+      _zz_593[20 : 19] = _zz_357;
+      _zz_593[18 : 18] = _zz_355;
+      _zz_593[17 : 17] = _zz_354;
+      _zz_593[16 : 16] = _zz_353;
+      _zz_593[12 : 11] = _zz_338;
+      _zz_593[10 : 10] = _zz_336;
+      _zz_593[9 : 9] = _zz_335;
+      _zz_593[8 : 8] = _zz_334;
+      _zz_593[4 : 3] = _zz_319;
+      _zz_593[2 : 2] = _zz_317;
+      _zz_593[1 : 1] = _zz_316;
+      _zz_593[0 : 0] = _zz_315;
     end
   end
 
   always @ (*) begin
-    _zz_533_ = 32'h0;
+    _zz_594 = 32'h0;
     if(execute_CsrPlugin_csr_3857)begin
-      _zz_533_[0 : 0] = (1'b1);
+      _zz_594[0 : 0] = 1'b1;
     end
   end
 
   always @ (*) begin
-    _zz_534_ = 32'h0;
+    _zz_595 = 32'h0;
     if(execute_CsrPlugin_csr_3858)begin
-      _zz_534_[1 : 0] = (2'b10);
+      _zz_595[1 : 0] = 2'b10;
     end
   end
 
   always @ (*) begin
-    _zz_535_ = 32'h0;
+    _zz_596 = 32'h0;
     if(execute_CsrPlugin_csr_3859)begin
-      _zz_535_[1 : 0] = (2'b11);
+      _zz_596[1 : 0] = 2'b11;
     end
   end
 
   always @ (*) begin
-    _zz_536_ = 32'h0;
+    _zz_597 = 32'h0;
     if(execute_CsrPlugin_csr_769)begin
-      _zz_536_[31 : 30] = CsrPlugin_misa_base;
-      _zz_536_[25 : 0] = CsrPlugin_misa_extensions;
+      _zz_597[31 : 30] = CsrPlugin_misa_base;
+      _zz_597[25 : 0] = CsrPlugin_misa_extensions;
     end
   end
 
   always @ (*) begin
-    _zz_537_ = 32'h0;
+    _zz_598 = 32'h0;
     if(execute_CsrPlugin_csr_768)begin
-      _zz_537_[12 : 11] = CsrPlugin_mstatus_MPP;
-      _zz_537_[7 : 7] = CsrPlugin_mstatus_MPIE;
-      _zz_537_[3 : 3] = CsrPlugin_mstatus_MIE;
+      _zz_598[12 : 11] = CsrPlugin_mstatus_MPP;
+      _zz_598[7 : 7] = CsrPlugin_mstatus_MPIE;
+      _zz_598[3 : 3] = CsrPlugin_mstatus_MIE;
     end
   end
 
   always @ (*) begin
-    _zz_538_ = 32'h0;
+    _zz_599 = 32'h0;
     if(execute_CsrPlugin_csr_836)begin
-      _zz_538_[11 : 11] = CsrPlugin_mip_MEIP;
-      _zz_538_[7 : 7] = CsrPlugin_mip_MTIP;
-      _zz_538_[3 : 3] = CsrPlugin_mip_MSIP;
+      _zz_599[11 : 11] = CsrPlugin_mip_MEIP;
+      _zz_599[7 : 7] = CsrPlugin_mip_MTIP;
+      _zz_599[3 : 3] = CsrPlugin_mip_MSIP;
     end
   end
 
   always @ (*) begin
-    _zz_539_ = 32'h0;
+    _zz_600 = 32'h0;
     if(execute_CsrPlugin_csr_772)begin
-      _zz_539_[11 : 11] = CsrPlugin_mie_MEIE;
-      _zz_539_[7 : 7] = CsrPlugin_mie_MTIE;
-      _zz_539_[3 : 3] = CsrPlugin_mie_MSIE;
+      _zz_600[11 : 11] = CsrPlugin_mie_MEIE;
+      _zz_600[7 : 7] = CsrPlugin_mie_MTIE;
+      _zz_600[3 : 3] = CsrPlugin_mie_MSIE;
     end
   end
 
   always @ (*) begin
-    _zz_540_ = 32'h0;
+    _zz_601 = 32'h0;
     if(execute_CsrPlugin_csr_773)begin
-      _zz_540_[31 : 2] = CsrPlugin_mtvec_base;
-      _zz_540_[1 : 0] = CsrPlugin_mtvec_mode;
+      _zz_601[31 : 2] = CsrPlugin_mtvec_base;
+      _zz_601[1 : 0] = CsrPlugin_mtvec_mode;
     end
   end
 
   always @ (*) begin
-    _zz_541_ = 32'h0;
+    _zz_602 = 32'h0;
     if(execute_CsrPlugin_csr_833)begin
-      _zz_541_[31 : 0] = CsrPlugin_mepc;
+      _zz_602[31 : 0] = CsrPlugin_mepc;
     end
   end
 
   always @ (*) begin
-    _zz_542_ = 32'h0;
+    _zz_603 = 32'h0;
     if(execute_CsrPlugin_csr_832)begin
-      _zz_542_[31 : 0] = CsrPlugin_mscratch;
+      _zz_603[31 : 0] = CsrPlugin_mscratch;
     end
   end
 
   always @ (*) begin
-    _zz_543_ = 32'h0;
+    _zz_604 = 32'h0;
     if(execute_CsrPlugin_csr_834)begin
-      _zz_543_[31 : 31] = CsrPlugin_mcause_interrupt;
-      _zz_543_[3 : 0] = CsrPlugin_mcause_exceptionCode;
+      _zz_604[31 : 31] = CsrPlugin_mcause_interrupt;
+      _zz_604[3 : 0] = CsrPlugin_mcause_exceptionCode;
     end
   end
 
   always @ (*) begin
-    _zz_544_ = 32'h0;
+    _zz_605 = 32'h0;
     if(execute_CsrPlugin_csr_835)begin
-      _zz_544_[31 : 0] = CsrPlugin_mtval;
+      _zz_605[31 : 0] = CsrPlugin_mtval;
     end
   end
 
   always @ (*) begin
-    _zz_545_ = 32'h0;
+    _zz_606 = 32'h0;
     if(execute_CsrPlugin_csr_2816)begin
-      _zz_545_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_606[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_546_ = 32'h0;
+    _zz_607 = 32'h0;
     if(execute_CsrPlugin_csr_2944)begin
-      _zz_546_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_607[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_547_ = 32'h0;
+    _zz_608 = 32'h0;
     if(execute_CsrPlugin_csr_2818)begin
-      _zz_547_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_608[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_548_ = 32'h0;
+    _zz_609 = 32'h0;
     if(execute_CsrPlugin_csr_2946)begin
-      _zz_548_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_609[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_549_ = 32'h0;
+    _zz_610 = 32'h0;
     if(execute_CsrPlugin_csr_3072)begin
-      _zz_549_[31 : 0] = CsrPlugin_mcycle[31 : 0];
+      _zz_610[31 : 0] = CsrPlugin_mcycle[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_550_ = 32'h0;
+    _zz_611 = 32'h0;
     if(execute_CsrPlugin_csr_3200)begin
-      _zz_550_[31 : 0] = CsrPlugin_mcycle[63 : 32];
+      _zz_611[31 : 0] = CsrPlugin_mcycle[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_551_ = 32'h0;
+    _zz_612 = 32'h0;
     if(execute_CsrPlugin_csr_3074)begin
-      _zz_551_[31 : 0] = CsrPlugin_minstret[31 : 0];
+      _zz_612[31 : 0] = CsrPlugin_minstret[31 : 0];
     end
   end
 
   always @ (*) begin
-    _zz_552_ = 32'h0;
+    _zz_613 = 32'h0;
     if(execute_CsrPlugin_csr_3202)begin
-      _zz_552_[31 : 0] = CsrPlugin_minstret[63 : 32];
+      _zz_613[31 : 0] = CsrPlugin_minstret[63 : 32];
     end
   end
 
   always @ (*) begin
-    _zz_553_ = 32'h0;
+    _zz_614 = 32'h0;
     if(execute_CsrPlugin_csr_3008)begin
-      _zz_553_[31 : 0] = _zz_508_;
+      _zz_614[31 : 0] = _zz_569;
     end
   end
 
   always @ (*) begin
-    _zz_554_ = 32'h0;
+    _zz_615 = 32'h0;
     if(execute_CsrPlugin_csr_4032)begin
-      _zz_554_[31 : 0] = _zz_509_;
+      _zz_615[31 : 0] = _zz_570;
     end
   end
 
-  assign execute_CsrPlugin_readData = (((((_zz_1072_ | _zz_1073_) | (_zz_1074_ | _zz_1075_)) | ((_zz_1076_ | _zz_1077_) | (_zz_1078_ | _zz_1079_))) | (((_zz_1080_ | _zz_1081_) | (_zz_1082_ | _zz_1083_)) | ((_zz_1084_ | _zz_1085_) | (_zz_1086_ | _zz_1087_)))) | ((((_zz_543_ | _zz_544_) | (_zz_545_ | _zz_546_)) | ((_zz_547_ | _zz_548_) | (_zz_549_ | _zz_550_))) | ((_zz_551_ | _zz_552_) | (_zz_553_ | _zz_554_))));
-  assign iBusWishbone_ADR = {_zz_861_,_zz_555_};
-  assign iBusWishbone_CTI = ((_zz_555_ == (3'b111)) ? (3'b111) : (3'b010));
-  assign iBusWishbone_BTE = (2'b00);
-  assign iBusWishbone_SEL = (4'b1111);
+  assign execute_CsrPlugin_readData = (((((_zz_1178 | _zz_1179) | (_zz_1180 | _zz_1181)) | ((_zz_1182 | _zz_1183) | (_zz_1184 | _zz_1185))) | (((_zz_1186 | _zz_1187) | (_zz_1188 | _zz_1189)) | ((_zz_1190 | _zz_1191) | (_zz_1192 | _zz_1193)))) | ((((_zz_604 | _zz_605) | (_zz_606 | _zz_607)) | ((_zz_608 | _zz_609) | (_zz_610 | _zz_611))) | ((_zz_612 | _zz_613) | (_zz_614 | _zz_615))));
+  assign iBusWishbone_ADR = {_zz_958,_zz_616};
+  assign iBusWishbone_CTI = ((_zz_616 == 3'b111) ? 3'b111 : 3'b010);
+  assign iBusWishbone_BTE = 2'b00;
+  assign iBusWishbone_SEL = 4'b1111;
   assign iBusWishbone_WE = 1'b0;
   assign iBusWishbone_DAT_MOSI = 32'h0;
   always @ (*) begin
     iBusWishbone_CYC = 1'b0;
-    if(_zz_625_)begin
+    if(_zz_708)begin
       iBusWishbone_CYC = 1'b1;
     end
   end
 
   always @ (*) begin
     iBusWishbone_STB = 1'b0;
-    if(_zz_625_)begin
+    if(_zz_708)begin
       iBusWishbone_STB = 1'b1;
     end
   end
 
   assign iBus_cmd_ready = (iBus_cmd_valid && iBusWishbone_ACK);
-  assign iBus_rsp_valid = _zz_556_;
+  assign iBus_rsp_valid = _zz_617;
   assign iBus_rsp_payload_data = iBusWishbone_DAT_MISO_regNext;
   assign iBus_rsp_payload_error = 1'b0;
-  assign _zz_562_ = (dBus_cmd_payload_length != (3'b000));
-  assign _zz_558_ = dBus_cmd_valid;
-  assign _zz_560_ = dBus_cmd_payload_wr;
-  assign _zz_561_ = (_zz_557_ == dBus_cmd_payload_length);
-  assign dBus_cmd_ready = (_zz_559_ && (_zz_560_ || _zz_561_));
-  assign dBusWishbone_ADR = ((_zz_562_ ? {{dBus_cmd_payload_address[31 : 5],_zz_557_},(2'b00)} : {dBus_cmd_payload_address[31 : 2],(2'b00)}) >>> 2);
-  assign dBusWishbone_CTI = (_zz_562_ ? (_zz_561_ ? (3'b111) : (3'b010)) : (3'b000));
-  assign dBusWishbone_BTE = (2'b00);
-  assign dBusWishbone_SEL = (_zz_560_ ? dBus_cmd_payload_mask : (4'b1111));
-  assign dBusWishbone_WE = _zz_560_;
+  assign _zz_623 = (dBus_cmd_payload_length != 3'b000);
+  assign _zz_619 = dBus_cmd_valid;
+  assign _zz_621 = dBus_cmd_payload_wr;
+  assign _zz_622 = (_zz_618 == dBus_cmd_payload_length);
+  assign dBus_cmd_ready = (_zz_620 && (_zz_621 || _zz_622));
+  assign dBusWishbone_ADR = ((_zz_623 ? {{dBus_cmd_payload_address[31 : 5],_zz_618},2'b00} : {dBus_cmd_payload_address[31 : 2],2'b00}) >>> 2);
+  assign dBusWishbone_CTI = (_zz_623 ? (_zz_622 ? 3'b111 : 3'b010) : 3'b000);
+  assign dBusWishbone_BTE = 2'b00;
+  assign dBusWishbone_SEL = (_zz_621 ? dBus_cmd_payload_mask : 4'b1111);
+  assign dBusWishbone_WE = _zz_621;
   assign dBusWishbone_DAT_MOSI = dBus_cmd_payload_data;
-  assign _zz_559_ = (_zz_558_ && dBusWishbone_ACK);
-  assign dBusWishbone_CYC = _zz_558_;
-  assign dBusWishbone_STB = _zz_558_;
-  assign dBus_rsp_valid = _zz_563_;
+  assign _zz_620 = (_zz_619 && dBusWishbone_ACK);
+  assign dBusWishbone_CYC = _zz_619;
+  assign dBusWishbone_STB = _zz_619;
+  assign dBus_rsp_valid = _zz_624;
   assign dBus_rsp_payload_data = dBusWishbone_DAT_MISO_regNext;
   assign dBus_rsp_payload_error = 1'b0;
   always @ (posedge clk) begin
@@ -7568,91 +8472,59 @@ module VexRiscv (
       IBusCachedPlugin_fetchPc_correctionReg <= 1'b0;
       IBusCachedPlugin_fetchPc_booted <= 1'b0;
       IBusCachedPlugin_fetchPc_inc <= 1'b0;
-      _zz_68_ <= 1'b0;
-      _zz_70_ <= 1'b0;
+      _zz_65 <= 1'b0;
+      _zz_67 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_1 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_2 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_3 <= 1'b0;
       IBusCachedPlugin_injector_nextPcCalc_valids_4 <= 1'b0;
-      IBusCachedPlugin_rspCounter <= _zz_83_;
+      IBusCachedPlugin_rspCounter <= _zz_80;
       IBusCachedPlugin_rspCounter <= 32'h0;
-      dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
-      DBusCachedPlugin_rspCounter <= _zz_84_;
+      dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= 1'b0;
+      DBusCachedPlugin_rspCounter <= _zz_81;
       DBusCachedPlugin_rspCounter <= 32'h0;
-      _zz_93_ <= 1'b0;
-      _zz_94_ <= (2'b00);
-      _zz_99_ <= 1'b0;
-      _zz_100_ <= 1'b0;
-      _zz_109_ <= 1'b0;
-      _zz_110_ <= (2'b00);
-      _zz_115_ <= 1'b0;
-      _zz_116_ <= 1'b0;
-      _zz_125_ <= 1'b0;
-      _zz_126_ <= (2'b00);
-      _zz_131_ <= 1'b0;
-      _zz_132_ <= 1'b0;
-      _zz_141_ <= 1'b0;
-      _zz_142_ <= (2'b00);
-      _zz_147_ <= 1'b0;
-      _zz_148_ <= 1'b0;
-      _zz_157_ <= 1'b0;
-      _zz_158_ <= (2'b00);
-      _zz_163_ <= 1'b0;
-      _zz_164_ <= 1'b0;
-      _zz_173_ <= 1'b0;
-      _zz_174_ <= (2'b00);
-      _zz_179_ <= 1'b0;
-      _zz_180_ <= 1'b0;
-      _zz_189_ <= 1'b0;
-      _zz_190_ <= (2'b00);
-      _zz_195_ <= 1'b0;
-      _zz_196_ <= 1'b0;
-      _zz_205_ <= 1'b0;
-      _zz_206_ <= (2'b00);
-      _zz_211_ <= 1'b0;
-      _zz_212_ <= 1'b0;
-      _zz_221_ <= 1'b0;
-      _zz_222_ <= (2'b00);
-      _zz_227_ <= 1'b0;
-      _zz_228_ <= 1'b0;
-      _zz_237_ <= 1'b0;
-      _zz_238_ <= (2'b00);
-      _zz_243_ <= 1'b0;
-      _zz_244_ <= 1'b0;
-      _zz_253_ <= 1'b0;
-      _zz_254_ <= (2'b00);
-      _zz_259_ <= 1'b0;
-      _zz_260_ <= 1'b0;
-      _zz_269_ <= 1'b0;
-      _zz_270_ <= (2'b00);
-      _zz_275_ <= 1'b0;
-      _zz_276_ <= 1'b0;
-      _zz_285_ <= 1'b0;
-      _zz_286_ <= (2'b00);
-      _zz_291_ <= 1'b0;
-      _zz_292_ <= 1'b0;
-      _zz_301_ <= 1'b0;
-      _zz_302_ <= (2'b00);
-      _zz_307_ <= 1'b0;
-      _zz_308_ <= 1'b0;
-      _zz_317_ <= 1'b0;
-      _zz_318_ <= (2'b00);
-      _zz_323_ <= 1'b0;
-      _zz_324_ <= 1'b0;
-      _zz_333_ <= 1'b0;
-      _zz_334_ <= (2'b00);
-      _zz_339_ <= 1'b0;
-      _zz_340_ <= 1'b0;
-      _zz_460_ <= 1'b1;
-      _zz_472_ <= 1'b0;
-      _zz_497_ <= (2'b11);
-      CsrPlugin_misa_base <= (2'b01);
+      _zz_90 <= 1'b0;
+      _zz_91 <= 2'b00;
+      _zz_109 <= 1'b0;
+      _zz_110 <= 2'b00;
+      _zz_128 <= 1'b0;
+      _zz_129 <= 2'b00;
+      _zz_147 <= 1'b0;
+      _zz_148 <= 2'b00;
+      _zz_166 <= 1'b0;
+      _zz_167 <= 2'b00;
+      _zz_185 <= 1'b0;
+      _zz_186 <= 2'b00;
+      _zz_204 <= 1'b0;
+      _zz_205 <= 2'b00;
+      _zz_223 <= 1'b0;
+      _zz_224 <= 2'b00;
+      _zz_242 <= 1'b0;
+      _zz_243 <= 2'b00;
+      _zz_261 <= 1'b0;
+      _zz_262 <= 2'b00;
+      _zz_280 <= 1'b0;
+      _zz_281 <= 2'b00;
+      _zz_299 <= 1'b0;
+      _zz_300 <= 2'b00;
+      _zz_318 <= 1'b0;
+      _zz_319 <= 2'b00;
+      _zz_337 <= 1'b0;
+      _zz_338 <= 2'b00;
+      _zz_356 <= 1'b0;
+      _zz_357 <= 2'b00;
+      _zz_375 <= 1'b0;
+      _zz_376 <= 2'b00;
+      _zz_521 <= 1'b1;
+      _zz_533 <= 1'b0;
+      _zz_558 <= 2'b11;
+      CsrPlugin_misa_base <= 2'b01;
       CsrPlugin_misa_extensions <= 26'h0101064;
       CsrPlugin_mstatus_MIE <= 1'b0;
       CsrPlugin_mstatus_MPIE <= 1'b0;
-      CsrPlugin_mstatus_MPP <= (2'b11);
+      CsrPlugin_mstatus_MPP <= 2'b11;
       CsrPlugin_mie_MEIE <= 1'b0;
       CsrPlugin_mie_MTIE <= 1'b0;
       CsrPlugin_mie_MSIE <= 1'b0;
@@ -7668,17 +8540,15 @@ module VexRiscv (
       CsrPlugin_hadException <= 1'b0;
       execute_CsrPlugin_wfiWake <= 1'b0;
       memory_DivPlugin_div_counter_value <= 6'h0;
-      _zz_508_ <= 32'h0;
+      _zz_569 <= 32'h0;
       execute_arbitration_isValid <= 1'b0;
       memory_arbitration_isValid <= 1'b0;
       writeBack_arbitration_isValid <= 1'b0;
-      _zz_511_ <= (3'b000);
-      memory_to_writeBack_REGFILE_WRITE_DATA <= 32'h0;
-      memory_to_writeBack_INSTRUCTION <= 32'h0;
-      _zz_555_ <= (3'b000);
-      _zz_556_ <= 1'b0;
-      _zz_557_ <= (3'b000);
-      _zz_563_ <= 1'b0;
+      _zz_572 <= 3'b000;
+      _zz_616 <= 3'b000;
+      _zz_617 <= 1'b0;
+      _zz_618 <= 3'b000;
+      _zz_624 <= 1'b0;
     end else begin
       if(IBusCachedPlugin_fetchPc_correction)begin
         IBusCachedPlugin_fetchPc_correctionReg <= 1'b1;
@@ -7700,16 +8570,16 @@ module VexRiscv (
         IBusCachedPlugin_fetchPc_pcReg <= IBusCachedPlugin_fetchPc_pc;
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_68_ <= 1'b0;
+        _zz_65 <= 1'b0;
       end
-      if(_zz_66_)begin
-        _zz_68_ <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
+      if(_zz_63)begin
+        _zz_65 <= (IBusCachedPlugin_iBusRsp_stages_0_output_valid && (! 1'b0));
       end
       if(IBusCachedPlugin_iBusRsp_flush)begin
-        _zz_70_ <= 1'b0;
+        _zz_67 <= 1'b0;
       end
       if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-        _zz_70_ <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
+        _zz_67 <= (IBusCachedPlugin_iBusRsp_stages_1_output_valid && (! IBusCachedPlugin_iBusRsp_flush));
       end
       if(IBusCachedPlugin_fetchPc_flushed)begin
         IBusCachedPlugin_injector_nextPcCalc_valids_0 <= 1'b0;
@@ -7756,260 +8626,84 @@ module VexRiscv (
       if(iBus_rsp_valid)begin
         IBusCachedPlugin_rspCounter <= (IBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= 1'b0;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= 1'b0;
       end
-      if(_zz_626_)begin
-        dataCache_1__io_mem_cmd_s2mPipe_rValid <= dataCache_1__io_mem_cmd_valid;
+      if(_zz_709)begin
+        dataCache_1_io_mem_cmd_s2mPipe_rValid <= dataCache_1_io_mem_cmd_valid;
       end
-      if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-        dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1__io_mem_cmd_s2mPipe_valid;
+      if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+        dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rValid <= dataCache_1_io_mem_cmd_s2mPipe_valid;
       end
       if(dBus_rsp_valid)begin
         DBusCachedPlugin_rspCounter <= (DBusCachedPlugin_rspCounter + 32'h00000001);
       end
-      if(_zz_627_)begin
-        _zz_99_ <= _zz_93_;
-        _zz_100_ <= 1'b1;
-        case(_zz_94_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_100_ <= 1'b0;
-          end
-        endcase
+      if(_zz_710)begin
+        _zz_90 <= _zz_96;
+        _zz_91 <= _zz_97;
       end
-      if(_zz_628_)begin
-        _zz_115_ <= _zz_109_;
-        _zz_116_ <= 1'b1;
-        case(_zz_110_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_116_ <= 1'b0;
-          end
-        endcase
+      if(_zz_711)begin
+        _zz_109 <= _zz_115;
+        _zz_110 <= _zz_116;
       end
-      if(_zz_629_)begin
-        _zz_131_ <= _zz_125_;
-        _zz_132_ <= 1'b1;
-        case(_zz_126_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_132_ <= 1'b0;
-          end
-        endcase
+      if(_zz_712)begin
+        _zz_128 <= _zz_134;
+        _zz_129 <= _zz_135;
       end
-      if(_zz_630_)begin
-        _zz_147_ <= _zz_141_;
-        _zz_148_ <= 1'b1;
-        case(_zz_142_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_148_ <= 1'b0;
-          end
-        endcase
+      if(_zz_713)begin
+        _zz_147 <= _zz_153;
+        _zz_148 <= _zz_154;
       end
-      if(_zz_631_)begin
-        _zz_163_ <= _zz_157_;
-        _zz_164_ <= 1'b1;
-        case(_zz_158_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_164_ <= 1'b0;
-          end
-        endcase
+      if(_zz_714)begin
+        _zz_166 <= _zz_172;
+        _zz_167 <= _zz_173;
       end
-      if(_zz_632_)begin
-        _zz_179_ <= _zz_173_;
-        _zz_180_ <= 1'b1;
-        case(_zz_174_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_180_ <= 1'b0;
-          end
-        endcase
+      if(_zz_715)begin
+        _zz_185 <= _zz_191;
+        _zz_186 <= _zz_192;
       end
-      if(_zz_633_)begin
-        _zz_195_ <= _zz_189_;
-        _zz_196_ <= 1'b1;
-        case(_zz_190_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_196_ <= 1'b0;
-          end
-        endcase
+      if(_zz_716)begin
+        _zz_204 <= _zz_210;
+        _zz_205 <= _zz_211;
       end
-      if(_zz_634_)begin
-        _zz_211_ <= _zz_205_;
-        _zz_212_ <= 1'b1;
-        case(_zz_206_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_212_ <= 1'b0;
-          end
-        endcase
+      if(_zz_717)begin
+        _zz_223 <= _zz_229;
+        _zz_224 <= _zz_230;
       end
-      if(_zz_635_)begin
-        _zz_227_ <= _zz_221_;
-        _zz_228_ <= 1'b1;
-        case(_zz_222_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_228_ <= 1'b0;
-          end
-        endcase
+      if(_zz_718)begin
+        _zz_242 <= _zz_248;
+        _zz_243 <= _zz_249;
       end
-      if(_zz_636_)begin
-        _zz_243_ <= _zz_237_;
-        _zz_244_ <= 1'b1;
-        case(_zz_238_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_244_ <= 1'b0;
-          end
-        endcase
+      if(_zz_719)begin
+        _zz_261 <= _zz_267;
+        _zz_262 <= _zz_268;
       end
-      if(_zz_637_)begin
-        _zz_259_ <= _zz_253_;
-        _zz_260_ <= 1'b1;
-        case(_zz_254_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_260_ <= 1'b0;
-          end
-        endcase
+      if(_zz_720)begin
+        _zz_280 <= _zz_286;
+        _zz_281 <= _zz_287;
       end
-      if(_zz_638_)begin
-        _zz_275_ <= _zz_269_;
-        _zz_276_ <= 1'b1;
-        case(_zz_270_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_276_ <= 1'b0;
-          end
-        endcase
+      if(_zz_721)begin
+        _zz_299 <= _zz_305;
+        _zz_300 <= _zz_306;
       end
-      if(_zz_639_)begin
-        _zz_291_ <= _zz_285_;
-        _zz_292_ <= 1'b1;
-        case(_zz_286_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_292_ <= 1'b0;
-          end
-        endcase
+      if(_zz_722)begin
+        _zz_318 <= _zz_324;
+        _zz_319 <= _zz_325;
       end
-      if(_zz_640_)begin
-        _zz_307_ <= _zz_301_;
-        _zz_308_ <= 1'b1;
-        case(_zz_302_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_308_ <= 1'b0;
-          end
-        endcase
+      if(_zz_723)begin
+        _zz_337 <= _zz_343;
+        _zz_338 <= _zz_344;
       end
-      if(_zz_641_)begin
-        _zz_323_ <= _zz_317_;
-        _zz_324_ <= 1'b1;
-        case(_zz_318_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_324_ <= 1'b0;
-          end
-        endcase
+      if(_zz_724)begin
+        _zz_356 <= _zz_362;
+        _zz_357 <= _zz_363;
       end
-      if(_zz_642_)begin
-        _zz_339_ <= _zz_333_;
-        _zz_340_ <= 1'b1;
-        case(_zz_334_)
-          2'b01 : begin
-          end
-          2'b10 : begin
-          end
-          2'b11 : begin
-          end
-          default : begin
-            _zz_340_ <= 1'b0;
-          end
-        endcase
+      if(_zz_725)begin
+        _zz_375 <= _zz_381;
+        _zz_376 <= _zz_382;
       end
-      _zz_460_ <= 1'b0;
-      _zz_472_ <= (_zz_41_ && writeBack_arbitration_isFiring);
+      _zz_521 <= 1'b0;
+      _zz_533 <= (_zz_41 && writeBack_arbitration_isFiring);
       if((! decode_arbitration_isStuck))begin
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_decode <= 1'b0;
       end else begin
@@ -8031,14 +8725,14 @@ module VexRiscv (
         CsrPlugin_exceptionPortCtrl_exceptionValidsRegs_writeBack <= 1'b0;
       end
       CsrPlugin_interrupt_valid <= 1'b0;
-      if(_zz_643_)begin
-        if(_zz_644_)begin
+      if(_zz_726)begin
+        if(_zz_727)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_645_)begin
+        if(_zz_728)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
-        if(_zz_646_)begin
+        if(_zz_729)begin
           CsrPlugin_interrupt_valid <= 1'b1;
         end
       end
@@ -8063,8 +8757,8 @@ module VexRiscv (
         CsrPlugin_interrupt_valid <= 1'b0;
       end
       CsrPlugin_hadException <= CsrPlugin_exception;
-      if(_zz_605_)begin
-        _zz_497_ <= CsrPlugin_targetPrivilege;
+      if(_zz_688)begin
+        _zz_558 <= CsrPlugin_targetPrivilege;
         case(CsrPlugin_targetPrivilege)
           2'b11 : begin
             CsrPlugin_mstatus_MIE <= 1'b0;
@@ -8075,26 +8769,20 @@ module VexRiscv (
           end
         endcase
       end
-      if(_zz_606_)begin
-        case(_zz_608_)
+      if(_zz_689)begin
+        case(_zz_691)
           2'b11 : begin
-            CsrPlugin_mstatus_MPP <= (2'b00);
+            CsrPlugin_mstatus_MPP <= 2'b00;
             CsrPlugin_mstatus_MIE <= CsrPlugin_mstatus_MPIE;
             CsrPlugin_mstatus_MPIE <= 1'b1;
-            _zz_497_ <= CsrPlugin_mstatus_MPP;
+            _zz_558 <= CsrPlugin_mstatus_MPP;
           end
           default : begin
           end
         endcase
       end
-      execute_CsrPlugin_wfiWake <= (({_zz_500_,{_zz_499_,_zz_498_}} != (3'b000)) || CsrPlugin_thirdPartyWake);
+      execute_CsrPlugin_wfiWake <= (({_zz_561,{_zz_560,_zz_559}} != 3'b000) || CsrPlugin_thirdPartyWake);
       memory_DivPlugin_div_counter_value <= memory_DivPlugin_div_counter_valueNext;
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32_;
-      end
-      if((! writeBack_arbitration_isStuck))begin
-        memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
-      end
       if(((! execute_arbitration_isStuck) || execute_arbitration_removeIt))begin
         execute_arbitration_isValid <= 1'b0;
       end
@@ -8113,77 +8801,29 @@ module VexRiscv (
       if(((! memory_arbitration_isStuck) && (! memory_arbitration_removeIt)))begin
         writeBack_arbitration_isValid <= memory_arbitration_isValid;
       end
-      case(_zz_511_)
+      case(_zz_572)
         3'b000 : begin
           if(IBusCachedPlugin_injectionPort_valid)begin
-            _zz_511_ <= (3'b001);
+            _zz_572 <= 3'b001;
           end
         end
         3'b001 : begin
-          _zz_511_ <= (3'b010);
+          _zz_572 <= 3'b010;
         end
         3'b010 : begin
-          _zz_511_ <= (3'b011);
+          _zz_572 <= 3'b011;
         end
         3'b011 : begin
           if((! decode_arbitration_isStuck))begin
-            _zz_511_ <= (3'b100);
+            _zz_572 <= 3'b100;
           end
         end
         3'b100 : begin
-          _zz_511_ <= (3'b000);
+          _zz_572 <= 3'b000;
         end
         default : begin
         end
       endcase
-      if(execute_CsrPlugin_csr_928)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_141_ <= _zz_790_[0];
-          _zz_125_ <= _zz_791_[0];
-          _zz_109_ <= _zz_792_[0];
-          _zz_93_ <= _zz_793_[0];
-          _zz_142_ <= execute_CsrPlugin_writeData[28 : 27];
-          _zz_126_ <= execute_CsrPlugin_writeData[20 : 19];
-          _zz_110_ <= execute_CsrPlugin_writeData[12 : 11];
-          _zz_94_ <= execute_CsrPlugin_writeData[4 : 3];
-        end
-      end
-      if(execute_CsrPlugin_csr_929)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_205_ <= _zz_806_[0];
-          _zz_189_ <= _zz_807_[0];
-          _zz_173_ <= _zz_808_[0];
-          _zz_157_ <= _zz_809_[0];
-          _zz_206_ <= execute_CsrPlugin_writeData[28 : 27];
-          _zz_190_ <= execute_CsrPlugin_writeData[20 : 19];
-          _zz_174_ <= execute_CsrPlugin_writeData[12 : 11];
-          _zz_158_ <= execute_CsrPlugin_writeData[4 : 3];
-        end
-      end
-      if(execute_CsrPlugin_csr_930)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_269_ <= _zz_822_[0];
-          _zz_253_ <= _zz_823_[0];
-          _zz_237_ <= _zz_824_[0];
-          _zz_221_ <= _zz_825_[0];
-          _zz_270_ <= execute_CsrPlugin_writeData[28 : 27];
-          _zz_254_ <= execute_CsrPlugin_writeData[20 : 19];
-          _zz_238_ <= execute_CsrPlugin_writeData[12 : 11];
-          _zz_222_ <= execute_CsrPlugin_writeData[4 : 3];
-        end
-      end
-      if(execute_CsrPlugin_csr_931)begin
-        if(execute_CsrPlugin_writeEnable)begin
-          _zz_333_ <= _zz_838_[0];
-          _zz_317_ <= _zz_839_[0];
-          _zz_301_ <= _zz_840_[0];
-          _zz_285_ <= _zz_841_[0];
-          _zz_334_ <= execute_CsrPlugin_writeData[28 : 27];
-          _zz_318_ <= execute_CsrPlugin_writeData[20 : 19];
-          _zz_302_ <= execute_CsrPlugin_writeData[12 : 11];
-          _zz_286_ <= execute_CsrPlugin_writeData[4 : 3];
-        end
-      end
       if(execute_CsrPlugin_csr_769)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_misa_base <= execute_CsrPlugin_writeData[31 : 30];
@@ -8193,41 +8833,41 @@ module VexRiscv (
       if(execute_CsrPlugin_csr_768)begin
         if(execute_CsrPlugin_writeEnable)begin
           CsrPlugin_mstatus_MPP <= execute_CsrPlugin_writeData[12 : 11];
-          CsrPlugin_mstatus_MPIE <= _zz_854_[0];
-          CsrPlugin_mstatus_MIE <= _zz_855_[0];
+          CsrPlugin_mstatus_MPIE <= _zz_951[0];
+          CsrPlugin_mstatus_MIE <= _zz_952[0];
         end
       end
       if(execute_CsrPlugin_csr_772)begin
         if(execute_CsrPlugin_writeEnable)begin
-          CsrPlugin_mie_MEIE <= _zz_857_[0];
-          CsrPlugin_mie_MTIE <= _zz_858_[0];
-          CsrPlugin_mie_MSIE <= _zz_859_[0];
+          CsrPlugin_mie_MEIE <= _zz_954[0];
+          CsrPlugin_mie_MTIE <= _zz_955[0];
+          CsrPlugin_mie_MSIE <= _zz_956[0];
         end
       end
       if(execute_CsrPlugin_csr_3008)begin
         if(execute_CsrPlugin_writeEnable)begin
-          _zz_508_ <= execute_CsrPlugin_writeData[31 : 0];
+          _zz_569 <= execute_CsrPlugin_writeData[31 : 0];
         end
       end
-      if(_zz_625_)begin
+      if(_zz_708)begin
         if(iBusWishbone_ACK)begin
-          _zz_555_ <= (_zz_555_ + (3'b001));
+          _zz_616 <= (_zz_616 + 3'b001);
         end
       end
-      _zz_556_ <= (iBusWishbone_CYC && iBusWishbone_ACK);
-      if((_zz_558_ && _zz_559_))begin
-        _zz_557_ <= (_zz_557_ + (3'b001));
-        if(_zz_561_)begin
-          _zz_557_ <= (3'b000);
+      _zz_617 <= (iBusWishbone_CYC && iBusWishbone_ACK);
+      if((_zz_619 && _zz_620))begin
+        _zz_618 <= (_zz_618 + 3'b001);
+        if(_zz_622)begin
+          _zz_618 <= 3'b000;
         end
       end
-      _zz_563_ <= ((_zz_558_ && (! dBusWishbone_WE)) && dBusWishbone_ACK);
+      _zz_624 <= ((_zz_619 && (! dBusWishbone_WE)) && dBusWishbone_ACK);
     end
   end
 
   always @ (posedge clk) begin
     if(IBusCachedPlugin_iBusRsp_stages_1_output_ready)begin
-      _zz_71_ <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
+      _zz_68 <= IBusCachedPlugin_iBusRsp_stages_1_output_payload;
     end
     if(IBusCachedPlugin_iBusRsp_stages_1_input_ready)begin
       IBusCachedPlugin_s1_tightlyCoupledHit <= IBusCachedPlugin_s0_tightlyCoupledHit;
@@ -8235,376 +8875,122 @@ module VexRiscv (
     if(IBusCachedPlugin_iBusRsp_stages_2_input_ready)begin
       IBusCachedPlugin_s2_tightlyCoupledHit <= IBusCachedPlugin_s1_tightlyCoupledHit;
     end
-    if(_zz_626_)begin
-      dataCache_1__io_mem_cmd_s2mPipe_rData_wr <= dataCache_1__io_mem_cmd_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_address <= dataCache_1__io_mem_cmd_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_data <= dataCache_1__io_mem_cmd_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_mask <= dataCache_1__io_mem_cmd_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_length <= dataCache_1__io_mem_cmd_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_rData_last <= dataCache_1__io_mem_cmd_payload_last;
+    if(_zz_709)begin
+      dataCache_1_io_mem_cmd_s2mPipe_rData_wr <= dataCache_1_io_mem_cmd_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_uncached <= dataCache_1_io_mem_cmd_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_address <= dataCache_1_io_mem_cmd_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_data <= dataCache_1_io_mem_cmd_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_mask <= dataCache_1_io_mem_cmd_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_length <= dataCache_1_io_mem_cmd_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_rData_last <= dataCache_1_io_mem_cmd_payload_last;
     end
-    if(dataCache_1__io_mem_cmd_s2mPipe_ready)begin
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1__io_mem_cmd_s2mPipe_payload_wr;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1__io_mem_cmd_s2mPipe_payload_address;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1__io_mem_cmd_s2mPipe_payload_data;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1__io_mem_cmd_s2mPipe_payload_mask;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1__io_mem_cmd_s2mPipe_payload_length;
-      dataCache_1__io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1__io_mem_cmd_s2mPipe_payload_last;
+    if(dataCache_1_io_mem_cmd_s2mPipe_ready)begin
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_wr <= dataCache_1_io_mem_cmd_s2mPipe_payload_wr;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_uncached <= dataCache_1_io_mem_cmd_s2mPipe_payload_uncached;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_address <= dataCache_1_io_mem_cmd_s2mPipe_payload_address;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_data <= dataCache_1_io_mem_cmd_s2mPipe_payload_data;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_mask <= dataCache_1_io_mem_cmd_s2mPipe_payload_mask;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_length <= dataCache_1_io_mem_cmd_s2mPipe_payload_length;
+      dataCache_1_io_mem_cmd_s2mPipe_m2sPipe_rData_last <= dataCache_1_io_mem_cmd_s2mPipe_payload_last;
     end
-    if(_zz_627_)begin
-      _zz_96_ <= _zz_90_;
-      _zz_97_ <= _zz_91_;
-      _zz_98_ <= _zz_92_;
-      case(_zz_94_)
-        2'b01 : begin
-          _zz_101_ <= 32'h0;
-          _zz_102_ <= _zz_103_;
-        end
-        2'b10 : begin
-          _zz_101_ <= _zz_103_;
-          _zz_102_ <= (_zz_103_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_101_ <= _zz_105_;
-          _zz_102_ <= (_zz_105_ + _zz_694_);
-        end
-        default : begin
-          _zz_102_ <= _zz_103_;
-        end
-      endcase
+    if(_zz_710)begin
+      _zz_87 <= _zz_93;
+      _zz_88 <= _zz_94;
+      _zz_89 <= _zz_95;
+      _zz_92 <= _zz_98;
     end
-    if(_zz_628_)begin
-      _zz_112_ <= _zz_106_;
-      _zz_113_ <= _zz_107_;
-      _zz_114_ <= _zz_108_;
-      case(_zz_110_)
-        2'b01 : begin
-          _zz_117_ <= _zz_102_;
-          _zz_118_ <= _zz_119_;
-        end
-        2'b10 : begin
-          _zz_117_ <= _zz_119_;
-          _zz_118_ <= (_zz_119_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_117_ <= _zz_121_;
-          _zz_118_ <= (_zz_121_ + _zz_697_);
-        end
-        default : begin
-          _zz_118_ <= _zz_119_;
-        end
-      endcase
+    if(_zz_711)begin
+      _zz_106 <= _zz_112;
+      _zz_107 <= _zz_113;
+      _zz_108 <= _zz_114;
+      _zz_111 <= _zz_117;
     end
-    if(_zz_629_)begin
-      _zz_128_ <= _zz_122_;
-      _zz_129_ <= _zz_123_;
-      _zz_130_ <= _zz_124_;
-      case(_zz_126_)
-        2'b01 : begin
-          _zz_133_ <= _zz_118_;
-          _zz_134_ <= _zz_135_;
-        end
-        2'b10 : begin
-          _zz_133_ <= _zz_135_;
-          _zz_134_ <= (_zz_135_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_133_ <= _zz_137_;
-          _zz_134_ <= (_zz_137_ + _zz_700_);
-        end
-        default : begin
-          _zz_134_ <= _zz_135_;
-        end
-      endcase
+    if(_zz_712)begin
+      _zz_125 <= _zz_131;
+      _zz_126 <= _zz_132;
+      _zz_127 <= _zz_133;
+      _zz_130 <= _zz_136;
     end
-    if(_zz_630_)begin
-      _zz_144_ <= _zz_138_;
-      _zz_145_ <= _zz_139_;
-      _zz_146_ <= _zz_140_;
-      case(_zz_142_)
-        2'b01 : begin
-          _zz_149_ <= _zz_134_;
-          _zz_150_ <= _zz_151_;
-        end
-        2'b10 : begin
-          _zz_149_ <= _zz_151_;
-          _zz_150_ <= (_zz_151_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_149_ <= _zz_153_;
-          _zz_150_ <= (_zz_153_ + _zz_703_);
-        end
-        default : begin
-          _zz_150_ <= _zz_151_;
-        end
-      endcase
+    if(_zz_713)begin
+      _zz_144 <= _zz_150;
+      _zz_145 <= _zz_151;
+      _zz_146 <= _zz_152;
+      _zz_149 <= _zz_155;
     end
-    if(_zz_631_)begin
-      _zz_160_ <= _zz_154_;
-      _zz_161_ <= _zz_155_;
-      _zz_162_ <= _zz_156_;
-      case(_zz_158_)
-        2'b01 : begin
-          _zz_165_ <= _zz_150_;
-          _zz_166_ <= _zz_167_;
-        end
-        2'b10 : begin
-          _zz_165_ <= _zz_167_;
-          _zz_166_ <= (_zz_167_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_165_ <= _zz_169_;
-          _zz_166_ <= (_zz_169_ + _zz_706_);
-        end
-        default : begin
-          _zz_166_ <= _zz_167_;
-        end
-      endcase
+    if(_zz_714)begin
+      _zz_163 <= _zz_169;
+      _zz_164 <= _zz_170;
+      _zz_165 <= _zz_171;
+      _zz_168 <= _zz_174;
     end
-    if(_zz_632_)begin
-      _zz_176_ <= _zz_170_;
-      _zz_177_ <= _zz_171_;
-      _zz_178_ <= _zz_172_;
-      case(_zz_174_)
-        2'b01 : begin
-          _zz_181_ <= _zz_166_;
-          _zz_182_ <= _zz_183_;
-        end
-        2'b10 : begin
-          _zz_181_ <= _zz_183_;
-          _zz_182_ <= (_zz_183_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_181_ <= _zz_185_;
-          _zz_182_ <= (_zz_185_ + _zz_709_);
-        end
-        default : begin
-          _zz_182_ <= _zz_183_;
-        end
-      endcase
+    if(_zz_715)begin
+      _zz_182 <= _zz_188;
+      _zz_183 <= _zz_189;
+      _zz_184 <= _zz_190;
+      _zz_187 <= _zz_193;
     end
-    if(_zz_633_)begin
-      _zz_192_ <= _zz_186_;
-      _zz_193_ <= _zz_187_;
-      _zz_194_ <= _zz_188_;
-      case(_zz_190_)
-        2'b01 : begin
-          _zz_197_ <= _zz_182_;
-          _zz_198_ <= _zz_199_;
-        end
-        2'b10 : begin
-          _zz_197_ <= _zz_199_;
-          _zz_198_ <= (_zz_199_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_197_ <= _zz_201_;
-          _zz_198_ <= (_zz_201_ + _zz_712_);
-        end
-        default : begin
-          _zz_198_ <= _zz_199_;
-        end
-      endcase
+    if(_zz_716)begin
+      _zz_201 <= _zz_207;
+      _zz_202 <= _zz_208;
+      _zz_203 <= _zz_209;
+      _zz_206 <= _zz_212;
     end
-    if(_zz_634_)begin
-      _zz_208_ <= _zz_202_;
-      _zz_209_ <= _zz_203_;
-      _zz_210_ <= _zz_204_;
-      case(_zz_206_)
-        2'b01 : begin
-          _zz_213_ <= _zz_198_;
-          _zz_214_ <= _zz_215_;
-        end
-        2'b10 : begin
-          _zz_213_ <= _zz_215_;
-          _zz_214_ <= (_zz_215_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_213_ <= _zz_217_;
-          _zz_214_ <= (_zz_217_ + _zz_715_);
-        end
-        default : begin
-          _zz_214_ <= _zz_215_;
-        end
-      endcase
+    if(_zz_717)begin
+      _zz_220 <= _zz_226;
+      _zz_221 <= _zz_227;
+      _zz_222 <= _zz_228;
+      _zz_225 <= _zz_231;
     end
-    if(_zz_635_)begin
-      _zz_224_ <= _zz_218_;
-      _zz_225_ <= _zz_219_;
-      _zz_226_ <= _zz_220_;
-      case(_zz_222_)
-        2'b01 : begin
-          _zz_229_ <= _zz_214_;
-          _zz_230_ <= _zz_231_;
-        end
-        2'b10 : begin
-          _zz_229_ <= _zz_231_;
-          _zz_230_ <= (_zz_231_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_229_ <= _zz_233_;
-          _zz_230_ <= (_zz_233_ + _zz_718_);
-        end
-        default : begin
-          _zz_230_ <= _zz_231_;
-        end
-      endcase
+    if(_zz_718)begin
+      _zz_239 <= _zz_245;
+      _zz_240 <= _zz_246;
+      _zz_241 <= _zz_247;
+      _zz_244 <= _zz_250;
     end
-    if(_zz_636_)begin
-      _zz_240_ <= _zz_234_;
-      _zz_241_ <= _zz_235_;
-      _zz_242_ <= _zz_236_;
-      case(_zz_238_)
-        2'b01 : begin
-          _zz_245_ <= _zz_230_;
-          _zz_246_ <= _zz_247_;
-        end
-        2'b10 : begin
-          _zz_245_ <= _zz_247_;
-          _zz_246_ <= (_zz_247_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_245_ <= _zz_249_;
-          _zz_246_ <= (_zz_249_ + _zz_721_);
-        end
-        default : begin
-          _zz_246_ <= _zz_247_;
-        end
-      endcase
+    if(_zz_719)begin
+      _zz_258 <= _zz_264;
+      _zz_259 <= _zz_265;
+      _zz_260 <= _zz_266;
+      _zz_263 <= _zz_269;
     end
-    if(_zz_637_)begin
-      _zz_256_ <= _zz_250_;
-      _zz_257_ <= _zz_251_;
-      _zz_258_ <= _zz_252_;
-      case(_zz_254_)
-        2'b01 : begin
-          _zz_261_ <= _zz_246_;
-          _zz_262_ <= _zz_263_;
-        end
-        2'b10 : begin
-          _zz_261_ <= _zz_263_;
-          _zz_262_ <= (_zz_263_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_261_ <= _zz_265_;
-          _zz_262_ <= (_zz_265_ + _zz_724_);
-        end
-        default : begin
-          _zz_262_ <= _zz_263_;
-        end
-      endcase
+    if(_zz_720)begin
+      _zz_277 <= _zz_283;
+      _zz_278 <= _zz_284;
+      _zz_279 <= _zz_285;
+      _zz_282 <= _zz_288;
     end
-    if(_zz_638_)begin
-      _zz_272_ <= _zz_266_;
-      _zz_273_ <= _zz_267_;
-      _zz_274_ <= _zz_268_;
-      case(_zz_270_)
-        2'b01 : begin
-          _zz_277_ <= _zz_262_;
-          _zz_278_ <= _zz_279_;
-        end
-        2'b10 : begin
-          _zz_277_ <= _zz_279_;
-          _zz_278_ <= (_zz_279_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_277_ <= _zz_281_;
-          _zz_278_ <= (_zz_281_ + _zz_727_);
-        end
-        default : begin
-          _zz_278_ <= _zz_279_;
-        end
-      endcase
+    if(_zz_721)begin
+      _zz_296 <= _zz_302;
+      _zz_297 <= _zz_303;
+      _zz_298 <= _zz_304;
+      _zz_301 <= _zz_307;
     end
-    if(_zz_639_)begin
-      _zz_288_ <= _zz_282_;
-      _zz_289_ <= _zz_283_;
-      _zz_290_ <= _zz_284_;
-      case(_zz_286_)
-        2'b01 : begin
-          _zz_293_ <= _zz_278_;
-          _zz_294_ <= _zz_295_;
-        end
-        2'b10 : begin
-          _zz_293_ <= _zz_295_;
-          _zz_294_ <= (_zz_295_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_293_ <= _zz_297_;
-          _zz_294_ <= (_zz_297_ + _zz_730_);
-        end
-        default : begin
-          _zz_294_ <= _zz_295_;
-        end
-      endcase
+    if(_zz_722)begin
+      _zz_315 <= _zz_321;
+      _zz_316 <= _zz_322;
+      _zz_317 <= _zz_323;
+      _zz_320 <= _zz_326;
     end
-    if(_zz_640_)begin
-      _zz_304_ <= _zz_298_;
-      _zz_305_ <= _zz_299_;
-      _zz_306_ <= _zz_300_;
-      case(_zz_302_)
-        2'b01 : begin
-          _zz_309_ <= _zz_294_;
-          _zz_310_ <= _zz_311_;
-        end
-        2'b10 : begin
-          _zz_309_ <= _zz_311_;
-          _zz_310_ <= (_zz_311_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_309_ <= _zz_313_;
-          _zz_310_ <= (_zz_313_ + _zz_733_);
-        end
-        default : begin
-          _zz_310_ <= _zz_311_;
-        end
-      endcase
+    if(_zz_723)begin
+      _zz_334 <= _zz_340;
+      _zz_335 <= _zz_341;
+      _zz_336 <= _zz_342;
+      _zz_339 <= _zz_345;
     end
-    if(_zz_641_)begin
-      _zz_320_ <= _zz_314_;
-      _zz_321_ <= _zz_315_;
-      _zz_322_ <= _zz_316_;
-      case(_zz_318_)
-        2'b01 : begin
-          _zz_325_ <= _zz_310_;
-          _zz_326_ <= _zz_327_;
-        end
-        2'b10 : begin
-          _zz_325_ <= _zz_327_;
-          _zz_326_ <= (_zz_327_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_325_ <= _zz_329_;
-          _zz_326_ <= (_zz_329_ + _zz_736_);
-        end
-        default : begin
-          _zz_326_ <= _zz_327_;
-        end
-      endcase
+    if(_zz_724)begin
+      _zz_353 <= _zz_359;
+      _zz_354 <= _zz_360;
+      _zz_355 <= _zz_361;
+      _zz_358 <= _zz_364;
     end
-    if(_zz_642_)begin
-      _zz_336_ <= _zz_330_;
-      _zz_337_ <= _zz_331_;
-      _zz_338_ <= _zz_332_;
-      case(_zz_334_)
-        2'b01 : begin
-          _zz_341_ <= _zz_326_;
-          _zz_342_ <= _zz_343_;
-        end
-        2'b10 : begin
-          _zz_341_ <= _zz_343_;
-          _zz_342_ <= (_zz_343_ + 32'h00000004);
-        end
-        2'b11 : begin
-          _zz_341_ <= _zz_345_;
-          _zz_342_ <= (_zz_345_ + _zz_739_);
-        end
-        default : begin
-          _zz_342_ <= _zz_343_;
-        end
-      endcase
+    if(_zz_725)begin
+      _zz_372 <= _zz_378;
+      _zz_373 <= _zz_379;
+      _zz_374 <= _zz_380;
+      _zz_377 <= _zz_383;
     end
-    _zz_473_ <= _zz_40_[11 : 7];
-    _zz_474_ <= _zz_52_;
+    _zz_534 <= _zz_40[11 : 7];
+    _zz_535 <= _zz_50;
     CsrPlugin_mip_MEIP <= externalInterrupt;
     CsrPlugin_mip_MTIP <= timerInterrupt;
     CsrPlugin_mip_MSIP <= softwareInterrupt;
@@ -8612,9 +8998,9 @@ module VexRiscv (
     if(writeBack_arbitration_isFiring)begin
       CsrPlugin_minstret <= (CsrPlugin_minstret + 64'h0000000000000001);
     end
-    if(_zz_601_)begin
-      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_502_ ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
-      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_502_ ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
+    if(_zz_684)begin
+      CsrPlugin_exceptionPortCtrl_exceptionContext_code <= (_zz_563 ? IBusCachedPlugin_decodeExceptionPort_payload_code : decodeExceptionPort_payload_code);
+      CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= (_zz_563 ? IBusCachedPlugin_decodeExceptionPort_payload_badAddr : decodeExceptionPort_payload_badAddr);
     end
     if(CsrPlugin_selfException_valid)begin
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= CsrPlugin_selfException_payload_code;
@@ -8628,21 +9014,21 @@ module VexRiscv (
       CsrPlugin_exceptionPortCtrl_exceptionContext_code <= DBusCachedPlugin_exceptionBus_payload_code;
       CsrPlugin_exceptionPortCtrl_exceptionContext_badAddr <= DBusCachedPlugin_exceptionBus_payload_badAddr;
     end
-    if(_zz_643_)begin
-      if(_zz_644_)begin
-        CsrPlugin_interrupt_code <= (4'b0111);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+    if(_zz_726)begin
+      if(_zz_727)begin
+        CsrPlugin_interrupt_code <= 4'b0111;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_645_)begin
-        CsrPlugin_interrupt_code <= (4'b0011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_728)begin
+        CsrPlugin_interrupt_code <= 4'b0011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
-      if(_zz_646_)begin
-        CsrPlugin_interrupt_code <= (4'b1011);
-        CsrPlugin_interrupt_targetPrivilege <= (2'b11);
+      if(_zz_729)begin
+        CsrPlugin_interrupt_code <= 4'b1011;
+        CsrPlugin_interrupt_targetPrivilege <= 2'b11;
       end
     end
-    if(_zz_605_)begin
+    if(_zz_688)begin
       case(CsrPlugin_targetPrivilege)
         2'b11 : begin
           CsrPlugin_mcause_interrupt <= (! CsrPlugin_hadException);
@@ -8662,75 +9048,30 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       memory_DivPlugin_div_done <= 1'b0;
     end
-    if(_zz_596_)begin
-      if(_zz_622_)begin
+    if(_zz_679)begin
+      if(_zz_705)begin
         memory_DivPlugin_rs1[31 : 0] <= memory_DivPlugin_div_stage_0_outNumerator;
         memory_DivPlugin_accumulator[31 : 0] <= memory_DivPlugin_div_stage_0_outRemainder;
         if((memory_DivPlugin_div_counter_value == 6'h20))begin
-          memory_DivPlugin_div_result <= _zz_781_[31:0];
+          memory_DivPlugin_div_result <= _zz_878[31:0];
         end
       end
     end
-    if(_zz_623_)begin
+    if(_zz_706)begin
       memory_DivPlugin_accumulator <= 65'h0;
-      memory_DivPlugin_rs1 <= ((_zz_506_ ? (~ _zz_507_) : _zz_507_) + _zz_787_);
-      memory_DivPlugin_rs2 <= ((_zz_505_ ? (~ execute_RS2) : execute_RS2) + _zz_789_);
-      memory_DivPlugin_div_needRevert <= ((_zz_506_ ^ (_zz_505_ && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
+      memory_DivPlugin_rs1 <= ((_zz_567 ? (~ _zz_568) : _zz_568) + _zz_884);
+      memory_DivPlugin_rs2 <= ((_zz_566 ? (~ execute_RS2) : execute_RS2) + _zz_886);
+      memory_DivPlugin_div_needRevert <= ((_zz_567 ^ (_zz_566 && (! execute_INSTRUCTION[13]))) && (! (((execute_RS2 == 32'h0) && execute_IS_RS2_SIGNED) && (! execute_INSTRUCTION[13]))));
     end
     externalInterruptArray_regNext <= externalInterruptArray;
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_MUL <= decode_IS_MUL;
+      decode_to_execute_PC <= decode_PC;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_MUL <= execute_IS_MUL;
+      execute_to_memory_PC <= _zz_35;
     end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BRANCH_CTRL <= _zz_25_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS2 <= decode_RS2;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_CTRL <= _zz_23_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HH <= execute_MUL_HH;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LH <= execute_MUL_LH;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_RS1 <= decode_RS1;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
+      memory_to_writeBack_PC <= memory_PC;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_INSTRUCTION <= decode_INSTRUCTION;
@@ -8738,95 +9079,26 @@ module VexRiscv (
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_INSTRUCTION <= execute_INSTRUCTION;
     end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_INSTRUCTION <= memory_INSTRUCTION;
+    end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_FORMAL_PC_NEXT <= _zz_56_;
+      decode_to_execute_FORMAL_PC_NEXT <= _zz_53;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_FORMAL_PC_NEXT <= execute_FORMAL_PC_NEXT;
     end
     if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_55_;
+      memory_to_writeBack_FORMAL_PC_NEXT <= _zz_52;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+      decode_to_execute_MEMORY_FORCE_CONSTISTENCY <= decode_MEMORY_FORCE_CONSTISTENCY;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+      decode_to_execute_SRC1_CTRL <= _zz_25;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_BITWISE_CTRL <= _zz_20_;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_PC <= decode_PC;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_PC <= _zz_35_;
-    end
-    if(((! writeBack_arbitration_isStuck) && (! CsrPlugin_exceptionPortCtrl_exceptionValids_writeBack)))begin
-      memory_to_writeBack_PC <= memory_PC;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_DIV <= decode_IS_DIV;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_IS_DIV <= execute_IS_DIV;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ALU_CTRL <= _zz_17_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_LL <= execute_MUL_LL;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MUL_HL <= execute_MUL_HL;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_CSR <= decode_IS_CSR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
-    end
-    if((! execute_arbitration_isStuck))begin
-      decode_to_execute_ENV_CTRL <= _zz_14_;
-    end
-    if((! memory_arbitration_isStuck))begin
-      execute_to_memory_ENV_CTRL <= _zz_11_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_ENV_CTRL <= _zz_9_;
-    end
-    if((! writeBack_arbitration_isStuck))begin
-      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
+      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_MEMORY_ENABLE <= decode_MEMORY_ENABLE;
@@ -8838,25 +9110,148 @@ module VexRiscv (
       memory_to_writeBack_MEMORY_ENABLE <= memory_MEMORY_ENABLE;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+      decode_to_execute_ALU_CTRL <= _zz_22;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC1_CTRL <= _zz_7_;
+      decode_to_execute_SRC2_CTRL <= _zz_19;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SHIFT_CTRL <= _zz_4_;
+      decode_to_execute_REGFILE_WRITE_VALID <= decode_REGFILE_WRITE_VALID;
     end
     if((! memory_arbitration_isStuck))begin
-      execute_to_memory_SHIFT_CTRL <= _zz_1_;
+      execute_to_memory_REGFILE_WRITE_VALID <= execute_REGFILE_WRITE_VALID;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_VALID <= memory_REGFILE_WRITE_VALID;
     end
     if((! execute_arbitration_isStuck))begin
-      decode_to_execute_SRC_USE_SUB_LESS <= decode_SRC_USE_SUB_LESS;
+      decode_to_execute_BYPASSABLE_EXECUTE_STAGE <= decode_BYPASSABLE_EXECUTE_STAGE;
     end
     if((! execute_arbitration_isStuck))begin
       decode_to_execute_BYPASSABLE_MEMORY_STAGE <= decode_BYPASSABLE_MEMORY_STAGE;
     end
     if((! memory_arbitration_isStuck))begin
       execute_to_memory_BYPASSABLE_MEMORY_STAGE <= execute_BYPASSABLE_MEMORY_STAGE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_WR <= decode_MEMORY_WR;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_WR <= execute_MEMORY_WR;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_WR <= memory_MEMORY_WR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_MEMORY_MANAGMENT <= decode_MEMORY_MANAGMENT;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC_LESS_UNSIGNED <= decode_SRC_LESS_UNSIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ALU_BITWISE_CTRL <= _zz_16;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SHIFT_CTRL <= _zz_13;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_CTRL <= _zz_10;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_BRANCH_CTRL <= _zz_8;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_CSR <= decode_IS_CSR;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_ENV_CTRL <= _zz_6;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_ENV_CTRL <= _zz_3;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_ENV_CTRL <= _zz_1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_MUL <= decode_IS_MUL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_MUL <= execute_IS_MUL;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_IS_MUL <= memory_IS_MUL;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_DIV <= decode_IS_DIV;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_IS_DIV <= execute_IS_DIV;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS1_SIGNED <= decode_IS_RS1_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_IS_RS2_SIGNED <= decode_IS_RS2_SIGNED;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS1 <= decode_RS1;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_RS2 <= decode_RS2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_SRC2_FORCE_ZERO <= decode_SRC2_FORCE_ZERO;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_PREDICTION_HAD_BRANCHED2 <= decode_PREDICTION_HAD_BRANCHED2;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_WRITE_OPCODE <= decode_CSR_WRITE_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_CSR_READ_OPCODE <= decode_CSR_READ_OPCODE;
+    end
+    if((! execute_arbitration_isStuck))begin
+      decode_to_execute_DO_EBREAK <= decode_DO_EBREAK;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MEMORY_ADDRESS_LOW <= execute_MEMORY_ADDRESS_LOW;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MEMORY_ADDRESS_LOW <= memory_MEMORY_ADDRESS_LOW;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_REGFILE_WRITE_DATA <= _zz_31;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_REGFILE_WRITE_DATA <= _zz_32;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_SHIFT_RIGHT <= execute_SHIFT_RIGHT;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_DO <= execute_BRANCH_DO;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_BRANCH_CALC <= execute_BRANCH_CALC;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LL <= execute_MUL_LL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_LH <= execute_MUL_LH;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HL <= execute_MUL_HL;
+    end
+    if((! memory_arbitration_isStuck))begin
+      execute_to_memory_MUL_HH <= execute_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_HH <= memory_MUL_HH;
+    end
+    if((! writeBack_arbitration_isStuck))begin
+      memory_to_writeBack_MUL_LOW <= memory_MUL_LOW;
     end
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_3264 <= (decode_INSTRUCTION[31 : 20] == 12'hcc0);
@@ -8990,153 +9385,9 @@ module VexRiscv (
     if((! execute_arbitration_isStuck))begin
       execute_CsrPlugin_csr_4032 <= (decode_INSTRUCTION[31 : 20] == 12'hfc0);
     end
-    if(execute_CsrPlugin_csr_944)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_95_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_945)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_111_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_946)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_127_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_947)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_143_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_948)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_159_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_949)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_175_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_950)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_191_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_951)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_207_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_952)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_223_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_953)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_239_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_954)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_255_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_955)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_271_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_956)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_287_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_957)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_303_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_958)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_319_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_959)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_335_ <= execute_CsrPlugin_writeData[31 : 0];
-      end
-    end
-    if(execute_CsrPlugin_csr_928)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_140_ <= _zz_794_[0];
-        _zz_139_ <= _zz_795_[0];
-        _zz_138_ <= _zz_796_[0];
-        _zz_124_ <= _zz_797_[0];
-        _zz_123_ <= _zz_798_[0];
-        _zz_122_ <= _zz_799_[0];
-        _zz_108_ <= _zz_800_[0];
-        _zz_107_ <= _zz_801_[0];
-        _zz_106_ <= _zz_802_[0];
-        _zz_92_ <= _zz_803_[0];
-        _zz_91_ <= _zz_804_[0];
-        _zz_90_ <= _zz_805_[0];
-      end
-    end
-    if(execute_CsrPlugin_csr_929)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_204_ <= _zz_810_[0];
-        _zz_203_ <= _zz_811_[0];
-        _zz_202_ <= _zz_812_[0];
-        _zz_188_ <= _zz_813_[0];
-        _zz_187_ <= _zz_814_[0];
-        _zz_186_ <= _zz_815_[0];
-        _zz_172_ <= _zz_816_[0];
-        _zz_171_ <= _zz_817_[0];
-        _zz_170_ <= _zz_818_[0];
-        _zz_156_ <= _zz_819_[0];
-        _zz_155_ <= _zz_820_[0];
-        _zz_154_ <= _zz_821_[0];
-      end
-    end
-    if(execute_CsrPlugin_csr_930)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_268_ <= _zz_826_[0];
-        _zz_267_ <= _zz_827_[0];
-        _zz_266_ <= _zz_828_[0];
-        _zz_252_ <= _zz_829_[0];
-        _zz_251_ <= _zz_830_[0];
-        _zz_250_ <= _zz_831_[0];
-        _zz_236_ <= _zz_832_[0];
-        _zz_235_ <= _zz_833_[0];
-        _zz_234_ <= _zz_834_[0];
-        _zz_220_ <= _zz_835_[0];
-        _zz_219_ <= _zz_836_[0];
-        _zz_218_ <= _zz_837_[0];
-      end
-    end
-    if(execute_CsrPlugin_csr_931)begin
-      if(execute_CsrPlugin_writeEnable)begin
-        _zz_332_ <= _zz_842_[0];
-        _zz_331_ <= _zz_843_[0];
-        _zz_330_ <= _zz_844_[0];
-        _zz_316_ <= _zz_845_[0];
-        _zz_315_ <= _zz_846_[0];
-        _zz_314_ <= _zz_847_[0];
-        _zz_300_ <= _zz_848_[0];
-        _zz_299_ <= _zz_849_[0];
-        _zz_298_ <= _zz_850_[0];
-        _zz_284_ <= _zz_851_[0];
-        _zz_283_ <= _zz_852_[0];
-        _zz_282_ <= _zz_853_[0];
-      end
-    end
     if(execute_CsrPlugin_csr_836)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mip_MSIP <= _zz_856_[0];
+        CsrPlugin_mip_MSIP <= _zz_953[0];
       end
     end
     if(execute_CsrPlugin_csr_773)begin
@@ -9157,7 +9408,7 @@ module VexRiscv (
     end
     if(execute_CsrPlugin_csr_834)begin
       if(execute_CsrPlugin_writeEnable)begin
-        CsrPlugin_mcause_interrupt <= _zz_860_[0];
+        CsrPlugin_mcause_interrupt <= _zz_957[0];
         CsrPlugin_mcause_exceptionCode <= execute_CsrPlugin_writeData[3 : 0];
       end
     end
@@ -9196,12 +9447,12 @@ module VexRiscv (
       DebugPlugin_firstCycle <= 1'b1;
     end
     DebugPlugin_secondCycle <= DebugPlugin_firstCycle;
-    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != (4'b0000)) || IBusCachedPlugin_incomingInstruction);
+    DebugPlugin_isPipBusy <= (({writeBack_arbitration_isValid,{memory_arbitration_isValid,{execute_arbitration_isValid,decode_arbitration_isValid}}} != 4'b0000) || IBusCachedPlugin_incomingInstruction);
     if(writeBack_arbitration_isValid)begin
-      DebugPlugin_busReadDataReg <= _zz_52_;
+      DebugPlugin_busReadDataReg <= _zz_50;
     end
-    _zz_510_ <= debug_bus_cmd_payload_address[2];
-    if(_zz_603_)begin
+    _zz_571 <= debug_bus_cmd_payload_address[2];
+    if(_zz_686)begin
       DebugPlugin_busReadDataReg <= execute_PC;
     end
     DebugPlugin_resetIt_regNext <= DebugPlugin_resetIt;
@@ -9219,8 +9470,8 @@ module VexRiscv (
         DebugPlugin_godmode <= 1'b1;
       end
       if(debug_bus_cmd_valid)begin
-        case(_zz_624_)
-          6'b000000 : begin
+        case(_zz_707)
+          6'h0 : begin
             if(debug_bus_cmd_payload_wr)begin
               DebugPlugin_stepIt <= debug_bus_cmd_payload_data[4];
               if(debug_bus_cmd_payload_data[16])begin
@@ -9243,23 +9494,1112 @@ module VexRiscv (
               end
             end
           end
-          6'b000001 : begin
-          end
           default : begin
           end
         endcase
       end
-      if(_zz_603_)begin
-        if(_zz_604_)begin
+      if(_zz_686)begin
+        if(_zz_687)begin
           DebugPlugin_haltIt <= 1'b1;
           DebugPlugin_haltedByBreak <= 1'b1;
         end
       end
-      if(_zz_607_)begin
+      if(_zz_690)begin
         if(decode_arbitration_isValid)begin
           DebugPlugin_haltIt <= 1'b1;
         end
       end
+    end
+  end
+
+
+endmodule
+
+module DataCache (
+  input               io_cpu_execute_isValid,
+  input      [31:0]   io_cpu_execute_address,
+  output              io_cpu_execute_haltIt,
+  input               io_cpu_execute_args_wr,
+  input      [31:0]   io_cpu_execute_args_data,
+  input      [1:0]    io_cpu_execute_args_size,
+  input               io_cpu_execute_args_totalyConsistent,
+  output              io_cpu_execute_refilling,
+  input               io_cpu_memory_isValid,
+  input               io_cpu_memory_isStuck,
+  output              io_cpu_memory_isWrite,
+  input      [31:0]   io_cpu_memory_address,
+  input      [31:0]   io_cpu_memory_mmuRsp_physicalAddress,
+  input               io_cpu_memory_mmuRsp_isIoAccess,
+  input               io_cpu_memory_mmuRsp_isPaging,
+  input               io_cpu_memory_mmuRsp_allowRead,
+  input               io_cpu_memory_mmuRsp_allowWrite,
+  input               io_cpu_memory_mmuRsp_allowExecute,
+  input               io_cpu_memory_mmuRsp_exception,
+  input               io_cpu_memory_mmuRsp_refilling,
+  input               io_cpu_memory_mmuRsp_bypassTranslation,
+  input               io_cpu_writeBack_isValid,
+  input               io_cpu_writeBack_isStuck,
+  input               io_cpu_writeBack_isUser,
+  output reg          io_cpu_writeBack_haltIt,
+  output              io_cpu_writeBack_isWrite,
+  output reg [31:0]   io_cpu_writeBack_data,
+  input      [31:0]   io_cpu_writeBack_address,
+  output              io_cpu_writeBack_mmuException,
+  output              io_cpu_writeBack_unalignedAccess,
+  output reg          io_cpu_writeBack_accessError,
+  output              io_cpu_writeBack_keepMemRspData,
+  input               io_cpu_writeBack_fence_SW,
+  input               io_cpu_writeBack_fence_SR,
+  input               io_cpu_writeBack_fence_SO,
+  input               io_cpu_writeBack_fence_SI,
+  input               io_cpu_writeBack_fence_PW,
+  input               io_cpu_writeBack_fence_PR,
+  input               io_cpu_writeBack_fence_PO,
+  input               io_cpu_writeBack_fence_PI,
+  input      [3:0]    io_cpu_writeBack_fence_FM,
+  output reg          io_cpu_redo,
+  input               io_cpu_flush_valid,
+  output reg          io_cpu_flush_ready,
+  output reg          io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output reg          io_mem_cmd_payload_wr,
+  output              io_mem_cmd_payload_uncached,
+  output reg [31:0]   io_mem_cmd_payload_address,
+  output     [31:0]   io_mem_cmd_payload_data,
+  output     [3:0]    io_mem_cmd_payload_mask,
+  output reg [2:0]    io_mem_cmd_payload_length,
+  output              io_mem_cmd_payload_last,
+  input               io_mem_rsp_valid,
+  input               io_mem_rsp_payload_last,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input               clk,
+  input               reset
+);
+  reg        [21:0]   _zz_10;
+  reg        [31:0]   _zz_11;
+  wire                _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire                _zz_15;
+  wire                _zz_16;
+  wire                _zz_17;
+  wire                _zz_18;
+  wire       [0:0]    _zz_19;
+  wire       [0:0]    _zz_20;
+  wire       [9:0]    _zz_21;
+  wire       [9:0]    _zz_22;
+  wire       [0:0]    _zz_23;
+  wire       [0:0]    _zz_24;
+  wire       [2:0]    _zz_25;
+  wire       [1:0]    _zz_26;
+  wire       [21:0]   _zz_27;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  wire                haltCpu;
+  reg                 tagsReadCmd_valid;
+  reg        [6:0]    tagsReadCmd_payload;
+  reg                 tagsWriteCmd_valid;
+  reg        [0:0]    tagsWriteCmd_payload_way;
+  reg        [6:0]    tagsWriteCmd_payload_address;
+  reg                 tagsWriteCmd_payload_data_valid;
+  reg                 tagsWriteCmd_payload_data_error;
+  reg        [19:0]   tagsWriteCmd_payload_data_address;
+  reg                 tagsWriteLastCmd_valid;
+  reg        [0:0]    tagsWriteLastCmd_payload_way;
+  reg        [6:0]    tagsWriteLastCmd_payload_address;
+  reg                 tagsWriteLastCmd_payload_data_valid;
+  reg                 tagsWriteLastCmd_payload_data_error;
+  reg        [19:0]   tagsWriteLastCmd_payload_data_address;
+  reg                 dataReadCmd_valid;
+  reg        [9:0]    dataReadCmd_payload;
+  reg                 dataWriteCmd_valid;
+  reg        [0:0]    dataWriteCmd_payload_way;
+  reg        [9:0]    dataWriteCmd_payload_address;
+  reg        [31:0]   dataWriteCmd_payload_data;
+  reg        [3:0]    dataWriteCmd_payload_mask;
+  wire                _zz_3;
+  wire                ways_0_tagsReadRsp_valid;
+  wire                ways_0_tagsReadRsp_error;
+  wire       [19:0]   ways_0_tagsReadRsp_address;
+  wire       [21:0]   _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   ways_0_dataReadRspMem;
+  wire       [31:0]   ways_0_dataReadRsp;
+  wire                rspSync;
+  wire                rspLast;
+  reg                 memCmdSent;
+  reg        [3:0]    _zz_6;
+  wire       [3:0]    stage0_mask;
+  wire       [0:0]    stage0_dataColisions;
+  wire       [0:0]    stage0_wayInvalidate;
+  wire                stage0_isAmo;
+  reg                 stageA_request_wr;
+  reg        [31:0]   stageA_request_data;
+  reg        [1:0]    stageA_request_size;
+  reg                 stageA_request_totalyConsistent;
+  reg        [3:0]    stageA_mask;
+  wire                stageA_isAmo;
+  wire                stageA_isLrsc;
+  wire       [0:0]    stageA_wayHits;
+  wire       [0:0]    _zz_7;
+  reg        [0:0]    stageA_wayInvalidate;
+  reg        [0:0]    stage0_dataColisions_regNextWhen;
+  wire       [0:0]    _zz_8;
+  wire       [0:0]    stageA_dataColisions;
+  reg                 stageB_request_wr;
+  reg        [31:0]   stageB_request_data;
+  reg        [1:0]    stageB_request_size;
+  reg                 stageB_request_totalyConsistent;
+  reg                 stageB_mmuRspFreeze;
+  reg        [31:0]   stageB_mmuRsp_physicalAddress;
+  reg                 stageB_mmuRsp_isIoAccess;
+  reg                 stageB_mmuRsp_isPaging;
+  reg                 stageB_mmuRsp_allowRead;
+  reg                 stageB_mmuRsp_allowWrite;
+  reg                 stageB_mmuRsp_allowExecute;
+  reg                 stageB_mmuRsp_exception;
+  reg                 stageB_mmuRsp_refilling;
+  reg                 stageB_mmuRsp_bypassTranslation;
+  reg                 stageB_tagsReadRsp_0_valid;
+  reg                 stageB_tagsReadRsp_0_error;
+  reg        [19:0]   stageB_tagsReadRsp_0_address;
+  reg        [31:0]   stageB_dataReadRsp_0;
+  reg        [0:0]    stageB_wayInvalidate;
+  wire                stageB_consistancyHazard;
+  reg        [0:0]    stageB_dataColisions;
+  reg                 stageB_unaligned;
+  reg        [0:0]    stageB_waysHitsBeforeInvalidate;
+  wire       [0:0]    stageB_waysHits;
+  wire                stageB_waysHit;
+  wire       [31:0]   stageB_dataMux;
+  reg        [3:0]    stageB_mask;
+  reg                 stageB_loaderValid;
+  wire       [31:0]   stageB_ioMemRspMuxed;
+  reg                 stageB_flusher_valid;
+  wire                stageB_flusher_hold;
+  reg                 stageB_flusher_start;
+  wire                stageB_isAmo;
+  wire                stageB_isAmoCached;
+  wire                stageB_isExternalLsrc;
+  wire                stageB_isExternalAmo;
+  wire       [31:0]   stageB_requestDataBypass;
+  reg                 stageB_cpuWriteToCache;
+  wire                stageB_badPermissions;
+  wire                stageB_loadStoreFault;
+  wire                stageB_bypassCache;
+  wire       [0:0]    _zz_9;
+  reg                 loader_valid;
+  reg                 loader_counter_willIncrement;
+  wire                loader_counter_willClear;
+  reg        [2:0]    loader_counter_valueNext;
+  reg        [2:0]    loader_counter_value;
+  wire                loader_counter_willOverflowIfInc;
+  wire                loader_counter_willOverflow;
+  reg        [0:0]    loader_waysAllocator;
+  reg                 loader_error;
+  wire                loader_kill;
+  reg                 loader_killReg;
+  wire                loader_done;
+  reg                 loader_valid_regNext;
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol0 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol1 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol2 [0:1023];
+  (* ram_style = "block" *) reg [7:0] ways_0_data_symbol3 [0:1023];
+  reg [7:0] _zz_28;
+  reg [7:0] _zz_29;
+  reg [7:0] _zz_30;
+  reg [7:0] _zz_31;
+
+  assign _zz_12 = (io_cpu_execute_isValid && (! io_cpu_memory_isStuck));
+  assign _zz_13 = ((((stageB_consistancyHazard || stageB_mmuRsp_refilling) || io_cpu_writeBack_accessError) || io_cpu_writeBack_mmuException) || io_cpu_writeBack_unalignedAccess);
+  assign _zz_14 = ((loader_valid && io_mem_rsp_valid) && rspLast);
+  assign _zz_15 = (stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc);
+  assign _zz_16 = (stageB_waysHit || (stageB_request_wr && (! stageB_isAmoCached)));
+  assign _zz_17 = (! stageB_flusher_hold);
+  assign _zz_18 = (stageB_mmuRsp_physicalAddress[11 : 5] != 7'h7f);
+  assign _zz_19 = _zz_4[0 : 0];
+  assign _zz_20 = _zz_4[1 : 1];
+  assign _zz_21 = (io_cpu_execute_address[11 : 2] >>> 0);
+  assign _zz_22 = (io_cpu_memory_address[11 : 2] >>> 0);
+  assign _zz_23 = 1'b1;
+  assign _zz_24 = loader_counter_willIncrement;
+  assign _zz_25 = {2'd0, _zz_24};
+  assign _zz_26 = {loader_waysAllocator,loader_waysAllocator[0]};
+  assign _zz_27 = {tagsWriteCmd_payload_data_address,{tagsWriteCmd_payload_data_error,tagsWriteCmd_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_3) begin
+      _zz_10 <= ways_0_tags[tagsReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[tagsWriteCmd_payload_address] <= _zz_27;
+    end
+  end
+
+  always @ (*) begin
+    _zz_11 = {_zz_31, _zz_30, _zz_29, _zz_28};
+  end
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_28 <= ways_0_data_symbol0[dataReadCmd_payload];
+      _zz_29 <= ways_0_data_symbol1[dataReadCmd_payload];
+      _zz_30 <= ways_0_data_symbol2[dataReadCmd_payload];
+      _zz_31 <= ways_0_data_symbol3[dataReadCmd_payload];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(dataWriteCmd_payload_mask[0] && _zz_1) begin
+      ways_0_data_symbol0[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[7 : 0];
+    end
+    if(dataWriteCmd_payload_mask[1] && _zz_1) begin
+      ways_0_data_symbol1[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[15 : 8];
+    end
+    if(dataWriteCmd_payload_mask[2] && _zz_1) begin
+      ways_0_data_symbol2[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[23 : 16];
+    end
+    if(dataWriteCmd_payload_mask[3] && _zz_1) begin
+      ways_0_data_symbol3[dataWriteCmd_payload_address] <= dataWriteCmd_payload_data[31 : 24];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if((dataWriteCmd_valid && dataWriteCmd_payload_way[0]))begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if((tagsWriteCmd_valid && tagsWriteCmd_payload_way[0]))begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  assign haltCpu = 1'b0;
+  assign _zz_3 = (tagsReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign _zz_4 = _zz_10;
+  assign ways_0_tagsReadRsp_valid = _zz_19[0];
+  assign ways_0_tagsReadRsp_error = _zz_20[0];
+  assign ways_0_tagsReadRsp_address = _zz_4[21 : 2];
+  assign _zz_5 = (dataReadCmd_valid && (! io_cpu_memory_isStuck));
+  assign ways_0_dataReadRspMem = _zz_11;
+  assign ways_0_dataReadRsp = ways_0_dataReadRspMem[31 : 0];
+  always @ (*) begin
+    tagsReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      tagsReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsReadCmd_payload = 7'h0;
+    if(_zz_12)begin
+      tagsReadCmd_payload = io_cpu_execute_address[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_valid = 1'b0;
+    if(_zz_12)begin
+      dataReadCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataReadCmd_payload = 10'h0;
+    if(_zz_12)begin
+      dataReadCmd_payload = io_cpu_execute_address[11 : 2];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_valid = 1'b0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_valid = stageB_flusher_valid;
+    end
+    if(_zz_13)begin
+      tagsWriteCmd_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_way = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_way = 1'b1;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_address = 7'h0;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 5];
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_valid = 1'bx;
+    if(stageB_flusher_valid)begin
+      tagsWriteCmd_payload_data_valid = 1'b0;
+    end
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_valid = (! (loader_kill || loader_killReg));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_error = 1'bx;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_error = (loader_error || (io_mem_rsp_valid && io_mem_rsp_payload_error));
+    end
+  end
+
+  always @ (*) begin
+    tagsWriteCmd_payload_data_address = 20'h0;
+    if(loader_done)begin
+      tagsWriteCmd_payload_data_address = stageB_mmuRsp_physicalAddress[31 : 12];
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_valid = 1'b0;
+    if(stageB_cpuWriteToCache)begin
+      if((stageB_request_wr && stageB_waysHit))begin
+        dataWriteCmd_valid = 1'b1;
+      end
+    end
+    if(_zz_13)begin
+      dataWriteCmd_valid = 1'b0;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_valid = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_way = 1'bx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_way = stageB_waysHits;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_way = loader_waysAllocator;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_address = 10'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_address = stageB_mmuRsp_physicalAddress[11 : 2];
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_address = {stageB_mmuRsp_physicalAddress[11 : 5],loader_counter_value};
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_data = 32'h0;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_data[31 : 0] = stageB_requestDataBypass;
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_data = io_mem_rsp_payload_data;
+    end
+  end
+
+  always @ (*) begin
+    dataWriteCmd_payload_mask = 4'bxxxx;
+    if(stageB_cpuWriteToCache)begin
+      dataWriteCmd_payload_mask = 4'b0000;
+      if(_zz_23[0])begin
+        dataWriteCmd_payload_mask[3 : 0] = stageB_mask;
+      end
+    end
+    if(_zz_14)begin
+      dataWriteCmd_payload_mask = 4'b1111;
+    end
+  end
+
+  assign io_cpu_execute_haltIt = 1'b0;
+  assign rspSync = 1'b1;
+  assign rspLast = 1'b1;
+  always @ (*) begin
+    case(io_cpu_execute_args_size)
+      2'b00 : begin
+        _zz_6 = 4'b0001;
+      end
+      2'b01 : begin
+        _zz_6 = 4'b0011;
+      end
+      default : begin
+        _zz_6 = 4'b1111;
+      end
+    endcase
+  end
+
+  assign stage0_mask = (_zz_6 <<< io_cpu_execute_address[1 : 0]);
+  assign stage0_dataColisions[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_21)) && ((stage0_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stage0_wayInvalidate = 1'b0;
+  assign stage0_isAmo = 1'b0;
+  assign io_cpu_memory_isWrite = stageA_request_wr;
+  assign stageA_isAmo = 1'b0;
+  assign stageA_isLrsc = 1'b0;
+  assign _zz_7[0] = ((io_cpu_memory_mmuRsp_physicalAddress[31 : 12] == ways_0_tagsReadRsp_address) && ways_0_tagsReadRsp_valid);
+  assign stageA_wayHits = _zz_7;
+  assign _zz_8[0] = (((dataWriteCmd_valid && dataWriteCmd_payload_way[0]) && (dataWriteCmd_payload_address == _zz_22)) && ((stageA_mask & dataWriteCmd_payload_mask[3 : 0]) != 4'b0000));
+  assign stageA_dataColisions = (stage0_dataColisions_regNextWhen | _zz_8);
+  always @ (*) begin
+    stageB_mmuRspFreeze = 1'b0;
+    if((stageB_loaderValid || loader_valid))begin
+      stageB_mmuRspFreeze = 1'b1;
+    end
+  end
+
+  assign stageB_consistancyHazard = 1'b0;
+  assign stageB_waysHits = (stageB_waysHitsBeforeInvalidate & (~ stageB_wayInvalidate));
+  assign stageB_waysHit = (stageB_waysHits != 1'b0);
+  assign stageB_dataMux = stageB_dataReadRsp_0;
+  always @ (*) begin
+    stageB_loaderValid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            if(io_mem_cmd_ready)begin
+              stageB_loaderValid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      stageB_loaderValid = 1'b0;
+    end
+  end
+
+  assign stageB_ioMemRspMuxed = io_mem_rsp_payload_data[31 : 0];
+  always @ (*) begin
+    io_cpu_writeBack_haltIt = io_cpu_writeBack_isValid;
+    if(stageB_flusher_valid)begin
+      io_cpu_writeBack_haltIt = 1'b1;
+    end
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          if(((! stageB_request_wr) ? (io_mem_rsp_valid && rspSync) : io_mem_cmd_ready))begin
+            io_cpu_writeBack_haltIt = 1'b0;
+          end
+        end else begin
+          if(_zz_16)begin
+            if(((! stageB_request_wr) || io_mem_cmd_ready))begin
+              io_cpu_writeBack_haltIt = 1'b0;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_cpu_writeBack_haltIt = 1'b0;
+    end
+  end
+
+  assign stageB_flusher_hold = 1'b0;
+  always @ (*) begin
+    io_cpu_flush_ready = 1'b0;
+    if(stageB_flusher_start)begin
+      io_cpu_flush_ready = 1'b1;
+    end
+  end
+
+  assign stageB_isAmo = 1'b0;
+  assign stageB_isAmoCached = 1'b0;
+  assign stageB_isExternalLsrc = 1'b0;
+  assign stageB_isExternalAmo = 1'b0;
+  assign stageB_requestDataBypass = stageB_request_data;
+  always @ (*) begin
+    stageB_cpuWriteToCache = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            stageB_cpuWriteToCache = 1'b1;
+          end
+        end
+      end
+    end
+  end
+
+  assign stageB_badPermissions = (((! stageB_mmuRsp_allowWrite) && stageB_request_wr) || ((! stageB_mmuRsp_allowRead) && ((! stageB_request_wr) || stageB_isAmo)));
+  assign stageB_loadStoreFault = (io_cpu_writeBack_isValid && (stageB_mmuRsp_exception || stageB_badPermissions));
+  always @ (*) begin
+    io_cpu_redo = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            if((((! stageB_request_wr) || stageB_isAmoCached) && ((stageB_dataColisions & stageB_waysHits) != 1'b0)))begin
+              io_cpu_redo = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if((io_cpu_writeBack_isValid && (stageB_mmuRsp_refilling || stageB_consistancyHazard)))begin
+      io_cpu_redo = 1'b1;
+    end
+    if((loader_valid && (! loader_valid_regNext)))begin
+      io_cpu_redo = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_writeBack_accessError = 1'b0;
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_accessError = ((((! stageB_request_wr) && 1'b1) && io_mem_rsp_valid) && io_mem_rsp_payload_error);
+    end else begin
+      io_cpu_writeBack_accessError = (((stageB_waysHits & _zz_9) != 1'b0) || (stageB_loadStoreFault && (! stageB_mmuRsp_isPaging)));
+    end
+  end
+
+  assign io_cpu_writeBack_mmuException = (stageB_loadStoreFault && stageB_mmuRsp_isPaging);
+  assign io_cpu_writeBack_unalignedAccess = (io_cpu_writeBack_isValid && stageB_unaligned);
+  assign io_cpu_writeBack_isWrite = stageB_request_wr;
+  always @ (*) begin
+    io_mem_cmd_valid = 1'b0;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(_zz_15)begin
+          io_mem_cmd_valid = (! memCmdSent);
+        end else begin
+          if(_zz_16)begin
+            if(stageB_request_wr)begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end else begin
+            if((! memCmdSent))begin
+              io_mem_cmd_valid = 1'b1;
+            end
+          end
+        end
+      end
+    end
+    if(_zz_13)begin
+      io_mem_cmd_valid = 1'b0;
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 2],2'b00};
+          end else begin
+            io_mem_cmd_payload_address = {stageB_mmuRsp_physicalAddress[31 : 5],5'h0};
+          end
+        end
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_mem_cmd_payload_length = 3'b000;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(_zz_16)begin
+            io_mem_cmd_payload_length = 3'b000;
+          end else begin
+            io_mem_cmd_payload_length = 3'b111;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_last = 1'b1;
+  always @ (*) begin
+    io_mem_cmd_payload_wr = stageB_request_wr;
+    if(io_cpu_writeBack_isValid)begin
+      if(! stageB_isExternalAmo) begin
+        if(! _zz_15) begin
+          if(! _zz_16) begin
+            io_mem_cmd_payload_wr = 1'b0;
+          end
+        end
+      end
+    end
+  end
+
+  assign io_mem_cmd_payload_mask = stageB_mask;
+  assign io_mem_cmd_payload_data = stageB_requestDataBypass;
+  assign io_mem_cmd_payload_uncached = stageB_mmuRsp_isIoAccess;
+  assign stageB_bypassCache = ((stageB_mmuRsp_isIoAccess || stageB_isExternalLsrc) || stageB_isExternalAmo);
+  assign io_cpu_writeBack_keepMemRspData = 1'b0;
+  always @ (*) begin
+    if(stageB_bypassCache)begin
+      io_cpu_writeBack_data = stageB_ioMemRspMuxed;
+    end else begin
+      io_cpu_writeBack_data = stageB_dataMux;
+    end
+  end
+
+  assign _zz_9[0] = stageB_tagsReadRsp_0_error;
+  always @ (*) begin
+    loader_counter_willIncrement = 1'b0;
+    if(_zz_14)begin
+      loader_counter_willIncrement = 1'b1;
+    end
+  end
+
+  assign loader_counter_willClear = 1'b0;
+  assign loader_counter_willOverflowIfInc = (loader_counter_value == 3'b111);
+  assign loader_counter_willOverflow = (loader_counter_willOverflowIfInc && loader_counter_willIncrement);
+  always @ (*) begin
+    loader_counter_valueNext = (loader_counter_value + _zz_25);
+    if(loader_counter_willClear)begin
+      loader_counter_valueNext = 3'b000;
+    end
+  end
+
+  assign loader_kill = 1'b0;
+  assign loader_done = loader_counter_willOverflow;
+  assign io_cpu_execute_refilling = loader_valid;
+  always @ (posedge clk) begin
+    tagsWriteLastCmd_valid <= tagsWriteCmd_valid;
+    tagsWriteLastCmd_payload_way <= tagsWriteCmd_payload_way;
+    tagsWriteLastCmd_payload_address <= tagsWriteCmd_payload_address;
+    tagsWriteLastCmd_payload_data_valid <= tagsWriteCmd_payload_data_valid;
+    tagsWriteLastCmd_payload_data_error <= tagsWriteCmd_payload_data_error;
+    tagsWriteLastCmd_payload_data_address <= tagsWriteCmd_payload_data_address;
+    if((! io_cpu_memory_isStuck))begin
+      stageA_request_wr <= io_cpu_execute_args_wr;
+      stageA_request_data <= io_cpu_execute_args_data;
+      stageA_request_size <= io_cpu_execute_args_size;
+      stageA_request_totalyConsistent <= io_cpu_execute_args_totalyConsistent;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_mask <= stage0_mask;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stageA_wayInvalidate <= stage0_wayInvalidate;
+    end
+    if((! io_cpu_memory_isStuck))begin
+      stage0_dataColisions_regNextWhen <= stage0_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_request_wr <= stageA_request_wr;
+      stageB_request_data <= stageA_request_data;
+      stageB_request_size <= stageA_request_size;
+      stageB_request_totalyConsistent <= stageA_request_totalyConsistent;
+    end
+    if(((! io_cpu_writeBack_isStuck) && (! stageB_mmuRspFreeze)))begin
+      stageB_mmuRsp_physicalAddress <= io_cpu_memory_mmuRsp_physicalAddress;
+      stageB_mmuRsp_isIoAccess <= io_cpu_memory_mmuRsp_isIoAccess;
+      stageB_mmuRsp_isPaging <= io_cpu_memory_mmuRsp_isPaging;
+      stageB_mmuRsp_allowRead <= io_cpu_memory_mmuRsp_allowRead;
+      stageB_mmuRsp_allowWrite <= io_cpu_memory_mmuRsp_allowWrite;
+      stageB_mmuRsp_allowExecute <= io_cpu_memory_mmuRsp_allowExecute;
+      stageB_mmuRsp_exception <= io_cpu_memory_mmuRsp_exception;
+      stageB_mmuRsp_refilling <= io_cpu_memory_mmuRsp_refilling;
+      stageB_mmuRsp_bypassTranslation <= io_cpu_memory_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_tagsReadRsp_0_valid <= ways_0_tagsReadRsp_valid;
+      stageB_tagsReadRsp_0_error <= ways_0_tagsReadRsp_error;
+      stageB_tagsReadRsp_0_address <= ways_0_tagsReadRsp_address;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataReadRsp_0 <= ways_0_dataReadRsp;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_wayInvalidate <= stageA_wayInvalidate;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_dataColisions <= stageA_dataColisions;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_unaligned <= (((stageA_request_size == 2'b10) && (io_cpu_memory_address[1 : 0] != 2'b00)) || ((stageA_request_size == 2'b01) && (io_cpu_memory_address[0 : 0] != 1'b0)));
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_waysHitsBeforeInvalidate <= stageA_wayHits;
+    end
+    if((! io_cpu_writeBack_isStuck))begin
+      stageB_mask <= stageA_mask;
+    end
+    if(stageB_flusher_valid)begin
+      if(_zz_17)begin
+        if(_zz_18)begin
+          stageB_mmuRsp_physicalAddress[11 : 5] <= (stageB_mmuRsp_physicalAddress[11 : 5] + 7'h01);
+        end
+      end
+    end
+    if(stageB_flusher_start)begin
+      stageB_mmuRsp_physicalAddress[11 : 5] <= 7'h0;
+    end
+    loader_valid_regNext <= loader_valid;
+  end
+
+  always @ (posedge clk) begin
+    if(reset) begin
+      memCmdSent <= 1'b0;
+      stageB_flusher_valid <= 1'b0;
+      stageB_flusher_start <= 1'b1;
+      loader_valid <= 1'b0;
+      loader_counter_value <= 3'b000;
+      loader_waysAllocator <= 1'b1;
+      loader_error <= 1'b0;
+      loader_killReg <= 1'b0;
+    end else begin
+      if(io_mem_cmd_ready)begin
+        memCmdSent <= 1'b1;
+      end
+      if((! io_cpu_writeBack_isStuck))begin
+        memCmdSent <= 1'b0;
+      end
+      if(stageB_flusher_valid)begin
+        if(_zz_17)begin
+          if(! _zz_18) begin
+            stageB_flusher_valid <= 1'b0;
+          end
+        end
+      end
+      stageB_flusher_start <= ((((((! stageB_flusher_start) && io_cpu_flush_valid) && (! io_cpu_execute_isValid)) && (! io_cpu_memory_isValid)) && (! io_cpu_writeBack_isValid)) && (! io_cpu_redo));
+      if(stageB_flusher_start)begin
+        stageB_flusher_valid <= 1'b1;
+      end
+      `ifndef SYNTHESIS
+        `ifdef FORMAL
+          assert((! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck)));
+        `else
+          if(!(! ((io_cpu_writeBack_isValid && (! io_cpu_writeBack_haltIt)) && io_cpu_writeBack_isStuck))) begin
+            $display("FAILURE writeBack stuck by another plugin is not allowed");
+            $finish;
+          end
+        `endif
+      `endif
+      if(stageB_loaderValid)begin
+        loader_valid <= 1'b1;
+      end
+      loader_counter_value <= loader_counter_valueNext;
+      if(loader_kill)begin
+        loader_killReg <= 1'b1;
+      end
+      if(_zz_14)begin
+        loader_error <= (loader_error || io_mem_rsp_payload_error);
+      end
+      if(loader_done)begin
+        loader_valid <= 1'b0;
+        loader_error <= 1'b0;
+        loader_killReg <= 1'b0;
+      end
+      if((! loader_valid))begin
+        loader_waysAllocator <= _zz_26[0:0];
+      end
+    end
+  end
+
+
+endmodule
+
+module InstructionCache (
+  input               io_flush,
+  input               io_cpu_prefetch_isValid,
+  output reg          io_cpu_prefetch_haltIt,
+  input      [31:0]   io_cpu_prefetch_pc,
+  input               io_cpu_fetch_isValid,
+  input               io_cpu_fetch_isStuck,
+  input               io_cpu_fetch_isRemoved,
+  input      [31:0]   io_cpu_fetch_pc,
+  output     [31:0]   io_cpu_fetch_data,
+  input      [31:0]   io_cpu_fetch_mmuRsp_physicalAddress,
+  input               io_cpu_fetch_mmuRsp_isIoAccess,
+  input               io_cpu_fetch_mmuRsp_isPaging,
+  input               io_cpu_fetch_mmuRsp_allowRead,
+  input               io_cpu_fetch_mmuRsp_allowWrite,
+  input               io_cpu_fetch_mmuRsp_allowExecute,
+  input               io_cpu_fetch_mmuRsp_exception,
+  input               io_cpu_fetch_mmuRsp_refilling,
+  input               io_cpu_fetch_mmuRsp_bypassTranslation,
+  output     [31:0]   io_cpu_fetch_physicalAddress,
+  input               io_cpu_decode_isValid,
+  input               io_cpu_decode_isStuck,
+  input      [31:0]   io_cpu_decode_pc,
+  output     [31:0]   io_cpu_decode_physicalAddress,
+  output     [31:0]   io_cpu_decode_data,
+  output              io_cpu_decode_cacheMiss,
+  output              io_cpu_decode_error,
+  output              io_cpu_decode_mmuRefilling,
+  output              io_cpu_decode_mmuException,
+  input               io_cpu_decode_isUser,
+  input               io_cpu_fill_valid,
+  input      [31:0]   io_cpu_fill_payload,
+  output              io_mem_cmd_valid,
+  input               io_mem_cmd_ready,
+  output     [31:0]   io_mem_cmd_payload_address,
+  output     [2:0]    io_mem_cmd_payload_size,
+  input               io_mem_rsp_valid,
+  input      [31:0]   io_mem_rsp_payload_data,
+  input               io_mem_rsp_payload_error,
+  input      [2:0]    _zz_9,
+  input      [31:0]   _zz_10,
+  input               clk,
+  input               reset
+);
+  reg        [31:0]   _zz_11;
+  reg        [21:0]   _zz_12;
+  wire                _zz_13;
+  wire                _zz_14;
+  wire       [0:0]    _zz_15;
+  wire       [0:0]    _zz_16;
+  wire       [21:0]   _zz_17;
+  reg                 _zz_1;
+  reg                 _zz_2;
+  reg                 lineLoader_fire;
+  reg                 lineLoader_valid;
+  (* keep , syn_keep *) reg        [31:0]   lineLoader_address /* synthesis syn_keep = 1 */ ;
+  reg                 lineLoader_hadError;
+  reg                 lineLoader_flushPending;
+  reg        [7:0]    lineLoader_flushCounter;
+  reg                 _zz_3;
+  reg                 lineLoader_cmdSent;
+  reg                 lineLoader_wayToAllocate_willIncrement;
+  wire                lineLoader_wayToAllocate_willClear;
+  wire                lineLoader_wayToAllocate_willOverflowIfInc;
+  wire                lineLoader_wayToAllocate_willOverflow;
+  (* keep , syn_keep *) reg        [2:0]    lineLoader_wordIndex /* synthesis syn_keep = 1 */ ;
+  wire                lineLoader_write_tag_0_valid;
+  wire       [6:0]    lineLoader_write_tag_0_payload_address;
+  wire                lineLoader_write_tag_0_payload_data_valid;
+  wire                lineLoader_write_tag_0_payload_data_error;
+  wire       [19:0]   lineLoader_write_tag_0_payload_data_address;
+  wire                lineLoader_write_data_0_valid;
+  wire       [9:0]    lineLoader_write_data_0_payload_address;
+  wire       [31:0]   lineLoader_write_data_0_payload_data;
+  wire       [9:0]    _zz_4;
+  wire                _zz_5;
+  wire       [31:0]   fetchStage_read_banksValue_0_dataMem;
+  wire       [31:0]   fetchStage_read_banksValue_0_data;
+  wire       [6:0]    _zz_6;
+  wire                _zz_7;
+  wire                fetchStage_read_waysValues_0_tag_valid;
+  wire                fetchStage_read_waysValues_0_tag_error;
+  wire       [19:0]   fetchStage_read_waysValues_0_tag_address;
+  wire       [21:0]   _zz_8;
+  wire                fetchStage_hit_hits_0;
+  wire                fetchStage_hit_valid;
+  wire                fetchStage_hit_error;
+  wire       [31:0]   fetchStage_hit_data;
+  wire       [31:0]   fetchStage_hit_word;
+  reg        [31:0]   io_cpu_fetch_data_regNextWhen;
+  reg        [31:0]   decodeStage_mmuRsp_physicalAddress;
+  reg                 decodeStage_mmuRsp_isIoAccess;
+  reg                 decodeStage_mmuRsp_isPaging;
+  reg                 decodeStage_mmuRsp_allowRead;
+  reg                 decodeStage_mmuRsp_allowWrite;
+  reg                 decodeStage_mmuRsp_allowExecute;
+  reg                 decodeStage_mmuRsp_exception;
+  reg                 decodeStage_mmuRsp_refilling;
+  reg                 decodeStage_mmuRsp_bypassTranslation;
+  reg                 decodeStage_hit_valid;
+  reg                 decodeStage_hit_error;
+  (* ram_style = "block" *) reg [31:0] banks_0 [0:1023];
+  (* ram_style = "block" *) reg [21:0] ways_0_tags [0:127];
+
+  assign _zz_13 = (! lineLoader_flushCounter[7]);
+  assign _zz_14 = (lineLoader_flushPending && (! (lineLoader_valid || io_cpu_fetch_isValid)));
+  assign _zz_15 = _zz_8[0 : 0];
+  assign _zz_16 = _zz_8[1 : 1];
+  assign _zz_17 = {lineLoader_write_tag_0_payload_data_address,{lineLoader_write_tag_0_payload_data_error,lineLoader_write_tag_0_payload_data_valid}};
+  always @ (posedge clk) begin
+    if(_zz_1) begin
+      banks_0[lineLoader_write_data_0_payload_address] <= lineLoader_write_data_0_payload_data;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_5) begin
+      _zz_11 <= banks_0[_zz_4];
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_2) begin
+      ways_0_tags[lineLoader_write_tag_0_payload_address] <= _zz_17;
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(_zz_7) begin
+      _zz_12 <= ways_0_tags[_zz_6];
+    end
+  end
+
+  always @ (*) begin
+    _zz_1 = 1'b0;
+    if(lineLoader_write_data_0_valid)begin
+      _zz_1 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    _zz_2 = 1'b0;
+    if(lineLoader_write_tag_0_valid)begin
+      _zz_2 = 1'b1;
+    end
+  end
+
+  always @ (*) begin
+    lineLoader_fire = 1'b0;
+    if(io_mem_rsp_valid)begin
+      if((lineLoader_wordIndex == 3'b111))begin
+        lineLoader_fire = 1'b1;
+      end
+    end
+  end
+
+  always @ (*) begin
+    io_cpu_prefetch_haltIt = (lineLoader_valid || lineLoader_flushPending);
+    if(_zz_13)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if((! _zz_3))begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+    if(io_flush)begin
+      io_cpu_prefetch_haltIt = 1'b1;
+    end
+  end
+
+  assign io_mem_cmd_valid = (lineLoader_valid && (! lineLoader_cmdSent));
+  assign io_mem_cmd_payload_address = {lineLoader_address[31 : 5],5'h0};
+  assign io_mem_cmd_payload_size = 3'b101;
+  always @ (*) begin
+    lineLoader_wayToAllocate_willIncrement = 1'b0;
+    if((! lineLoader_valid))begin
+      lineLoader_wayToAllocate_willIncrement = 1'b1;
+    end
+  end
+
+  assign lineLoader_wayToAllocate_willClear = 1'b0;
+  assign lineLoader_wayToAllocate_willOverflowIfInc = 1'b1;
+  assign lineLoader_wayToAllocate_willOverflow = (lineLoader_wayToAllocate_willOverflowIfInc && lineLoader_wayToAllocate_willIncrement);
+  assign lineLoader_write_tag_0_valid = ((1'b1 && lineLoader_fire) || (! lineLoader_flushCounter[7]));
+  assign lineLoader_write_tag_0_payload_address = (lineLoader_flushCounter[7] ? lineLoader_address[11 : 5] : lineLoader_flushCounter[6 : 0]);
+  assign lineLoader_write_tag_0_payload_data_valid = lineLoader_flushCounter[7];
+  assign lineLoader_write_tag_0_payload_data_error = (lineLoader_hadError || io_mem_rsp_payload_error);
+  assign lineLoader_write_tag_0_payload_data_address = lineLoader_address[31 : 12];
+  assign lineLoader_write_data_0_valid = (io_mem_rsp_valid && 1'b1);
+  assign lineLoader_write_data_0_payload_address = {lineLoader_address[11 : 5],lineLoader_wordIndex};
+  assign lineLoader_write_data_0_payload_data = io_mem_rsp_payload_data;
+  assign _zz_4 = io_cpu_prefetch_pc[11 : 2];
+  assign _zz_5 = (! io_cpu_fetch_isStuck);
+  assign fetchStage_read_banksValue_0_dataMem = _zz_11;
+  assign fetchStage_read_banksValue_0_data = fetchStage_read_banksValue_0_dataMem[31 : 0];
+  assign _zz_6 = io_cpu_prefetch_pc[11 : 5];
+  assign _zz_7 = (! io_cpu_fetch_isStuck);
+  assign _zz_8 = _zz_12;
+  assign fetchStage_read_waysValues_0_tag_valid = _zz_15[0];
+  assign fetchStage_read_waysValues_0_tag_error = _zz_16[0];
+  assign fetchStage_read_waysValues_0_tag_address = _zz_8[21 : 2];
+  assign fetchStage_hit_hits_0 = (fetchStage_read_waysValues_0_tag_valid && (fetchStage_read_waysValues_0_tag_address == io_cpu_fetch_mmuRsp_physicalAddress[31 : 12]));
+  assign fetchStage_hit_valid = (fetchStage_hit_hits_0 != 1'b0);
+  assign fetchStage_hit_error = fetchStage_read_waysValues_0_tag_error;
+  assign fetchStage_hit_data = fetchStage_read_banksValue_0_data;
+  assign fetchStage_hit_word = fetchStage_hit_data;
+  assign io_cpu_fetch_data = fetchStage_hit_word;
+  assign io_cpu_decode_data = io_cpu_fetch_data_regNextWhen;
+  assign io_cpu_fetch_physicalAddress = io_cpu_fetch_mmuRsp_physicalAddress;
+  assign io_cpu_decode_cacheMiss = (! decodeStage_hit_valid);
+  assign io_cpu_decode_error = (decodeStage_hit_error || ((! decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute))));
+  assign io_cpu_decode_mmuRefilling = decodeStage_mmuRsp_refilling;
+  assign io_cpu_decode_mmuException = (((! decodeStage_mmuRsp_refilling) && decodeStage_mmuRsp_isPaging) && (decodeStage_mmuRsp_exception || (! decodeStage_mmuRsp_allowExecute)));
+  assign io_cpu_decode_physicalAddress = decodeStage_mmuRsp_physicalAddress;
+  always @ (posedge clk) begin
+    if(reset) begin
+      lineLoader_valid <= 1'b0;
+      lineLoader_hadError <= 1'b0;
+      lineLoader_flushPending <= 1'b1;
+      lineLoader_cmdSent <= 1'b0;
+      lineLoader_wordIndex <= 3'b000;
+    end else begin
+      if(lineLoader_fire)begin
+        lineLoader_valid <= 1'b0;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_hadError <= 1'b0;
+      end
+      if(io_cpu_fill_valid)begin
+        lineLoader_valid <= 1'b1;
+      end
+      if(io_flush)begin
+        lineLoader_flushPending <= 1'b1;
+      end
+      if(_zz_14)begin
+        lineLoader_flushPending <= 1'b0;
+      end
+      if((io_mem_cmd_valid && io_mem_cmd_ready))begin
+        lineLoader_cmdSent <= 1'b1;
+      end
+      if(lineLoader_fire)begin
+        lineLoader_cmdSent <= 1'b0;
+      end
+      if(io_mem_rsp_valid)begin
+        lineLoader_wordIndex <= (lineLoader_wordIndex + 3'b001);
+        if(io_mem_rsp_payload_error)begin
+          lineLoader_hadError <= 1'b1;
+        end
+      end
+    end
+  end
+
+  always @ (posedge clk) begin
+    if(io_cpu_fill_valid)begin
+      lineLoader_address <= io_cpu_fill_payload;
+    end
+    if(_zz_13)begin
+      lineLoader_flushCounter <= (lineLoader_flushCounter + 8'h01);
+    end
+    _zz_3 <= lineLoader_flushCounter[7];
+    if(_zz_14)begin
+      lineLoader_flushCounter <= 8'h0;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      io_cpu_fetch_data_regNextWhen <= io_cpu_fetch_data;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_mmuRsp_physicalAddress <= io_cpu_fetch_mmuRsp_physicalAddress;
+      decodeStage_mmuRsp_isIoAccess <= io_cpu_fetch_mmuRsp_isIoAccess;
+      decodeStage_mmuRsp_isPaging <= io_cpu_fetch_mmuRsp_isPaging;
+      decodeStage_mmuRsp_allowRead <= io_cpu_fetch_mmuRsp_allowRead;
+      decodeStage_mmuRsp_allowWrite <= io_cpu_fetch_mmuRsp_allowWrite;
+      decodeStage_mmuRsp_allowExecute <= io_cpu_fetch_mmuRsp_allowExecute;
+      decodeStage_mmuRsp_exception <= io_cpu_fetch_mmuRsp_exception;
+      decodeStage_mmuRsp_refilling <= io_cpu_fetch_mmuRsp_refilling;
+      decodeStage_mmuRsp_bypassTranslation <= io_cpu_fetch_mmuRsp_bypassTranslation;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_valid <= fetchStage_hit_valid;
+    end
+    if((! io_cpu_decode_isStuck))begin
+      decodeStage_hit_error <= fetchStage_hit_error;
+    end
+    if((_zz_9 != 3'b000))begin
+      io_cpu_fetch_data_regNextWhen <= _zz_10;
     end
   end
 

--- a/pythondata_cpu_vexriscv/verilog/build.sbt
+++ b/pythondata_cpu_vexriscv/verilog/build.sbt
@@ -1,4 +1,4 @@
-val spinalVersion = "1.4.2"
+val spinalVersion = "1.4.3"
 
 lazy val root = (project in file(".")).
   settings(

--- a/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -25,6 +25,7 @@ case class ArgConfig(
   dCacheSize : Int = 4096,
   pmp : Boolean = false,
   mulDiv : Boolean = true,
+  cfu : Boolean = false,
   atomics: Boolean = false,
   compressedGen: Boolean = false,
   singleCycleMulDiv : Boolean = true,
@@ -62,6 +63,7 @@ object GenCoreDefault{
       opt[Int]("dCacheSize")     action { (v, c) => c.copy(dCacheSize = v) } text("Set data cache size, 0 mean no cache")
       opt[Boolean]("pmp")    action { (v, c) => c.copy(pmp = v)   } text("Enable physical memory protection")
       opt[Boolean]("mulDiv")    action { (v, c) => c.copy(mulDiv = v)   } text("set RV32IM")
+      opt[Boolean]("cfu")       action { (v, c) => c.copy(cfu = v)   } text("If true, add SIMD ADD custom function unit")
       opt[Boolean]("atomics")    action { (v, c) => c.copy(atomics = v)   } text("set RV32I[A]")
       opt[Boolean]("compressedGen")    action { (v, c) => c.copy(compressedGen = v)   } text("set RV32I[C]")
       opt[Boolean]("singleCycleMulDiv")    action { (v, c) => c.copy(singleCycleMulDiv = v)   } text("If true, MUL/DIV are single-cycle")
@@ -104,7 +106,7 @@ object GenCoreDefault{
             config = InstructionCacheConfig(
               cacheSize = argConfig.iCacheSize,
               bytePerLine = 32,
-              wayCount = 1,
+              wayCount = (argConfig.iCacheSize + 4095) / 4096,
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
@@ -133,7 +135,7 @@ object GenCoreDefault{
             config = new DataCacheConfig(
               cacheSize = argConfig.dCacheSize,
               bytePerLine = 32,
-              wayCount = 1,
+              wayCount = (argConfig.dCacheSize + 4095) / 4096,
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
@@ -183,7 +185,8 @@ object GenCoreDefault{
           pessimisticAddressMatch = false
         ),
         new BranchPlugin(
-          earlyBranch = false,
+          // If using CFU, use earlyBranch to avoid incorrect CFU execution
+          earlyBranch = argConfig.cfu,
           catchAddressMisaligned = true
         ),
         new CsrPlugin(
@@ -228,6 +231,45 @@ object GenCoreDefault{
       // Add in the Debug plugin, if requested
       if(argConfig.debug) {
         plugins += new DebugPlugin(ClockDomain.current.clone(reset = Bool().setName("debugReset")))
+      }
+
+      // CFU plugin/port
+      if(argConfig.cfu) {
+        plugins ++= List(
+          new CfuPlugin(
+            stageCount = 1,
+            allowZeroLatency = true,
+            encodings = List(
+              // CFU R-type
+              CfuPluginEncoding (
+                instruction = M"-------------------------0001011",
+                functionId = List(14 downto 12, 31 downto 25),
+                input2Kind = CfuPlugin.Input2Kind.RS
+              )
+              //,
+              // CFU I-type
+              //CfuPluginEncoding (
+              //  instruction = M"-----------------000-----0101011",
+              //  functionId = List(23 downto 20),
+              //  input2Kind = CfuPlugin.Input2Kind.IMM_I
+              //)
+            ),
+            busParameter = CfuBusParameter(
+              CFU_VERSION = 0,
+              CFU_INTERFACE_ID_W = 0,
+              CFU_FUNCTION_ID_W = 10,
+              CFU_REORDER_ID_W = 0,
+              CFU_REQ_RESP_ID_W = 0,
+              CFU_STATE_INDEX_NUM = 0,
+              CFU_INPUTS = 2,
+              CFU_INPUT_DATA_W = 32,
+              CFU_OUTPUTS = 1,
+              CFU_OUTPUT_DATA_W = 32,
+              CFU_FLOW_REQ_READY_ALWAYS = false,
+              CFU_FLOW_RESP_READY_ALWAYS = false
+            )
+          )
+        )
       }
 
       // CPU configuration

--- a/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
+++ b/pythondata_cpu_vexriscv/verilog/src/main/scala/vexriscv/GenCoreDefault.scala
@@ -94,7 +94,7 @@ object GenCoreDefault{
             cmdForkOnSecondStage = false,
             cmdForkPersistence = false, //Not required as the wishbone bridge ensure it
             compressedGen = argConfig.compressedGen,
-            memoryTranslatorPortConfig = if(linux) MmuPortConfig(portTlbSize = 4)
+            memoryTranslatorPortConfig = if(linux) MmuPortConfig(portTlbSize = 4) else null
           )
         }else {
           new IBusCachedPlugin(
@@ -102,11 +102,11 @@ object GenCoreDefault{
             relaxedPcCalculation = argConfig.relaxedPcCalculation,
             prediction = argConfig.prediction,
             compressedGen = argConfig.compressedGen,
-            memoryTranslatorPortConfig = if(linux) MmuPortConfig(portTlbSize = 4),
+            memoryTranslatorPortConfig = if(linux) MmuPortConfig(portTlbSize = 4) else null,
             config = InstructionCacheConfig(
               cacheSize = argConfig.iCacheSize,
               bytePerLine = 32,
-              wayCount = (argConfig.iCacheSize + 4095) / 4096,
+              wayCount = if(linux) ((argConfig.iCacheSize + 4095) / 4096) else 1,
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
@@ -124,7 +124,7 @@ object GenCoreDefault{
             catchAddressMisaligned = true,
             catchAccessFault = true,
             withLrSc = linux || argConfig.atomics,
-            memoryTranslatorPortConfig = if(linux) MmuPortConfig(portTlbSize = 4)
+            memoryTranslatorPortConfig = if(linux) MmuPortConfig(portTlbSize = 4) else null
           )
         }else {
           new DBusCachedPlugin(
@@ -135,7 +135,7 @@ object GenCoreDefault{
             config = new DataCacheConfig(
               cacheSize = argConfig.dCacheSize,
               bytePerLine = 32,
-              wayCount = (argConfig.dCacheSize + 4095) / 4096,
+              wayCount = if(linux) ((argConfig.dCacheSize + 4095) / 4096) else 1,
               addressWidth = 32,
               cpuDataWidth = 32,
               memDataWidth = 32,
@@ -146,7 +146,7 @@ object GenCoreDefault{
               withAmo = linux,
               earlyWaysHits = argConfig.dBusCachedEarlyWaysHits
             ),
-            memoryTranslatorPortConfig = if(linux) MmuPortConfig(portTlbSize = 4),
+            memoryTranslatorPortConfig = if(linux) MmuPortConfig(portTlbSize = 4) else null,
             csrInfo = true
           )
         },


### PR DESCRIPTION
* R-format custom instructions only, for now.
* Bump SpinalHDL to 1.4.3.
* Bump ext/VexRiscv to current head of master
* use earlyBranch=true when CFU is used
* Allow caches > 4kB by upping wayCount as needed (one way per 4kB)
* Only two new prebuilts for now:
    VexRiscv_FullCfu.v, VexRiscv_FullCfuDebug.v.
* Rebuilt all existing variants
